### PR TITLE
Decouple text runs from Editor and CanvasCoordinator

### DIFF
--- a/apps/desktop/src/renderer/src/components/EditorView.tsx
+++ b/apps/desktop/src/renderer/src/components/EditorView.tsx
@@ -8,6 +8,7 @@ import { InteractiveScene } from "./InteractiveScene";
 import { OverlayScene } from "./OverlayScene";
 import { StaticScene } from "./StaticScene";
 import { DebugPanel } from "./debug/DebugPanel";
+import { HiddenTextInput } from "./HiddenTextInput";
 import { Vec2 } from "@shift/geo";
 
 interface EditorViewProps {
@@ -105,6 +106,7 @@ export const EditorView: FC<EditorViewProps> = ({ glyphId }) => {
         <OverlayScene />
         <InteractiveScene />
       </CanvasContextProvider>
+      <HiddenTextInput />
       <DebugPanel />
     </div>
   );

--- a/apps/desktop/src/renderer/src/components/HiddenTextInput.tsx
+++ b/apps/desktop/src/renderer/src/components/HiddenTextInput.tsx
@@ -3,7 +3,7 @@
  *
  * Handles IME composition, clipboard paste, and special characters natively.
  * The textarea is positioned off-screen but remains focused. Input events
- * feed into the TextRunController; the canvas renders the glyphs.
+ * feed into the TextRunController; rendering updates reactively.
  */
 import { useEffect, useRef, useState } from "react";
 import { getEditor } from "@/store/store";
@@ -44,8 +44,6 @@ export function HiddenTextInput() {
       }
     }
 
-    ctrl.recompute();
-    editor.requestRedraw();
     textarea.value = "";
   };
 
@@ -59,18 +57,12 @@ export function HiddenTextInput() {
         return;
 
       case "Backspace":
-        if (ctrl.delete()) {
-          ctrl.recompute();
-          editor.requestRedraw();
-        }
+        ctrl.delete();
         e.preventDefault();
         return;
 
       case "Delete":
-        if (ctrl.deleteForward()) {
-          ctrl.recompute();
-          editor.requestRedraw();
-        }
+        ctrl.deleteForward();
         e.preventDefault();
         return;
 
@@ -80,8 +72,6 @@ export function HiddenTextInput() {
         } else {
           ctrl.moveCursorLeft(extend);
         }
-        ctrl.recompute();
-        editor.requestRedraw();
         e.preventDefault();
         return;
 
@@ -91,16 +81,12 @@ export function HiddenTextInput() {
         } else {
           ctrl.moveCursorRight(extend);
         }
-        ctrl.recompute();
-        editor.requestRedraw();
         e.preventDefault();
         return;
 
       case "a":
         if (e.metaKey || e.ctrlKey) {
           ctrl.selectAll();
-          ctrl.recompute();
-          editor.requestRedraw();
           e.preventDefault();
           return;
         }
@@ -127,8 +113,6 @@ export function HiddenTextInput() {
                 editor.insertTextCodepoint(codepoint);
               }
             }
-            ctrl.recompute();
-            editor.requestRedraw();
           });
           e.preventDefault();
           return;

--- a/apps/desktop/src/renderer/src/components/HiddenTextInput.tsx
+++ b/apps/desktop/src/renderer/src/components/HiddenTextInput.tsx
@@ -78,7 +78,17 @@ export function HiddenTextInput() {
   useEffect(() => {
     if (!isTextTool || !ref.current) return;
     ref.current.focus();
-  }, [isTextTool]);
+
+    // Re-focus textarea when canvas steals focus (e.g. click on canvas)
+    const handleFocusLost = () => {
+      if (editor.getActiveTool() === "text") {
+        setTimeout(() => ref.current?.focus(), 0);
+      }
+    };
+
+    ref.current.addEventListener("blur", handleFocusLost);
+    return () => ref.current?.removeEventListener("blur", handleFocusLost);
+  }, [isTextTool, editor]);
 
   if (!isTextTool) return null;
 

--- a/apps/desktop/src/renderer/src/components/HiddenTextInput.tsx
+++ b/apps/desktop/src/renderer/src/components/HiddenTextInput.tsx
@@ -8,6 +8,60 @@
 import { useEffect, useRef, useState } from "react";
 import { getEditor } from "@/store/store";
 import { effect } from "@/lib/reactive/signal";
+import type { TextRunController } from "@/lib/tools/text/TextRunController";
+
+function moveCursorVertically(ctrl: TextRunController, direction: 1 | -1, extend: boolean): void {
+  const state = ctrl.state.peek();
+  if (!state) return;
+
+  const { layout } = state;
+  const slots = layout.slots;
+  if (slots.length === 0) return;
+
+  const cursorIdx = ctrl.cursor;
+  const cursorSlot = cursorIdx > 0 ? slots[cursorIdx - 1] : slots[0];
+  if (!cursorSlot) return;
+
+  const currentY = cursorSlot.y;
+  const cursorX = cursorIdx > 0 ? cursorSlot.x + cursorSlot.advance : cursorSlot.x;
+
+  // Find unique line Y values, sorted descending (UPM: higher Y = higher on screen)
+  const lineYs = [...new Set(slots.map((s) => s.y))].sort((a, b) => b - a);
+  const currentLineIdx = lineYs.indexOf(currentY);
+  if (currentLineIdx === -1) return;
+
+  // direction 1 = down = next line (lower Y in UPM)
+  // direction -1 = up = previous line (higher Y in UPM)
+  const targetLineIdx = currentLineIdx + direction;
+  if (targetLineIdx < 0 || targetLineIdx >= lineYs.length) return;
+
+  const targetY = lineYs[targetLineIdx];
+
+  // Find closest slot on target line by X position
+  let bestIdx = 0;
+  let bestDist = Infinity;
+  for (const [i, slot] of slots.entries()) {
+    if (slot.y !== targetY) continue;
+    const slotMidX = slot.x + slot.advance / 2;
+    const dist = Math.abs(slotMidX - cursorX);
+    if (dist < bestDist) {
+      bestDist = dist;
+      bestIdx = i + 1; // cursor goes after this slot
+    }
+  }
+
+  // Check if cursor should be before the first slot on the target line
+  const firstOnLine = slots.find((s) => s.y === targetY);
+  if (firstOnLine && cursorX <= firstOnLine.x) {
+    bestIdx = slots.indexOf(firstOnLine);
+  }
+
+  if (extend) {
+    ctrl.extendSelection(bestIdx);
+  } else {
+    ctrl.placeCaret(bestIdx);
+  }
+}
 
 export function HiddenTextInput() {
   const editor = getEditor();
@@ -86,6 +140,16 @@ export function HiddenTextInput() {
         } else {
           ctrl.moveCursorRight(extend);
         }
+        e.preventDefault();
+        return;
+
+      case "ArrowUp":
+        moveCursorVertically(ctrl, -1, extend);
+        e.preventDefault();
+        return;
+
+      case "ArrowDown":
+        moveCursorVertically(ctrl, 1, extend);
         e.preventDefault();
         return;
 

--- a/apps/desktop/src/renderer/src/components/HiddenTextInput.tsx
+++ b/apps/desktop/src/renderer/src/components/HiddenTextInput.tsx
@@ -1,0 +1,158 @@
+/**
+ * Hidden textarea that captures text input when the text tool is active.
+ *
+ * Handles IME composition, clipboard paste, and special characters natively.
+ * The textarea is positioned off-screen but remains focused. Input events
+ * feed into the TextRunController; the canvas renders the glyphs.
+ */
+import { useEffect, useRef, useState } from "react";
+import { getEditor } from "@/store/store";
+import { effect } from "@/lib/reactive/signal";
+
+export function HiddenTextInput() {
+  const editor = getEditor();
+  const ref = useRef<HTMLTextAreaElement>(null);
+  const [isTextTool, setIsTextTool] = useState(false);
+
+  useEffect(() => {
+    const fx = effect(() => {
+      setIsTextTool(editor.getActiveTool() === "text");
+    });
+    return () => fx.dispose();
+  }, [editor]);
+
+  useEffect(() => {
+    if (!isTextTool || !ref.current) return;
+    ref.current.focus();
+  }, [isTextTool]);
+
+  if (!isTextTool) return null;
+
+  const ctrl = editor.textRunController;
+
+  const handleInput = () => {
+    const textarea = ref.current;
+    if (!textarea) return;
+
+    const text = textarea.value;
+    if (!text) return;
+
+    for (const char of text) {
+      const codepoint = char.codePointAt(0);
+      if (codepoint !== undefined) {
+        editor.insertTextCodepoint(codepoint);
+      }
+    }
+
+    ctrl.recompute();
+    editor.requestRedraw();
+    textarea.value = "";
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    const extend = e.shiftKey;
+
+    switch (e.key) {
+      case "Escape":
+        editor.setActiveTool("select");
+        e.preventDefault();
+        return;
+
+      case "Backspace":
+        if (ctrl.delete()) {
+          ctrl.recompute();
+          editor.requestRedraw();
+        }
+        e.preventDefault();
+        return;
+
+      case "Delete":
+        if (ctrl.deleteForward()) {
+          ctrl.recompute();
+          editor.requestRedraw();
+        }
+        e.preventDefault();
+        return;
+
+      case "ArrowLeft":
+        if (e.metaKey) {
+          ctrl.moveCursorToStart(extend);
+        } else {
+          ctrl.moveCursorLeft(extend);
+        }
+        ctrl.recompute();
+        editor.requestRedraw();
+        e.preventDefault();
+        return;
+
+      case "ArrowRight":
+        if (e.metaKey) {
+          ctrl.moveCursorToEnd(extend);
+        } else {
+          ctrl.moveCursorRight(extend);
+        }
+        ctrl.recompute();
+        editor.requestRedraw();
+        e.preventDefault();
+        return;
+
+      case "a":
+        if (e.metaKey || e.ctrlKey) {
+          ctrl.selectAll();
+          ctrl.recompute();
+          editor.requestRedraw();
+          e.preventDefault();
+          return;
+        }
+        break;
+
+      case "c":
+        if (e.metaKey || e.ctrlKey) {
+          const codepoints = ctrl.getCodepoints();
+          if (codepoints.length > 0) {
+            const text = String.fromCodePoint(...codepoints);
+            navigator.clipboard?.writeText(text);
+          }
+          e.preventDefault();
+          return;
+        }
+        break;
+
+      case "v":
+        if (e.metaKey || e.ctrlKey) {
+          navigator.clipboard?.readText().then((text) => {
+            for (const char of text) {
+              const codepoint = char.codePointAt(0);
+              if (codepoint !== undefined) {
+                editor.insertTextCodepoint(codepoint);
+              }
+            }
+            ctrl.recompute();
+            editor.requestRedraw();
+          });
+          e.preventDefault();
+          return;
+        }
+        break;
+    }
+  };
+
+  return (
+    <textarea
+      ref={ref}
+      onInput={handleInput}
+      onKeyDown={handleKeyDown}
+      aria-label="Text input"
+      autoComplete="off"
+      style={{
+        position: "absolute",
+        left: -9999,
+        top: -9999,
+        width: 1,
+        height: 1,
+        opacity: 0,
+        pointerEvents: "none",
+      }}
+    />
+  );
+}

--- a/apps/desktop/src/renderer/src/components/HiddenTextInput.tsx
+++ b/apps/desktop/src/renderer/src/components/HiddenTextInput.tsx
@@ -8,60 +8,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getEditor } from "@/store/store";
 import { effect } from "@/lib/reactive/signal";
