### PR TITLE
[codex] Add stable ID font index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,6 +1738,7 @@ dependencies = [
  "kurbo 0.13.0",
  "linesweeper",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
 ]
 

--- a/crates/shift-backends/src/binary/reader.rs
+++ b/crates/shift-backends/src/binary/reader.rs
@@ -13,7 +13,7 @@ pub fn read_font_file(path: &str) -> FormatBackendResult<Font> {
         .map_err(|e| FormatBackendError::Binary(format!("failed to read '{path}': {e}")))?;
     let font = FontRef::new(&bytes)
         .map_err(|e| FormatBackendError::Binary(format!("failed to parse '{path}': {e}")))?;
-    Ok(font_from_skrifa(&font))
+    font_from_skrifa(&font)
 }
 
 #[derive(Default)]
@@ -119,7 +119,7 @@ fn detect_smooth_points(contours: &mut [Contour]) {
     }
 }
 
-fn font_from_skrifa(font: &FontRef<'_>) -> Font {
+fn font_from_skrifa(font: &FontRef<'_>) -> FormatBackendResult<Font> {
     let outlines = font.outline_glyphs();
     let char_map = font.charmap();
 
@@ -164,10 +164,10 @@ fn font_from_skrifa(font: &FontRef<'_>) -> Font {
             layer.add_contour(contour);
         }
         glyph.set_layer(layer);
-        ir_font.insert_glyph(glyph);
+        ir_font.insert_glyph(glyph)?;
     }
 
-    ir_font
+    Ok(ir_font)
 }
 
 fn localized_string(font: &FontRef<'_>, id: StringId) -> Option<String> {

--- a/crates/shift-backends/src/designspace/error.rs
+++ b/crates/shift-backends/src/designspace/error.rs
@@ -57,4 +57,7 @@ pub enum DesignspaceError {
 
     #[error("failed to parse axisless designspace XML: {details}")]
     ParseAxislessXml { details: String },
+
+    #[error(transparent)]
+    Font(#[from] shift_font::CoreError),
 }

--- a/crates/shift-backends/src/designspace/mod.rs
+++ b/crates/shift-backends/src/designspace/mod.rs
@@ -30,7 +30,7 @@ mod tests {
         contour.close();
         layer.add_contour(contour);
         glyph.set_layer(layer);
-        font.insert_glyph(glyph);
+        font.insert_glyph(glyph).unwrap();
 
         font
     }
@@ -65,7 +65,7 @@ mod tests {
             Some("Placeholder Sans")
         );
         assert_eq!(loaded.glyph_count(), 1);
-        assert!(loaded.glyph("o").is_some());
+        assert!(loaded.glyph_by_name("o").is_some());
 
         let _ = fs::remove_dir_all(&temp_dir);
     }

--- a/crates/shift-backends/src/designspace/reader.rs
+++ b/crates/shift-backends/src/designspace/reader.rs
@@ -109,7 +109,7 @@ impl DesignspaceReader {
             default_ds_source.filename.clone(),
         ));
         font.set_default_source_id(default_source_id);
-        move_glyph_layers_to_source(&mut font, default_ufo_source_id, default_source_id);
+        move_glyph_layers_to_source(&mut font, default_ufo_source_id, default_source_id)?;
 
         // Cache loaded UFO fonts so we don't re-read the same file for support layers.
         let mut ufo_cache: HashMap<String, Font> = HashMap::new();
@@ -164,17 +164,19 @@ impl DesignspaceReader {
             ));
 
             // Copy glyphs from the resolved layer into the new layer.
-            for (glyph_name, source_glyph) in source_font.glyphs() {
+            for source_glyph in source_font.glyphs() {
                 if let Some(source_layer) = source_glyph.layer_for_source(source_source_id) {
-                    if let Some(existing_glyph) = font.glyph_mut(glyph_name) {
-                        existing_glyph
-                            .set_layer(source_layer.clone_with_identity(LayerId::new(), source_id));
+                    if let Some(glyph_id) = font.glyph_id_by_name(source_glyph.name()) {
+                        font.insert_glyph_layer(
+                            glyph_id,
+                            source_layer.clone_with_identity(LayerId::new(), source_id),
+                        )?;
                     }
                 }
             }
         }
 
-        remove_glyph_layers_without_source(&mut font);
+        remove_glyph_layers_without_source(&mut font)?;
         Ok(font)
     }
 }
@@ -241,7 +243,7 @@ fn load_axisless_designspace(
         default_source.filename.clone(),
     ));
     font.set_default_source_id(default_source_id);
-    move_glyph_layers_to_source(&mut font, default_ufo_source_id, default_source_id);
+    move_glyph_layers_to_source(&mut font, default_ufo_source_id, default_source_id)?;
 
     let mut ufo_cache: HashMap<String, Font> = HashMap::new();
     for (idx, ds_source) in sources.iter().enumerate().skip(1) {
@@ -286,17 +288,19 @@ fn load_axisless_designspace(
             ds_source.filename.clone(),
         ));
 
-        for (glyph_name, source_glyph) in source_font.glyphs() {
+        for source_glyph in source_font.glyphs() {
             if let Some(source_layer) = source_glyph.layer_for_source(source_source_id) {
-                if let Some(existing_glyph) = font.glyph_mut(glyph_name) {
-                    existing_glyph
-                        .set_layer(source_layer.clone_with_identity(LayerId::new(), source_id));
+                if let Some(glyph_id) = font.glyph_id_by_name(source_glyph.name()) {
+                    font.insert_glyph_layer(
+                        glyph_id,
+                        source_layer.clone_with_identity(LayerId::new(), source_id),
+                    )?;
                 }
             }
         }
     }
 
-    remove_glyph_layers_without_source(&mut font);
+    remove_glyph_layers_without_source(&mut font)?;
     Ok(font)
 }
 
@@ -423,50 +427,51 @@ fn find_source_by_external_layer_name(font: &Font, name: &str) -> Option<SourceI
         .map(Source::id)
 }
 