-import type { TextRunController } from "@/lib/tools/text/TextRunController";
-
-function moveCursorVertically(ctrl: TextRunController, direction: 1 | -1, extend: boolean): void {
-  const state = ctrl.state.peek();
-  if (!state) return;
-
-  const { layout } = state;
-  const slots = layout.slots;
-  if (slots.length === 0) return;
-
-  const cursorIdx = ctrl.cursor;
-  const cursorSlot = cursorIdx > 0 ? slots[cursorIdx - 1] : slots[0];
-  if (!cursorSlot) return;
-
-  const currentY = cursorSlot.y;
-  const cursorX = cursorIdx > 0 ? cursorSlot.x + cursorSlot.advance : cursorSlot.x;
-
-  // Find unique line Y values, sorted descending (UPM: higher Y = higher on screen)
-  const lineYs = [...new Set(slots.map((s) => s.y))].sort((a, b) => b - a);
-  const currentLineIdx = lineYs.indexOf(currentY);
-  if (currentLineIdx === -1) return;
-
-  // direction 1 = down = next line (lower Y in UPM)
-  // direction -1 = up = previous line (higher Y in UPM)
-  const targetLineIdx = currentLineIdx + direction;
-  if (targetLineIdx < 0 || targetLineIdx >= lineYs.length) return;
-
-  const targetY = lineYs[targetLineIdx];
-
-  // Find closest slot on target line by X position
-  let bestIdx = 0;
-  let bestDist = Infinity;
-  for (const [i, slot] of slots.entries()) {
-    if (slot.y !== targetY) continue;
-    const slotMidX = slot.x + slot.advance / 2;
-    const dist = Math.abs(slotMidX - cursorX);
-    if (dist < bestDist) {
-      bestDist = dist;
-      bestIdx = i + 1; // cursor goes after this slot
-    }
-  }
-
-  // Check if cursor should be before the first slot on the target line
-  const firstOnLine = slots.find((s) => s.y === targetY);
-  if (firstOnLine && cursorX <= firstOnLine.x) {
-    bestIdx = slots.indexOf(firstOnLine);
-  }
-
-  if (extend) {
-    ctrl.extendSelection(bestIdx);
-  } else {
-    ctrl.placeCaret(bestIdx);
-  }
-}
 
 export function HiddenTextInput() {
   const editor = getEditor();
@@ -140,7 +86,9 @@ export function HiddenTextInput() {
 
       case "ArrowLeft":
         if (e.metaKey) {
-          ctrl.moveCursorToStart(extend);
+          ctrl.moveCursorToLineStart(extend);
+        } else if (e.altKey) {
+          ctrl.moveCursorByWord(-1, extend);
         } else {
           ctrl.moveCursorLeft(extend);
         }
@@ -149,7 +97,9 @@ export function HiddenTextInput() {
 
       case "ArrowRight":
         if (e.metaKey) {
-          ctrl.moveCursorToEnd(extend);
+          ctrl.moveCursorToLineEnd(extend);
+        } else if (e.altKey) {
+          ctrl.moveCursorByWord(1, extend);
         } else {
           ctrl.moveCursorRight(extend);
         }
@@ -157,12 +107,12 @@ export function HiddenTextInput() {
         return;
 
       case "ArrowUp":
-        moveCursorVertically(ctrl, -1, extend);
+        ctrl.moveCursorVertically(-1, extend);
         e.preventDefault();
         return;
 
       case "ArrowDown":
-        moveCursorVertically(ctrl, 1, extend);
+        ctrl.moveCursorVertically(1, extend);
         e.preventDefault();
         return;
 

--- a/apps/desktop/src/renderer/src/components/HiddenTextInput.tsx
+++ b/apps/desktop/src/renderer/src/components/HiddenTextInput.tsx
@@ -5,7 +5,7 @@
  * The textarea is positioned off-screen but remains focused. Input events
  * feed into the TextRunController; rendering updates reactively.
  */
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { getEditor } from "@/store/store";
 import { effect } from "@/lib/reactive/signal";
 import type { TextRunController } from "@/lib/tools/text/TextRunController";
@@ -75,20 +75,23 @@ export function HiddenTextInput() {
     return () => fx.dispose();
   }, [editor]);
 
-  useEffect(() => {
-    if (!isTextTool || !ref.current) return;
-    ref.current.focus();
+  const textareaRef = useCallback(
+    (node: HTMLTextAreaElement | null) => {
+      (ref as React.MutableRefObject<HTMLTextAreaElement | null>).current = node;
+      if (!node) return;
 
-    // Re-focus textarea when canvas steals focus (e.g. click on canvas)
-    const handleFocusLost = () => {
-      if (editor.getActiveTool() === "text") {
-        setTimeout(() => ref.current?.focus(), 0);
-      }
-    };
+      node.focus();
 
-    ref.current.addEventListener("blur", handleFocusLost);
-    return () => ref.current?.removeEventListener("blur", handleFocusLost);
-  }, [isTextTool, editor]);
+      const handleFocusLost = () => {
+        if (editor.getActiveTool() === "text") {
+          setTimeout(() => node.focus(), 0);
+        }
+      };
+
+      node.addEventListener("blur", handleFocusLost);
+    },
+    [editor],
+  );
 
   if (!isTextTool) return null;
 
@@ -202,7 +205,7 @@ export function HiddenTextInput() {
 
   return (
     <textarea
-      ref={ref}
+      ref={textareaRef}
       onInput={handleInput}
       onKeyDown={handleKeyDown}
       aria-label="Text input"

--- a/apps/desktop/src/renderer/src/components/HiddenTextInput.tsx
+++ b/apps/desktop/src/renderer/src/components/HiddenTextInput.tsx
@@ -56,6 +56,11 @@ export function HiddenTextInput() {
         e.preventDefault();
         return;
 
+      case "Enter":
+        ctrl.insert({ glyphName: ".newline", unicode: 10 });
+        e.preventDefault();
+        return;
+
       case "Backspace":
         ctrl.delete();
         e.preventDefault();

--- a/apps/desktop/src/renderer/src/lib/cache/GlyphStore.test.ts
+++ b/apps/desktop/src/renderer/src/lib/cache/GlyphStore.test.ts
@@ -32,7 +32,7 @@ describe("GlyphStore", () => {
     expect(first).toBe(second);
   });
 
-  it("does not re-fetch during edits to the same glyph", () => {
+  it("re-fetches when editing glyph is mutated", () => {
     engine.startEditSession({ glyphName: "A", unicode: 65 });
 
     engine.addPoint({ x: 0, y: 0, pointType: "onCurve", smooth: false });
@@ -45,9 +45,7 @@ describe("GlyphStore", () => {
 
     engine.addPoint({ x: 0, y: 100, pointType: "onCurve", smooth: false });
 
-    // Store entry is NOT updated during edits to the current glyph.
-    // The live glyph path handles rendering for the editing glyph.
-    expect(entry.value!.svgPath).toBe(svgBefore);
+    expect(entry.value!.svgPath).not.toBe(svgBefore);
   });
 
   it("clear removes all entries", () => {

--- a/apps/desktop/src/renderer/src/lib/cache/GlyphStore.test.ts
+++ b/apps/desktop/src/renderer/src/lib/cache/GlyphStore.test.ts
@@ -32,7 +32,7 @@ describe("GlyphStore", () => {
     expect(first).toBe(second);
   });
 
-  it("self-heals when editing glyph is mutated", () => {
+  it("does not re-fetch during edits to the same glyph", () => {
     engine.startEditSession({ glyphName: "A", unicode: 65 });
 
     engine.addPoint({ x: 0, y: 0, pointType: "onCurve", smooth: false });
@@ -45,7 +45,9 @@ describe("GlyphStore", () => {
 
     engine.addPoint({ x: 0, y: 100, pointType: "onCurve", smooth: false });
 
-    expect(entry.value!.svgPath).not.toBe(svgBefore);
+    // Store entry is NOT updated during edits to the current glyph.
+    // The live glyph path handles rendering for the editing glyph.
+    expect(entry.value!.svgPath).toBe(svgBefore);
   });
 
   it("clear removes all entries", () => {

--- a/apps/desktop/src/renderer/src/lib/cache/GlyphStore.ts
+++ b/apps/desktop/src/renderer/src/lib/cache/GlyphStore.ts
@@ -42,9 +42,20 @@ export class GlyphStore {
   constructor(font: FontEngine) {
     this.#font = font;
 
+    let lastGlyphName: string | null = null;
+
     this.#effect = effect(() => {
       const glyph = font.$glyph.value;
-      if (!glyph) return;
+      if (!glyph) {
+        lastGlyphName = null;
+        return;
+      }
+
+      // Only re-fetch when the editing glyph changes (different name).
+      // Position-only changes (translate, drag) don't need a store
+      // re-fetch — the live glyph path handles rendering.
+      if (glyph.name === lastGlyphName) return;
+      lastGlyphName = glyph.name;
 
       const entry = this.#entries.get(glyph.name);
       if (!entry) return;
@@ -52,8 +63,6 @@ export class GlyphStore {
       if (this.#isWritable(entry)) {
         entry.set(this.#fetch(glyph.name));
       } else {
-        // Composite — tear down and recreate on next access.
-        // The fresh computed will read the current component list.
         this.#entries.delete(glyph.name);
       }
     });

--- a/apps/desktop/src/renderer/src/lib/cache/GlyphStore.ts
+++ b/apps/desktop/src/renderer/src/lib/cache/GlyphStore.ts
@@ -42,20 +42,9 @@ export class GlyphStore {
   constructor(font: FontEngine) {
     this.#font = font;
 
-    let lastGlyphName: string | null = null;
-
     this.#effect = effect(() => {
       const glyph = font.$glyph.value;
-      if (!glyph) {
-        lastGlyphName = null;
-        return;
-      }
-
-      // Only re-fetch when the editing glyph changes (different name).
-      // Position-only changes (translate, drag) don't need a store
-      // re-fetch — the live glyph path handles rendering.
-      if (glyph.name === lastGlyphName) return;
-      lastGlyphName = glyph.name;
+      if (!glyph) return;
 
       const entry = this.#entries.get(glyph.name);
       if (!entry) return;

--- a/apps/desktop/src/renderer/src/lib/editor/Editor.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/Editor.ts
@@ -482,6 +482,11 @@ export class Editor implements ShiftEditor {
   }
 
   /** @knipclassignore Indirectly consumed through CanvasCoordinatorContext. */
+  /** @knipclassignore Indirectly consumed through CanvasCoordinatorContext. */
+  public renderToolInScene(draw: DrawAPI): void {
+    this.#toolManager.renderInScene(draw);
+  }
+
   public renderTool(draw: DrawAPI): void {
     this.#toolManager.render(draw);
   }

--- a/apps/desktop/src/renderer/src/lib/editor/Editor.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/Editor.ts
@@ -99,7 +99,7 @@ import type {
   SnapIndicator,
 } from "./snapping/types";
 import { SnapManager } from "./managers/SnapManager";
-import { TextRunController, type TextRunRenderState } from "@/lib/tools/text/TextRunController";
+import { TextRunController } from "@/lib/tools/text/TextRunController";
 import { SnapPreferencesSchema, TextRunModulePayloadSchema } from "@shift/validation";
 import type { TextRunModulePayload } from "@/persistence/types";
 
@@ -928,86 +928,11 @@ export class Editor implements ShiftEditor {
     return this.#textRunController;
   }
 
-  /** @knipclassignore Indirectly consumed through CanvasCoordinatorContext. */
-  public getTextRunState(): TextRunRenderState | null {
-    return this.#textRunController.state.value;
-  }
-
-  public getTextRunLength(): number {
-    return this.#textRunController.length;
-  }
-
-  public ensureTextRunSeed(glyph: GlyphRef | null): void {
-    if (glyph === null) return;
-    this.#textRunController.seed(glyph);
-  }
-
-  public setTextRunCursorVisible(visible: boolean): void {
-    this.#textRunController.setCursorVisible(visible);
-  }
-
-  public setTextRunEditingSlot(index: number | null, glyph?: GlyphRef | null): void {
-    this.#textRunController.setEditingSlot(index, glyph);
-  }
-
-  public resetTextRunEditingContext(): void {
-    this.#textRunController.resetEditingContext();
-  }
-
-  public setTextRunHovered(index: number | null): void {
-    this.#textRunController.setHovered(index);
-  }
-
-  public setTextRunInspectionSlot(index: number | null): void {
-    this.#textRunController.setInspectionSlot(index);
-  }
-
-  public setTextRunInspectionComponent(index: number | null): void {
-    this.#textRunController.setInspectionHoveredComponent(index);
-  }
-
-  public clearTextRunInspection(): void {
-    this.#textRunController.clearInspection();
-  }
-
+  /** Resolve a unicode codepoint to a glyph ref and insert into the text run. */
   public insertTextCodepoint(codepoint: number): void {
     const glyphName = this.#fontEngine.getGlyphNameForUnicode(codepoint);
     if (!glyphName) return;
     this.#textRunController.insert({ glyphName, unicode: codepoint });
-  }
-
-  public insertTextGlyphAt(index: number, glyph: GlyphRef): void {
-    this.#textRunController.insertAt(index, glyph);
-  }
-
-  public getTextRunCodepoints(): number[] {
-    return this.#textRunController.getCodepoints();
-  }
-
-  public deleteTextCodepoint(): boolean {
-    return this.#textRunController.delete();
-  }
-
-  public moveTextCursorLeft(extend = false): boolean {
-    this.#textRunController.moveCursorLeft(extend);
-    return true;
-  }
-
-  public moveTextCursorRight(extend = false): boolean {
-    this.#textRunController.moveCursorRight(extend);
-    return true;
-  }
-
-  public moveTextCursorToEnd(): void {
-    this.#textRunController.moveCursorToEnd();
-  }
-
-  public selectAllText(): void {
-    this.#textRunController.selectAll();
-  }
-
-  public recomputeTextRun(originX?: number): void {
-    this.#textRunController.recompute(originX);
   }
 
   /** @knipclassignore Indirectly consumed through CanvasCoordinatorContext. */

--- a/apps/desktop/src/renderer/src/lib/editor/Editor.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/Editor.ts
@@ -318,7 +318,6 @@ export class Editor implements ShiftEditor {
       deserialize: (json) => {
         const payload = TextRunModulePayloadSchema.parse(json);
         this.#textRunController.hydrateRuns(payload.runsByGlyph);
-        this.#textRunController.recompute();
         return payload;
       },
     });
@@ -915,14 +914,10 @@ export class Editor implements ShiftEditor {
   public startEditSession(glyph: GlyphRef): void {
     const glyphName = glyph.glyphName;
     const currentGlyphName = this.#fontEngine.getEditingGlyphName();
-    if (currentGlyphName === glyphName) {
-      this.#textRunController.recompute();
-      return;
-    }
+    if (currentGlyphName === glyphName) return;
 
     this.#fontEngine.startEditSession(glyph);
     this.#fontEngine.addContour();
-    this.#textRunController.recompute();
   }
 
   public endEditSession(): void {
@@ -1026,7 +1021,6 @@ export class Editor implements ShiftEditor {
     this.#mainGlyphUnicode = unicode;
     const glyphRef = unicode === null ? null : this.glyphRefFromUnicode(unicode);
     this.#textRunController.setOwnerGlyph(glyphRef);
-    this.#textRunController.recompute();
   }
 
   public getMainGlyphUnicode(): number | null {

--- a/apps/desktop/src/renderer/src/lib/editor/rendering/CanvasCoordinator.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/rendering/CanvasCoordinator.ts
@@ -8,9 +8,6 @@ import type { SnapIndicator } from "../snapping/types";
 import type { DebugOverlays } from "@shared/ipc/types";
 import type { DrawAPI } from "@/lib/tools/core/DrawAPI";
 import type { BoundingBoxHitResult } from "@/types/boundingBox";
-import type { TextRunController, TextRunRenderState } from "@/lib/tools/text/TextRunController";
-import type { CompositeComponentsPayload } from "@shared/bridge/FontEngineAPI";
-import type { CompositeInspectionRenderData } from "./passes/textRun";
 
 import {
   BOUNDING_RECTANGLE_STYLES,
@@ -43,7 +40,6 @@ import {
   renderDebugGlyphBbox,
   renderBoundingRect,
   renderBoundingBoxHandles,
-  renderTextRun,
 } from "./passes";
 import { packHandleInstances } from "./gpu/classifyHandles";
 import { getVisibleSceneBounds } from "./visibleSceneBounds";
@@ -107,6 +103,8 @@ export interface CanvasCoordinatorContext {
   projectSceneToScreen(scene: Point2D): Point2D;
   getDebugOverlays(): DebugOverlays;
   getVisualGlyphAdvance(glyph: Glyph): number;
+  /** Delegates to the active tool's scene-space render method (static canvas, before glyph). */
+  renderToolInScene(draw: DrawAPI): void;
   /** Delegates to the active tool's render method (interactive canvas). */
   renderTool(draw: DrawAPI): void;
   /** Delegates to the active tool's render-below-handles method (static canvas, drawn before point handles). */
@@ -115,10 +113,6 @@ export interface CanvasCoordinatorContext {
   getSelectionBoundingRect(): Rect2D | null;
   getHoveredBoundingBoxHandle(): BoundingBoxHitResult;
   getZoom(): number;
-  readonly textRunController: TextRunController;
-  getGlyphCompositeComponents(glyphName: string): CompositeComponentsPayload | null;
-  getActiveGlyphName(): string | null;
-  getActiveGlyphUnicode(): number | null;
 }
 
 /**
@@ -310,7 +304,7 @@ export class CanvasCoordinator {
 
     ctx.save();
     this.#applyViewportTransform(ctx);
-    this.#renderTextRun(rc, visibleSceneBounds);
+    this.#ctx.renderToolInScene(this.#staticDraw!);
     this.#renderSelectionBoundingRect(ctx, rc);
     ctx.restore();
 
@@ -466,63 +460,6 @@ export class CanvasCoordinator {
       ...(hoveredHandle ? { hoveredHandle } : {}),
     });
     ctx.restore();
-  }
-
-  #resolveCompositeInspection(
-    textRunState: TextRunRenderState,
-  ): CompositeInspectionRenderData | null {
-    const inspection = textRunState.compositeInspection;
-    if (!inspection) return null;
-
-    const slot = textRunState.layout.slots[inspection.slotIndex];
-    if (!slot) return null;
-
-    const composite = this.#ctx.getGlyphCompositeComponents(slot.glyph.glyphName);
-    if (!composite || composite.components.length === 0) return null;
-
-    return {
-      slotIndex: inspection.slotIndex,
-      hoveredComponentIndex: inspection.hoveredComponentIndex,
-      components: composite.components,
-    };
-  }
-
-  #renderTextRun(
-    rc: {
-      ctx: IRenderer;
-      pxToUpm: (px?: number) => number;
-      applyStyle: (style: DrawStyle) => void;
-    },
-    visibleSceneBounds: { minX: number; maxX: number; minY: number; maxY: number },
-  ): void {
-    const textRunState = this.#ctx.textRunController.state.value;
-    if (!textRunState) return;
-
-    const metrics = this.#ctx.font.getMetrics();
-    const glyph = this.#ctx.glyph.peek();
-    const activeGlyphName = this.#ctx.getActiveGlyphName();
-    const liveGlyph =
-      glyph && activeGlyphName
-        ? {
-            name: activeGlyphName,
-            unicode: this.#ctx.getActiveGlyphUnicode(),
-            contours: glyph.contours,
-            compositeContours: glyph.compositeContours,
-          }
-        : null;
-
-    renderTextRun(
-      {
-        ctx: rc.ctx,
-        pxToUpm: rc.pxToUpm,
-        applyStyle: rc.applyStyle,
-      },
-      textRunState,
-      metrics,
-      liveGlyph,
-      this.#resolveCompositeInspection(textRunState),
-      visibleSceneBounds,
-    );
   }
 
   #projectGlyphLocalToScreen(x: number, y: number): Point2D {

--- a/apps/desktop/src/renderer/src/lib/editor/rendering/CanvasCoordinator.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/rendering/CanvasCoordinator.ts
@@ -8,7 +8,7 @@ import type { SnapIndicator } from "../snapping/types";
 import type { DebugOverlays } from "@shared/ipc/types";
 import type { DrawAPI } from "@/lib/tools/core/DrawAPI";
 import type { BoundingBoxHitResult } from "@/types/boundingBox";
-import type { TextRunRenderState } from "@/lib/tools/text/TextRunController";
+import type { TextRunController, TextRunRenderState } from "@/lib/tools/text/TextRunController";
 import type { CompositeComponentsPayload } from "@shared/bridge/FontEngineAPI";
 import type { CompositeInspectionRenderData } from "./passes/textRun";
 
@@ -115,7 +115,7 @@ export interface CanvasCoordinatorContext {
   getSelectionBoundingRect(): Rect2D | null;
   getHoveredBoundingBoxHandle(): BoundingBoxHitResult;
   getZoom(): number;
-  getTextRunState(): TextRunRenderState | null;
+  readonly textRunController: TextRunController;
   getGlyphCompositeComponents(glyphName: string): CompositeComponentsPayload | null;
   getActiveGlyphName(): string | null;
   getActiveGlyphUnicode(): number | null;
@@ -495,7 +495,7 @@ export class CanvasCoordinator {
     },
     visibleSceneBounds: { minX: number; maxX: number; minY: number; maxY: number },
   ): void {
-    const textRunState = this.#ctx.getTextRunState();
+    const textRunState = this.#ctx.textRunController.state.value;
     if (!textRunState) return;
 
     const metrics = this.#ctx.font.getMetrics();

--- a/apps/desktop/src/renderer/src/lib/editor/rendering/passes/textRun.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/rendering/passes/textRun.ts
@@ -17,7 +17,6 @@ import { Bounds, type Bounds as BoundsType } from "@shift/geo";
 
 const CURSOR_COLOR = "#0C92F4";
 const CURSOR_WIDTH_PX = 1.25;
-const CURSOR_BAR_HALF_PX = 20;
 const SELECTION_FILL = "rgba(12, 146, 244, 0.2)";
 const HOVER_OUTLINE = "#0C92F4";
 const HOVER_OUTLINE_WIDTH_PX = 3;
@@ -121,20 +120,12 @@ export function renderTextRun(
     const top = metrics.ascender;
     const bottom = metrics.descender;
     const lw = pxToUpm(CURSOR_WIDTH_PX);
-    const barHalf = pxToUpm(CURSOR_BAR_HALF_PX);
 
     ctx.save();
     ctx.strokeStyle = CURSOR_COLOR;
     ctx.lineWidth = lw;
 
-    // Vertical line
     ctx.drawLine(cursorX, bottom, cursorX, top);
-
-    // Top bar
-    ctx.drawLine(cursorX - barHalf, top, cursorX + barHalf, top);
-
-    // Bottom bar
-    ctx.drawLine(cursorX - barHalf, bottom, cursorX + barHalf, bottom);
 
     ctx.restore();
   }

--- a/apps/desktop/src/renderer/src/lib/editor/rendering/passes/textRun.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/rendering/passes/textRun.ts
@@ -63,8 +63,10 @@ export function renderTextRun(
       continue;
     }
 
+    if (!slot.path2d && !shouldUseLiveGlyph) continue;
+
     ctx.save();
-    ctx.translate(slot.x, 0);
+    ctx.translate(slot.x, slot.y);
     ctx.fillStyle = "black";
 
     if (shouldUseLiveGlyph && liveGlyph) {
@@ -101,7 +103,7 @@ export function renderTextRun(
       const lw = pxToUpm(HOVER_OUTLINE_WIDTH_PX);
 
       ctx.save();
-      ctx.translate(slot.x, 0);
+      ctx.translate(slot.x, slot.y);
       ctx.strokeStyle = HOVER_OUTLINE;
       ctx.lineWidth = lw;
 
@@ -117,8 +119,9 @@ export function renderTextRun(
 
   // Draw cursor
   if (cursorX !== null) {
-    const top = metrics.ascender;
-    const bottom = metrics.descender;
+    const cursorY = textRun.cursorY;
+    const top = cursorY + metrics.ascender;
+    const bottom = cursorY + metrics.descender;
     const lw = pxToUpm(CURSOR_WIDTH_PX);
 
     ctx.save();
@@ -144,7 +147,7 @@ function renderCompositeInspection(
   const { ctx, applyStyle } = rc;
 
   ctx.save();
-  ctx.translate(slot.x, 0);
+  ctx.translate(slot.x, slot.y);
 
   if (slot.path2d) {
     ctx.fillStyle = COMPOSITE_ARM_FILL;

--- a/apps/desktop/src/renderer/src/lib/editor/rendering/passes/textRun.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/rendering/passes/textRun.ts
@@ -13,7 +13,7 @@ import { buildContourPath, getCachedContourPath } from "../render";
 import type { CompositeComponentsPayload } from "@shared/bridge/FontEngineAPI";
 import { getGuides, renderGuides } from ".";
 import { GUIDE_STYLES } from "@/lib/styles/style";
-import { Bounds, type Bounds as BoundsType } from "@shift/geo";
+import { Bounds } from "@shift/geo";
 
 const CURSOR_COLOR = "#0C92F4";
 const CURSOR_WIDTH_PX = 1.25;
@@ -58,23 +58,16 @@ export function renderTextRun(
   for (const [i, slot] of layout.slots.entries()) {
     if (i === editingIndex) continue;
 
-    const shouldUseLiveGlyph = isLiveGlyphSlot(slot, liveGlyph);
-    if (!isSlotVisible(slot, metrics, visibleSceneBounds, shouldUseLiveGlyph ? liveGlyph : null)) {
-      continue;
-    }
+    const useLive = isLiveGlyphSlot(slot, liveGlyph);
+    if (!isSlotVisible(slot, metrics, visibleSceneBounds, useLive ? liveGlyph : null)) continue;
 
-    if (!slot.path2d && !shouldUseLiveGlyph) continue;
+    const path = useLive ? getCachedLiveGlyphPath(liveGlyph!).path : slot.path2d;
+    if (!path) continue;
 
     ctx.save();
     ctx.translate(slot.x, slot.y);
     ctx.fillStyle = "black";
-
-    if (shouldUseLiveGlyph && liveGlyph) {
-      ctx.fillPath(getCachedLiveGlyphPath(liveGlyph).path);
-    } else if (slot.path2d) {
-      ctx.fillPath(slot.path2d);
-    }
-
+    ctx.fillPath(path);
     ctx.restore();
   }
 
@@ -94,26 +87,17 @@ export function renderTextRun(
   if (hoveredIndex !== null && hoveredIndex !== editingIndex) {
     const slot = layout.slots[hoveredIndex];
     if (slot) {
-      const shouldUseLiveGlyph = isLiveGlyphSlot(slot, liveGlyph);
-      if (
-        !isSlotVisible(slot, metrics, visibleSceneBounds, shouldUseLiveGlyph ? liveGlyph : null)
-      ) {
-        return;
+      const useLive = isLiveGlyphSlot(slot, liveGlyph);
+      const path = useLive ? getCachedLiveGlyphPath(liveGlyph!).path : slot.path2d;
+
+      if (path && isSlotVisible(slot, metrics, visibleSceneBounds, useLive ? liveGlyph : null)) {
+        ctx.save();
+        ctx.translate(slot.x, slot.y);
+        ctx.strokeStyle = HOVER_OUTLINE;
+        ctx.lineWidth = pxToUpm(HOVER_OUTLINE_WIDTH_PX);
+        ctx.strokePath(path);
+        ctx.restore();
       }
-      const lw = pxToUpm(HOVER_OUTLINE_WIDTH_PX);
-
-      ctx.save();
-      ctx.translate(slot.x, slot.y);
-      ctx.strokeStyle = HOVER_OUTLINE;
-      ctx.lineWidth = lw;
-
-      if (shouldUseLiveGlyph && liveGlyph) {
-        ctx.strokePath(getCachedLiveGlyphPath(liveGlyph).path);
-      } else if (slot.path2d) {
-        ctx.strokePath(slot.path2d);
-      }
-
-      ctx.restore();
     }
   }
 
@@ -178,34 +162,31 @@ function isLiveGlyphSlot(
   slot: { glyph: { glyphName: string }; unicode: number | null },
   liveGlyph?: LiveGlyphRenderData | null,
 ): boolean {
-  const slotGlyphName = slot.glyph.glyphName;
-  const liveUnicode = liveGlyph?.unicode;
-  return (
-    liveGlyph !== null &&
-    liveGlyph !== undefined &&
-    (liveGlyph.name === slotGlyphName ||
-      (typeof liveUnicode === "number" && slot.unicode !== null && slot.unicode === liveUnicode)) &&
-    liveGlyph.contours.length + liveGlyph.compositeContours.length > 0
-  );
+  if (!liveGlyph) return false;
+  if (liveGlyph.contours.length + liveGlyph.compositeContours.length === 0) return false;
+
+  if (liveGlyph.name === slot.glyph.glyphName) return true;
+
+  return liveGlyph.unicode !== null && slot.unicode !== null && liveGlyph.unicode === slot.unicode;
 }
 
 const liveGlyphPathCache = new WeakMap<
   LiveGlyphRenderData,
   {
     path: Path2D;
-    bounds: BoundsType | null;
+    bounds: Bounds | null;
   }
 >();
 
 function getCachedLiveGlyphPath(liveGlyph: LiveGlyphRenderData): {
   path: Path2D;
-  bounds: BoundsType | null;
+  bounds: Bounds | null;
 } {
   const cached = liveGlyphPathCache.get(liveGlyph);
   if (cached) return cached;
 
   const path = new Path2D();
-  const bounds: Array<BoundsType | null> = [];
+  const bounds: Array<Bounds | null> = [];
 
   for (const contour of liveGlyph.contours) {
     const contourPath = getCachedContourPath(contour);
@@ -240,8 +221,8 @@ function isSlotVisible(
 
   const minX = slot.x + (bounds?.min.x ?? 0);
   const maxX = slot.x + (bounds?.max.x ?? Math.max(slot.advance, 0));
-  const minY = bounds?.min.y ?? metrics.descender;
-  const maxY = bounds?.max.y ?? metrics.ascender;
+  const minY = slot.y + (bounds?.min.y ?? metrics.descender);
+  const maxY = slot.y + (bounds?.max.y ?? metrics.ascender);
 
   return !(
     maxX < visibleSceneBounds.minX ||

--- a/apps/desktop/src/renderer/src/lib/keyboard/KeyboardRouter.test.ts
+++ b/apps/desktop/src/renderer/src/lib/keyboard/KeyboardRouter.test.ts
@@ -76,9 +76,12 @@ describe("KeyboardRouter", () => {
       setPreviewMode: vi.fn(),
       openGlyphFinder: vi.fn(),
       insertTextCodepoint: vi.fn(),
-      recomputeTextRun: vi.fn(),
-      getTextRunCodepoints: vi.fn(() => []),
-      selectAllText: vi.fn(),
+      textRunController: {
+        recompute: vi.fn(),
+        getCodepoints: vi.fn(() => []),
+        selectAll: vi.fn(),
+        state: { value: null },
+      },
     };
 
     toolManager = {

--- a/apps/desktop/src/renderer/src/lib/keyboard/KeyboardRouter.test.ts
+++ b/apps/desktop/src/renderer/src/lib/keyboard/KeyboardRouter.test.ts
@@ -75,13 +75,6 @@ describe("KeyboardRouter", () => {
       isPreviewMode: vi.fn(() => false),
       setPreviewMode: vi.fn(),
       openGlyphFinder: vi.fn(),
-      insertTextCodepoint: vi.fn(),
-      textRunController: {
-        recompute: vi.fn(),
-        getCodepoints: vi.fn(() => []),
-        selectAll: vi.fn(),
-        state: { value: null },
-      },
     };
 
     toolManager = {
@@ -178,41 +171,32 @@ describe("KeyboardRouter", () => {
     expect(toolManager.handleKeyDown).not.toHaveBeenCalled();
   });
 
-  it("captures plain typing in text mode before tool shortcuts", () => {
+  it("does not intercept plain typing in text mode (textarea handles it)", () => {
     activeTool = "text";
     const e = createKeyboardEvent({ key: "s" });
-    (toolManager.handleKeyDown as ReturnType<typeof vi.fn>).mockReturnValue(true);
 
     const handled = router.handleKeyDown(e);
 
-    expect(handled).toBe(true);
-    expect(toolManager.handleKeyDown).toHaveBeenCalledWith(e);
+    expect(handled).toBe(false);
     expect(editor.setActiveTool).not.toHaveBeenCalled();
-    expect(e.preventDefault).toHaveBeenCalledTimes(1);
   });
 
-  it("routes paste to text handler in text mode instead of global paste", () => {
+  it("does not intercept paste in text mode (textarea handles it)", () => {
     activeTool = "text";
     const e = createKeyboardEvent({ key: "v", metaKey: true });
 
-    const handled = router.handleKeyDown(e);
+    router.handleKeyDown(e);
 
-    expect(handled).toBe(true);
     expect(editor.paste).not.toHaveBeenCalled();
-    expect(toolManager.handleKeyDown).not.toHaveBeenCalled();
-    expect(e.preventDefault).toHaveBeenCalledTimes(1);
   });
 
-  it("routes copy to text handler in text mode instead of global copy", () => {
+  it("does not intercept copy in text mode (textarea handles it)", () => {
     activeTool = "text";
     const e = createKeyboardEvent({ key: "c", metaKey: true });
 
-    const handled = router.handleKeyDown(e);
+    router.handleKeyDown(e);
 
-    expect(handled).toBe(true);
     expect(editor.copy).not.toHaveBeenCalled();
-    expect(toolManager.handleKeyDown).not.toHaveBeenCalled();
-    expect(e.preventDefault).toHaveBeenCalledTimes(1);
   });
 
   it("inserts space in text mode instead of activating temporary hand", () => {

--- a/apps/desktop/src/renderer/src/lib/keyboard/keymaps.ts
+++ b/apps/desktop/src/renderer/src/lib/keyboard/keymaps.ts
@@ -74,7 +74,7 @@ export function createTextKeyDownBindings(): KeyBinding[] {
               ctx.editor.insertTextCodepoint(codepoint);
             }
           }
-          ctx.editor.recomputeTextRun();
+          ctx.editor.textRunController.recompute();
           ctx.editor.requestRedraw();
         });
         return true;
@@ -86,7 +86,7 @@ export function createTextKeyDownBindings(): KeyBinding[] {
       when: (ctx) => ctx.activeTool === "text",
       match: (event) => matchChord(event, { key: "c", primaryModifier: true }),
       run: (ctx) => {
-        const codepoints = ctx.editor.getTextRunCodepoints();
+        const codepoints = ctx.editor.textRunController.getCodepoints();
         if (codepoints.length > 0) {
           const text = String.fromCodePoint(...codepoints);
           navigator.clipboard?.writeText(text);
@@ -100,8 +100,8 @@ export function createTextKeyDownBindings(): KeyBinding[] {
       when: (ctx) => ctx.activeTool === "text",
       match: (event) => matchChord(event, { key: "a", primaryModifier: true }),
       run: (ctx) => {
-        ctx.editor.selectAllText();
-        ctx.editor.recomputeTextRun();
+        ctx.editor.textRunController.selectAll();
+        ctx.editor.textRunController.recompute();
         ctx.editor.requestRedraw();
         return true;
       },

--- a/apps/desktop/src/renderer/src/lib/keyboard/keymaps.ts
+++ b/apps/desktop/src/renderer/src/lib/keyboard/keymaps.ts
@@ -60,60 +60,9 @@ export function createGlobalKeyDownBindings(): KeyBinding[] {
 }
 
 export function createTextKeyDownBindings(): KeyBinding[] {
-  return [
-    {
-      id: "text.paste",
-      preventDefault: true,
-      when: (ctx) => ctx.activeTool === "text",
-      match: (event) => matchChord(event, { key: "v", primaryModifier: true }),
-      run: (ctx) => {
-        navigator.clipboard?.readText().then((text) => {
-          for (const char of text) {
-            const codepoint = char.codePointAt(0);
-            if (codepoint !== undefined) {
-              ctx.editor.insertTextCodepoint(codepoint);
-            }
-          }
-          ctx.editor.textRunController.recompute();
-          ctx.editor.requestRedraw();
-        });
-        return true;
-      },
-    },
-    {
-      id: "text.copy",
-      preventDefault: true,
-      when: (ctx) => ctx.activeTool === "text",
-      match: (event) => matchChord(event, { key: "c", primaryModifier: true }),
-      run: (ctx) => {
-        const codepoints = ctx.editor.textRunController.getCodepoints();
-        if (codepoints.length > 0) {
-          const text = String.fromCodePoint(...codepoints);
-          navigator.clipboard?.writeText(text);
-        }
-        return true;
-      },
-    },
-    {
-      id: "text.selectAll",
-      preventDefault: true,
-      when: (ctx) => ctx.activeTool === "text",
-      match: (event) => matchChord(event, { key: "a", primaryModifier: true }),
-      run: (ctx) => {
-        ctx.editor.textRunController.selectAll();
-        ctx.editor.textRunController.recompute();
-        ctx.editor.requestRedraw();
-        return true;
-      },
-    },
-    {
-      id: "text.capture",
-      preventDefault: true,
-      when: (ctx) => ctx.activeTool === "text",
-      match: (event) => !event.metaKey && !event.ctrlKey,
-      run: (ctx, e) => ctx.toolManager.handleKeyDown(e),
-    },
-  ];
+  // Text input is handled by the hidden textarea (HiddenTextInput component).
+  // No keybindings needed — the textarea handles IME, clipboard, and character input.
+  return [];
 }
 
 export function createCanvasKeyDownBindings(handlers: KeymapHandlers): KeyBinding[] {

--- a/apps/desktop/src/renderer/src/lib/keyboard/types.ts
+++ b/apps/desktop/src/renderer/src/lib/keyboard/types.ts
@@ -1,5 +1,6 @@
 import type { ToolName } from "@/lib/tools/core";
 import type { ToolShortcutEntry } from "@/types/tools";
+import type { TextRunController } from "@/lib/tools/text/TextRunController";
 
 export interface KeyboardEditorActions {
   zoomIn(): void;
@@ -22,9 +23,7 @@ export interface KeyboardEditorActions {
   isPreviewMode(): boolean;
   setPreviewMode(enabled: boolean): void;
   insertTextCodepoint(codepoint: number): void;
-  recomputeTextRun(): void;
-  getTextRunCodepoints(): number[];
-  selectAllText(): void;
+  readonly textRunController: TextRunController;
   openGlyphFinder(): void;
 }
 

--- a/apps/desktop/src/renderer/src/lib/keyboard/types.ts
+++ b/apps/desktop/src/renderer/src/lib/keyboard/types.ts
@@ -1,6 +1,5 @@
 import type { ToolName } from "@/lib/tools/core";
 import type { ToolShortcutEntry } from "@/types/tools";
-import type { TextRunController } from "@/lib/tools/text/TextRunController";
 
 export interface KeyboardEditorActions {
   zoomIn(): void;
@@ -22,8 +21,6 @@ export interface KeyboardEditorActions {
   returnFromTemporaryTool(): void;
   isPreviewMode(): boolean;
   setPreviewMode(enabled: boolean): void;
-  insertTextCodepoint(codepoint: number): void;
-  readonly textRunController: TextRunController;
   openGlyphFinder(): void;
 }
 

--- a/apps/desktop/src/renderer/src/lib/tools/core/BaseTool.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/core/BaseTool.ts
@@ -64,6 +64,8 @@ export abstract class BaseTool<S extends ToolState, Settings = Record<string, ne
   protected preTransition?(state: S, event: ToolEvent): { state: S } | null;
   protected onStateChange?(prev: S, next: S, event: ToolEvent): void;
 
+  /** Draw in viewport (scene) space, before the editable glyph. Used for text runs. */
+  renderInScene?(draw: DrawAPI): void;
   /** Draw tool-specific overlays above handles (e.g. pen preview segments). */
   render?(draw: DrawAPI): void;
   /** Draw tool-specific overlays below handles (e.g. marquee rectangle). */

--- a/apps/desktop/src/renderer/src/lib/tools/core/BaseTool.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/core/BaseTool.ts
@@ -5,6 +5,7 @@ import type { DrawAPI } from "./DrawAPI";
 import type { Behavior, ToolContext } from "./Behavior";
 import { batch, computed, type ComputedSignal } from "../../reactive/signal";
 import type { CursorType } from "@/types/editor";
+import { renderTextRunInScene } from "../text/renderTextRunScene";
 
 export type { ToolName, ToolState };
 
@@ -64,8 +65,11 @@ export abstract class BaseTool<S extends ToolState, Settings = Record<string, ne
   protected preTransition?(state: S, event: ToolEvent): { state: S } | null;
   protected onStateChange?(prev: S, next: S, event: ToolEvent): void;
 
-  /** Draw in viewport (scene) space, before the editable glyph. Used for text runs. */
-  renderInScene?(draw: DrawAPI): void;
+  /** Draw in viewport (scene) space, before the editable glyph. Renders text runs by default. */
+  renderInScene(draw: DrawAPI): void {
+    renderTextRunInScene(this.editor, draw);
+  }
+
   /** Draw tool-specific overlays above handles (e.g. pen preview segments). */
   render?(draw: DrawAPI): void;
   /** Draw tool-specific overlays below handles (e.g. marquee rectangle). */

--- a/apps/desktop/src/renderer/src/lib/tools/core/DrawAPI.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/core/DrawAPI.ts
@@ -51,6 +51,11 @@ export class DrawAPI {
     return this.#renderer;
   }
 
+  /** Convert screen pixels to UPM units at the current zoom level. */
+  pxToUpm(px = 1): number {
+    return this.#screen.toUpmDistance(px);
+  }
+
   #toUpm(px: number): number {
     return this.#screen.toUpmDistance(px);
   }

--- a/apps/desktop/src/renderer/src/lib/tools/core/EditorAPI.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/core/EditorAPI.ts
@@ -50,7 +50,7 @@ import type {
   SnapIndicator,
 } from "@/lib/editor/snapping/types";
 import type { Font } from "@/lib/editor/Font";
-import type { TextRunRenderState } from "@/lib/tools/text/TextRunController";
+import type { TextRunController } from "@/lib/tools/text/TextRunController";
 import type { Coordinates } from "@/types/coordinates";
 import type { GlyphRef } from "../text/layout";
 import { CompositeComponentsPayload } from "@shared/bridge/FontEngineAPI";
@@ -215,32 +215,13 @@ export interface Editing {
 }
 
 /**
- * Text-run editing access.
- *
- * Keeps text-run ownership and mutation APIs explicit, without exposing
- * manager internals to tools.
+ * Text-run access.
  */
 export interface TextRunAccess {
-  getTextRunState(): TextRunRenderState | null;
-  getTextRunLength(): number;
-  ensureTextRunSeed(glyph: GlyphRef | null): void;
-  setTextRunCursorVisible(visible: boolean): void;
-  setTextRunEditingSlot(index: number | null, glyph?: GlyphRef | null): void;
-  resetTextRunEditingContext(): void;
-  setTextRunHovered(index: number | null): void;
-  setTextRunInspectionSlot(index: number | null): void;
-  setTextRunInspectionComponent(index: number | null): void;
-  clearTextRunInspection(): void;
+  readonly textRunController: TextRunController;
+  /** Insert a glyph by unicode codepoint (resolves name via font engine). */
   insertTextCodepoint(codepoint: number): void;
-  insertTextGlyphAt(index: number, glyph: GlyphRef): void;
-  getTextRunCodepoints(): number[];
-  deleteTextCodepoint(): boolean;
-  moveTextCursorLeft(extend?: boolean): boolean;
-  moveTextCursorRight(extend?: boolean): boolean;
-  moveTextCursorToEnd(): void;
-  selectAllText(): void;
-  recomputeTextRun(originX?: number): void;
-  shouldRenderGlyph(): boolean;
+  /** Composite component data for a glyph (font engine query). */
   getGlyphCompositeComponents(glyphName: string): CompositeComponentsPayload | null;
 }
 

--- a/apps/desktop/src/renderer/src/lib/tools/core/ToolManager.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/core/ToolManager.test.ts
@@ -54,7 +54,7 @@ describe("ToolManager", () => {
 
     it("returns true when active tool handles keydown", () => {
       toolManager.activate("text");
-      const handled = toolManager.handleKeyDown(createKeyboardEvent("keydown", { key: "a" }));
+      const handled = toolManager.handleKeyDown(createKeyboardEvent("keydown", { key: "Escape" }));
 
       expect(handled).toBe(true);
     });

--- a/apps/desktop/src/renderer/src/lib/tools/core/ToolManager.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/core/ToolManager.ts
@@ -209,7 +209,7 @@ export class ToolManager implements ToolSwitchHandler {
   }
 
   renderInScene(draw: DrawAPI): void {
-    if (this.activeTool?.renderInScene) this.activeTool.renderInScene(draw);
+    this.activeTool?.renderInScene(draw);
   }
 
   render(draw: DrawAPI): void {

--- a/apps/desktop/src/renderer/src/lib/tools/core/ToolManager.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/core/ToolManager.ts
@@ -208,6 +208,10 @@ export class ToolManager implements ToolSwitchHandler {
     );
   }
 
+  renderInScene(draw: DrawAPI): void {
+    if (this.activeTool?.renderInScene) this.activeTool.renderInScene(draw);
+  }
+
   render(draw: DrawAPI): void {
     if (this.activeTool?.render) this.activeTool.render(draw);
   }

--- a/apps/desktop/src/renderer/src/lib/tools/select/Select.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/Select.ts
@@ -19,6 +19,7 @@ import { TextRunHoverBehavior } from "./behaviors/TextRunHoverBehavior";
 import { normalizeRect } from "./utils";
 import { SELECTION_RECTANGLE_STYLES } from "@/lib/styles/style";
 import type { CursorType } from "@/types/editor";
+import { renderTextRunInScene } from "../text/renderTextRunScene";
 
 export type { BoundingRectEdge, SelectState };
 
@@ -109,6 +110,10 @@ export class Select extends BaseTool<SelectState> {
       return { state };
     }
     return null;
+  }
+
+  override renderInScene(draw: DrawAPI): void {
+    renderTextRunInScene(this.editor, draw);
   }
 
   override render(draw: DrawAPI): void {

--- a/apps/desktop/src/renderer/src/lib/tools/select/Select.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/Select.ts
@@ -19,7 +19,6 @@ import { TextRunHoverBehavior } from "./behaviors/TextRunHoverBehavior";
 import { normalizeRect } from "./utils";
 import { SELECTION_RECTANGLE_STYLES } from "@/lib/styles/style";
 import type { CursorType } from "@/types/editor";
-import { renderTextRunInScene } from "../text/renderTextRunScene";
 
 export type { BoundingRectEdge, SelectState };
 
@@ -110,10 +109,6 @@ export class Select extends BaseTool<SelectState> {
       return { state };
     }
     return null;
-  }
-
-  override renderInScene(draw: DrawAPI): void {
-    renderTextRunInScene(this.editor, draw);
   }
 
   override render(draw: DrawAPI): void {

--- a/apps/desktop/src/renderer/src/lib/tools/select/behaviors/TextRunEditBehavior.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/behaviors/TextRunEditBehavior.ts
@@ -28,7 +28,7 @@ export class TextRunEditBehavior implements SelectHandlerBehavior {
         glyphName: activeName,
         unicode: ctx.editor.getActiveGlyphUnicode(),
       });
-      ctrl.recompute(ctx.editor.getDrawOffset().x);
+      ctrl.setOriginX(ctx.editor.getDrawOffset().x);
       textRunState = ctrl.state.value;
     }
     if (!textRunState) return false;
@@ -73,7 +73,6 @@ export class TextRunEditBehavior implements SelectHandlerBehavior {
 
       const insertedIndex = hitIndex + 1;
       ctrl.insertAt(insertedIndex, insertedGlyph);
-      ctrl.recompute();
 
       const nextState = ctrl.state.value;
       const insertedSlot = nextState?.layout.slots[insertedIndex];

--- a/apps/desktop/src/renderer/src/lib/tools/select/behaviors/TextRunEditBehavior.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/behaviors/TextRunEditBehavior.ts
@@ -79,7 +79,7 @@ export class TextRunEditBehavior implements SelectHandlerBehavior {
       const slotX = insertedSlot?.x ?? slot.x;
 
       ctx.editor.startEditSession(insertedGlyph);
-      ctx.editor.setDrawOffsetForGlyph({ x: slotX, y: 0 }, insertedGlyph);
+      ctx.editor.setDrawOffsetForGlyph({ x: slotX, y: insertedSlot?.y ?? slot.y }, insertedGlyph);
       ctx.editor.setPreviewMode(false);
       ctrl.setEditingSlot(insertedIndex, insertedGlyph);
       ctrl.clearInspection();
@@ -92,7 +92,7 @@ export class TextRunEditBehavior implements SelectHandlerBehavior {
     }
 
     ctx.editor.startEditSession(slot.glyph);
-    ctx.editor.setDrawOffsetForGlyph({ x: slot.x, y: 0 }, slot.glyph);
+    ctx.editor.setDrawOffsetForGlyph({ x: slot.x, y: slot.y }, slot.glyph);
     ctx.editor.setPreviewMode(false);
     ctrl.setEditingSlot(hitIndex, slot.glyph);
     ctrl.clearInspection();

--- a/apps/desktop/src/renderer/src/lib/tools/select/behaviors/TextRunEditBehavior.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/behaviors/TextRunEditBehavior.ts
@@ -18,16 +18,18 @@ export class TextRunEditBehavior implements SelectHandlerBehavior {
   ): boolean {
     if (state.type !== "ready" && state.type !== "selected") return false;
 
-    let textRunState = ctx.editor.getTextRunState();
+    const ctrl = ctx.editor.textRunController;
+
+    let textRunState = ctrl.state.value;
     if (!textRunState) {
       const activeName = ctx.editor.getActiveGlyphName();
       if (!activeName) return false;
-      ctx.editor.ensureTextRunSeed({
+      ctrl.seed({
         glyphName: activeName,
         unicode: ctx.editor.getActiveGlyphUnicode(),
       });
-      ctx.editor.recomputeTextRun(ctx.editor.getDrawOffset().x);
-      textRunState = ctx.editor.getTextRunState();
+      ctrl.recompute(ctx.editor.getDrawOffset().x);
+      textRunState = ctrl.state.value;
     }
     if (!textRunState) return false;
 
@@ -39,7 +41,7 @@ export class TextRunEditBehavior implements SelectHandlerBehavior {
     });
     if (hitIndex === null) {
       if (textRunState.compositeInspection !== null) {
-        ctx.editor.clearTextRunInspection();
+        ctrl.clearInspection();
         return true;
       }
       return false;
@@ -53,9 +55,9 @@ export class TextRunEditBehavior implements SelectHandlerBehavior {
     const isInspected = textRunState.compositeInspection?.slotIndex === hitIndex;
 
     if (isComposite && !isInspected) {
-      ctx.editor.setTextRunInspectionSlot(hitIndex);
-      ctx.editor.setTextRunInspectionComponent(null);
-      ctx.editor.setTextRunEditingSlot(null);
+      ctrl.setInspectionSlot(hitIndex);
+      ctrl.setInspectionHoveredComponent(null);
+      ctrl.setEditingSlot(null);
       return true;
     }
 
@@ -70,31 +72,31 @@ export class TextRunEditBehavior implements SelectHandlerBehavior {
       };
 
       const insertedIndex = hitIndex + 1;
-      ctx.editor.insertTextGlyphAt(insertedIndex, insertedGlyph);
-      ctx.editor.recomputeTextRun();
+      ctrl.insertAt(insertedIndex, insertedGlyph);
+      ctrl.recompute();
 
-      const nextState = ctx.editor.getTextRunState();
+      const nextState = ctrl.state.value;
       const insertedSlot = nextState?.layout.slots[insertedIndex];
       const slotX = insertedSlot?.x ?? slot.x;
 
       ctx.editor.startEditSession(insertedGlyph);
       ctx.editor.setDrawOffsetForGlyph({ x: slotX, y: 0 }, insertedGlyph);
       ctx.editor.setPreviewMode(false);
-      ctx.editor.setTextRunEditingSlot(insertedIndex, insertedGlyph);
-      ctx.editor.clearTextRunInspection();
+      ctrl.setEditingSlot(insertedIndex, insertedGlyph);
+      ctrl.clearInspection();
       return true;
     }
 
     if (isComposite) {
-      ctx.editor.setTextRunInspectionComponent(null);
+      ctrl.setInspectionHoveredComponent(null);
       return true;
     }
 
     ctx.editor.startEditSession(slot.glyph);
     ctx.editor.setDrawOffsetForGlyph({ x: slot.x, y: 0 }, slot.glyph);
     ctx.editor.setPreviewMode(false);
-    ctx.editor.setTextRunEditingSlot(hitIndex, slot.glyph);
-    ctx.editor.clearTextRunInspection();
+    ctrl.setEditingSlot(hitIndex, slot.glyph);
+    ctrl.clearInspection();
     return true;
   }
 }

--- a/apps/desktop/src/renderer/src/lib/tools/select/behaviors/TextRunHoverBehavior.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/behaviors/TextRunHoverBehavior.ts
@@ -18,7 +18,8 @@ export class TextRunHoverBehavior implements SelectHandlerBehavior {
   ): boolean {
     if (state.type !== "ready" && state.type !== "selected") return false;
 
-    const textRunState = ctx.editor.getTextRunState();
+    const ctrl = ctx.editor.textRunController;
+    const textRunState = ctrl.state.value;
     if (!textRunState) return false;
 
     const metrics = ctx.editor.font.getMetrics();
@@ -28,25 +29,24 @@ export class TextRunHoverBehavior implements SelectHandlerBehavior {
       requireShape: true,
     });
 
-    ctx.editor.setTextRunHovered(hitIndex);
+    ctrl.setHovered(hitIndex);
     const inspection = textRunState.compositeInspection;
     if (!inspection || hitIndex !== inspection.slotIndex) {
-      ctx.editor.setTextRunInspectionComponent(null);
+      ctrl.setInspectionHoveredComponent(null);
       return false;
     }
 
     const slot = textRunState.layout.slots[inspection.slotIndex];
     if (!slot) {
-      ctx.editor.setTextRunInspectionComponent(null);
+      ctrl.setInspectionHoveredComponent(null);
       return false;
     }
 
     const composite = ctx.editor.getGlyphCompositeComponents(slot.glyph.glyphName);
     const localPoint = { x: event.point.x - slot.x, y: event.point.y };
     const hitComponent = resolveComponentAtPoint(composite, localPoint);
-    ctx.editor.setTextRunInspectionComponent(hitComponent?.index ?? null);
+    ctrl.setInspectionHoveredComponent(hitComponent?.index ?? null);
 
-    // Do not consume pointerMove -- later behaviors still need it.
     return false;
   }
 }

--- a/apps/desktop/src/renderer/src/lib/tools/text/Text.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/Text.ts
@@ -1,23 +1,13 @@
 import { BaseTool, type ToolName } from "../core/BaseTool";
 import type { TextBehavior, TextState } from "./types";
 import type { CursorType } from "@/types/editor";
-import type { Point2D } from "@shift/types";
 import { TypingBehavior } from "./behaviors/TypingBehaviour";
-import type { GlyphRef } from "./layout";
-
-interface ResumeEditContext {
-  drawOffset: Point2D;
-  editingIndex: number | null;
-  editingGlyph: GlyphRef | null;
-  activeUnicode: number | null;
-  activeGlyphName: string | null;
-}
 
 export class Text extends BaseTool<TextState> {
   readonly id: ToolName = "text";
 
   readonly behaviors: TextBehavior[] = [new TypingBehavior()];
-  #resumeContext: ResumeEditContext | null = null;
+  #hadEditingSlot = false;
   #pendingOriginX: number | null = null;
 
   override getCursor(_state: TextState): CursorType {
@@ -30,28 +20,27 @@ export class Text extends BaseTool<TextState> {
 
   override activate(): void {
     const ctrl = this.editor.textRunController;
-    const previous = ctrl.state.value;
     const hasExistingRun = ctrl.length > 0;
     const drawOffset = this.editor.getDrawOffset();
-    const activeUnicode = this.editor.getActiveGlyphUnicode();
     const activeGlyphName = this.editor.getActiveGlyphName();
+    const activeUnicode = this.editor.getActiveGlyphUnicode();
     const activeGlyph =
       activeGlyphName !== null ? { glyphName: activeGlyphName, unicode: activeUnicode } : null;
 
-    this.#resumeContext = {
-      drawOffset: { x: drawOffset.x, y: drawOffset.y },
-      editingIndex: previous?.editingIndex ?? null,
-      editingGlyph: previous?.editingGlyph ?? null,
-      activeUnicode,
-      activeGlyphName,
-    };
+    this.#hadEditingSlot = ctrl.state.value?.editingIndex !== null;
 
     if (activeGlyph) ctrl.seed(activeGlyph);
     this.#pendingOriginX = hasExistingRun ? null : drawOffset.x;
-    ctrl.moveCursorToEnd();
+
+    const editingIndex = ctrl.state.value?.editingIndex;
+    if (editingIndex !== null && editingIndex !== undefined) {
+      ctrl.placeCaret(editingIndex + 1);
+    } else {
+      ctrl.moveCursorToEnd();
+    }
 
     this.state = { type: "typing" };
-    ctrl.resetEditingContext();
+    ctrl.suspendEditing();
     ctrl.setCursorVisible(true);
     this.editor.setPreviewMode(true);
     if (this.#pendingOriginX !== null) {
@@ -66,81 +55,34 @@ export class Text extends BaseTool<TextState> {
     this.editor.setPreviewMode(false);
     this.#restoreEditingContext();
     this.state = { type: "idle" };
-    this.#resumeContext = null;
+    this.#hadEditingSlot = false;
     this.#pendingOriginX = null;
   }
 
   #restoreEditingContext(): void {
     const ctrl = this.editor.textRunController;
 
-    if (!this.#resumeContext) {
+    if (!this.#hadEditingSlot) {
       this.editor.setDrawOffset({ x: 0, y: 0 });
       ctrl.resetEditingContext();
       return;
     }
 
-    const restored = this.#resolveEditingSlot();
-    if (restored) {
-      this.editor.setDrawOffset(this.#resumeContext.drawOffset);
-      ctrl.setEditingSlot(restored.index, restored.glyph);
+    const restored = ctrl.resumeEditing();
+    if (!restored) {
+      this.editor.setDrawOffset({ x: 0, y: 0 });
+      ctrl.resetEditingContext();
       return;
     }
 
-    this.editor.setDrawOffset({ x: 0, y: 0 });
-    ctrl.resetEditingContext();
-  }
-
-  #resolveEditingSlot(): { index: number; glyph: GlyphRef } | null {
-    const resume = this.#resumeContext;
-    const textRunState = this.editor.textRunController.state.value;
-    if (!resume || !textRunState) return null;
-
-    const slots = textRunState.layout.slots;
-    if (slots.length === 0) return null;
-
-    if (resume.editingIndex !== null) {
-      const slot = slots[resume.editingIndex];
-      if (slot) {
-        return {
-          index: resume.editingIndex,
-          glyph: resume.editingGlyph ?? slot.glyph,
-        };
-      }
+    const textRunState = ctrl.state.value;
+    const slot = textRunState?.layout.slots[restored.index];
+    if (slot) {
+      this.editor.setDrawOffsetForGlyph({ x: slot.x, y: slot.y }, restored.glyph);
+    } else {
+      this.editor.setDrawOffset({ x: 0, y: 0 });
+      ctrl.resetEditingContext();
     }
-
-    let nearestIndex: number | null = null;
-    let nearestDistance = Number.POSITIVE_INFINITY;
-    for (const [i, slot] of slots.entries()) {
-      if (
-        resume.activeGlyphName !== null &&
-        slot.glyph.glyphName !== resume.activeGlyphName &&
-        (resume.activeUnicode === null || slot.glyph.unicode !== resume.activeUnicode)
-      ) {
-        continue;
-      }
-
-      const distance = Math.abs(slot.x - resume.drawOffset.x);
-      if (distance < 0.001) {
-        return { index: i, glyph: slot.glyph };
-      }
-      if (distance < nearestDistance) {
-        nearestDistance = distance;
-        nearestIndex = i;
-      }
-    }
-
-    if (nearestIndex !== null) {
-      const nearestSlot = slots[nearestIndex];
-      if (!nearestSlot) {
-        return null;
-      }
-      return {
-        index: nearestIndex,
-        glyph: nearestSlot.glyph,
-      };
-    }
-
-    return null;
   }
 }
 

--- a/apps/desktop/src/renderer/src/lib/tools/text/Text.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/Text.ts
@@ -29,8 +29,9 @@ export class Text extends BaseTool<TextState> {
   }
 
   override activate(): void {
-    const previous = this.editor.getTextRunState();
-    const hasExistingRun = this.editor.getTextRunLength() > 0;
+    const ctrl = this.editor.textRunController;
+    const previous = ctrl.state.value;
+    const hasExistingRun = ctrl.length > 0;
     const drawOffset = this.editor.getDrawOffset();
     const activeUnicode = this.editor.getActiveGlyphUnicode();
     const activeGlyphName = this.editor.getActiveGlyphName();
@@ -44,46 +45,48 @@ export class Text extends BaseTool<TextState> {
       activeGlyphName,
     };
 
-    this.editor.ensureTextRunSeed(activeGlyph);
+    if (activeGlyph) ctrl.seed(activeGlyph);
     this.#pendingOriginX = hasExistingRun ? null : drawOffset.x;
-    this.editor.moveTextCursorToEnd();
+    ctrl.moveCursorToEnd();
 
     this.state = { type: "typing" };
-    this.editor.resetTextRunEditingContext();
-    this.editor.setTextRunCursorVisible(true);
+    ctrl.resetEditingContext();
+    ctrl.setCursorVisible(true);
     this.editor.setPreviewMode(true);
     this.#recompute();
   }
 
   override deactivate(): void {
-    this.editor.setTextRunCursorVisible(false);
+    const ctrl = this.editor.textRunController;
+    ctrl.setCursorVisible(false);
     this.editor.setPreviewMode(false);
     this.#restoreEditingContext();
     this.state = { type: "idle" };
     this.#resumeContext = null;
     this.#pendingOriginX = null;
-    // Keep typed buffer/layout persisted across tool switches.
   }
 
   #restoreEditingContext(): void {
+    const ctrl = this.editor.textRunController;
+
     if (!this.#resumeContext) {
       this.editor.setDrawOffset({ x: 0, y: 0 });
-      this.editor.resetTextRunEditingContext();
+      ctrl.resetEditingContext();
       return;
     }
 
     this.editor.setDrawOffset(this.#resumeContext.drawOffset);
     const restored = this.#resolveEditingSlot();
     if (restored) {
-      this.editor.setTextRunEditingSlot(restored.index, restored.glyph);
+      ctrl.setEditingSlot(restored.index, restored.glyph);
       return;
     }
-    this.editor.resetTextRunEditingContext();
+    ctrl.resetEditingContext();
   }
 
   #resolveEditingSlot(): { index: number; glyph: GlyphRef } | null {
     const resume = this.#resumeContext;
-    const textRunState = this.editor.getTextRunState();
+    const textRunState = this.editor.textRunController.state.value;
     if (!resume || !textRunState) return null;
 
     const slots = textRunState.layout.slots;
@@ -135,12 +138,13 @@ export class Text extends BaseTool<TextState> {
   }
 
   #recompute(): void {
+    const ctrl = this.editor.textRunController;
     if (this.#pendingOriginX !== null) {
-      this.editor.recomputeTextRun(this.#pendingOriginX);
+      ctrl.recompute(this.#pendingOriginX);
       this.#pendingOriginX = null;
       return;
     }
-    this.editor.recomputeTextRun();
+    ctrl.recompute();
   }
 }
 

--- a/apps/desktop/src/renderer/src/lib/tools/text/Text.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/Text.ts
@@ -79,12 +79,14 @@ export class Text extends BaseTool<TextState> {
       return;
     }
 
-    this.editor.setDrawOffset(this.#resumeContext.drawOffset);
     const restored = this.#resolveEditingSlot();
     if (restored) {
+      this.editor.setDrawOffset(this.#resumeContext.drawOffset);
       ctrl.setEditingSlot(restored.index, restored.glyph);
       return;
     }
+
+    this.editor.setDrawOffset({ x: 0, y: 0 });
     ctrl.resetEditingContext();
   }
 

--- a/apps/desktop/src/renderer/src/lib/tools/text/Text.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/Text.ts
@@ -4,8 +4,6 @@ import type { CursorType } from "@/types/editor";
 import type { Point2D } from "@shift/types";
 import { TypingBehavior } from "./behaviors/TypingBehaviour";
 import type { GlyphRef } from "./layout";
-import type { DrawAPI } from "../core/DrawAPI";
-import { renderTextRunInScene } from "./renderTextRunScene";
 
 interface ResumeEditContext {
   drawOffset: Point2D;
@@ -24,10 +22,6 @@ export class Text extends BaseTool<TextState> {
 
   override getCursor(_state: TextState): CursorType {
     return { type: "text" };
-  }
-
-  override renderInScene(draw: DrawAPI): void {
-    renderTextRunInScene(this.editor, draw);
   }
 
   initialState(): TextState {

--- a/apps/desktop/src/renderer/src/lib/tools/text/Text.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/Text.ts
@@ -59,7 +59,10 @@ export class Text extends BaseTool<TextState> {
     ctrl.resetEditingContext();
     ctrl.setCursorVisible(true);
     this.editor.setPreviewMode(true);
-    this.#recompute();
+    if (this.#pendingOriginX !== null) {
+      ctrl.setOriginX(this.#pendingOriginX);
+      this.#pendingOriginX = null;
+    }
   }
 
   override deactivate(): void {
@@ -141,16 +144,6 @@ export class Text extends BaseTool<TextState> {
     }
 
     return null;
-  }
-
-  #recompute(): void {
-    const ctrl = this.editor.textRunController;
-    if (this.#pendingOriginX !== null) {
-      ctrl.recompute(this.#pendingOriginX);
-      this.#pendingOriginX = null;
-      return;
-    }
-    ctrl.recompute();
   }
 }
 

--- a/apps/desktop/src/renderer/src/lib/tools/text/Text.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/Text.ts
@@ -43,6 +43,7 @@ export class Text extends BaseTool<TextState> {
     const activeGlyphName = this.editor.getActiveGlyphName();
     const activeGlyph =
       activeGlyphName !== null ? { glyphName: activeGlyphName, unicode: activeUnicode } : null;
+
     this.#resumeContext = {
       drawOffset: { x: drawOffset.x, y: drawOffset.y },
       editingIndex: previous?.editingIndex ?? null,

--- a/apps/desktop/src/renderer/src/lib/tools/text/Text.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/Text.ts
@@ -4,6 +4,8 @@ import type { CursorType } from "@/types/editor";
 import type { Point2D } from "@shift/types";
 import { TypingBehavior } from "./behaviors/TypingBehaviour";
 import type { GlyphRef } from "./layout";
+import type { DrawAPI } from "../core/DrawAPI";
+import { renderTextRunInScene } from "./renderTextRunScene";
 
 interface ResumeEditContext {
   drawOffset: Point2D;
@@ -22,6 +24,10 @@ export class Text extends BaseTool<TextState> {
 
   override getCursor(_state: TextState): CursorType {
     return { type: "text" };
+  }
+
+  override renderInScene(draw: DrawAPI): void {
+    renderTextRunInScene(this.editor, draw);
   }
 
   initialState(): TextState {

--- a/apps/desktop/src/renderer/src/lib/tools/text/TextRunController.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/TextRunController.test.ts
@@ -327,4 +327,99 @@ describe("TextRunController", () => {
       expect(ctrl.state.peek()).toBe(null);
     });
   });
+
+  describe("suspendEditing / resumeEditing", () => {
+    it("suspends and resumes editing index", () => {
+      ctrl.insert(glyph("A"));
+      ctrl.insert(glyph("B"));
+      ctrl.setEditingSlot(1, glyph("B"));
+
+      ctrl.suspendEditing();
+
+      const restored = ctrl.resumeEditing();
+      expect(restored).toEqual({ index: 1, glyph: glyph("B") });
+    });
+
+    it("tracks editing index through insert before", () => {
+      ctrl.insert(glyph("A"));
+      ctrl.insert(glyph("B"));
+      ctrl.setEditingSlot(1, glyph("B"));
+
+      ctrl.suspendEditing();
+      ctrl.placeCaret(0);
+      ctrl.insert(glyph("X"));
+
+      const restored = ctrl.resumeEditing();
+      expect(restored?.index).toBe(2);
+      expect(restored?.glyph).toEqual(glyph("B"));
+    });
+
+    it("tracks editing index through insert after", () => {
+      ctrl.insert(glyph("A"));
+      ctrl.insert(glyph("B"));
+      ctrl.setEditingSlot(0, glyph("A"));
+
+      ctrl.suspendEditing();
+      ctrl.insert(glyph("C"));
+
+      const restored = ctrl.resumeEditing();
+      expect(restored?.index).toBe(0);
+    });
+
+    it("nulls editing index when editing glyph is deleted", () => {
+      ctrl.insert(glyph("A"));
+      ctrl.insert(glyph("B"));
+      ctrl.insert(glyph("C"));
+      ctrl.setEditingSlot(1, glyph("B"));
+
+      ctrl.suspendEditing();
+      ctrl.placeCaret(2);
+      ctrl.delete();
+
+      const restored = ctrl.resumeEditing();
+      expect(restored).toBeNull();
+    });
+
+    it("tracks editing index through deleteForward", () => {
+      ctrl.insert(glyph("A"));
+      ctrl.insert(glyph("B"));
+      ctrl.insert(glyph("C"));
+      ctrl.setEditingSlot(2, glyph("C"));
+
+      ctrl.suspendEditing();
+      ctrl.placeCaret(0);
+      ctrl.deleteForward();
+
+      const restored = ctrl.resumeEditing();
+      expect(restored?.index).toBe(1);
+    });
+
+    it("tracks editing index through selection delete", () => {
+      ctrl.insert(glyph("A"));
+      ctrl.insert(glyph("B"));
+      ctrl.insert(glyph("C"));
+      ctrl.insert(glyph("D"));
+      ctrl.setEditingSlot(3, glyph("D"));
+
+      ctrl.suspendEditing();
+      ctrl.selectRange(0, 2);
+      ctrl.delete();
+
+      const restored = ctrl.resumeEditing();
+      expect(restored?.index).toBe(1);
+    });
+
+    it("tracks editing index through insertMany", () => {
+      ctrl.insert(glyph("A"));
+      ctrl.insert(glyph("B"));
+      ctrl.setEditingSlot(1, glyph("B"));
+
+      ctrl.suspendEditing();
+      ctrl.placeCaret(0);
+      ctrl.insertMany([glyph("X"), glyph("Y")]);
+
+      const restored = ctrl.resumeEditing();
+      expect(restored?.index).toBe(3);
+    });
+  });
 });

--- a/apps/desktop/src/renderer/src/lib/tools/text/TextRunController.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/TextRunController.ts
@@ -77,6 +77,8 @@ interface RunState {
   readonly cursorVisible: boolean;
   readonly editingIndex: number | null;
   readonly editingGlyph: GlyphRef | null;
+  readonly suspendedEditingIndex: number | null;
+  readonly suspendedEditingGlyph: GlyphRef | null;
   readonly hoveredIndex: number | null;
   readonly inspectionSlotIndex: number | null;
   readonly inspectionHoveredComponentIndex: number | null;
@@ -90,10 +92,37 @@ const EMPTY_RUN: RunState = {
   cursorVisible: false,
   editingIndex: null,
   editingGlyph: null,
+  suspendedEditingIndex: null,
+  suspendedEditingGlyph: null,
   hoveredIndex: null,
   inspectionSlotIndex: null,
   inspectionHoveredComponentIndex: null,
 };
+
+/**
+ * Adjusts an index after a delete-then-insert operation on the glyph array.
+ * Returns null if the index falls within the deleted range.
+ */
+function adjustIndex(
+  index: number | null,
+  deleteStart: number,
+  deleteCount: number,
+  insertAt: number,
+  insertCount: number,
+): number | null {
+  if (index === null) return null;
+
+  if (deleteCount > 0) {
+    if (index >= deleteStart && index < deleteStart + deleteCount) return null;
+    if (index >= deleteStart + deleteCount) index -= deleteCount;
+  }
+
+  if (insertCount > 0 && index >= insertAt) {
+    index += insertCount;
+  }
+
+  return index;
+}
 
 export class TextRunController {
   #runs = new Map<string, WritableSignal<RunState>>();
@@ -178,13 +207,11 @@ export class TextRunController {
   /** @knipclassignore — used via editor.textRunController in HiddenTextInput */
   moveCursorToLineStart(extend = false): void {
     this.#goalX = null;
-    const state = this.#$state.peek();
-    if (!state) return;
+    const cursorY = this.#getCursorLineY();
+    if (cursorY === null) return;
 
-    const r = this.#peek();
+    const state = this.#$state.peek()!;
     const slots = state.layout.slots;
-    const cursorSlot = r.cursor > 0 ? slots[r.cursor - 1] : slots[0];
-    const cursorY = cursorSlot?.y ?? 0;
 
     let lineStart = 0;
     for (let i = 0; i < slots.length; i++) {
@@ -200,19 +227,16 @@ export class TextRunController {
   /** @knipclassignore — used via editor.textRunController in HiddenTextInput */
   moveCursorToLineEnd(extend = false): void {
     this.#goalX = null;
-    const state = this.#$state.peek();
-    if (!state) return;
+    const cursorY = this.#getCursorLineY();
+    if (cursorY === null) return;
 
-    const r = this.#peek();
+    const state = this.#$state.peek()!;
     const slots = state.layout.slots;
-    const cursorSlot = r.cursor > 0 ? slots[r.cursor - 1] : slots[0];
-    const cursorY = cursorSlot?.y ?? 0;
 
     let lineEnd = slots.length;
     for (let i = slots.length - 1; i >= 0; i--) {
       if (slots[i].y === cursorY) {
         lineEnd = i + 1;
-        // Skip newline at end of line
         if (slots[i].unicode === 10) lineEnd = i;
         break;
       }
@@ -409,10 +433,20 @@ export class TextRunController {
 
   insert(glyph: GlyphRef): void {
     this.#update((r) => {
+      const selStart = Math.min(r.anchor, r.cursor);
+      const selCount = Math.abs(r.anchor - r.cursor);
       const { glyphs, cursor } = deleteRange(r);
       const next = [...glyphs];
       next.splice(cursor, 0, glyph);
-      return { ...r, glyphs: next, cursor: cursor + 1, anchor: cursor + 1 };
+      const sei = adjustIndex(r.suspendedEditingIndex, selStart, selCount, cursor, 1);
+      return {
+        ...r,
+        glyphs: next,
+        cursor: cursor + 1,
+        anchor: cursor + 1,
+        suspendedEditingIndex: sei,
+        suspendedEditingGlyph: sei !== null ? r.suspendedEditingGlyph : null,
+      };
     });
   }
 
@@ -421,21 +455,34 @@ export class TextRunController {
       const clamped = Math.max(0, Math.min(index, r.glyphs.length));
       const next = [...r.glyphs];
       next.splice(clamped, 0, glyph);
+      const sei = adjustIndex(r.suspendedEditingIndex, 0, 0, clamped, 1);
       return {
         ...r,
         glyphs: next,
         cursor: r.cursor >= clamped ? r.cursor + 1 : r.cursor,
         anchor: r.anchor >= clamped ? r.anchor + 1 : r.anchor,
+        suspendedEditingIndex: sei,
+        suspendedEditingGlyph: sei !== null ? r.suspendedEditingGlyph : null,
       };
     });
   }
 
   insertMany(glyphs: GlyphRef[]): void {
     this.#update((r) => {
+      const selStart = Math.min(r.anchor, r.cursor);
+      const selCount = Math.abs(r.anchor - r.cursor);
       const { glyphs: current, cursor } = deleteRange(r);
       const next = [...current];
       next.splice(cursor, 0, ...glyphs);
-      return { ...r, glyphs: next, cursor: cursor + glyphs.length, anchor: cursor + glyphs.length };
+      const sei = adjustIndex(r.suspendedEditingIndex, selStart, selCount, cursor, glyphs.length);
+      return {
+        ...r,
+        glyphs: next,
+        cursor: cursor + glyphs.length,
+        anchor: cursor + glyphs.length,
+        suspendedEditingIndex: sei,
+        suspendedEditingGlyph: sei !== null ? r.suspendedEditingGlyph : null,
+      };
     });
   }
 
@@ -444,8 +491,18 @@ export class TextRunController {
 
     if (r.anchor !== r.cursor) {
       this.#update((r) => {
+        const selStart = Math.min(r.anchor, r.cursor);
+        const selCount = Math.abs(r.anchor - r.cursor);
         const { glyphs, cursor } = deleteRange(r);
-        return { ...r, glyphs, cursor, anchor: cursor };
+        const sei = adjustIndex(r.suspendedEditingIndex, selStart, selCount, 0, 0);
+        return {
+          ...r,
+          glyphs,
+          cursor,
+          anchor: cursor,
+          suspendedEditingIndex: sei,
+          suspendedEditingGlyph: sei !== null ? r.suspendedEditingGlyph : null,
+        };
       });
       return true;
     }
@@ -455,7 +512,15 @@ export class TextRunController {
     this.#update((r) => {
       const next = [...r.glyphs];
       next.splice(r.cursor - 1, 1);
-      return { ...r, glyphs: next, cursor: r.cursor - 1, anchor: r.cursor - 1 };
+      const sei = adjustIndex(r.suspendedEditingIndex, r.cursor - 1, 1, 0, 0);
+      return {
+        ...r,
+        glyphs: next,
+        cursor: r.cursor - 1,
+        anchor: r.cursor - 1,
+        suspendedEditingIndex: sei,
+        suspendedEditingGlyph: sei !== null ? r.suspendedEditingGlyph : null,
+      };
     });
     return true;
   }
@@ -465,8 +530,18 @@ export class TextRunController {
 
     if (r.anchor !== r.cursor) {
       this.#update((r) => {
+        const selStart = Math.min(r.anchor, r.cursor);
+        const selCount = Math.abs(r.anchor - r.cursor);
         const { glyphs, cursor } = deleteRange(r);
-        return { ...r, glyphs, cursor, anchor: cursor };
+        const sei = adjustIndex(r.suspendedEditingIndex, selStart, selCount, 0, 0);
+        return {
+          ...r,
+          glyphs,
+          cursor,
+          anchor: cursor,
+          suspendedEditingIndex: sei,
+          suspendedEditingGlyph: sei !== null ? r.suspendedEditingGlyph : null,
+        };
       });
       return true;
     }
@@ -476,7 +551,13 @@ export class TextRunController {
     this.#update((r) => {
       const next = [...r.glyphs];
       next.splice(r.cursor, 1);
-      return { ...r, glyphs: next };
+      const sei = adjustIndex(r.suspendedEditingIndex, r.cursor, 1, 0, 0);
+      return {
+        ...r,
+        glyphs: next,
+        suspendedEditingIndex: sei,
+        suspendedEditingGlyph: sei !== null ? r.suspendedEditingGlyph : null,
+      };
     });
     return true;
   }
@@ -535,10 +616,40 @@ export class TextRunController {
       ...r,
       editingIndex: null,
       editingGlyph: null,
+      suspendedEditingIndex: null,
+      suspendedEditingGlyph: null,
       hoveredIndex: null,
       inspectionSlotIndex: null,
       inspectionHoveredComponentIndex: null,
     }));
+  }
+
+  suspendEditing(): void {
+    this.#update((r) => ({
+      ...r,
+      suspendedEditingIndex: r.editingIndex,
+      suspendedEditingGlyph: r.editingGlyph,
+      editingIndex: null,
+      editingGlyph: null,
+      hoveredIndex: null,
+      inspectionSlotIndex: null,
+      inspectionHoveredComponentIndex: null,
+    }));
+  }
+
+  resumeEditing(): { index: number; glyph: GlyphRef } | null {
+    const r = this.#peek();
+    const index = r.suspendedEditingIndex;
+    const glyph = r.suspendedEditingGlyph;
+    this.#update((r) => ({
+      ...r,
+      editingIndex: r.suspendedEditingIndex,
+      editingGlyph: r.suspendedEditingGlyph,
+      suspendedEditingIndex: null,
+      suspendedEditingGlyph: null,
+    }));
+    if (index === null || glyph === null) return null;
+    return { index, glyph };
   }
 
   setHovered(index: number | null): void {
@@ -660,6 +771,26 @@ export class TextRunController {
     const $r = this.#signal();
     const next = fn($r.peek());
     $r.set(next);
+  }
+
+  #getCursorLineY(): number | null {
+    const state = this.#$state.peek();
+    const font = this.#$font.peek();
+    if (!state || !font) return null;
+
+    const r = this.#peek();
+    const slots = state.layout.slots;
+    if (slots.length === 0) return null;
+
+    const prevSlot = r.cursor > 0 ? slots[r.cursor - 1] : null;
+
+    if (prevSlot && prevSlot.unicode === 10) {
+      const metrics = font.getMetrics();
+      const lineHeight = metrics.ascender - metrics.descender + (metrics.lineGap ?? 0);
+      return prevSlot.y - lineHeight;
+    }
+
+    return (prevSlot ?? slots[0])?.y ?? 0;
   }
 
   #deriveRenderState(): TextRunRenderState | null {

--- a/apps/desktop/src/renderer/src/lib/tools/text/TextRunController.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/TextRunController.ts
@@ -299,16 +299,28 @@ export class TextRunController {
 
     const targetY = lineYs[targetLineIdx];
 
-    // Find closest visible slot on target line by goal X (skip newline slots)
+    // Find the slot on the target line where goalX falls, placing cursor
+    // on whichever edge (left or right) is closer — same as VS Code.
     let bestIdx = -1;
     let bestDist = Infinity;
     for (const [i, slot] of slots.entries()) {
       if (slot.y !== targetY || slot.unicode === 10) continue;
-      const slotMidX = slot.x + slot.advance / 2;
-      const dist = Math.abs(slotMidX - goalX);
-      if (dist < bestDist) {
-        bestDist = dist;
-        bestIdx = i + 1;
+
+      const leftEdge = slot.x;
+      const rightEdge = slot.x + slot.advance;
+
+      // Distance to left edge (cursor before this slot)
+      const leftDist = Math.abs(leftEdge - goalX);
+      if (leftDist < bestDist) {
+        bestDist = leftDist;
+        bestIdx = i; // cursor before this slot
+      }
+
+      // Distance to right edge (cursor after this slot)
+      const rightDist = Math.abs(rightEdge - goalX);
+      if (rightDist < bestDist) {
+        bestDist = rightDist;
+        bestIdx = i + 1; // cursor after this slot
       }
     }
 
@@ -324,12 +336,6 @@ export class TextRunController {
     }
 
     if (bestIdx === -1) return;
-
-    // Check if cursor should be before the first slot on the target line
-    const firstOnLine = slots.find((s) => s.y === targetY && s.unicode !== 10);
-    if (firstOnLine && goalX <= firstOnLine.x) {
-      bestIdx = slots.indexOf(firstOnLine);
-    }
 
     if (extend) {
       this.extendSelection(bestIdx);

--- a/apps/desktop/src/renderer/src/lib/tools/text/TextRunController.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/TextRunController.ts
@@ -240,36 +240,70 @@ export class TextRunController {
     const state = this.#$state.peek();
     if (!state) return;
 
+    const font = this.#$font.peek();
+    if (!font) return;
+
     const { layout } = state;
     const slots = layout.slots;
     if (slots.length === 0) return;
 
     const r = this.#peek();
-    const cursorSlot = r.cursor > 0 ? slots[r.cursor - 1] : slots[0];
-    if (!cursorSlot) return;
+    const metrics = font.getMetrics();
+    const lineHeight = metrics.ascender - metrics.descender + (metrics.lineGap ?? 0);
+    const prevSlot = r.cursor > 0 ? slots[r.cursor - 1] : null;
 
-    const currentY = cursorSlot.y;
-    const cursorX = r.cursor > 0 ? cursorSlot.x + cursorSlot.advance : cursorSlot.x;
+    // Determine the cursor's effective Y position.
+    // If the cursor is right after a newline, it's on the NEXT line.
+    let currentY: number;
+    let cursorX: number;
 
-    // Set or reuse goal column
+    if (prevSlot && prevSlot.unicode === 10) {
+      currentY = prevSlot.y - lineHeight;
+      cursorX = r.originX;
+    } else if (prevSlot) {
+      currentY = prevSlot.y;
+      cursorX = prevSlot.x + prevSlot.advance;
+    } else {
+      currentY = slots[0]?.y ?? 0;
+      cursorX = r.originX;
+    }
+
     if (this.#goalX === null) this.#goalX = cursorX;
     const goalX = this.#goalX;
 
-    // Find unique line Y values, sorted descending (UPM: higher Y = higher on screen)
+    // Find unique line Y values, sorted descending (higher Y = higher on screen in UPM)
     const lineYs = [...new Set(slots.map((s) => s.y))].sort((a, b) => b - a);
-    const currentLineIdx = lineYs.indexOf(currentY);
-    if (currentLineIdx === -1) return;
+
+    // Also include the line below the last newline (cursor can be there)
+    for (const slot of slots) {
+      if (slot.unicode === 10) {
+        const belowY = slot.y - lineHeight;
+        if (!lineYs.includes(belowY)) lineYs.push(belowY);
+      }
+    }
+    lineYs.sort((a, b) => b - a);
+
+    // Find closest line to currentY
+    let currentLineIdx = 0;
+    let closestDist = Infinity;
+    for (let i = 0; i < lineYs.length; i++) {
+      const dist = Math.abs(lineYs[i] - currentY);
+      if (dist < closestDist) {
+        closestDist = dist;
+        currentLineIdx = i;
+      }
+    }
 
     const targetLineIdx = currentLineIdx + direction;
     if (targetLineIdx < 0 || targetLineIdx >= lineYs.length) return;
 
     const targetY = lineYs[targetLineIdx];
 
-    // Find closest slot on target line by goal X
-    let bestIdx = 0;
+    // Find closest visible slot on target line by goal X (skip newline slots)
+    let bestIdx = -1;
     let bestDist = Infinity;
     for (const [i, slot] of slots.entries()) {
-      if (slot.y !== targetY) continue;
+      if (slot.y !== targetY || slot.unicode === 10) continue;
       const slotMidX = slot.x + slot.advance / 2;
       const dist = Math.abs(slotMidX - goalX);
       if (dist < bestDist) {
@@ -278,8 +312,21 @@ export class TextRunController {
       }
     }
 
+    // If no visible slots on target line (empty line after newline),
+    // place cursor at the newline that created this line
+    if (bestIdx === -1) {
+      for (const [i, slot] of slots.entries()) {
+        if (slot.unicode === 10 && Math.abs(slot.y - lineHeight - targetY) < 1) {
+          bestIdx = i + 1;
+          break;
+        }
+      }
+    }
+
+    if (bestIdx === -1) return;
+
     // Check if cursor should be before the first slot on the target line
-    const firstOnLine = slots.find((s) => s.y === targetY);
+    const firstOnLine = slots.find((s) => s.y === targetY && s.unicode !== 10);
     if (firstOnLine && goalX <= firstOnLine.x) {
       bestIdx = slots.indexOf(firstOnLine);
     }
@@ -289,7 +336,6 @@ export class TextRunController {
     } else {
       this.placeCaret(bestIdx);
     }
-    // Don't reset goalX — preserve it for subsequent vertical movements
     this.#goalX = goalX;
   }
 

--- a/apps/desktop/src/renderer/src/lib/tools/text/TextRunController.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/TextRunController.ts
@@ -494,7 +494,8 @@ export class TextRunController {
     const metrics = font.getMetrics();
     const selectionRects = sel ? computeSelectionRects(layout.slots, sel, metrics) : [];
 
-    const cursorPos = r.cursorVisible && !sel ? computeCursorPosition(r, layout) : null;
+    const lineHeight = metrics.ascender - metrics.descender + (metrics.lineGap ?? 0);
+    const cursorPos = r.cursorVisible && !sel ? computeCursorPosition(r, layout, lineHeight) : null;
 
     const compositeInspection =
       r.inspectionSlotIndex !== null
@@ -527,7 +528,11 @@ function deleteRange(r: RunState): { glyphs: GlyphRef[]; cursor: number } {
   return { glyphs, cursor: start };
 }
 
-function computeCursorPosition(r: RunState, layout: TextLayout): { x: number; y: number } | null {
+function computeCursorPosition(
+  r: RunState,
+  layout: TextLayout,
+  lineHeight: number,
+): { x: number; y: number } | null {
   if (!r.cursorVisible) return null;
 
   if (r.cursor === 0) {
@@ -537,11 +542,23 @@ function computeCursorPosition(r: RunState, layout: TextLayout): { x: number; y:
 
   if (r.cursor <= layout.slots.length) {
     const prevSlot = layout.slots[r.cursor - 1];
-    if (prevSlot) return { x: prevSlot.x + prevSlot.advance, y: prevSlot.y };
+    if (!prevSlot) return { x: r.originX, y: 0 };
+
+    if (prevSlot.unicode === 10) {
+      return { x: r.originX, y: prevSlot.y - lineHeight };
+    }
+
+    return { x: prevSlot.x + prevSlot.advance, y: prevSlot.y };
   }
 
   const lastSlot = layout.slots[layout.slots.length - 1];
-  return { x: r.originX + layout.totalAdvance, y: lastSlot?.y ?? 0 };
+  if (!lastSlot) return { x: r.originX, y: 0 };
+
+  if (lastSlot.unicode === 10) {
+    return { x: r.originX, y: lastSlot.y - lineHeight };
+  }
+
+  return { x: lastSlot.x + lastSlot.advance, y: lastSlot.y };
 }
 
 function computeSelectionRects(

--- a/apps/desktop/src/renderer/src/lib/tools/text/TextRunController.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/TextRunController.ts
@@ -366,7 +366,7 @@ export class TextRunController {
     this.#run().cursorVisible = visible;
   }
 
-  /** Return codepoints for the current run (for clipboard copy). */
+  /** @knipclassignore — used via editor.textRunController in keymaps */
   getCodepoints(): number[] {
     return this.#run()
       .glyphs.map((ref) => ref.unicode)

--- a/apps/desktop/src/renderer/src/lib/tools/text/TextRunController.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/TextRunController.ts
@@ -474,9 +474,8 @@ export class TextRunController {
   }
 
   #deriveRenderState(): TextRunRenderState | null {
-    const key = this.#$activeKey.value; // track active key changes
-    const $run = this.#runs.get(key);
-    const r = $run ? $run.value : EMPTY_RUN; // track run state changes
+    this.#$activeKey.value; // track active key changes
+    const r = this.#signal().value; // track run state changes (creates signal if needed)
     const font = this.#$font.value; // track font changes
     if (!font) return null;
 

--- a/apps/desktop/src/renderer/src/lib/tools/text/TextRunController.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/TextRunController.ts
@@ -99,6 +99,7 @@ export class TextRunController {
   #runs = new Map<string, WritableSignal<RunState>>();
   #$activeKey: WritableSignal<string>;
   #$font: WritableSignal<Font | null>;
+  #goalX: number | null = null;
 
   #$state: ComputedSignal<TextRunRenderState | null>;
 
@@ -149,6 +150,7 @@ export class TextRunController {
   }
 
   moveCursorLeft(extend = false): void {
+    this.#goalX = null;
     this.#update((r) => {
       if (!extend && r.anchor !== r.cursor) {
         const start = Math.min(r.anchor, r.cursor);
@@ -161,6 +163,7 @@ export class TextRunController {
   }
 
   moveCursorRight(extend = false): void {
+    this.#goalX = null;
     this.#update((r) => {
       if (!extend && r.anchor !== r.cursor) {
         const end = Math.max(r.anchor, r.cursor);
@@ -172,11 +175,59 @@ export class TextRunController {
     });
   }
 
+  /** @knipclassignore — used via editor.textRunController in HiddenTextInput */
+  moveCursorToLineStart(extend = false): void {
+    this.#goalX = null;
+    const state = this.#$state.peek();
+    if (!state) return;
+
+    const r = this.#peek();
+    const slots = state.layout.slots;
+    const cursorSlot = r.cursor > 0 ? slots[r.cursor - 1] : slots[0];
+    const cursorY = cursorSlot?.y ?? 0;
+
+    let lineStart = 0;
+    for (let i = 0; i < slots.length; i++) {
+      if (slots[i].y === cursorY) {
+        lineStart = i;
+        break;
+      }
+    }
+
+    this.#update((r) => ({ ...r, cursor: lineStart, anchor: extend ? r.anchor : lineStart }));
+  }
+
+  /** @knipclassignore — used via editor.textRunController in HiddenTextInput */
+  moveCursorToLineEnd(extend = false): void {
+    this.#goalX = null;
+    const state = this.#$state.peek();
+    if (!state) return;
+
+    const r = this.#peek();
+    const slots = state.layout.slots;
+    const cursorSlot = r.cursor > 0 ? slots[r.cursor - 1] : slots[0];
+    const cursorY = cursorSlot?.y ?? 0;
+
+    let lineEnd = slots.length;
+    for (let i = slots.length - 1; i >= 0; i--) {
+      if (slots[i].y === cursorY) {
+        lineEnd = i + 1;
+        // Skip newline at end of line
+        if (slots[i].unicode === 10) lineEnd = i;
+        break;
+      }
+    }
+
+    this.#update((r) => ({ ...r, cursor: lineEnd, anchor: extend ? r.anchor : lineEnd }));
+  }
+
   moveCursorToStart(extend = false): void {
+    this.#goalX = null;
     this.#update((r) => ({ ...r, cursor: 0, anchor: extend ? r.anchor : 0 }));
   }
 
   moveCursorToEnd(extend = false): void {
+    this.#goalX = null;
     this.#update((r) => ({
       ...r,
       cursor: r.glyphs.length,
@@ -184,7 +235,92 @@ export class TextRunController {
     }));
   }
 
+  /** @knipclassignore — used via editor.textRunController in HiddenTextInput */
+  moveCursorVertically(direction: 1 | -1, extend = false): void {
+    const state = this.#$state.peek();
+    if (!state) return;
+
+    const { layout } = state;
+    const slots = layout.slots;
+    if (slots.length === 0) return;
+
+    const r = this.#peek();
+    const cursorSlot = r.cursor > 0 ? slots[r.cursor - 1] : slots[0];
+    if (!cursorSlot) return;
+
+    const currentY = cursorSlot.y;
+    const cursorX = r.cursor > 0 ? cursorSlot.x + cursorSlot.advance : cursorSlot.x;
+
+    // Set or reuse goal column
+    if (this.#goalX === null) this.#goalX = cursorX;
+    const goalX = this.#goalX;
+
+    // Find unique line Y values, sorted descending (UPM: higher Y = higher on screen)
+    const lineYs = [...new Set(slots.map((s) => s.y))].sort((a, b) => b - a);
+    const currentLineIdx = lineYs.indexOf(currentY);
+    if (currentLineIdx === -1) return;
+
+    const targetLineIdx = currentLineIdx + direction;
+    if (targetLineIdx < 0 || targetLineIdx >= lineYs.length) return;
+
+    const targetY = lineYs[targetLineIdx];
+
+    // Find closest slot on target line by goal X
+    let bestIdx = 0;
+    let bestDist = Infinity;
+    for (const [i, slot] of slots.entries()) {
+      if (slot.y !== targetY) continue;
+      const slotMidX = slot.x + slot.advance / 2;
+      const dist = Math.abs(slotMidX - goalX);
+      if (dist < bestDist) {
+        bestDist = dist;
+        bestIdx = i + 1;
+      }
+    }
+
+    // Check if cursor should be before the first slot on the target line
+    const firstOnLine = slots.find((s) => s.y === targetY);
+    if (firstOnLine && goalX <= firstOnLine.x) {
+      bestIdx = slots.indexOf(firstOnLine);
+    }
+
+    if (extend) {
+      this.extendSelection(bestIdx);
+    } else {
+      this.placeCaret(bestIdx);
+    }
+    // Don't reset goalX — preserve it for subsequent vertical movements
+    this.#goalX = goalX;
+  }
+
+  /** @knipclassignore — used via editor.textRunController in HiddenTextInput */
+  moveCursorByWord(direction: -1 | 1, extend = false): void {
+    this.#goalX = null;
+    const r = this.#peek();
+    const glyphs = r.glyphs;
+    let pos = r.cursor;
+
+    if (direction === -1) {
+      if (pos <= 0) return;
+      pos--;
+      // Skip whitespace
+      while (pos > 0 && isWhitespace(glyphs[pos - 1])) pos--;
+      // Skip word characters
+      while (pos > 0 && !isWhitespace(glyphs[pos - 1]) && !isPunctuation(glyphs[pos - 1])) pos--;
+    } else {
+      if (pos >= glyphs.length) return;
+      // Skip word characters
+      while (pos < glyphs.length && !isWhitespace(glyphs[pos]) && !isPunctuation(glyphs[pos]))
+        pos++;
+      // Skip whitespace
+      while (pos < glyphs.length && isWhitespace(glyphs[pos])) pos++;
+    }
+
+    this.#update((r) => ({ ...r, cursor: pos, anchor: extend ? r.anchor : pos }));
+  }
+
   selectAll(): void {
+    this.#goalX = null;
     this.#update((r) => ({ ...r, anchor: 0, cursor: r.glyphs.length }));
   }
 
@@ -205,6 +341,7 @@ export class TextRunController {
   }
 
   placeCaret(index: number): void {
+    this.#goalX = null;
     this.#update((r) => {
       const clamped = Math.max(0, Math.min(index, r.glyphs.length));
       return { ...r, cursor: clamped, anchor: clamped };
@@ -599,4 +736,20 @@ function mergeAdjacentRects(rects: SelectionRect[]): SelectionRect[] {
   }
 
   return merged;
+}
+
+function isWhitespace(glyph: GlyphRef): boolean {
+  if (glyph.unicode === null) return false;
+  return glyph.unicode === 32 || glyph.unicode === 9 || glyph.unicode === 10;
+}
+
+function isPunctuation(glyph: GlyphRef): boolean {
+  if (glyph.unicode === null) return false;
+  const cp = glyph.unicode;
+  return (
+    (cp >= 0x21 && cp <= 0x2f) || // !"#$%&'()*+,-./
+    (cp >= 0x3a && cp <= 0x40) || // :;<=>?@
+    (cp >= 0x5b && cp <= 0x60) || // [\]^_`
+    (cp >= 0x7b && cp <= 0x7e) // {|}~
+  );
 }

--- a/apps/desktop/src/renderer/src/lib/tools/text/TextRunController.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/TextRunController.ts
@@ -41,6 +41,7 @@ export interface TextRunCompositeInspection {
 export interface TextRunRenderState {
   layout: TextLayout;
   cursorX: number | null;
+  cursorY: number;
   selection: SelectionRange | null;
   selectionRects: SelectionRect[];
   editingIndex: number | null;
@@ -383,8 +384,6 @@ export class TextRunController {
     }));
   }
 
-  // ── Serialization / Persistence ──────────────────────────────────
-
   snapshot(): TextRunSnapshot {
     const r = this.#peek();
     return {
@@ -495,7 +494,7 @@ export class TextRunController {
     const metrics = font.getMetrics();
     const selectionRects = sel ? computeSelectionRects(layout.slots, sel, metrics) : [];
 
-    const cursorX = r.cursorVisible && !sel ? computeCursorX(r, layout) : null;
+    const cursorPos = r.cursorVisible && !sel ? computeCursorPosition(r, layout) : null;
 
     const compositeInspection =
       r.inspectionSlotIndex !== null
@@ -507,7 +506,8 @@ export class TextRunController {
 
     return {
       layout,
-      cursorX,
+      cursorX: cursorPos?.x ?? null,
+      cursorY: cursorPos?.y ?? 0,
       selection: sel,
       selectionRects,
       editingIndex: r.editingIndex,
@@ -527,14 +527,21 @@ function deleteRange(r: RunState): { glyphs: GlyphRef[]; cursor: number } {
   return { glyphs, cursor: start };
 }
 
-function computeCursorX(r: RunState, layout: TextLayout): number | null {
+function computeCursorPosition(r: RunState, layout: TextLayout): { x: number; y: number } | null {
   if (!r.cursorVisible) return null;
-  if (r.cursor === 0) return r.originX;
+
+  if (r.cursor === 0) {
+    const firstSlot = layout.slots[0];
+    return { x: r.originX, y: firstSlot?.y ?? 0 };
+  }
+
   if (r.cursor <= layout.slots.length) {
     const prevSlot = layout.slots[r.cursor - 1];
-    if (prevSlot) return prevSlot.x + prevSlot.advance;
+    if (prevSlot) return { x: prevSlot.x + prevSlot.advance, y: prevSlot.y };
   }
-  return r.originX + layout.totalAdvance;
+
+  const lastSlot = layout.slots[layout.slots.length - 1];
+  return { x: r.originX + layout.totalAdvance, y: lastSlot?.y ?? 0 };
 }
 
 function computeSelectionRects(
@@ -550,8 +557,8 @@ function computeSelectionRects(
     rects.push({
       x: slot.x,
       width: Math.max(slot.advance, 0),
-      top: metrics.ascender,
-      bottom: metrics.descender,
+      top: slot.y + metrics.ascender,
+      bottom: slot.y + metrics.descender,
     });
   }
 

--- a/apps/desktop/src/renderer/src/lib/tools/text/TextRunController.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/TextRunController.ts
@@ -1,23 +1,28 @@
 /**
- * TextRunController — self-contained text buffer with cursor, selection, and layout.
+ * TextRunController — reactive text buffer with cursor, selection, and layout.
  *
- * Owns the text editing model for the text tool. A hidden <textarea> feeds input
- * into this controller; the render pass reads from its reactive signal.
+ * All state is immutable signals. Mutations replace the state value.
+ * The render state is a computed that derives layout, selection rects,
+ * and cursor position from the buffer state — zero manual recompute calls.
  *
  * Selection uses the anchor/focus model (same as DOM Selection API):
  * - anchor: where the selection started (stays put during shift+arrow)
  * - focus:  where the caret is (moves during shift+arrow)
  * - when anchor === focus, there is no selection (just a caret)
  */
-import { signal, type Signal, type WritableSignal } from "@/lib/reactive/signal";
+import {
+  signal,
+  computed,
+  type Signal,
+  type WritableSignal,
+  type ComputedSignal,
+} from "@/lib/reactive/signal";
 import { computeTextLayout, type GlyphRef, type GlyphSlot, type TextLayout } from "./layout";
 import type { Font } from "@/lib/editor/Font";
 import type { FontMetrics } from "@shift/types";
 
 export interface SelectionRange {
-  /** Inclusive start index. */
   start: number;
-  /** Exclusive end index. */
   end: number;
 }
 
@@ -53,7 +58,6 @@ export interface TextRunSnapshot {
   editingGlyph: GlyphRef | null;
 }
 
-/** Persisted form of a single text run (serializable to JSON). */
 export interface PersistedTextRun {
   glyphs: GlyphRef[];
   cursorPosition: number;
@@ -65,54 +69,40 @@ export interface PersistedTextRun {
 const DEFAULT_TEXT_RUN_KEY = "__default__";
 
 interface RunState {
-  glyphs: GlyphRef[];
-  cursor: number;
-  anchor: number;
-  originX: number;
-  cursorVisible: boolean;
-  editingIndex: number | null;
-  editingGlyph: GlyphRef | null;
-  hoveredIndex: number | null;
-  inspectionSlotIndex: number | null;
-  inspectionHoveredComponentIndex: number | null;
+  readonly glyphs: readonly GlyphRef[];
+  readonly cursor: number;
+  readonly anchor: number;
+  readonly originX: number;
+  readonly cursorVisible: boolean;
+  readonly editingIndex: number | null;
+  readonly editingGlyph: GlyphRef | null;
+  readonly hoveredIndex: number | null;
+  readonly inspectionSlotIndex: number | null;
+  readonly inspectionHoveredComponentIndex: number | null;
 }
 
-function createRunState(): RunState {
-  return {
-    glyphs: [],
-    cursor: 0,
-    anchor: 0,
-    originX: 0,
-    cursorVisible: false,
-    editingIndex: null,
-    editingGlyph: null,
-    hoveredIndex: null,
-    inspectionSlotIndex: null,
-    inspectionHoveredComponentIndex: null,
-  };
-}
+const EMPTY_RUN: RunState = {
+  glyphs: [],
+  cursor: 0,
+  anchor: 0,
+  originX: 0,
+  cursorVisible: false,
+  editingIndex: null,
+  editingGlyph: null,
+  hoveredIndex: null,
+  inspectionSlotIndex: null,
+  inspectionHoveredComponentIndex: null,
+};
 
 export class TextRunController {
-  #runs = new Map<string, RunState>();
+  #runs = new Map<string, WritableSignal<RunState>>();
   #activeKey = DEFAULT_TEXT_RUN_KEY;
   #font: Font | null = null;
 
-  #$state: WritableSignal<TextRunRenderState | null>;
+  #$state: ComputedSignal<TextRunRenderState | null>;
 
   constructor() {
-    this.#$state = signal<TextRunRenderState | null>(null);
-  }
-
-  /** Switch which glyph's text run is active. */
-  setOwnerGlyph(glyph: GlyphRef | null): void {
-    const nextKey = glyph ? glyph.glyphName : DEFAULT_TEXT_RUN_KEY;
-    if (nextKey === this.#activeKey) return;
-
-    this.#activeKey = nextKey;
-    const run = this.#run();
-    run.hoveredIndex = null;
-    run.inspectionSlotIndex = null;
-    run.inspectionHoveredComponentIndex = null;
+    this.#$state = computed(() => this.#deriveRenderState());
   }
 
   get state(): Signal<TextRunRenderState | null> {
@@ -122,236 +112,205 @@ export class TextRunController {
   // ── Derived (read-only) ──────────────────────────────────────────
 
   get length(): number {
-    return this.#run().glyphs.length;
+    return this.#peek().glyphs.length;
   }
 
   get cursor(): number {
-    return this.#run().cursor;
+    return this.#peek().cursor;
   }
 
   get anchor(): number {
-    return this.#run().anchor;
+    return this.#peek().anchor;
   }
 
   get hasSelection(): boolean {
-    const r = this.#run();
+    const r = this.#peek();
     return r.anchor !== r.cursor;
   }
 
   get selection(): SelectionRange | null {
-    const r = this.#run();
+    const r = this.#peek();
     if (r.anchor === r.cursor) return null;
-    const start = Math.min(r.anchor, r.cursor);
-    const end = Math.max(r.anchor, r.cursor);
-    return { start, end };
+    return {
+      start: Math.min(r.anchor, r.cursor),
+      end: Math.max(r.anchor, r.cursor),
+    };
   }
 
   get glyphs(): readonly GlyphRef[] {
-    return this.#run().glyphs;
+    return this.#peek().glyphs;
   }
 
   get selectedGlyphs(): GlyphRef[] {
     const sel = this.selection;
     if (!sel) return [];
-    return this.#run().glyphs.slice(sel.start, sel.end);
+    return this.#peek().glyphs.slice(sel.start, sel.end);
   }
 
   // ── Cursor movement ──────────────────────────────────────────────
 
-  /**
-   * Move cursor left by one position.
-   * @param extend - If true (shift held), keep anchor in place to grow/shrink selection.
-   */
   moveCursorLeft(extend = false): void {
-    const r = this.#run();
+    this.#update((r) => {
+      if (!extend && r.anchor !== r.cursor) {
+        const start = Math.min(r.anchor, r.cursor);
+        return { ...r, cursor: start, anchor: start };
+      }
 
-    if (!extend && this.hasSelection) {
-      const start = Math.min(r.anchor, r.cursor);
-      r.cursor = start;
-      r.anchor = start;
-      return;
-    }
-
-    if (r.cursor > 0) {
-      r.cursor--;
-    }
-
-    if (!extend) {
-      r.anchor = r.cursor;
-    }
+      const cursor = Math.max(0, r.cursor - 1);
+      return { ...r, cursor, anchor: extend ? r.anchor : cursor };
+    });
   }
 
-  /**
-   * Move cursor right by one position.
-   * @param extend - If true (shift held), keep anchor in place to grow/shrink selection.
-   */
   moveCursorRight(extend = false): void {
-    const r = this.#run();
+    this.#update((r) => {
+      if (!extend && r.anchor !== r.cursor) {
+        const end = Math.max(r.anchor, r.cursor);
+        return { ...r, cursor: end, anchor: end };
+      }
 
-    if (!extend && this.hasSelection) {
-      const end = Math.max(r.anchor, r.cursor);
-      r.cursor = end;
-      r.anchor = end;
-      return;
-    }
-
-    if (r.cursor < r.glyphs.length) {
-      r.cursor++;
-    }
-
-    if (!extend) {
-      r.anchor = r.cursor;
-    }
+      const cursor = Math.min(r.glyphs.length, r.cursor + 1);
+      return { ...r, cursor, anchor: extend ? r.anchor : cursor };
+    });
   }
 
-  /** Move cursor to start (Home / Cmd+Left). */
   moveCursorToStart(extend = false): void {
-    const r = this.#run();
-    r.cursor = 0;
-    if (!extend) {
-      r.anchor = 0;
-    }
+    this.#update((r) => ({ ...r, cursor: 0, anchor: extend ? r.anchor : 0 }));
   }
 
-  /** Move cursor to end (End / Cmd+Right). */
   moveCursorToEnd(extend = false): void {
-    const r = this.#run();
-    r.cursor = r.glyphs.length;
-    if (!extend) {
-      r.anchor = r.glyphs.length;
-    }
+    this.#update((r) => ({
+      ...r,
+      cursor: r.glyphs.length,
+      anchor: extend ? r.anchor : r.glyphs.length,
+    }));
   }
 
   // ── Selection ────────────────────────────────────────────────────
 
-  /** Select all glyphs (Cmd+A). */
   selectAll(): void {
-    const r = this.#run();
-    r.anchor = 0;
-    r.cursor = r.glyphs.length;
+    this.#update((r) => ({ ...r, anchor: 0, cursor: r.glyphs.length }));
   }
 
-  /** Select a specific range. */
   selectRange(start: number, end: number): void {
-    const r = this.#run();
-    r.anchor = Math.max(0, Math.min(start, r.glyphs.length));
-    r.cursor = Math.max(0, Math.min(end, r.glyphs.length));
+    this.#update((r) => ({
+      ...r,
+      anchor: Math.max(0, Math.min(start, r.glyphs.length)),
+      cursor: Math.max(0, Math.min(end, r.glyphs.length)),
+    }));
   }
 
-  /** Collapse selection to one side. */
   collapseSelection(to: "start" | "end" = "end"): void {
-    const sel = this.selection;
-    if (!sel) return;
-    const r = this.#run();
-    const pos = to === "start" ? sel.start : sel.end;
-    r.cursor = pos;
-    r.anchor = pos;
+    this.#update((r) => {
+      if (r.anchor === r.cursor) return r;
+      const pos = to === "start" ? Math.min(r.anchor, r.cursor) : Math.max(r.anchor, r.cursor);
+      return { ...r, cursor: pos, anchor: pos };
+    });
   }
 
-  // ── Click placement ──────────────────────────────────────────────
-
-  /** Click — collapse any selection and place caret at index. */
   placeCaret(index: number): void {
-    const r = this.#run();
-    const clamped = Math.max(0, Math.min(index, r.glyphs.length));
-    r.cursor = clamped;
-    r.anchor = clamped;
+    this.#update((r) => {
+      const clamped = Math.max(0, Math.min(index, r.glyphs.length));
+      return { ...r, cursor: clamped, anchor: clamped };
+    });
   }
 
-  /** Shift+click — anchor stays, focus moves to index. */
   extendSelection(index: number): void {
-    const r = this.#run();
-    r.cursor = Math.max(0, Math.min(index, r.glyphs.length));
+    this.#update((r) => ({
+      ...r,
+      cursor: Math.max(0, Math.min(index, r.glyphs.length)),
+    }));
   }
 
   // ── Mutation ─────────────────────────────────────────────────────
 
-  /** Insert a glyph at cursor. Replaces selection if any. */
   insert(glyph: GlyphRef): void {
-    const r = this.#run();
-    this.#deleteSelectionRange(r);
-    r.glyphs.splice(r.cursor, 0, glyph);
-    r.cursor++;
-    r.anchor = r.cursor;
+    this.#update((r) => {
+      const { glyphs, cursor } = deleteRange(r);
+      const next = [...glyphs];
+      next.splice(cursor, 0, glyph);
+      return { ...r, glyphs: next, cursor: cursor + 1, anchor: cursor + 1 };
+    });
   }
 
-  /** Insert a glyph at a specific index (for composite drill-down). */
   insertAt(index: number, glyph: GlyphRef): void {
-    const r = this.#run();
-    const clamped = Math.max(0, Math.min(index, r.glyphs.length));
-    r.glyphs.splice(clamped, 0, glyph);
-    if (r.cursor >= clamped) r.cursor++;
-    if (r.anchor >= clamped) r.anchor++;
+    this.#update((r) => {
+      const clamped = Math.max(0, Math.min(index, r.glyphs.length));
+      const next = [...r.glyphs];
+      next.splice(clamped, 0, glyph);
+      return {
+        ...r,
+        glyphs: next,
+        cursor: r.cursor >= clamped ? r.cursor + 1 : r.cursor,
+        anchor: r.anchor >= clamped ? r.anchor + 1 : r.anchor,
+      };
+    });
   }
 
-  /** Insert multiple glyphs at cursor (paste). Replaces selection if any. */
   insertMany(glyphs: GlyphRef[]): void {
-    const r = this.#run();
-    this.#deleteSelectionRange(r);
-    r.glyphs.splice(r.cursor, 0, ...glyphs);
-    r.cursor += glyphs.length;
-    r.anchor = r.cursor;
+    this.#update((r) => {
+      const { glyphs: current, cursor } = deleteRange(r);
+      const next = [...current];
+      next.splice(cursor, 0, ...glyphs);
+      return { ...r, glyphs: next, cursor: cursor + glyphs.length, anchor: cursor + glyphs.length };
+    });
   }
 
-  /** Backspace — delete selection, or the glyph before cursor. */
   delete(): boolean {
-    const r = this.#run();
+    const r = this.#peek();
 
-    if (this.hasSelection) {
-      this.#deleteSelectionRange(r);
+    if (r.anchor !== r.cursor) {
+      this.#update((r) => {
+        const { glyphs, cursor } = deleteRange(r);
+        return { ...r, glyphs, cursor, anchor: cursor };
+      });
       return true;
     }
 
     if (r.cursor === 0) return false;
-    r.cursor--;
-    r.glyphs.splice(r.cursor, 1);
-    r.anchor = r.cursor;
+
+    this.#update((r) => {
+      const next = [...r.glyphs];
+      next.splice(r.cursor - 1, 1);
+      return { ...r, glyphs: next, cursor: r.cursor - 1, anchor: r.cursor - 1 };
+    });
     return true;
   }
 
-  /** Delete key — delete selection, or the glyph after cursor. */
   deleteForward(): boolean {
-    const r = this.#run();
+    const r = this.#peek();
 
-    if (this.hasSelection) {
-      this.#deleteSelectionRange(r);
+    if (r.anchor !== r.cursor) {
+      this.#update((r) => {
+        const { glyphs, cursor } = deleteRange(r);
+        return { ...r, glyphs, cursor, anchor: cursor };
+      });
       return true;
     }
 
     if (r.cursor >= r.glyphs.length) return false;
-    r.glyphs.splice(r.cursor, 1);
+
+    this.#update((r) => {
+      const next = [...r.glyphs];
+      next.splice(r.cursor, 1);
+      return { ...r, glyphs: next };
+    });
     return true;
   }
 
   // ── Text run lifecycle ───────────────────────────────────────────
 
-  /** Seed with an initial glyph if buffer is empty. */
   seed(glyph: GlyphRef): void {
-    const r = this.#run();
+    const r = this.#peek();
     if (r.glyphs.length > 0) return;
-    r.glyphs.push(glyph);
-    r.cursor = 1;
-    r.anchor = 1;
+    this.#set({ ...r, glyphs: [glyph], cursor: 1, anchor: 1 });
   }
 
   clear(): void {
-    const r = this.#run();
-    r.glyphs = [];
-    r.cursor = 0;
-    r.anchor = 0;
-    r.originX = 0;
-    r.cursorVisible = false;
-    r.editingIndex = null;
-    r.editingGlyph = null;
-    r.hoveredIndex = null;
-    r.inspectionSlotIndex = null;
-    r.inspectionHoveredComponentIndex = null;
-    this.#$state.set(null);
+    this.#set(EMPTY_RUN);
   }
 
   clearAll(): void {
     this.#runs.clear();
-    this.#$state.set(null);
   }
 
   setFont(font: Font): void {
@@ -359,109 +318,83 @@ export class TextRunController {
   }
 
   setOriginX(x: number): void {
-    this.#run().originX = x;
+    this.#update((r) => ({ ...r, originX: x }));
   }
 
   setCursorVisible(visible: boolean): void {
-    this.#run().cursorVisible = visible;
+    this.#update((r) => ({ ...r, cursorVisible: visible }));
   }
 
-  /** @knipclassignore — used via editor.textRunController in keymaps */
+  /** @knipclassignore — used via editor.textRunController in HiddenTextInput */
   getCodepoints(): number[] {
-    return this.#run()
+    return this.#peek()
       .glyphs.map((ref) => ref.unicode)
       .filter((unicode): unicode is number => unicode !== null);
   }
 
-  /**
-   * Recompute layout and selection rects, then push to the reactive signal.
-   * Call after any mutation or cursor movement.
-   */
-  recompute(originX?: number): void {
-    if (!this.#font) {
-      this.#$state.set(null);
-      return;
-    }
-
-    const r = this.#run();
-    if (originX !== undefined) {
-      r.originX = originX;
-    }
-
-    const layout =
-      r.glyphs.length > 0
-        ? computeTextLayout(r.glyphs, { x: r.originX, y: 0 }, this.#font)
-        : { slots: [], totalAdvance: 0 };
-
-    if (r.glyphs.length === 0 && !r.cursorVisible) {
-      this.#$state.set(null);
-      return;
-    }
-
-    const sel = this.selection;
-    const metrics = this.#font.getMetrics();
-    const selectionRects = sel ? computeSelectionRects(layout.slots, sel, metrics) : [];
-
-    this.#$state.set({
-      layout,
-      cursorX: r.cursorVisible && !this.hasSelection ? this.#computeCursorX(r, layout) : null,
-      selection: sel,
-      selectionRects,
-      editingIndex: r.editingIndex,
-      editingGlyph: r.editingGlyph,
-      hoveredIndex: r.hoveredIndex,
-      compositeInspection: this.#compositeInspection(r),
-    });
+  setOwnerGlyph(glyph: GlyphRef | null): void {
+    const nextKey = glyph ? glyph.glyphName : DEFAULT_TEXT_RUN_KEY;
+    if (nextKey === this.#activeKey) return;
+    this.#activeKey = nextKey;
+    this.#update((r) => ({
+      ...r,
+      hoveredIndex: null,
+      inspectionSlotIndex: null,
+      inspectionHoveredComponentIndex: null,
+    }));
   }
 
-  // ── Editing slot ─────────────────────────────────────────────────
-
   setEditingSlot(index: number | null, glyph: GlyphRef | null = null): void {
-    const r = this.#run();
-    r.editingIndex = index;
-    r.editingGlyph = glyph;
+    this.#update((r) => ({ ...r, editingIndex: index, editingGlyph: glyph }));
   }
 
   resetEditingContext(): void {
-    const r = this.#run();
-    r.editingIndex = null;
-    r.editingGlyph = null;
-    r.hoveredIndex = null;
-    r.inspectionSlotIndex = null;
-    r.inspectionHoveredComponentIndex = null;
+    this.#update((r) => ({
+      ...r,
+      editingIndex: null,
+      editingGlyph: null,
+      hoveredIndex: null,
+      inspectionSlotIndex: null,
+      inspectionHoveredComponentIndex: null,
+    }));
   }
 
-  // ── Hover / inspection ───────────────────────────────────────────
-
   setHovered(index: number | null): void {
-    const r = this.#run();
-    r.hoveredIndex = index;
-    if (r.inspectionSlotIndex !== index) {
-      r.inspectionHoveredComponentIndex = null;
-    }
+    this.#update((r) => ({
+      ...r,
+      hoveredIndex: index,
+      inspectionHoveredComponentIndex:
+        r.inspectionSlotIndex !== index ? null : r.inspectionHoveredComponentIndex,
+    }));
   }
 
   setInspectionSlot(index: number | null): void {
-    const r = this.#run();
-    r.inspectionSlotIndex = index;
-    r.inspectionHoveredComponentIndex = null;
+    this.#update((r) => ({
+      ...r,
+      inspectionSlotIndex: index,
+      inspectionHoveredComponentIndex: null,
+    }));
   }
 
   setInspectionHoveredComponent(index: number | null): void {
-    const r = this.#run();
-    r.inspectionHoveredComponentIndex = r.inspectionSlotIndex === null ? null : index;
+    this.#update((r) => ({
+      ...r,
+      inspectionHoveredComponentIndex: r.inspectionSlotIndex === null ? null : index,
+    }));
   }
 
   clearInspection(): void {
-    const r = this.#run();
-    r.inspectionSlotIndex = null;
-    r.inspectionHoveredComponentIndex = null;
+    this.#update((r) => ({
+      ...r,
+      inspectionSlotIndex: null,
+      inspectionHoveredComponentIndex: null,
+    }));
   }
 
   // ── Serialization / Persistence ──────────────────────────────────
 
   snapshot(): TextRunSnapshot {
-    const r = this.#run();
+    const r = this.#peek();
     return {
       glyphs: [...r.glyphs],
       cursor: r.cursor,
@@ -473,19 +406,23 @@ export class TextRunController {
   }
 
   restore(snapshot: TextRunSnapshot): void {
-    const r = this.#run();
-    r.glyphs = [...snapshot.glyphs];
-    r.cursor = snapshot.cursor;
-    r.anchor = snapshot.anchor;
-    r.originX = snapshot.originX;
-    r.editingIndex = snapshot.editingIndex;
-    r.editingGlyph = snapshot.editingGlyph;
+    this.#set({
+      ...this.#peek(),
+      glyphs: [...snapshot.glyphs],
+      cursor: snapshot.cursor,
+      anchor: snapshot.anchor,
+      originX: snapshot.originX,
+      editingIndex: snapshot.editingIndex,
+      editingGlyph: snapshot.editingGlyph,
+    });
   }
 
   exportRuns(): Record<string, PersistedTextRun> {
     const out: Record<string, PersistedTextRun> = {};
-    for (const [key, run] of this.#runs.entries()) {
-      if (key === DEFAULT_TEXT_RUN_KEY || run.glyphs.length === 0) continue;
+    for (const [key, $run] of this.#runs.entries()) {
+      if (key === DEFAULT_TEXT_RUN_KEY) continue;
+      const run = $run.peek();
+      if (run.glyphs.length === 0) continue;
       out[key] = {
         glyphs: [...run.glyphs],
         cursorPosition: run.cursor,
@@ -500,60 +437,109 @@ export class TextRunController {
   hydrateRuns(next: Record<string, PersistedTextRun>): void {
     this.#runs.clear();
     for (const [glyphKey, persisted] of Object.entries(next)) {
-      const r = createRunState();
-      r.glyphs = [...persisted.glyphs];
-      r.cursor = persisted.cursorPosition;
-      r.anchor = persisted.cursorPosition;
-      r.originX = persisted.originX;
-      r.editingIndex = persisted.editingIndex;
-      r.editingGlyph = persisted.editingGlyph;
-      this.#runs.set(glyphKey, r);
+      this.#runs.set(
+        glyphKey,
+        signal<RunState>({
+          ...EMPTY_RUN,
+          glyphs: [...persisted.glyphs],
+          cursor: persisted.cursorPosition,
+          anchor: persisted.cursorPosition,
+          originX: persisted.originX,
+          editingIndex: persisted.editingIndex,
+          editingGlyph: persisted.editingGlyph,
+        }),
+      );
     }
 
     if (!this.#runs.has(this.#activeKey)) {
-      this.#runs.set(this.#activeKey, createRunState());
+      this.#runs.set(this.#activeKey, signal<RunState>(EMPTY_RUN));
     }
   }
 
   // ── Private ──────────────────────────────────────────────────────
 
-  #run(): RunState {
-    let r = this.#runs.get(this.#activeKey);
-    if (r) return r;
-    r = createRunState();
-    this.#runs.set(this.#activeKey, r);
-    return r;
+  #signal(): WritableSignal<RunState> {
+    let $r = this.#runs.get(this.#activeKey);
+    if ($r) return $r;
+    $r = signal<RunState>(EMPTY_RUN);
+    this.#runs.set(this.#activeKey, $r);
+    return $r;
   }
 
-  #deleteSelectionRange(r: RunState): void {
-    if (r.anchor === r.cursor) return;
-    const start = Math.min(r.anchor, r.cursor);
-    const end = Math.max(r.anchor, r.cursor);
-    r.glyphs.splice(start, end - start);
-    r.cursor = start;
-    r.anchor = start;
+  /** Read current state without tracking. */
+  #peek(): RunState {
+    return this.#signal().peek();
   }
 
-  #computeCursorX(r: RunState, layout: TextLayout): number | null {
-    if (!r.cursorVisible) return null;
-
-    if (r.cursor === 0) return r.originX;
-
-    if (r.cursor <= layout.slots.length) {
-      const prevSlot = layout.slots[r.cursor - 1];
-      if (prevSlot) return prevSlot.x + prevSlot.advance;
-    }
-
-    return r.originX + layout.totalAdvance;
+  /** Replace state (triggers signal). */
+  #set(next: RunState): void {
+    this.#signal().set(next);
   }
 
-  #compositeInspection(r: RunState): TextRunCompositeInspection | null {
-    if (r.inspectionSlotIndex === null) return null;
+  /** Update state with a function (triggers signal). */
+  #update(fn: (current: RunState) => RunState): void {
+    const $r = this.#signal();
+    $r.set(fn($r.peek()));
+  }
+
+  #deriveRenderState(): TextRunRenderState | null {
+    const r = this.#signal().value; // reactive read — tracks dependency
+    if (!this.#font) return null;
+
+    const layout =
+      r.glyphs.length > 0
+        ? computeTextLayout([...r.glyphs], { x: r.originX, y: 0 }, this.#font)
+        : { slots: [], totalAdvance: 0 };
+
+    if (r.glyphs.length === 0 && !r.cursorVisible) return null;
+
+    const sel =
+      r.anchor !== r.cursor
+        ? { start: Math.min(r.anchor, r.cursor), end: Math.max(r.anchor, r.cursor) }
+        : null;
+    const metrics = this.#font.getMetrics();
+    const selectionRects = sel ? computeSelectionRects(layout.slots, sel, metrics) : [];
+
+    const cursorX = r.cursorVisible && !sel ? computeCursorX(r, layout) : null;
+
+    const compositeInspection =
+      r.inspectionSlotIndex !== null
+        ? {
+            slotIndex: r.inspectionSlotIndex,
+            hoveredComponentIndex: r.inspectionHoveredComponentIndex,
+          }
+        : null;
+
     return {
-      slotIndex: r.inspectionSlotIndex,
-      hoveredComponentIndex: r.inspectionHoveredComponentIndex,
+      layout,
+      cursorX,
+      selection: sel,
+      selectionRects,
+      editingIndex: r.editingIndex,
+      editingGlyph: r.editingGlyph,
+      hoveredIndex: r.hoveredIndex,
+      compositeInspection,
     };
   }
+}
+
+function deleteRange(r: RunState): { glyphs: GlyphRef[]; cursor: number } {
+  if (r.anchor === r.cursor) return { glyphs: [...r.glyphs], cursor: r.cursor };
+  const start = Math.min(r.anchor, r.cursor);
+  const end = Math.max(r.anchor, r.cursor);
+  const glyphs = [...r.glyphs];
+  glyphs.splice(start, end - start);
+  return { glyphs, cursor: start };
+}
+
+function computeCursorX(r: RunState, layout: TextLayout): number | null {
+  if (!r.cursorVisible) return null;
+  if (r.cursor === 0) return r.originX;
+  if (r.cursor <= layout.slots.length) {
+    const prevSlot = layout.slots[r.cursor - 1];
+    if (prevSlot) return prevSlot.x + prevSlot.advance;
+  }
+  return r.originX + layout.totalAdvance;
 }
 
 function computeSelectionRects(
@@ -566,7 +552,6 @@ function computeSelectionRects(
   for (let i = selection.start; i < selection.end; i++) {
     const slot = slots[i];
     if (!slot) continue;
-
     rects.push({
       x: slot.x,
       width: Math.max(slot.advance, 0),
@@ -578,10 +563,6 @@ function computeSelectionRects(
   return mergeAdjacentRects(rects);
 }
 
-/**
- * Merge consecutive selection rects that share an edge into single rects.
- * Reduces draw calls for contiguous selections.
- */
 function mergeAdjacentRects(rects: SelectionRect[]): SelectionRect[] {
   if (rects.length <= 1) return rects;
 
@@ -590,8 +571,8 @@ function mergeAdjacentRects(rects: SelectionRect[]): SelectionRect[] {
   for (let i = 1; i < rects.length; i++) {
     const prev = merged[merged.length - 1];
     const curr = rects[i];
-
     const prevEnd = prev.x + prev.width;
+
     if (Math.abs(prevEnd - curr.x) < 0.5 && prev.top === curr.top && prev.bottom === curr.bottom) {
       prev.width = curr.x + curr.width - prev.x;
     } else {

--- a/apps/desktop/src/renderer/src/lib/tools/text/TextRunController.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/TextRunController.ts
@@ -96,20 +96,20 @@ const EMPTY_RUN: RunState = {
 
 export class TextRunController {
   #runs = new Map<string, WritableSignal<RunState>>();
-  #activeKey = DEFAULT_TEXT_RUN_KEY;
-  #font: Font | null = null;
+  #$activeKey: WritableSignal<string>;
+  #$font: WritableSignal<Font | null>;
 
   #$state: ComputedSignal<TextRunRenderState | null>;
 
   constructor() {
+    this.#$activeKey = signal(DEFAULT_TEXT_RUN_KEY);
+    this.#$font = signal<Font | null>(null);
     this.#$state = computed(() => this.#deriveRenderState());
   }
 
   get state(): Signal<TextRunRenderState | null> {
     return this.#$state;
   }
-
-  // ── Derived (read-only) ──────────────────────────────────────────
 
   get length(): number {
     return this.#peek().glyphs.length;
@@ -147,8 +147,6 @@ export class TextRunController {
     return this.#peek().glyphs.slice(sel.start, sel.end);
   }
 
-  // ── Cursor movement ──────────────────────────────────────────────
-
   moveCursorLeft(extend = false): void {
     this.#update((r) => {
       if (!extend && r.anchor !== r.cursor) {
@@ -185,8 +183,6 @@ export class TextRunController {
     }));
   }
 
-  // ── Selection ────────────────────────────────────────────────────
-
   selectAll(): void {
     this.#update((r) => ({ ...r, anchor: 0, cursor: r.glyphs.length }));
   }
@@ -220,8 +216,6 @@ export class TextRunController {
       cursor: Math.max(0, Math.min(index, r.glyphs.length)),
     }));
   }
-
-  // ── Mutation ─────────────────────────────────────────────────────
 
   insert(glyph: GlyphRef): void {
     this.#update((r) => {
@@ -297,8 +291,6 @@ export class TextRunController {
     return true;
   }
 
-  // ── Text run lifecycle ───────────────────────────────────────────
-
   seed(glyph: GlyphRef): void {
     const r = this.#peek();
     if (r.glyphs.length > 0) return;
@@ -314,7 +306,7 @@ export class TextRunController {
   }
 
   setFont(font: Font): void {
-    this.#font = font;
+    this.#$font.set(font);
   }
 
   setOriginX(x: number): void {
@@ -334,8 +326,8 @@ export class TextRunController {
 
   setOwnerGlyph(glyph: GlyphRef | null): void {
     const nextKey = glyph ? glyph.glyphName : DEFAULT_TEXT_RUN_KEY;
-    if (nextKey === this.#activeKey) return;
-    this.#activeKey = nextKey;
+    if (nextKey === this.#$activeKey.peek()) return;
+    this.#$activeKey.set(nextKey);
     this.#update((r) => ({
       ...r,
       hoveredIndex: null,
@@ -451,44 +443,47 @@ export class TextRunController {
       );
     }
 
-    if (!this.#runs.has(this.#activeKey)) {
-      this.#runs.set(this.#activeKey, signal<RunState>(EMPTY_RUN));
+    const key = this.#$activeKey.peek();
+    if (!this.#runs.has(key)) {
+      this.#runs.set(key, signal<RunState>(EMPTY_RUN));
     }
   }
 
-  // ── Private ──────────────────────────────────────────────────────
-
   #signal(): WritableSignal<RunState> {
-    let $r = this.#runs.get(this.#activeKey);
+    const key = this.#$activeKey.peek();
+    let $r = this.#runs.get(key);
     if ($r) return $r;
     $r = signal<RunState>(EMPTY_RUN);
-    this.#runs.set(this.#activeKey, $r);
+    this.#runs.set(key, $r);
     return $r;
   }
 
-  /** Read current state without tracking. */
   #peek(): RunState {
-    return this.#signal().peek();
+    const key = this.#$activeKey.peek();
+    const $r = this.#runs.get(key);
+    return $r ? $r.peek() : EMPTY_RUN;
   }
 
-  /** Replace state (triggers signal). */
   #set(next: RunState): void {
     this.#signal().set(next);
   }
 
-  /** Update state with a function (triggers signal). */
   #update(fn: (current: RunState) => RunState): void {
     const $r = this.#signal();
-    $r.set(fn($r.peek()));
+    const next = fn($r.peek());
+    $r.set(next);
   }
 
   #deriveRenderState(): TextRunRenderState | null {
-    const r = this.#signal().value; // reactive read — tracks dependency
-    if (!this.#font) return null;
+    const key = this.#$activeKey.value; // track active key changes
+    const $run = this.#runs.get(key);
+    const r = $run ? $run.value : EMPTY_RUN; // track run state changes
+    const font = this.#$font.value; // track font changes
+    if (!font) return null;
 
     const layout =
       r.glyphs.length > 0
-        ? computeTextLayout([...r.glyphs], { x: r.originX, y: 0 }, this.#font)
+        ? computeTextLayout([...r.glyphs], { x: r.originX, y: 0 }, font)
         : { slots: [], totalAdvance: 0 };
 
     if (r.glyphs.length === 0 && !r.cursorVisible) return null;
@@ -497,7 +492,7 @@ export class TextRunController {
       r.anchor !== r.cursor
         ? { start: Math.min(r.anchor, r.cursor), end: Math.max(r.anchor, r.cursor) }
         : null;
-    const metrics = this.#font.getMetrics();
+    const metrics = font.getMetrics();
     const selectionRects = sel ? computeSelectionRects(layout.slots, sel, metrics) : [];
 
     const cursorX = r.cursorVisible && !sel ? computeCursorX(r, layout) : null;

--- a/apps/desktop/src/renderer/src/lib/tools/text/behaviors/TypingBehaviour.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/behaviors/TypingBehaviour.ts
@@ -6,35 +6,36 @@ export class TypingBehavior implements TextBehavior {
   onKeyDown(state: TextState, ctx: ToolContext<TextState>, event: ToolEventOf<"keyDown">): boolean {
     if (state.type !== "typing") return false;
 
+    const ctrl = ctx.editor.textRunController;
     const extend = event.shiftKey;
 
     switch (event.key) {
       case "Backspace":
-        if (ctx.editor.deleteTextCodepoint()) {
-          ctx.editor.recomputeTextRun();
+        if (ctrl.delete()) {
+          ctrl.recompute();
         }
         return true;
       case "Delete":
-        ctx.editor.recomputeTextRun();
+        ctrl.recompute();
         return true;
       case "Escape":
         ctx.setState({ type: "idle" });
         ctx.editor.setActiveTool("select");
         return true;
       case "ArrowLeft":
-        ctx.editor.moveTextCursorLeft(extend);
-        ctx.editor.recomputeTextRun();
+        ctrl.moveCursorLeft(extend);
+        ctrl.recompute();
         return true;
       case "ArrowRight":
-        ctx.editor.moveTextCursorRight(extend);
-        ctx.editor.recomputeTextRun();
+        ctrl.moveCursorRight(extend);
+        ctrl.recompute();
         return true;
       default: {
         if (event.key.length !== 1 || event.metaKey) return false;
         const codepoint = event.key.codePointAt(0);
         if (codepoint === undefined) return false;
         ctx.editor.insertTextCodepoint(codepoint);
-        ctx.editor.recomputeTextRun();
+        ctrl.recompute();
         return true;
       }
     }

--- a/apps/desktop/src/renderer/src/lib/tools/text/behaviors/TypingBehaviour.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/behaviors/TypingBehaviour.ts
@@ -2,42 +2,24 @@ import type { ToolContext } from "../../core/Behavior";
 import type { ToolEventOf } from "../../core/GestureDetector";
 import type { TextBehavior, TextState } from "../types";
 
+/**
+ * Handles tool-level keyboard events for the text tool.
+ *
+ * Character input, arrows, backspace, clipboard, and IME are handled by the
+ * hidden textarea (HiddenTextInput component). This behavior only handles
+ * events that affect tool state (Escape to exit).
+ */
 export class TypingBehavior implements TextBehavior {
   onKeyDown(state: TextState, ctx: ToolContext<TextState>, event: ToolEventOf<"keyDown">): boolean {
     if (state.type !== "typing") return false;
 
-    const ctrl = ctx.editor.textRunController;
-    const extend = event.shiftKey;
-
     switch (event.key) {
-      case "Backspace":
-        if (ctrl.delete()) {
-          ctrl.recompute();
-        }
-        return true;
-      case "Delete":
-        ctrl.recompute();
-        return true;
       case "Escape":
         ctx.setState({ type: "idle" });
         ctx.editor.setActiveTool("select");
         return true;
-      case "ArrowLeft":
-        ctrl.moveCursorLeft(extend);
-        ctrl.recompute();
-        return true;
-      case "ArrowRight":
-        ctrl.moveCursorRight(extend);
-        ctrl.recompute();
-        return true;
-      default: {
-        if (event.key.length !== 1 || event.metaKey) return false;
-        const codepoint = event.key.codePointAt(0);
-        if (codepoint === undefined) return false;
-        ctx.editor.insertTextCodepoint(codepoint);
-        ctrl.recompute();
-        return true;
-      }
+      default:
+        return false;
     }
   }
 }

--- a/apps/desktop/src/renderer/src/lib/tools/text/layout.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/layout.test.ts
@@ -116,6 +116,28 @@ describe("computeTextLayout", () => {
   });
 });
 
+describe("computeTextLayout (multi-line)", () => {
+  it("should place slots on the next line after a newline", () => {
+    const font = createMockFont({ 72: 600, 101: 500 });
+    // H, newline, e
+    const glyphs: GlyphRef[] = [
+      ...toGlyphs([72]),
+      { glyphName: ".newline", unicode: 10 },
+      ...toGlyphs([101]),
+    ];
+    const layout = computeTextLayout(glyphs, { x: 0, y: 0 }, font);
+
+    expect(layout.slots).toHaveLength(3);
+    // Line 1: H at y=0
+    expect(expectAt(layout.slots, 0).y).toBe(0);
+    // Newline slot at y=0
+    expect(expectAt(layout.slots, 1).y).toBe(0);
+    // Line 2: e at y=-1000 (lineHeight = 800 - (-200) + 0 = 1000)
+    expect(expectAt(layout.slots, 2).y).toBe(-1000);
+    expect(expectAt(layout.slots, 2).x).toBe(0);
+  });
+});
+
 describe("hitTestTextSlot", () => {
   const metrics = {
     unitsPerEm: 1000,
@@ -234,6 +256,36 @@ describe("hitTestTextSlot", () => {
     expect(pathHitTester.hitPath).toHaveBeenCalled();
   });
 
+  it("should hit slots on the second line", () => {
+    const font = createMockFont({ 72: 600, 101: 500 });
+    // H, newline, e — "e" is on line 2 at y=-1000
+    const glyphs: GlyphRef[] = [
+      ...toGlyphs([72]),
+      { glyphName: ".newline", unicode: 10 },
+      ...toGlyphs([101]),
+    ];
+    const layout = computeTextLayout(glyphs, { x: 0, y: 0 }, font);
+
+    // Click on line 2 (y=-500 is between descender -1200 and ascender -200)
+    expect(hitTestTextSlot(layout, { x: 250, y: -500 }, metrics)).toBe(2);
+
+    // Click on line 1 still works
+    expect(hitTestTextSlot(layout, { x: 100, y: 400 }, metrics)).toBe(0);
+  });
+
+  it("should not match line 1 slot when clicking on line 2 Y", () => {
+    const font = createMockFont({ 72: 600, 101: 500 });
+    const glyphs: GlyphRef[] = [
+      ...toGlyphs([72]),
+      { glyphName: ".newline", unicode: 10 },
+      ...toGlyphs([101]),
+    ];
+    const layout = computeTextLayout(glyphs, { x: 0, y: 0 }, font);
+
+    // x=100 is within H's advance, but y=-500 is on line 2 — should not hit H
+    expect(hitTestTextSlot(layout, { x: 100, y: -500 }, metrics)).not.toBe(0);
+  });
+
   it("shape hit test should return slot only when path hit succeeds", () => {
     const pathHitTester = {
       hitPath: vi.fn(
@@ -302,5 +354,32 @@ describe("hitTestTextCaret", () => {
     expect(hitTestTextCaret(layout, { x: 400, y: 400 }, metrics)).toBe(1);
     expect(hitTestTextCaret(layout, { x: 700, y: 400 }, metrics)).toBe(1);
     expect(hitTestTextCaret(layout, { x: 1400, y: 400 }, metrics)).toBe(3);
+  });
+
+  it("should place caret on the correct line in multi-line layout", () => {
+    const font = createMockFont({ 72: 600, 101: 500 });
+    // H, newline, e — slots: [H@0, \n@0, e@-1000]
+    const glyphs: GlyphRef[] = [
+      ...toGlyphs([72]),
+      { glyphName: ".newline", unicode: 10 },
+      ...toGlyphs([101]),
+    ];
+    const layout = computeTextLayout(glyphs, { x: 0, y: 0 }, font);
+
+    // Click on line 2 before "e" midpoint (midX = 250) — caret before "e" (index 2)
+    expect(hitTestTextCaret(layout, { x: 100, y: -500 }, metrics)).toBe(2);
+
+    // Click on line 2 after "e" midpoint — caret after "e" (index 3)
+    expect(hitTestTextCaret(layout, { x: 400, y: -500 }, metrics)).toBe(3);
+
+    // Click on line 1 before "H" midpoint — caret before "H" (index 0)
+    expect(hitTestTextCaret(layout, { x: 100, y: 400 }, metrics)).toBe(0);
+  });
+
+  it("should return null for clicks far below all lines", () => {
+    const font = createMockFont({ 72: 600 });
+    const layout = computeTextLayout(toGlyphs([72]), { x: 0, y: 0 }, font);
+
+    expect(hitTestTextCaret(layout, { x: 100, y: -2000 }, metrics)).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/src/lib/tools/text/layout.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/layout.ts
@@ -19,7 +19,6 @@ export interface GlyphSlot {
   bounds: Bounds | null;
   path2d: Path2D | null;
   svgPath: string | null;
-  selected: boolean;
 }
 
 const NEWLINE_GLYPH_NAME = ".newline";
@@ -90,7 +89,6 @@ export function computeTextLayout(glyphs: GlyphRef[], origin: Point2D, font: Fon
   const lineHeight = metrics.ascender - metrics.descender + (metrics.lineGap ?? 0);
   let x = origin.x;
   let y = 0;
-  const selected = false;
 
   for (const ref of glyphs) {
     if (ref.glyphName === NEWLINE_GLYPH_NAME || ref.unicode === 10) {
@@ -103,7 +101,6 @@ export function computeTextLayout(glyphs: GlyphRef[], origin: Point2D, font: Fon
         bounds: null,
         path2d: null,
         svgPath: null,
-        selected,
       });
       x = origin.x;
       y -= lineHeight;
@@ -122,7 +119,6 @@ export function computeTextLayout(glyphs: GlyphRef[], origin: Point2D, font: Fon
       bounds: resolved?.bbox ?? null,
       path2d: resolved?.path2d ?? null,
       svgPath: resolved?.svgPath ?? null,
-      selected,
     });
 
     x += advance;
@@ -144,10 +140,15 @@ function resolveEditorAdvance(glyph: GlyphRef, advance: number): number {
   return NON_SPACING_EDITOR_ADVANCE;
 }
 
-function isWithinVerticalBounds(pos: Point2D, metrics: FontMetrics): boolean {
-  const top = metrics.ascender;
-  const bottom = metrics.descender;
-  return !(pos.y > top || pos.y < bottom);
+function isWithinSlotVerticalBounds(
+  slot: GlyphSlot,
+  y: number,
+  metrics: FontMetrics,
+  padding: number,
+): boolean {
+  const top = slot.y + metrics.ascender + padding;
+  const bottom = slot.y + metrics.descender - padding;
+  return y <= top && y >= bottom;
 }
 
 function isWithinSlotAdvance(
@@ -178,8 +179,8 @@ function isWithinSlotGlyphBounds(slot: GlyphSlot, pos: Point2D, padding: number)
 
   const minX = slot.x + slot.bounds.min.x - padding;
   const maxX = slot.x + slot.bounds.max.x + padding;
-  const minY = slot.bounds.min.y - padding;
-  const maxY = slot.bounds.max.y + padding;
+  const minY = slot.y + slot.bounds.min.y - padding;
+  const maxY = slot.y + slot.bounds.max.y + padding;
 
   return pos.x >= minX && pos.x <= maxX && pos.y >= minY && pos.y <= maxY;
 }
@@ -207,7 +208,6 @@ export function hitTestTextSlot(
 ): number | null {
   const { slots } = layout;
   if (slots.length === 0) return null;
-  if (!isWithinVerticalBounds(pos, metrics)) return null;
 
   const outlineRadius = Math.max(options.outlineRadius ?? 0, 0);
   const includeFill = options.includeFill ?? false;
@@ -216,6 +216,8 @@ export function hitTestTextSlot(
     options.pathHitTester === undefined ? getDefaultTextPathHitTester() : options.pathHitTester;
 
   for (const [i, slot] of slots.entries()) {
+    if (!isWithinSlotVerticalBounds(slot, pos.y, metrics, outlineRadius)) continue;
+
     const withinAdvance = isWithinSlotAdvance(slot, i, slots.length, pos.x, outlineRadius);
 
     if (requireShape && slot.bounds) {
@@ -235,7 +237,7 @@ export function hitTestTextSlot(
       const hit = pathHitTester.hitPath(
         slot.path2d,
         pos.x - slot.x,
-        pos.y,
+        pos.y - slot.y,
         Math.max(outlineRadius * 2, Number.EPSILON),
         includeFill,
       );
@@ -254,6 +256,9 @@ export function hitTestTextSlot(
 /**
  * Returns caret insertion index using midpoint partitioning.
  * Can return `layout.slots.length` when after the final slot midpoint.
+ *
+ * For multi-line layouts, finds the closest line by Y distance
+ * and partitions only among slots on that line.
  */
 export function hitTestTextCaret(
   layout: TextLayout,
@@ -262,12 +267,44 @@ export function hitTestTextCaret(
 ): number | null {
   const { slots } = layout;
   if (slots.length === 0) return null;
-  if (!isWithinVerticalBounds(pos, metrics)) return null;
 
+  const lineY = findClosestLineY(slots, pos.y, metrics);
+  if (lineY === null) return null;
+
+  // Check the click is within reasonable vertical distance of the line
+  const lineHeight = metrics.ascender - metrics.descender;
+  const top = lineY + metrics.ascender;
+  const bottom = lineY + metrics.descender;
+  if (pos.y > top + lineHeight / 2 || pos.y < bottom - lineHeight / 2) return null;
+
+  // Midpoint partitioning among slots on this line only
   for (const [i, slot] of slots.entries()) {
+    if (slot.y !== lineY) continue;
+
     const midX = slot.x + slot.advance / 2;
     if (pos.x < midX) return i;
   }
 
+  // After the last slot on this line
+  for (let i = slots.length - 1; i >= 0; i--) {
+    if (slots[i].y === lineY) return i + 1;
+  }
+
   return slots.length;
+}
+
+function findClosestLineY(slots: GlyphSlot[], y: number, metrics: FontMetrics): number | null {
+  let bestY: number | null = null;
+  let bestDist = Infinity;
+
+  for (const slot of slots) {
+    const lineCenter = slot.y + (metrics.ascender + metrics.descender) / 2;
+    const dist = Math.abs(y - lineCenter);
+    if (dist < bestDist) {
+      bestDist = dist;
+      bestY = slot.y;
+    }
+  }
+
+  return bestY;
 }

--- a/apps/desktop/src/renderer/src/lib/tools/text/layout.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/layout.ts
@@ -14,12 +14,15 @@ export interface GlyphSlot {
   glyph: GlyphRef;
   unicode: number | null;
   x: number;
+  y: number;
   advance: number;
   bounds: Bounds | null;
   path2d: Path2D | null;
   svgPath: string | null;
   selected: boolean;
 }
+
+const NEWLINE_GLYPH_NAME = ".newline";
 
 export interface TextLayout {
   slots: GlyphSlot[];
@@ -83,10 +86,30 @@ function getDefaultTextPathHitTester(): TextPathHitTester | null {
 
 export function computeTextLayout(glyphs: GlyphRef[], origin: Point2D, font: Font): TextLayout {
   const slots: GlyphSlot[] = [];
+  const metrics = font.getMetrics();
+  const lineHeight = metrics.ascender - metrics.descender + (metrics.lineGap ?? 0);
   let x = origin.x;
+  let y = 0;
   const selected = false;
 
   for (const ref of glyphs) {
+    if (ref.glyphName === NEWLINE_GLYPH_NAME || ref.unicode === 10) {
+      slots.push({
+        glyph: ref,
+        unicode: 10,
+        x,
+        y,
+        advance: 0,
+        bounds: null,
+        path2d: null,
+        svgPath: null,
+        selected,
+      });
+      x = origin.x;
+      y -= lineHeight;
+      continue;
+    }
+
     const resolved = font.getGlyph(ref.glyphName);
     const advance = resolveEditorAdvance(ref, resolved?.advance ?? 0);
 
@@ -94,6 +117,7 @@ export function computeTextLayout(glyphs: GlyphRef[], origin: Point2D, font: Fon
       glyph: ref,
       unicode: ref.unicode,
       x,
+      y,
       advance,
       bounds: resolved?.bbox ?? null,
       path2d: resolved?.path2d ?? null,
@@ -109,6 +133,8 @@ export function computeTextLayout(glyphs: GlyphRef[], origin: Point2D, font: Fon
     totalAdvance: x - origin.x,
   };
 }
+
+export { NEWLINE_GLYPH_NAME };
 
 function resolveEditorAdvance(glyph: GlyphRef, advance: number): number {
   if (advance > 0) return advance;

--- a/apps/desktop/src/renderer/src/lib/tools/text/renderTextRunScene.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/renderTextRunScene.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared text run scene rendering — called from tool renderInScene hooks.
+ *
+ * Renders text run glyph silhouettes, selection highlights, cursor, hover
+ * outlines, and composite inspection overlays in viewport (scene) space.
+ */
+import type { DrawAPI } from "../core/DrawAPI";
+import type { EditorAPI } from "../core/EditorAPI";
+import { renderTextRun } from "@/lib/editor/rendering/passes/textRun";
+import type { CompositeInspectionRenderData } from "@/lib/editor/rendering/passes/textRun";
+import type { TextRunRenderState } from "./TextRunController";
+
+function resolveDrawStyle(pxToUpm: (px?: number) => number) {
+  return (style: { lineWidth?: number; strokeStyle?: string; fillStyle?: string }) => {
+    return {
+      lineWidth: style.lineWidth ? pxToUpm(style.lineWidth) : undefined,
+      strokeStyle: style.strokeStyle,
+      fillStyle: style.fillStyle,
+    };
+  };
+}
+
+export function renderTextRunInScene(editor: EditorAPI, draw: DrawAPI): void {
+  const textRunState = editor.textRunController.state.value;
+  if (!textRunState) return;
+
+  const ctx = draw.renderer;
+  const metrics = editor.font.getMetrics();
+  const glyph = editor.glyph.peek();
+  const activeGlyphName = editor.getActiveGlyphName();
+
+  const liveGlyph =
+    glyph && activeGlyphName
+      ? {
+          name: activeGlyphName,
+          unicode: editor.getActiveGlyphUnicode(),
+          contours: glyph.contours,
+          compositeContours: glyph.compositeContours,
+        }
+      : null;
+
+  const inspection = resolveCompositeInspection(editor, textRunState);
+
+  renderTextRun(
+    {
+      ctx,
+      pxToUpm: (px?: number) => draw.pxToUpm(px),
+      applyStyle: (style) => {
+        const resolved = resolveDrawStyle(draw.pxToUpm.bind(draw))(style);
+        if (resolved.lineWidth !== undefined) ctx.lineWidth = resolved.lineWidth;
+        if (resolved.strokeStyle) ctx.strokeStyle = resolved.strokeStyle;
+        if (resolved.fillStyle) ctx.fillStyle = resolved.fillStyle;
+      },
+    },
+    textRunState,
+    metrics,
+    liveGlyph,
+    inspection,
+  );
+}
+
+function resolveCompositeInspection(
+  editor: EditorAPI,
+  textRunState: TextRunRenderState,
+): CompositeInspectionRenderData | null {
+  const inspection = textRunState.compositeInspection;
+  if (!inspection) return null;
+
+  const slot = textRunState.layout.slots[inspection.slotIndex];
+  if (!slot) return null;
+
+  const composite = editor.getGlyphCompositeComponents(slot.glyph.glyphName);
+  if (!composite || composite.components.length === 0) return null;
+
+  return {
+    slotIndex: inspection.slotIndex,
+    hoveredComponentIndex: inspection.hoveredComponentIndex,
+    components: composite.components,
+  };
+}

--- a/apps/desktop/src/renderer/src/lib/tools/text/renderTextRunScene.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/renderTextRunScene.ts
@@ -10,16 +10,6 @@ import { renderTextRun } from "@/lib/editor/rendering/passes/textRun";
 import type { CompositeInspectionRenderData } from "@/lib/editor/rendering/passes/textRun";
 import type { TextRunRenderState } from "./TextRunController";
 
-function resolveDrawStyle(pxToUpm: (px?: number) => number) {
-  return (style: { lineWidth?: number; strokeStyle?: string; fillStyle?: string }) => {
-    return {
-      lineWidth: style.lineWidth ? pxToUpm(style.lineWidth) : undefined,
-      strokeStyle: style.strokeStyle,
-      fillStyle: style.fillStyle,
-    };
-  };
-}
-
 export function renderTextRunInScene(editor: EditorAPI, draw: DrawAPI): void {
   const textRunState = editor.textRunController.state.value;
   if (!textRunState) return;
@@ -46,10 +36,9 @@ export function renderTextRunInScene(editor: EditorAPI, draw: DrawAPI): void {
       ctx,
       pxToUpm: (px?: number) => draw.pxToUpm(px),
       applyStyle: (style) => {
-        const resolved = resolveDrawStyle(draw.pxToUpm.bind(draw))(style);
-        if (resolved.lineWidth !== undefined) ctx.lineWidth = resolved.lineWidth;
-        if (resolved.strokeStyle) ctx.strokeStyle = resolved.strokeStyle;
-        if (resolved.fillStyle) ctx.fillStyle = resolved.fillStyle;
+        if (style.lineWidth) ctx.lineWidth = draw.pxToUpm(style.lineWidth);
+        if (style.strokeStyle) ctx.strokeStyle = style.strokeStyle;
+        if (style.fillStyle) ctx.fillStyle = style.fillStyle;
       },
     },
     textRunState,

--- a/apps/desktop/src/renderer/src/views/Editor.tsx
+++ b/apps/desktop/src/renderer/src/views/Editor.tsx
@@ -40,8 +40,6 @@ export const Editor = ({ glyphId: glyphIdProp }: EditorProps = {}) => {
     (codepoint: number) => {
       if (editor.toolManager.activeToolId === "text") {
         editor.insertTextCodepoint(codepoint);
-        editor.textRunController.recompute();
-        editor.requestRedraw();
       } else {
         navigate(`/editor/${codepointToHex(codepoint)}`);
       }

--- a/apps/desktop/src/renderer/src/views/Editor.tsx
+++ b/apps/desktop/src/renderer/src/views/Editor.tsx
@@ -40,7 +40,7 @@ export const Editor = ({ glyphId: glyphIdProp }: EditorProps = {}) => {
     (codepoint: number) => {
       if (editor.toolManager.activeToolId === "text") {
         editor.insertTextCodepoint(codepoint);
-        editor.recomputeTextRun();
+        editor.textRunController.recompute();
         editor.requestRedraw();
       } else {
         navigate(`/editor/${codepointToHex(codepoint)}`);


### PR DESCRIPTION
## Summary

Two-part decoupling of text run state from Editor and text run rendering from CanvasCoordinator.

### Part 1: Remove TextRunAccess delegation (-85 lines)
- Delete 18 text delegation methods from Editor (pure pass-throughs to TextRunController)
- Tools access `editor.textRunController` directly
- TextRunAccess interface reduced to: `textRunController` getter + `insertTextCodepoint` + `getGlyphCompositeComponents`
- CanvasCoordinatorContext uses `textRunController` directly

### Part 2: Move text run rendering to tools
- Add `renderInScene` hook to BaseTool — runs in viewport (scene) space, before the editable glyph
- Text tool and Select tool implement `renderInScene` via shared `renderTextRunInScene` utility
- CanvasCoordinator no longer renders text runs — calls `renderToolInScene(draw)` instead
- Add `DrawAPI.pxToUpm()` for tools to convert screen pixels to UPM
- Remove from CanvasCoordinatorContext: `textRunController`, `getGlyphCompositeComponents`, `getActiveGlyphName`, `getActiveGlyphUnicode`
- Delete `#renderTextRun` and `#resolveCompositeInspection` from CanvasCoordinator

### Architecture
The TextRunController is a **canvas entity** — it lives on Editor because it spans tools (Text tool types into it, Select tool hovers/edits it). But Editor no longer mediates access or owns the rendering. Tools interact with the controller directly and render it themselves.

## Test plan

- [x] `pnpm typecheck` — all packages pass
- [x] `pnpm test` — all tests pass
- [x] `pnpm lint:check` — clean
- [x] `pnpm deadcode:strict` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)