-fn move_glyph_layers_to_source(font: &mut Font, from_source_id: SourceId, to_source_id: SourceId) {
-    let glyph_names: Vec<_> = font.glyphs().keys().cloned().collect();
+fn move_glyph_layers_to_source(
+    font: &mut Font,
+    from_source_id: SourceId,
+    to_source_id: SourceId,
+) -> DesignspaceResult<()> {
+    let layer_moves: Vec<_> = font
+        .glyphs()
+        .filter_map(|glyph| {
+            glyph.layer_for_source(from_source_id).map(|layer| {
+                (
+                    glyph.id(),
+                    layer.id(),
+                    layer.clone_with_identity(LayerId::new(), to_source_id),
+                )
+            })
+        })
+        .collect();
 
-    for glyph_name in glyph_names {
-        let Some(glyph) = font.glyph_mut(&glyph_name) else {
-            continue;
-        };
-        let Some(layer) = glyph
-            .layer_for_source(from_source_id)
-            .map(|layer| layer.clone_with_identity(LayerId::new(), to_source_id))
-        else {
-            continue;
-        };
-        let old_layer_ids: Vec<_> = glyph
-            .layers()
-            .values()
-            .filter(|layer| layer.source_id() == from_source_id)
-            .map(|layer| layer.id())
-            .collect();
-        for old_layer_id in old_layer_ids {
-            glyph.remove_layer(old_layer_id);
-        }
-        glyph.set_layer(layer);
+    for (glyph_id, old_layer_id, layer) in layer_moves {
+        font.remove_glyph_layer(old_layer_id)?;
+        font.insert_glyph_layer(glyph_id, layer)?;
     }
+
+    Ok(())
 }
 
-fn remove_glyph_layers_without_source(font: &mut Font) {
+fn remove_glyph_layers_without_source(font: &mut Font) -> DesignspaceResult<()> {
     let source_ids: Vec<_> = font.sources().iter().map(Source::id).collect();
-    let glyph_names: Vec<_> = font.glyphs().keys().cloned().collect();
+    let orphan_layer_ids: Vec<_> = font
+        .glyphs()
+        .flat_map(|glyph| {
+            glyph
+                .layers()
+                .values()
+                .filter(|layer| !source_ids.contains(&layer.source_id()))
+                .map(|layer| layer.id())
+                .collect::<Vec<_>>()
+        })
+        .collect();
 
-    for glyph_name in glyph_names {
-        let Some(glyph) = font.glyph_mut(&glyph_name) else {
-            continue;
-        };
-        let orphan_layer_ids: Vec<_> = glyph
-            .layers()
-            .values()
-            .filter(|layer| !source_ids.contains(&layer.source_id()))
-            .map(|layer| layer.id())
-            .collect();
-        for layer_id in orphan_layer_ids {
-            glyph.remove_layer(layer_id);
-        }
+    for layer_id in orphan_layer_ids {
+        font.remove_glyph_layer(layer_id)?;
     }
+
+    Ok(())
 }
 
 /// Derive (minimum, maximum) for an axis from norad's parsed designspace.

--- a/crates/shift-backends/src/errors.rs
+++ b/crates/shift-backends/src/errors.rs
@@ -63,6 +63,9 @@ pub enum FormatBackendError {
     #[error(transparent)]
     Designspace(#[from] DesignspaceError),
 
+    #[error(transparent)]
+    Font(#[from] shift_font::CoreError),
+
     #[error("UFO backend error: {0}")]
     Ufo(String),
 

--- a/crates/shift-backends/src/export.rs
+++ b/crates/shift-backends/src/export.rs
@@ -159,7 +159,7 @@ mod tests {
         contour.close();
         layer.add_contour(contour);
         glyph.set_layer(layer);
-        font.insert_glyph(glyph);
+        font.insert_glyph(glyph).unwrap();
         font
     }
 

--- a/crates/shift-backends/src/glyphs/mod.rs
+++ b/crates/shift-backends/src/glyphs/mod.rs
@@ -37,7 +37,10 @@ mod tests {
         assert_eq!(font.metadata().family_name.as_deref(), Some("Homenaje"));
         assert_eq!(font.metrics().units_per_em, 1000.0);
         assert!(font.glyph_count() >= 300, "font should contain many glyphs");
-        assert!(font.glyph("A").is_some(), "glyph A should be present");
+        assert!(
+            font.glyph_by_name("A").is_some(),
+            "glyph A should be present"
+        );
 
         let fea = font
             .features()
@@ -47,7 +50,7 @@ mod tests {
 
         assert_eq!(font.kerning().get_kerning("A", "V"), Some(-55.0));
 
-        let aacute = font.glyph("Aacute").expect("Aacute should exist");
+        let aacute = font.glyph_by_name("Aacute").expect("Aacute should exist");
         let layer = aacute
             .layers()
             .values()
@@ -113,7 +116,10 @@ unicode = 0041;
             .expect("failed to load .glyphspackage fixture");
 
         assert_eq!(font.metadata().family_name.as_deref(), Some("Package Font"));
-        assert!(font.glyph("A").is_some(), "glyph A should be present");
+        assert!(
+            font.glyph_by_name("A").is_some(),
+            "glyph A should be present"
+        );
 
         let _ = fs::remove_dir_all(package_dir.parent().unwrap());
     }

--- a/crates/shift-backends/src/glyphs/reader.rs
+++ b/crates/shift-backends/src/glyphs/reader.rs
@@ -253,7 +253,7 @@ impl FontReader for GlyphsReader {
                 ir_glyph.set_layer(ir_layer);
             }
 
-            font.insert_glyph(ir_glyph);
+            font.insert_glyph(ir_glyph)?;
         }
 
         *font.features_mut() = Self::convert_features(&glyphs_font);

--- a/crates/shift-backends/src/traits.rs
+++ b/crates/shift-backends/src/traits.rs
@@ -40,11 +40,11 @@ impl FontView for Font {
     }
 
     fn glyphs(&self) -> Vec<&Glyph> {
-        self.glyphs().values().map(|glyph| glyph.as_ref()).collect()
+        self.glyphs().collect()
     }
 
     fn glyph(&self, name: &str) -> Option<&Glyph> {
-        self.glyph(name)
+        self.glyph_by_name(name)
     }
 
     fn kerning(&self) -> &KerningData {
@@ -68,7 +68,7 @@ pub trait FontReader: Send + Sync {
     fn load(&self, path: &str) -> FormatBackendResult<Font>;
 
     fn get_glyph(&self, font: &Font, name: &GlyphName) -> Option<Glyph> {
-        font.glyph(name).cloned()
+        font.glyph_by_name(name).cloned()
     }
 
     fn get_kerning(&self, font: &Font) -> KerningData {

--- a/crates/shift-backends/src/ufo/mod.rs
+++ b/crates/shift-backends/src/ufo/mod.rs
@@ -56,7 +56,7 @@ mod tests {
         layer.add_contour(inner);
 
         glyph.set_layer(layer);
-        font.insert_glyph(glyph);
+        font.insert_glyph(glyph).unwrap();
 
         font
     }
@@ -88,8 +88,8 @@ mod tests {
         );
         assert_eq!(loaded.glyph_count(), original.glyph_count());
 
-        let original_glyph = original.glyph("A").unwrap();
-        let loaded_glyph = loaded.glyph("A").unwrap();
+        let original_glyph = original.glyph_by_name("A").unwrap();
+        let loaded_glyph = loaded.glyph_by_name("A").unwrap();
 
         assert_eq!(
             original_glyph.primary_unicode(),
@@ -144,7 +144,7 @@ mod tests {
         layer.add_contour(Contour::new());
 
         glyph.set_layer(layer);
-        font.insert_glyph(glyph);
+        font.insert_glyph(glyph).unwrap();
 
         let temp_dir = std::env::temp_dir().join("shift_test_ufo_writer_format");
         let ufo_path = temp_dir.join("writer_format.ufo");

--- a/crates/shift-backends/src/ufo/reader.rs
+++ b/crates/shift-backends/src/ufo/reader.rs
@@ -256,12 +256,12 @@ impl FontReader for UfoReader {
             for norad_glyph in layer.iter() {
                 let glyph = Self::convert_glyph_layer(norad_glyph, LayerId::new(), source_id);
 
-                if let Some(existing) = font.glyph_mut(glyph.name()) {
+                if let Some(glyph_id) = font.glyph_id_by_name(glyph.name()) {
                     for layer_data in glyph.layers().values() {
-                        existing.set_layer(layer_data.as_ref().clone());
+                        font.insert_glyph_layer(glyph_id, layer_data.as_ref().clone())?;
                     }
                 } else {
-                    font.insert_glyph(glyph);
+                    font.insert_glyph(glyph)?;
                 }
             }
         }

--- a/crates/shift-backends/tests/export.rs
+++ b/crates/shift-backends/tests/export.rs
@@ -83,7 +83,8 @@ fn exports_mutatorsans_ufo_to_readable_ttf() {
 
     for codepoint in [0x0041, 0x004F, 0x0053] {
         let glyph = exported
-            .glyph_by_unicode(codepoint)
+            .glyphs_by_unicode(codepoint)
+            .next()
             .unwrap_or_else(|| panic!("exported TTF should contain U+{codepoint:04X}"));
         let layer = main_layer(glyph);
 
@@ -99,10 +100,12 @@ fn exports_mutatorsans_ufo_to_readable_ttf() {
 
     for codepoint in [0x0041, 0x004F] {
         let source_glyph = source
-            .glyph_by_unicode(codepoint)
+            .glyphs_by_unicode(codepoint)
+            .next()
             .unwrap_or_else(|| panic!("source UFO should contain U+{codepoint:04X}"));
         let exported_glyph = exported
-            .glyph_by_unicode(codepoint)
+            .glyphs_by_unicode(codepoint)
+            .next()
             .unwrap_or_else(|| panic!("exported TTF should contain U+{codepoint:04X}"));
         let source_layer = main_layer(source_glyph);
         let exported_layer = main_layer(exported_glyph);

--- a/crates/shift-backends/tests/loading.rs
+++ b/crates/shift-backends/tests/loading.rs
@@ -66,10 +66,10 @@ fn loads_ufo_metadata_metrics_and_geometry() {
     assert_eq!(metrics.cap_height, Some(700.0));
     assert_eq!(metrics.x_height, Some(500.0));
 
-    let glyph_a = font.glyph("A").expect("A glyph should exist");
+    let glyph_a = font.glyph_by_name("A").expect("A glyph should exist");
     assert!(!main_layer(glyph_a).contours().is_empty());
 
-    let glyph_o = font.glyph("O").expect("O glyph should exist");
+    let glyph_o = font.glyph_by_name("O").expect("O glyph should exist");
     let has_off_curve = main_layer(glyph_o)
         .contours_iter()
         .flat_map(|contour| contour.points())
@@ -81,7 +81,9 @@ fn loads_ufo_metadata_metrics_and_geometry() {
 fn loads_ufo_components_anchors_layers_and_kerning() {
     let font = load_font(&mutatorsans_ufo_path());
 
-    let aacute = font.glyph("Aacute").expect("Aacute glyph should exist");
+    let aacute = font
+        .glyph_by_name("Aacute")
+        .expect("Aacute glyph should exist");
     let component_bases: Vec<_> = main_layer(aacute)
         .components_iter()
         .map(|component| component.base_glyph().as_str())
@@ -90,7 +92,7 @@ fn loads_ufo_components_anchors_layers_and_kerning() {
     assert!(component_bases.contains(&"A"));
     assert!(component_bases.contains(&"acute"));
 
-    let e = font.glyph("E").expect("E glyph should exist");
+    let e = font.glyph_by_name("E").expect("E glyph should exist");
     let anchor_names: Vec<_> = e
         .layers()
         .values()
@@ -104,7 +106,6 @@ fn loads_ufo_components_anchors_layers_and_kerning() {
     assert!(font.sources().len() >= 2);
     assert!(font
         .glyphs()
-        .values()
         .flat_map(|glyph| glyph.layers().values())
         .all(|layer| font
             .sources()
@@ -120,7 +121,8 @@ fn loads_binary_fonts_with_contours() {
     for path in [mutatorsans_ttf_path(), mutatorsans_otf_path()] {
         let font = load_font(&path);
         let glyph_a = font
-            .glyph_by_unicode(65)
+            .glyphs_by_unicode(65)
+            .next()
             .unwrap_or_else(|| panic!("{} should contain U+0041", path.display()));
 
         assert!(font.glyph_count() > 0);
@@ -149,7 +151,9 @@ fn loads_glyphs_file_features_kerning_components_and_anchors() {
     assert_eq!(font.kerning().get_kerning("A", "V"), Some(-55.0));
     assert_eq!(font.kerning().get_kerning("V", "a"), Some(-65.0));
 
-    let aacute = font.glyph("Aacute").expect("Aacute glyph should exist");
+    let aacute = font
+        .glyph_by_name("Aacute")
+        .expect("Aacute glyph should exist");
     let component_bases: Vec<_> = main_layer(aacute)
         .components_iter()
         .map(|component| component.base_glyph().as_str())
@@ -158,7 +162,7 @@ fn loads_glyphs_file_features_kerning_components_and_anchors() {
     assert!(component_bases.contains(&"A"));
     assert!(component_bases.contains(&"acute"));
 
-    let u = font.glyph("u").expect("u glyph should exist");
+    let u = font.glyph_by_name("u").expect("u glyph should exist");
     let anchor_names: Vec<_> = main_layer(u)
         .anchors_iter()
         .filter_map(|anchor| anchor.name())
@@ -181,7 +185,7 @@ fn loads_variable_glyphs_sources_and_compatible_layers() {
     assert_eq!(font.sources()[0].location().get("wght"), Some(100.0));
     assert_eq!(font.sources()[1].location().get("wght"), Some(900.0));
 
-    let glyph_a = font.glyph("A").expect("A glyph should exist");
+    let glyph_a = font.glyph_by_name("A").expect("A glyph should exist");
     let layers: Vec<_> = glyph_a.layers().values().collect();
     assert_eq!(layers.len(), 2);
     assert_eq!(layers[0].contours().len(), layers[1].contours().len());
@@ -217,6 +221,6 @@ fn loads_designspace_sources_axes_and_default_metadata() {
     assert_eq!(font.sources()[0].location().get("wght"), Some(0.0));
     assert!(font.sources()[0].filename().is_some());
 
-    let glyph_a = font.glyph("A").expect("A glyph should exist");
+    let glyph_a = font.glyph_by_name("A").expect("A glyph should exist");
     assert!(glyph_a.layers().len() >= 4);
 }

--- a/crates/shift-backends/tests/round_trip/ufo.rs
+++ b/crates/shift-backends/tests/round_trip/ufo.rs
@@ -121,12 +121,12 @@ fn preserves_contours_points_and_widths_for_default_geometry() {
     for glyph_name in ["A", "O"] {
         let original_layer = main_layer(
             original
-                .glyph(glyph_name)
+                .glyph_by_name(glyph_name)
                 .unwrap_or_else(|| panic!("original {glyph_name} should exist")),
         );
         let reloaded_layer = main_layer(
             reloaded
-                .glyph(glyph_name)
+                .glyph_by_name(glyph_name)
                 .unwrap_or_else(|| panic!("reloaded {glyph_name} should exist")),
         );
 
@@ -138,20 +138,24 @@ fn preserves_contours_points_and_widths_for_default_geometry() {
 #[test]
 fn preserves_components_anchors_layers_and_kerning() {
     let mut original = load_font(&mutatorsans_ufo_path());
-    original
-        .glyph_mut("E")
+    let e_layer_id = original
+        .glyph_by_name("E")
         .expect("E glyph should exist")
         .layers()
         .iter()
         .max_by_key(|(_, layer)| layer.contours().len())
         .map(|(layer_id, _)| *layer_id)
-        .and_then(|layer_id| original.glyph_mut("E").unwrap().layer_mut(layer_id))
+        .expect("E should have a main layer");
+    original
+        .layer_mut(e_layer_id)
         .expect("E should have a main layer")
         .add_anchor(Anchor::new(None::<String>, 123.0, 456.0));
 
     let reloaded = round_trip(&original);
 
-    let aacute = reloaded.glyph("Aacute").expect("Aacute should exist");
+    let aacute = reloaded
+        .glyph_by_name("Aacute")
+        .expect("Aacute should exist");
     let component_bases: Vec<_> = main_layer(aacute)
         .components_iter()
         .map(|component| component.base_glyph().as_str())
@@ -160,7 +164,7 @@ fn preserves_components_anchors_layers_and_kerning() {
     assert!(component_bases.contains(&"A"));
     assert!(component_bases.contains(&"acute"));
 
-    let e = reloaded.glyph("E").expect("E should exist");
+    let e = reloaded.glyph_by_name("E").expect("E should exist");
     let anchors: Vec<_> = e
         .layers()
         .values()

--- a/crates/shift-bridge/src/bridge.rs
+++ b/crates/shift-bridge/src/bridge.rs
@@ -211,8 +211,6 @@ impl FontView for FontSaveSnapshot {
       self
         .font
         .glyphs()
-        .values()
-        .map(|glyph| glyph.as_ref())
         .filter(|glyph| override_name.as_deref() != Some(glyph.name())),
     );
 
@@ -226,7 +224,7 @@ impl FontView for FontSaveSnapshot {
       }
     }
 
-    self.font.glyph(name)
+    self.font.glyph_by_name(name)
   }
 
   fn kerning(&self) -> &shift_font::KerningData {
@@ -358,8 +356,6 @@ impl Bridge {
     let mut records: Vec<_> = self
       .font()?
       .glyphs()
-      .values()
-      .map(|glyph| glyph.as_ref())
       .map(GlyphRecord::from)
       .map(Into::into)
       .collect();
@@ -422,8 +418,7 @@ impl Bridge {
     let mut glyph_names: Vec<String> = self
       .font()?
       .glyphs()
-      .keys()
-      .map(|glyph_name| glyph_name.to_string())
+      .map(|glyph| glyph.name().to_string())
       .collect();
     glyph_names.sort();
 
@@ -477,7 +472,7 @@ impl Bridge {
   }
 
   fn glyph_for_read(&self, glyph_name: &str) -> BridgeResult<Option<Glyph>> {
-    Ok(self.font()?.glyph(glyph_name).cloned())
+    Ok(self.font()?.glyph_by_name(glyph_name).cloned())
   }
 
   fn glyph_layer_target(&self, glyph_ref: GlyphLayerRef) -> BridgeResult<GlyphLayerTarget> {
@@ -496,7 +491,7 @@ impl Bridge {
 
     let layer_id = self
       .font()?
-      .glyph(&glyph_ref.glyph_handle.name)
+      .glyph_by_name(&glyph_ref.glyph_handle.name)
       .and_then(|glyph| glyph.layer_for_source(source_id))
       .map(GlyphLayer::id)
       .unwrap_or_else(LayerId::new);

--- a/crates/shift-font/Cargo.toml
+++ b/crates/shift-font/Cargo.toml
@@ -15,3 +15,6 @@ kurbo = "0.13.0"
 linesweeper = "0.3.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 thiserror = "2.0.18"
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/crates/shift-font/src/composite.rs
+++ b/crates/shift-font/src/composite.rs
@@ -49,7 +49,7 @@ impl<'a> FontLayerProvider<'a> {
 impl GlyphLayerProvider for FontLayerProvider<'_> {
     fn glyph_layer(&self, glyph_name: &str) -> Option<&GlyphLayer> {
         self.font
-            .glyph(glyph_name)
+            .glyph_by_name(glyph_name)
             .and_then(preferred_layer_for_glyph)
     }
 }
@@ -496,18 +496,18 @@ mod tests {
         let mut base_layer = test_layer(source_id, 500.0);
         base_layer.add_contour(two_point_contour(0.0, 0.0, 10.0, 10.0));
         base.set_layer(base_layer);
-        font.insert_glyph(base);
+        font.insert_glyph(base).unwrap();
 
         let mut composite = Glyph::new("comp".to_string());
         let mut composite_layer = test_layer(source_id, 500.0);
         let composite_layer_id = composite_layer.id();
         composite_layer.add_component(Component::new("base".to_string()));
         composite.set_layer(composite_layer);
-        font.insert_glyph(composite);
+        font.insert_glyph(composite).unwrap();
 
         let provider = FontLayerProvider::new(&font);
         let layer = font
-            .glyph("comp")
+            .glyph_by_name("comp")
             .and_then(|glyph| glyph.layer(composite_layer_id))
             .unwrap();
         let resolved = flatten_component_contours_for_layer(&provider, layer, "comp");
@@ -527,24 +527,24 @@ mod tests {
         a_layer.add_component(Component::new("B".to_string()));
         a_layer.add_component(Component::new("C".to_string()));
         a.set_layer(a_layer);
-        font.insert_glyph(a);
+        font.insert_glyph(a).unwrap();
 
         let mut b = Glyph::new("B".to_string());
         let mut b_layer = test_layer(source_id, 500.0);
         b_layer.add_contour(two_point_contour(0.0, 0.0, 20.0, 20.0));
         b_layer.add_component(Component::new("A".to_string()));
         b.set_layer(b_layer);
-        font.insert_glyph(b);
+        font.insert_glyph(b).unwrap();
 
         let mut c = Glyph::new("C".to_string());
         let mut c_layer = test_layer(source_id, 500.0);
         c_layer.add_contour(two_point_contour(10.0, 0.0, 30.0, 20.0));
         c.set_layer(c_layer);
-        font.insert_glyph(c);
+        font.insert_glyph(c).unwrap();
 
         let provider = FontLayerProvider::new(&font);
         let layer = font
-            .glyph("A")
+            .glyph_by_name("A")
             .and_then(|glyph| glyph.layer(a_layer_id))
             .unwrap();
         let resolved = flatten_component_contours_for_layer(&provider, layer, "A");
@@ -562,14 +562,14 @@ mod tests {
         base_layer.add_contour(two_point_contour(0.0, 0.0, 10.0, 0.0));
         base_layer.add_anchor(Anchor::new(Some("top".to_string()), 100.0, 200.0));
         base.set_layer(base_layer);
-        font.insert_glyph(base);
+        font.insert_glyph(base).unwrap();
 
         let mut mark = Glyph::new("mark".to_string());
         let mut mark_layer = test_layer(source_id, 500.0);
         mark_layer.add_contour(two_point_contour(0.0, 0.0, 10.0, 0.0));
         mark_layer.add_anchor(Anchor::new(Some("_top".to_string()), 5.0, 0.0));
         mark.set_layer(mark_layer);
-        font.insert_glyph(mark);
+        font.insert_glyph(mark).unwrap();
 
         let mut comp = Glyph::new("comp".to_string());
         let mut comp_layer = test_layer(source_id, 500.0);
@@ -577,11 +577,11 @@ mod tests {
         comp_layer.add_component(Component::new("base".to_string()));
         comp_layer.add_component(Component::new("mark".to_string()));
         comp.set_layer(comp_layer);
-        font.insert_glyph(comp);
+        font.insert_glyph(comp).unwrap();
 
         let provider = FontLayerProvider::new(&font);
         let layer = font
-            .glyph("comp")
+            .glyph_by_name("comp")
             .and_then(|glyph| glyph.layer(comp_layer_id))
             .unwrap();
         let resolved = flatten_component_contours_for_layer(&provider, layer, "comp");
@@ -604,7 +604,7 @@ mod tests {
         mark_layer.add_contour(two_point_contour(0.0, 0.0, 10.0, 0.0));
         mark_layer.add_anchor(Anchor::new(Some("top".to_string()), 5.0, 0.0));
         mark.set_layer(mark_layer);
-        font.insert_glyph(mark);
+        font.insert_glyph(mark).unwrap();
 
         let mut comp = Glyph::new("comp".to_string());
         let mut comp_layer = test_layer(source_id, 500.0);
@@ -612,11 +612,11 @@ mod tests {
         let matrix = Transform::translate(30.0, 40.0);
         comp_layer.add_component(Component::with_matrix("mark".to_string(), &matrix));
         comp.set_layer(comp_layer);
-        font.insert_glyph(comp);
+        font.insert_glyph(comp).unwrap();
 
         let provider = FontLayerProvider::new(&font);
         let layer = font
-            .glyph("comp")
+            .glyph_by_name("comp")
             .and_then(|glyph| glyph.layer(comp_layer_id))
             .unwrap();
         let resolved = flatten_component_contours_for_layer(&provider, layer, "comp");
@@ -638,14 +638,14 @@ mod tests {
         base_layer.add_anchor(Anchor::new(Some("top".to_string()), 100.0, 200.0));
         base_layer.add_contour(two_point_contour(0.0, 0.0, 10.0, 0.0));
         base.set_layer(base_layer);
-        font.insert_glyph(base);
+        font.insert_glyph(base).unwrap();
 
         let mut mark = Glyph::new("mark".to_string());
         let mut mark_layer = test_layer(source_id, 500.0);
         mark_layer.add_anchor(Anchor::new(Some("top_extra".to_string()), 5.0, 0.0));
         mark_layer.add_contour(two_point_contour(0.0, 0.0, 10.0, 0.0));
         mark.set_layer(mark_layer);
-        font.insert_glyph(mark);
+        font.insert_glyph(mark).unwrap();
 
         let mut comp = Glyph::new("comp".to_string());
         let mut comp_layer = test_layer(source_id, 500.0);
@@ -654,11 +654,11 @@ mod tests {
         comp_layer.add_component(Component::new("base".to_string()));
         comp_layer.add_component(Component::new("mark".to_string()));
         comp.set_layer(comp_layer);
-        font.insert_glyph(comp);
+        font.insert_glyph(comp).unwrap();
 
         let provider = FontLayerProvider::new(&font);
         let layer = font
-            .glyph("comp")
+            .glyph_by_name("comp")
             .and_then(|glyph| glyph.layer(comp_layer_id))
             .unwrap();
         let resolved = flatten_component_contours_for_layer(&provider, layer, "comp");
@@ -681,7 +681,7 @@ mod tests {
         base_layer.add_anchor(Anchor::new(Some("top".to_string()), 100.0, 200.0));
         base_layer.add_contour(two_point_contour(0.0, 0.0, 10.0, 0.0));
         base.set_layer(base_layer);
-        font.insert_glyph(base);
+        font.insert_glyph(base).unwrap();
 
         let mut mark = Glyph::new("mark".to_string());
         let mut mark_layer = test_layer(source_id, 500.0);
@@ -689,7 +689,7 @@ mod tests {
         mark_layer.add_anchor(Anchor::new(Some("top".to_string()), 5.0, 20.0));
         mark_layer.add_contour(two_point_contour(0.0, 0.0, 10.0, 0.0));
         mark.set_layer(mark_layer);
-        font.insert_glyph(mark);
+        font.insert_glyph(mark).unwrap();
 
         let mut comp = Glyph::new("comp".to_string());
         let mut comp_layer = test_layer(source_id, 500.0);
@@ -698,11 +698,11 @@ mod tests {
         comp_layer.add_component(Component::new("mark".to_string()));
         comp_layer.add_component(Component::new("mark".to_string()));
         comp.set_layer(comp_layer);
-        font.insert_glyph(comp);
+        font.insert_glyph(comp).unwrap();
 
         let provider = FontLayerProvider::new(&font);
         let layer = font
-            .glyph("comp")
+            .glyph_by_name("comp")
             .and_then(|glyph| glyph.layer(comp_layer_id))
             .unwrap();
         let resolved = flatten_component_contours_for_layer(&provider, layer, "comp");

--- a/crates/shift-font/src/error.rs
+++ b/crates/shift-font/src/error.rs
@@ -1,4 +1,4 @@
-use crate::{AnchorId, ContourId, PointId};
+use crate::{AnchorId, ContourId, GlyphId, GlyphName, LayerId, PointId, SourceId};
 
 #[derive(Debug, thiserror::Error)]
 pub enum CoreError {
@@ -37,6 +37,33 @@ pub enum CoreError {
 
     #[error("invalid {kind}: {message}")]
     InvalidPositionUpdateInput { kind: &'static str, message: String },
+
+    #[error("glyph {0} not found")]
+    GlyphNotFound(GlyphId),
+
+    #[error("source {0} not found")]
+    SourceNotFound(SourceId),
+
+    #[error("layer {0} not found")]
+    LayerNotFound(LayerId),
+
+    #[error("duplicate glyph id {0}")]
+    DuplicateGlyphId(GlyphId),
+
+    #[error("duplicate glyph name {0}")]
+    DuplicateGlyphName(GlyphName),
+
+    #[error("duplicate glyph layer for glyph {glyph_id} and source {source_id}")]
+    DuplicateGlyphLayer {
+        glyph_id: GlyphId,
+        source_id: SourceId,
+    },
+
+    #[error("layer {0} is already owned by another glyph")]
+    DuplicateLayerId(LayerId),
+
+    #[error("glyph storage key {key} does not match glyph id {glyph_id}")]
+    MismatchedGlyphId { key: GlyphId, glyph_id: GlyphId },
 }
 
 pub type CoreResult<T> = Result<T, CoreError>;

--- a/crates/shift-font/src/ir/font.rs
+++ b/crates/shift-font/src/ir/font.rs
@@ -1,15 +1,17 @@
 use crate::axis::{Axis, Location};
-use crate::entity::SourceId;
+use crate::entity::{GlyphId, LayerId, SourceId};
+use crate::error::{CoreError, CoreResult};
 use crate::features::FeatureData;
-use crate::glyph::Glyph;
+use crate::glyph::{Glyph, GlyphLayer};
 use crate::guideline::Guideline;
 use crate::kerning::KerningData;
 use crate::lib_data::LibData;
 use crate::metrics::FontMetrics;
 use crate::source::Source;
 use crate::GlyphName;
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use indexmap::IndexMap;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -75,9 +77,15 @@ impl FontMetadata {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
 pub struct Font {
-    inner: Arc<FontData>,
+    state: Arc<FontState>,
+}
+
+#[derive(Clone, Debug)]
+struct FontState {
+    data: FontData,
+    index: FontIndex,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -88,11 +96,173 @@ struct FontData {
     sources: Vec<Source>,
     #[serde(default)]
     default_source_id: Option<SourceId>,
-    glyphs: HashMap<GlyphName, Arc<Glyph>>,
+    glyphs: IndexMap<GlyphId, Arc<Glyph>>,
     kerning: KerningData,
     features: FeatureData,
     guidelines: Vec<Guideline>,
     lib: LibData,
+}
+
+#[derive(Clone, Debug, Default)]
+struct FontIndex {
+    glyph_by_name: HashMap<GlyphName, GlyphId>,
+    layer_owner: HashMap<LayerId, GlyphId>,
+    layer_by_glyph_source: HashMap<(GlyphId, SourceId), LayerId>,
+    glyphs_by_unicode: HashMap<u32, Vec<GlyphId>>,
+}
+
+impl FontIndex {
+    fn from_glyphs(glyphs: &IndexMap<GlyphId, Arc<Glyph>>) -> CoreResult<Self> {
+        let mut index = Self::default();
+
+        for (glyph_id, glyph) in glyphs {
+            if *glyph_id != glyph.id() {
+                return Err(CoreError::MismatchedGlyphId {
+                    key: *glyph_id,
+                    glyph_id: glyph.id(),
+                });
+            }
+
+            if index
+                .glyph_by_name
+                .insert(glyph.glyph_name().clone(), *glyph_id)
+                .is_some()
+            {
+                return Err(CoreError::DuplicateGlyphName(glyph.glyph_name().clone()));
+            }
+
+            for unicode in glyph.unicodes() {
+                index
+                    .glyphs_by_unicode
+                    .entry(*unicode)
+                    .or_default()
+                    .push(*glyph_id);
+            }
+
+            for layer in glyph.layers().values().map(Arc::as_ref) {
+                if index.layer_owner.insert(layer.id(), *glyph_id).is_some() {
+                    return Err(CoreError::DuplicateLayerId(layer.id()));
+                }
+
+                if index
+                    .layer_by_glyph_source
+                    .insert((*glyph_id, layer.source_id()), layer.id())
+                    .is_some()
+                {
+                    return Err(CoreError::DuplicateGlyphLayer {
+                        glyph_id: *glyph_id,
+                        source_id: layer.source_id(),
+                    });
+                }
+            }
+        }
+
+        Ok(index)
+    }
+
+    fn validate_glyph_insert(&self, glyph_id: GlyphId, glyph: &Glyph) -> CoreResult<()> {
+        if glyph_id != glyph.id() {
+            return Err(CoreError::MismatchedGlyphId {
+                key: glyph_id,
+                glyph_id: glyph.id(),
+            });
+        }
+
+        if self.glyph_by_name.contains_key(glyph.glyph_name()) {
+            return Err(CoreError::DuplicateGlyphName(glyph.glyph_name().clone()));
+        }
+
+        let mut local_sources = HashSet::new();
+        for layer in glyph.layers().values().map(Arc::as_ref) {
+            if self.layer_owner.contains_key(&layer.id()) {
+                return Err(CoreError::DuplicateLayerId(layer.id()));
+            }
+
+            if self
+                .layer_by_glyph_source
+                .contains_key(&(glyph_id, layer.source_id()))
+                || !local_sources.insert(layer.source_id())
+            {
+                return Err(CoreError::DuplicateGlyphLayer {
+                    glyph_id,
+                    source_id: layer.source_id(),
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    fn insert_glyph(&mut self, glyph_id: GlyphId, glyph: &Glyph) {
+        self.glyph_by_name
+            .insert(glyph.glyph_name().clone(), glyph_id);
+
+        for unicode in glyph.unicodes() {
+            self.glyphs_by_unicode
+                .entry(*unicode)
+                .or_default()
+                .push(glyph_id);
+        }
+
+        for layer in glyph.layers().values().map(Arc::as_ref) {
+            self.layer_owner.insert(layer.id(), glyph_id);
+            self.layer_by_glyph_source
+                .insert((glyph_id, layer.source_id()), layer.id());
+        }
+    }
+
+    fn remove_glyph(&mut self, glyph_id: GlyphId, glyph: &Glyph) {
+        self.glyph_by_name.remove(glyph.glyph_name());
+
+        for unicode in glyph.unicodes() {
+            if let Some(glyph_ids) = self.glyphs_by_unicode.get_mut(unicode) {
+                glyph_ids.retain(|id| *id != glyph_id);
+                if glyph_ids.is_empty() {
+                    self.glyphs_by_unicode.remove(unicode);
+                }
+            }
+        }
+
+        for layer in glyph.layers().values().map(Arc::as_ref) {
+            self.layer_owner.remove(&layer.id());
+            self.layer_by_glyph_source
+                .remove(&(glyph_id, layer.source_id()));
+        }
+    }
+}
+
+impl FontState {
+    fn from_data(data: FontData) -> CoreResult<Self> {
+        let index = FontIndex::from_glyphs(&data.glyphs)?;
+        Ok(Self { data, index })
+    }
+
+    fn rebuild_index(&mut self) -> CoreResult<()> {
+        self.index = FontIndex::from_glyphs(&self.data.glyphs)?;
+        Ok(())
+    }
+}
+
+impl Serialize for Font {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.data().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Font {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let data = FontData::deserialize(deserializer)?;
+        let state = FontState::from_data(data).map_err(serde::de::Error::custom)?;
+        Ok(Self {
+            state: Arc::new(state),
+        })
+    }
 }
 
 impl Default for Font {
@@ -101,17 +271,20 @@ impl Default for Font {
         let default_source_id = default_source.id();
 
         Self {
-            inner: Arc::new(FontData {
-                metadata: FontMetadata::default(),
-                metrics: FontMetrics::default(),
-                axes: Vec::new(),
-                sources: vec![default_source],
-                default_source_id: Some(default_source_id),
-                glyphs: HashMap::new(),
-                kerning: KerningData::new(),
-                features: FeatureData::new(),
-                guidelines: Vec::new(),
-                lib: LibData::new(),
+            state: Arc::new(FontState {
+                data: FontData {
+                    metadata: FontMetadata::default(),
+                    metrics: FontMetrics::default(),
+                    axes: Vec::new(),
+                    sources: vec![default_source],
+                    default_source_id: Some(default_source_id),
+                    glyphs: IndexMap::new(),
+                    kerning: KerningData::new(),
+                    features: FeatureData::new(),
+                    guidelines: Vec::new(),
+                    lib: LibData::new(),
+                },
+                index: FontIndex::default(),
             }),
         }
     }
@@ -124,27 +297,38 @@ impl Font {
 
     pub fn empty() -> Self {
         Self {
-            inner: Arc::new(FontData {
-                metadata: FontMetadata::default(),
-                metrics: FontMetrics::default(),
-                axes: Vec::new(),
-                sources: Vec::new(),
-                default_source_id: None,
-                glyphs: HashMap::new(),
-                kerning: KerningData::new(),
-                features: FeatureData::new(),
-                guidelines: Vec::new(),
-                lib: LibData::new(),
+            state: Arc::new(FontState {
+                data: FontData {
+                    metadata: FontMetadata::default(),
+                    metrics: FontMetrics::default(),
+                    axes: Vec::new(),
+                    sources: Vec::new(),
+                    default_source_id: None,
+                    glyphs: IndexMap::new(),
+                    kerning: KerningData::new(),
+                    features: FeatureData::new(),
+                    guidelines: Vec::new(),
+                    lib: LibData::new(),
+                },
+                index: FontIndex::default(),
             }),
         }
     }
 
     fn data(&self) -> &FontData {
-        &self.inner
+        &self.state.data
     }
 
     fn data_mut(&mut self) -> &mut FontData {
-        Arc::make_mut(&mut self.inner)
+        &mut Arc::make_mut(&mut self.state).data
+    }
+
+    fn index(&self) -> &FontIndex {
+        &self.state.index
+    }
+
+    fn state_mut(&mut self) -> &mut FontState {
+        Arc::make_mut(&mut self.state)
     }
 
     pub fn metadata(&self) -> &FontMetadata {
@@ -211,62 +395,174 @@ impl Font {
         !self.data().axes.is_empty()
     }
 
-    pub fn glyphs(&self) -> &HashMap<GlyphName, Arc<Glyph>> {
-        &self.data().glyphs
+    pub fn glyphs(&self) -> impl Iterator<Item = &Glyph> {
+        self.data().glyphs.values().map(Arc::as_ref)
     }
 
-    pub fn glyph(&self, name: &str) -> Option<&Glyph> {
-        self.data().glyphs.get(name).map(Arc::as_ref)
+    pub fn glyph(&self, glyph_id: GlyphId) -> Option<&Glyph> {
+        self.data().glyphs.get(&glyph_id).map(Arc::as_ref)
     }
 
-    pub fn glyph_mut(&mut self, name: &str) -> Option<&mut Glyph> {
-        self.data_mut().glyphs.get_mut(name).map(Arc::make_mut)
+    pub fn glyph_id_by_name(&self, name: &str) -> Option<GlyphId> {
+        self.index().glyph_by_name.get(name).copied()
     }
 
-    pub fn glyph_by_unicode(&self, unicode: u32) -> Option<&Glyph> {
-        self.data()
-            .glyphs
-            .values()
-            .find(|g| g.unicodes().contains(&unicode))
-            .map(Arc::as_ref)
+    pub fn glyph_by_name(&self, name: &str) -> Option<&Glyph> {
+        self.glyph(self.glyph_id_by_name(name)?)
     }
 
-    pub fn glyph_by_unicode_mut(&mut self, unicode: u32) -> Option<&mut Glyph> {
+    pub fn glyphs_by_unicode(&self, unicode: u32) -> impl Iterator<Item = &Glyph> {
+        self.index()
+            .glyphs_by_unicode
+            .get(&unicode)
+            .into_iter()
+            .flatten()
+            .filter_map(|glyph_id| self.glyph(*glyph_id))
+    }
+
+    pub fn glyph_id_by_layer(&self, layer_id: LayerId) -> Option<GlyphId> {
+        self.index().layer_owner.get(&layer_id).copied()
+    }
+
+    pub fn layer_id_for_glyph_source(
+        &self,
+        glyph_id: GlyphId,
+        source_id: SourceId,
+    ) -> Option<LayerId> {
+        self.index()
+            .layer_by_glyph_source
+            .get(&(glyph_id, source_id))
+            .copied()
+    }
+
+    pub fn layer(&self, layer_id: LayerId) -> Option<&GlyphLayer> {
+        let glyph_id = self.glyph_id_by_layer(layer_id)?;
+        self.glyph(glyph_id)?.layer(layer_id)
+    }
+
+    pub fn layer_mut(&mut self, layer_id: LayerId) -> Option<&mut GlyphLayer> {
+        let glyph_id = self.glyph_id_by_layer(layer_id)?;
         self.data_mut()
             .glyphs
-            .values_mut()
-            .find(|g| g.unicodes().contains(&unicode))
-            .map(Arc::make_mut)
+            .get_mut(&glyph_id)
+            .and_then(|glyph| Arc::make_mut(glyph).layer_mut(layer_id))
     }
 
-    pub fn insert_glyph(&mut self, glyph: Glyph) {
-        self.data_mut()
-            .glyphs
-            .insert(glyph.glyph_name().clone(), Arc::new(glyph));
+    pub fn insert_glyph(&mut self, glyph: Glyph) -> CoreResult<GlyphId> {
+        let glyph_id = glyph.id();
+        if self.data().glyphs.contains_key(&glyph_id) {
+            return Err(CoreError::DuplicateGlyphId(glyph_id));
+        }
+        self.index().validate_glyph_insert(glyph_id, &glyph)?;
+
+        let state = self.state_mut();
+        state.index.insert_glyph(glyph_id, &glyph);
+        state.data.glyphs.insert(glyph_id, Arc::new(glyph));
+        Ok(glyph_id)
     }
 
-    pub fn remove_glyph(&mut self, name: &str) -> Option<Glyph> {
-        self.data_mut()
+    pub fn remove_glyph(&mut self, glyph_id: GlyphId) -> Option<Glyph> {
+        let state = self.state_mut();
+        let glyph = state
+            .data
             .glyphs
-            .remove(name)
-            .map(Arc::unwrap_or_clone)
+            .shift_remove(&glyph_id)
+            .map(Arc::unwrap_or_clone)?;
+        state.index.remove_glyph(glyph_id, &glyph);
+        Some(glyph)
     }
 
     pub fn glyph_count(&self) -> usize {
         self.data().glyphs.len()
     }
 
-    pub fn take_glyph(&mut self, name: &str) -> Option<Glyph> {
-        self.data_mut()
+    pub fn rename_glyph(&mut self, glyph_id: GlyphId, name: GlyphName) -> CoreResult<()> {
+        let mut state = (*self.state).clone();
+        let glyph = state
+            .data
             .glyphs
-            .remove(name)
-            .map(Arc::unwrap_or_clone)
+            .get_mut(&glyph_id)
+            .ok_or(CoreError::GlyphNotFound(glyph_id))?;
+        Arc::make_mut(glyph).set_name(name);
+        state.rebuild_index()?;
+        self.state = Arc::new(state);
+        Ok(())
     }
 
-    pub fn put_glyph(&mut self, glyph: Glyph) {
-        self.data_mut()
+    pub fn set_glyph_unicodes(&mut self, glyph_id: GlyphId, unicodes: Vec<u32>) -> CoreResult<()> {
+        let mut state = (*self.state).clone();
+        let glyph = state
+            .data
             .glyphs
-            .insert(glyph.glyph_name().clone(), Arc::new(glyph));
+            .get_mut(&glyph_id)
+            .ok_or(CoreError::GlyphNotFound(glyph_id))?;
+        Arc::make_mut(glyph).set_unicodes(unicodes);
+        state.rebuild_index()?;
+        self.state = Arc::new(state);
+        Ok(())
+    }
+
+    pub fn create_glyph_layer(
+        &mut self,
+        glyph_id: GlyphId,
+        source_id: SourceId,
+    ) -> CoreResult<LayerId> {
+        if !self.sources().iter().any(|source| source.id() == source_id) {
+            return Err(CoreError::SourceNotFound(source_id));
+        }
+        if self
+            .layer_id_for_glyph_source(glyph_id, source_id)
+            .is_some()
+        {
+            return Err(CoreError::DuplicateGlyphLayer {
+                glyph_id,
+                source_id,
+            });
+        }
+
+        let layer = GlyphLayer::new(LayerId::new(), source_id);
+        let layer_id = layer.id();
+        self.insert_glyph_layer(glyph_id, layer)?;
+        Ok(layer_id)
+    }
+
+    pub fn insert_glyph_layer(&mut self, glyph_id: GlyphId, layer: GlyphLayer) -> CoreResult<()> {
+        if !self
+            .sources()
+            .iter()
+            .any(|source| source.id() == layer.source_id())
+        {
+            return Err(CoreError::SourceNotFound(layer.source_id()));
+        }
+
+        let mut state = (*self.state).clone();
+        let glyph = state
+            .data
+            .glyphs
+            .get_mut(&glyph_id)
+            .ok_or(CoreError::GlyphNotFound(glyph_id))?;
+        Arc::make_mut(glyph).set_layer(layer);
+        state.rebuild_index()?;
+        self.state = Arc::new(state);
+        Ok(())
+    }
+
+    pub fn remove_glyph_layer(&mut self, layer_id: LayerId) -> CoreResult<GlyphLayer> {
+        let glyph_id = self
+            .glyph_id_by_layer(layer_id)
+            .ok_or(CoreError::LayerNotFound(layer_id))?;
+        let mut state = (*self.state).clone();
+        let glyph = state
+            .data
+            .glyphs
+            .get_mut(&glyph_id)
+            .ok_or(CoreError::GlyphNotFound(glyph_id))?;
+        let layer = Arc::make_mut(glyph)
+            .remove_layer(layer_id)
+            .ok_or(CoreError::LayerNotFound(layer_id))?;
+        state.rebuild_index()?;
+        self.state = Arc::new(state);
+        Ok(layer)
     }
 
     pub fn kerning(&self) -> &KerningData {
@@ -346,7 +642,7 @@ mod tests {
             }
 
             glyph.set_layer(layer);
-            font.insert_glyph(glyph);
+            font.insert_glyph(glyph).unwrap();
         }
 
         font
@@ -376,26 +672,177 @@ mod tests {
         let mut glyph = Glyph::with_unicode("A".to_string(), 65);
         let layer =
             GlyphLayer::with_width(LayerId::new(), font.default_source_id().unwrap(), 600.0);
+        let layer_id = layer.id();
         glyph.set_layer(layer);
 
-        font.insert_glyph(glyph);
+        let glyph_id = font.insert_glyph(glyph).unwrap();
 
         assert_eq!(font.glyph_count(), 1);
-        assert!(font.glyph("A").is_some());
-        assert!(font.glyph_by_unicode(65).is_some());
+        assert!(font.glyph(glyph_id).is_some());
+        assert_eq!(font.glyph_id_by_name("A"), Some(glyph_id));
+        assert!(font.glyph_by_name("A").is_some());
+        assert_eq!(font.glyph_id_by_layer(layer_id), Some(glyph_id));
+        assert_eq!(
+            font.layer_id_for_glyph_source(glyph_id, font.default_source_id().unwrap()),
+            Some(layer_id)
+        );
+        assert_eq!(
+            font.glyphs_by_unicode(65)
+                .map(Glyph::id)
+                .collect::<Vec<_>>(),
+            vec![glyph_id]
+        );
     }
 
     #[test]
-    fn font_take_put_glyph() {
+    fn font_remove_insert_glyph() {
         let mut font = Font::new();
-        font.insert_glyph(Glyph::with_unicode("A".to_string(), 65));
+        let glyph = Glyph::with_unicode("A".to_string(), 65);
+        let glyph_id = font.insert_glyph(glyph).unwrap();
 
-        let taken = font.take_glyph("A");
+        let taken = font.remove_glyph(glyph_id);
         assert!(taken.is_some());
         assert_eq!(font.glyph_count(), 0);
+        assert_eq!(font.glyph_id_by_name("A"), None);
 
-        font.put_glyph(taken.unwrap());
+        font.insert_glyph(taken.unwrap()).unwrap();
         assert_eq!(font.glyph_count(), 1);
+        assert_eq!(font.glyph_id_by_name("A"), Some(glyph_id));
+    }
+
+    #[test]
+    fn glyph_names_are_unique() {
+        let mut font = Font::new();
+        font.insert_glyph(Glyph::new("A")).unwrap();
+
+        let error = font.insert_glyph(Glyph::new("A")).unwrap_err();
+
+        assert!(matches!(error, CoreError::DuplicateGlyphName(name) if name.as_str() == "A"));
+    }
+
+    #[test]
+    fn glyph_iteration_preserves_insertion_order() {
+        let mut font = Font::new();
+        font.insert_glyph(Glyph::new("B")).unwrap();
+        font.insert_glyph(Glyph::new("A")).unwrap();
+
+        let names: Vec<_> = font
+            .glyphs()
+            .map(|glyph| glyph.name().to_string())
+            .collect();
+
+        assert_eq!(names, vec!["B", "A"]);
+    }
+
+    #[test]
+    fn rename_glyph_keeps_id_stable_and_updates_name_index() {
+        let mut font = Font::new();
+        let glyph_id = font.insert_glyph(Glyph::new("A")).unwrap();
+
+        font.rename_glyph(glyph_id, GlyphName::from("A.alt"))
+            .unwrap();
+
+        assert_eq!(font.glyph_id_by_name("A"), None);
+        assert_eq!(font.glyph_id_by_name("A.alt"), Some(glyph_id));
+        assert_eq!(font.glyph(glyph_id).unwrap().name(), "A.alt");
+    }
+
+    #[test]
+    fn unicode_lookup_returns_all_matching_glyphs() {
+        let mut font = Font::new();
+        let a = font.insert_glyph(Glyph::with_unicode("A", 0x41)).unwrap();
+        let a_alt = font
+            .insert_glyph(Glyph::with_unicode("A.alt", 0x41))
+            .unwrap();
+
+        let glyph_ids: Vec<_> = font.glyphs_by_unicode(0x41).map(Glyph::id).collect();
+
+        assert_eq!(glyph_ids, vec![a, a_alt]);
+    }
+
+    #[test]
+    fn deserialization_rebuilds_private_indexes() {
+        let mut font = Font::new();
+        let source_id = font.default_source_id().unwrap();
+        let mut glyph = Glyph::with_unicode("A", 0x41);
+        let layer = GlyphLayer::new(LayerId::new(), source_id);
+        let layer_id = layer.id();
+        glyph.set_layer(layer);
+        let glyph_id = font.insert_glyph(glyph).unwrap();
+
+        let json = serde_json::to_string(&font).unwrap();
+        let decoded: Font = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(decoded.glyph_id_by_name("A"), Some(glyph_id));
+        assert_eq!(decoded.glyph_id_by_layer(layer_id), Some(glyph_id));
+        assert_eq!(
+            decoded.layer_id_for_glyph_source(glyph_id, source_id),
+            Some(layer_id)
+        );
+        assert_eq!(
+            decoded
+                .glyphs_by_unicode(0x41)
+                .map(Glyph::id)
+                .collect::<Vec<_>>(),
+            vec![glyph_id]
+        );
+    }
+
+    #[test]
+    fn duplicate_glyph_source_layer_is_an_error() {
+        let mut font = Font::new();
+        let source_id = font.default_source_id().unwrap();
+        let glyph_id = font.insert_glyph(Glyph::new("A")).unwrap();
+
+        font.create_glyph_layer(glyph_id, source_id).unwrap();
+        let error = font.create_glyph_layer(glyph_id, source_id).unwrap_err();
+
+        assert!(matches!(
+            error,
+            CoreError::DuplicateGlyphLayer {
+                glyph_id: id,
+                source_id: source
+            } if id == glyph_id && source == source_id
+        ));
+    }
+
+    #[test]
+    fn layer_indexes_update_after_layer_removal() {
+        let mut font = Font::new();
+        let source_id = font.default_source_id().unwrap();
+        let glyph_id = font.insert_glyph(Glyph::new("A")).unwrap();
+        let layer_id = font.create_glyph_layer(glyph_id, source_id).unwrap();
+
+        assert_eq!(font.glyph_id_by_layer(layer_id), Some(glyph_id));
+        assert_eq!(
+            font.layer_id_for_glyph_source(glyph_id, source_id),
+            Some(layer_id)
+        );
+
+        font.remove_glyph_layer(layer_id).unwrap();
+
+        assert_eq!(font.glyph_id_by_layer(layer_id), None);
+        assert_eq!(font.layer_id_for_glyph_source(glyph_id, source_id), None);
+    }
+
+    #[test]
+    fn index_validation_rejects_duplicate_layers_for_one_glyph_source() {
+        let source_id = SourceId::new();
+        let mut glyph = Glyph::new("A");
+        glyph.set_layer(GlyphLayer::new(LayerId::new(), source_id));
+        glyph.set_layer(GlyphLayer::new(LayerId::new(), source_id));
+        let mut glyphs = IndexMap::new();
+        glyphs.insert(glyph.id(), Arc::new(glyph));
+
+        let error = FontIndex::from_glyphs(&glyphs).unwrap_err();
+
+        assert!(matches!(
+            error,
+            CoreError::DuplicateGlyphLayer {
+                glyph_id: _,
+                source_id: source
+            } if source == source_id
+        ));
     }
 
     #[test]
@@ -403,11 +850,11 @@ mod tests {
         let mut font = Font::new();
         let snapshot = font.clone();
 
-        assert!(Arc::ptr_eq(&font.inner, &snapshot.inner));
+        assert!(Arc::ptr_eq(&font.state, &snapshot.state));
 
         font.metadata_mut().family_name = Some("Edited".to_string());
 
-        assert!(!Arc::ptr_eq(&font.inner, &snapshot.inner));
+        assert!(!Arc::ptr_eq(&font.state, &snapshot.state));
         assert_eq!(font.metadata().family_name.as_deref(), Some("Edited"));
         assert_eq!(
             snapshot.metadata().family_name.as_deref(),
@@ -418,23 +865,25 @@ mod tests {
     #[test]
     fn mutating_one_glyph_after_snapshot_keeps_other_glyphs_shared() {
         let mut font = Font::new();
-        font.insert_glyph(Glyph::with_unicode("A".to_string(), 65));
-        font.insert_glyph(Glyph::with_unicode("B".to_string(), 66));
+        let a = font
+            .insert_glyph(Glyph::with_unicode("A".to_string(), 65))
+            .unwrap();
+        let b = font
+            .insert_glyph(Glyph::with_unicode("B".to_string(), 66))
+            .unwrap();
         let snapshot = font.clone();
 
-        font.glyph_mut("A")
-            .unwrap()
-            .set_unicodes(vec![0x41, 0x00C1]);
+        font.set_glyph_unicodes(a, vec![0x41, 0x00C1]).unwrap();
 
-        assert_eq!(font.glyph("A").unwrap().unicodes(), &[0x41, 0x00C1]);
-        assert_eq!(snapshot.glyph("A").unwrap().unicodes(), &[0x41]);
+        assert_eq!(font.glyph(a).unwrap().unicodes(), &[0x41, 0x00C1]);
+        assert_eq!(snapshot.glyph(a).unwrap().unicodes(), &[0x41]);
         assert!(!Arc::ptr_eq(
-            font.inner.glyphs.get("A").unwrap(),
-            snapshot.inner.glyphs.get("A").unwrap()
+            font.state.data.glyphs.get(&a).unwrap(),
+            snapshot.state.data.glyphs.get(&a).unwrap()
         ));
         assert!(Arc::ptr_eq(
-            font.inner.glyphs.get("B").unwrap(),
-            snapshot.inner.glyphs.get("B").unwrap()
+            font.state.data.glyphs.get(&b).unwrap(),
+            snapshot.state.data.glyphs.get(&b).unwrap()
         ));
     }
 
@@ -469,7 +918,7 @@ mod tests {
 
             assert_eq!(font.glyph_count(), mark.glyphs);
             for snapshot in &snapshots {
-                assert!(Arc::ptr_eq(&font.inner, &snapshot.inner));
+                assert!(Arc::ptr_eq(&font.state, &snapshot.state));
                 assert_eq!(snapshot.glyph_count(), font.glyph_count());
             }
 
@@ -493,46 +942,130 @@ mod tests {
         let mut font = synthetic_point_heavy_font(mark);
         let snapshot = font.clone();
         let default_source_id = font.default_source_id().unwrap();
+        let glyph_id = font.glyph_id_by_name("g00000").unwrap();
+        let layer_id = font
+            .layer_id_for_glyph_source(glyph_id, default_source_id)
+            .unwrap();
+        let other_glyph_id = font.glyph_id_by_name("g00001").unwrap();
         let start = Instant::now();
 
-        font.glyph_mut("g00000")
+        font.layer_mut(layer_id)
             .expect("target glyph should exist")
-            .layer_for_source_mut(default_source_id)
-            .expect("target source layer should exist")
             .set_width(777.0);
 
         let elapsed = start.elapsed();
 
         assert_eq!(
-            font.glyph("g00000")
-                .unwrap()
-                .layer_for_source(default_source_id)
-                .unwrap()
+            font.layer(layer_id)
+                .expect("target source layer should exist")
                 .width(),
             777.0
         );
         assert_ne!(
             snapshot
-                .glyph("g00000")
-                .unwrap()
-                .layer_for_source(snapshot.default_source_id().unwrap())
-                .unwrap()
+                .layer(layer_id)
+                .expect("target source layer should exist")
                 .width(),
             777.0
         );
         assert!(!Arc::ptr_eq(
-            font.inner.glyphs.get("g00000").unwrap(),
-            snapshot.inner.glyphs.get("g00000").unwrap()
+            font.state.data.glyphs.get(&glyph_id).unwrap(),
+            snapshot.state.data.glyphs.get(&glyph_id).unwrap()
         ));
         assert!(Arc::ptr_eq(
-            font.inner.glyphs.get("g00001").unwrap(),
-            snapshot.inner.glyphs.get("g00001").unwrap()
+            font.state.data.glyphs.get(&other_glyph_id).unwrap(),
+            snapshot.state.data.glyphs.get(&other_glyph_id).unwrap()
         ));
 
         print_perf_mark("single glyph mutation after snapshot", mark, elapsed);
         assert!(
             elapsed < Duration::from_secs(1),
             "single-glyph COW mutation should stay comfortably sub-second; got {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn perf_mark_large_font_rename_rebuilds_indexes_within_budget() {
+        let mark = PerfFontMark {
+            label: "cjk-scale",
+            glyphs: 10_000,
+            contours_per_glyph: 2,
+            points_per_contour: 8,
+        };
+        let mut font = synthetic_point_heavy_font(mark);
+        let glyph_id = font.glyph_id_by_name("g00000").unwrap();
+        let start = Instant::now();
+
+        font.rename_glyph(glyph_id, GlyphName::from("g00000.alt"))
+            .unwrap();
+
+        let elapsed = start.elapsed();
+
+        assert_eq!(font.glyph_id_by_name("g00000"), None);
+        assert_eq!(font.glyph_id_by_name("g00000.alt"), Some(glyph_id));
+        print_perf_mark("rename glyph and rebuild indexes", mark, elapsed);
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "glyph rename index rebuild should stay comfortably sub-second; got {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn perf_mark_large_font_unicode_update_rebuilds_indexes_within_budget() {
+        let mark = PerfFontMark {
+            label: "cjk-scale",
+            glyphs: 10_000,
+            contours_per_glyph: 2,
+            points_per_contour: 8,
+        };
+        let mut font = synthetic_point_heavy_font(mark);
+        let glyph_id = font.glyph_id_by_name("g00000").unwrap();
+        let unicode = 0xE000;
+        let start = Instant::now();
+
+        font.set_glyph_unicodes(glyph_id, vec![0x41, unicode])
+            .unwrap();
+
+        let elapsed = start.elapsed();
+
+        assert_eq!(
+            font.glyphs_by_unicode(unicode)
+                .map(Glyph::id)
+                .collect::<Vec<_>>(),
+            vec![glyph_id]
+        );
+        print_perf_mark("set glyph unicodes and rebuild indexes", mark, elapsed);
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "glyph Unicode index rebuild should stay comfortably sub-second; got {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn perf_mark_large_font_layer_membership_rebuilds_indexes_within_budget() {
+        let mark = PerfFontMark {
+            label: "cjk-scale",
+            glyphs: 10_000,
+            contours_per_glyph: 2,
+            points_per_contour: 8,
+        };
+        let mut font = synthetic_point_heavy_font(mark);
+        let glyph_id = font.glyph_id_by_name("g00000").unwrap();
+        let source_id = font.add_source(Source::new("Bold".to_string(), Location::new()));
+        let start = Instant::now();
+
+        let layer_id = font.create_glyph_layer(glyph_id, source_id).unwrap();
+        let removed = font.remove_glyph_layer(layer_id).unwrap();
+
+        let elapsed = start.elapsed();
+
+        assert_eq!(removed.id(), layer_id);
+        assert_eq!(font.glyph_id_by_layer(layer_id), None);
+        assert_eq!(font.layer_id_for_glyph_source(glyph_id, source_id), None);
+        print_perf_mark("create/remove layer and rebuild indexes", mark, elapsed);
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "glyph layer membership index rebuild should stay comfortably sub-second; got {elapsed:?}"
         );
     }
 }

--- a/crates/shift-store/src/change_set.rs
+++ b/crates/shift-store/src/change_set.rs
@@ -32,7 +32,7 @@ impl ShiftStore {
             upsert_source(&tx, source.id(), Some(source.name()))?;
         }
 
-        for glyph in font.glyphs().values().map(|glyph| glyph.as_ref()) {
+        for glyph in font.glyphs() {
             upsert_glyph(&tx, glyph.id(), glyph.glyph_name())?;
             replace_glyph_unicodes(&tx, glyph.id(), glyph.unicodes())?;
 

--- a/crates/shift-workspace/src/workspace.rs
+++ b/crates/shift-workspace/src/workspace.rs
@@ -127,8 +127,15 @@ impl FontWorkspace {
         let name = name.trim();
         let mut next_font = self.font.clone();
 
+        let glyph_id =
+            next_font
+                .glyph_id_by_name(from_name)
+                .ok_or_else(|| WorkspaceError::InvalidInput {
+                    kind: "glyph name",
+                    value: from_name.to_string(),
+                })?;
         let existing = next_font
-            .glyph(from_name)
+            .glyph(glyph_id)
             .ok_or_else(|| WorkspaceError::InvalidInput {
                 kind: "glyph name",
                 value: from_name.to_string(),
@@ -144,21 +151,16 @@ impl FontWorkspace {
             });
         }
 
-        if from_name != name && next_font.glyph(name).is_some() {
+        if from_name != name && next_font.glyph_id_by_name(name).is_some() {
             return Err(WorkspaceError::InvalidInput {
                 kind: "glyph name",
                 value: format!("{name} already exists"),
             });
         }
 
-        let Some(mut glyph) = next_font.take_glyph(from_name) else {
-            return Err(WorkspaceError::InvalidInput {
-                kind: "glyph name",
-                value: from_name.to_string(),
-            });
-        };
-
-        let glyph_id = glyph.id();
+        let glyph = next_font
+            .glyph(glyph_id)
+            .ok_or(CoreError::GlyphNotFound(glyph_id))?;
         let from_name = glyph.glyph_name().clone();
         let from_unicodes = glyph.unicodes().to_vec();
         let glyph_name = shift_font::GlyphName::new(name.to_string()).map_err(|_| {
@@ -168,11 +170,13 @@ impl FontWorkspace {
             }
         })?;
 
-        glyph.set_name(glyph_name);
-        glyph.set_unicodes(unicodes);
+        next_font.rename_glyph(glyph_id, glyph_name)?;
+        next_font.set_glyph_unicodes(glyph_id, unicodes)?;
+        let glyph = next_font
+            .glyph(glyph_id)
+            .ok_or(CoreError::GlyphNotFound(glyph_id))?;
         let to_name = glyph.glyph_name().clone();
         let to_unicodes = glyph.unicodes().to_vec();
-        next_font.put_glyph(glyph);
 
         self.commit_font(
             next_font,
@@ -198,7 +202,7 @@ impl FontWorkspace {
         let mut next_font = self.font.clone();
         let mut change_set = FontChangeSet::default();
 
-        if next_font.glyph(&target.glyph_name).is_none() {
+        if next_font.glyph_id_by_name(&target.glyph_name).is_none() {
             let mut glyph = Glyph::new(target.glyph_name.clone());
             if let Some(unicode) = target.unicode {
                 glyph.add_unicode(unicode);
@@ -209,7 +213,7 @@ impl FontWorkspace {
                 500.0,
             ));
             change_set.push(FontChange::GlyphCreated(GlyphCreated::from(&glyph)));
-            next_font.insert_glyph(glyph);
+            next_font.insert_glyph(glyph)?;
         }
 
         if !next_font
@@ -223,42 +227,43 @@ impl FontWorkspace {
             });
         }
 
-        if let Some(glyph) = next_font.glyph_mut(&target.glyph_name)
-            && glyph.layer(target.layer_id).is_none()
-        {
-            glyph.set_layer(GlyphLayer::with_width(
-                LayerId::new(),
-                target.source_id,
-                500.0,
-            ));
+        let glyph_id = next_font
+            .glyph_id_by_name(&target.glyph_name)
+            .ok_or_else(|| WorkspaceError::InvalidInput {
+                kind: "glyph name",
+                value: target.glyph_name.clone(),
+            })?;
+
+        if next_font.layer(target.layer_id).is_none() {
+            next_font.insert_glyph_layer(
+                glyph_id,
+                GlyphLayer::with_width(target.layer_id, target.source_id, 500.0),
+            )?;
         }
 
-        let glyph =
-            next_font
-                .glyph(&target.glyph_name)
-                .ok_or_else(|| WorkspaceError::InvalidInput {
-                    kind: "glyph name",
-                    value: target.glyph_name.clone(),
-                })?;
+        let glyph = next_font
+            .glyph(glyph_id)
+            .ok_or_else(|| WorkspaceError::InvalidInput {
+                kind: "glyph name",
+                value: target.glyph_name.clone(),
+            })?;
         let change_target = GlyphLayerChangeTarget {
             glyph_id: glyph.id(),
             glyph_name: glyph.glyph_name().clone(),
             source_id: target.source_id,
             layer_id: target.layer_id,
         };
-        let glyph = next_font.glyph_mut(&target.glyph_name).ok_or_else(|| {
-            WorkspaceError::InvalidInput {
-                kind: "glyph name",
-                value: target.glyph_name.clone(),
-            }
-        })?;
 
-        if let Some(unicode) = target.unicode {
-            glyph.add_unicode(unicode);
+        if let Some(unicode) = target.unicode
+            && !glyph.unicodes().contains(&unicode)
+        {
+            let mut unicodes = glyph.unicodes().to_vec();
+            unicodes.push(unicode);
+            next_font.set_glyph_unicodes(glyph_id, unicodes)?;
         }
 
         let layer =
-            glyph
+            next_font
                 .layer_mut(target.layer_id)
                 .ok_or_else(|| WorkspaceError::InvalidInput {
                     kind: "layer ID",

--- a/crates/shift-workspace/tests/workspace_test.rs
+++ b/crates/shift-workspace/tests/workspace_test.rs
@@ -32,7 +32,7 @@ fn creates_workspace_with_source_package_and_working_store() {
             .as_deref(),
         Some("Test Font")
     );
-    assert!(workspace.font().glyphs().is_empty());
+    assert_eq!(workspace.font().glyph_count(), 0);
 }
 
 #[test]
@@ -64,7 +64,7 @@ fn imports_external_fonts_without_a_save_target() {
         }
     );
     assert_eq!(workspace.save_target(), None);
-    assert!(!workspace.font().glyphs().is_empty());
+    assert!(workspace.font().glyph_count() > 0);
     assert!(
         workspace
             .font_info()


### PR DESCRIPTION
## Summary

Adds the stable-ID font substrate for `shift-font`.

- Stores glyphs by stable `GlyphId` in an ordered `IndexMap` instead of keying authored state by glyph name.
- Adds a private runtime `FontIndex` beside serializable `FontData` inside `FontState`.
- Exposes explicit lookup and identity mutation APIs on `Font`, including name, Unicode, layer, and glyph/source lookup paths.
- Removes broad attached-glyph mutation from callers and updates workspace, bridge, store, and backend paths to go through `Font` operations.
- Keeps `Font` cheap to clone with `Arc` copy-on-write semantics.

## Design Notes

`FontData` is now authored serializable data only. `FontIndex` is derived runtime state and is rebuilt/validated when deserializing. Bulk glyph insertion uses incremental index validation/update to avoid quadratic font construction, while broader identity edits still rebuild/validate indexes for now.

## Tests

- `cargo test --workspace`
- `pnpm --filter @shift/desktop typecheck`
- commit hook also ran `cargo check`, `cargo fmt`, `cargo clippy`, and `cargo test`

Added coverage for glyph name uniqueness, stable glyph order, Unicode multi-match lookup, layer lookup freshness, serde index rebuilds, and perf marks for rename/Unicode/layer index rebuilds.
