### PR TITLE
Make font changes target layers by id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1740,6 +1740,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "uuid",
 ]
 
 [[package]]

--- a/apps/desktop/src/renderer/src/lib/model/SourcePositionPatch.ts
+++ b/apps/desktop/src/renderer/src/lib/model/SourcePositionPatch.ts
@@ -1,9 +1,10 @@
 import type { GlyphPositions } from "@shift/glyph-state";
+import type { AnchorId, PointId } from "@shift/types";
 
 export type BridgePositionPatchPayload = readonly [
-  pointIds: BigUint64Array | null,
+  pointIds: PointId[] | null,
   pointCoords: Float64Array | null,
-  anchorIds: BigUint64Array | null,
+  anchorIds: AnchorId[] | null,
   anchorCoords: Float64Array | null,
 ];
 
@@ -31,28 +32,28 @@ export class SourcePositionPatch {
   }
 
   toBridgePayload(): BridgePositionPatchPayload {
-    const pointIds: bigint[] = [];
+    const pointIds: PointId[] = [];
     const pointCoords: number[] = [];
-    const anchorIds: bigint[] = [];
+    const anchorIds: AnchorId[] = [];
     const anchorCoords: number[] = [];
 
     for (const position of this.positions) {
       switch (position.kind) {
         case "point":
-          pointIds.push(BigInt(position.id));
+          pointIds.push(position.id);
           pointCoords.push(position.x, position.y);
           break;
         case "anchor":
-          anchorIds.push(BigInt(position.id));
+          anchorIds.push(position.id);
           anchorCoords.push(position.x, position.y);
           break;
       }
     }
 
     return [
-      pointIds.length > 0 ? BigUint64Array.from(pointIds) : null,
+      pointIds.length > 0 ? pointIds : null,
       pointCoords.length > 0 ? Float64Array.from(pointCoords) : null,
-      anchorIds.length > 0 ? BigUint64Array.from(anchorIds) : null,
+      anchorIds.length > 0 ? anchorIds : null,
       anchorCoords.length > 0 ? Float64Array.from(anchorCoords) : null,
     ];
   }

--- a/crates/shift-backends/src/binary/reader.rs
+++ b/crates/shift-backends/src/binary/reader.rs
@@ -156,8 +156,11 @@ fn font_from_skrifa(font: &FontRef<'_>) -> FormatBackendResult<Font> {
             .unwrap_or_else(|| format!("uni{unicode:04X}"));
 
         let mut glyph = Glyph::with_unicode(glyph_name, unicode);
-        let mut layer =
-            GlyphLayer::with_width(LayerId::new(), default_source_id, advance_width as f64);
+        let mut layer = GlyphLayer::with_width(
+            LayerId::new(),
+            default_source_id.clone(),
+            advance_width as f64,
+        );
         let mut contours = pen.contours();
         detect_smooth_points(&mut contours);
         for contour in contours {

--- a/crates/shift-backends/src/designspace/reader.rs
+++ b/crates/shift-backends/src/designspace/reader.rs
@@ -108,7 +108,7 @@ impl DesignspaceReader {
             default_location,
             default_ds_source.filename.clone(),
         ));
-        font.set_default_source_id(default_source_id);
+        font.set_default_source_id(default_source_id.clone());
         move_glyph_layers_to_source(&mut font, default_ufo_source_id, default_source_id)?;
 
         // Cache loaded UFO fonts so we don't re-read the same file for support layers.
@@ -165,11 +165,12 @@ impl DesignspaceReader {
 
             // Copy glyphs from the resolved layer into the new layer.
             for source_glyph in source_font.glyphs() {
-                if let Some(source_layer) = source_glyph.layer_for_source(source_source_id) {
+                if let Some(source_layer) = source_glyph.layer_for_source(source_source_id.clone())
+                {
                     if let Some(glyph_id) = font.glyph_id_by_name(source_glyph.name()) {
                         font.insert_glyph_layer(
                             glyph_id,
-                            source_layer.clone_with_identity(LayerId::new(), source_id),
+                            source_layer.clone_with_identity(LayerId::new(), source_id.clone()),
                         )?;
                     }
                 }
@@ -242,7 +243,7 @@ fn load_axisless_designspace(
         Location::new(),
         default_source.filename.clone(),
     ));
-    font.set_default_source_id(default_source_id);
+    font.set_default_source_id(default_source_id.clone());
     move_glyph_layers_to_source(&mut font, default_ufo_source_id, default_source_id)?;
 
     let mut ufo_cache: HashMap<String, Font> = HashMap::new();
@@ -289,11 +290,11 @@ fn load_axisless_designspace(
         ));
 
         for source_glyph in source_font.glyphs() {
-            if let Some(source_layer) = source_glyph.layer_for_source(source_source_id) {
+            if let Some(source_layer) = source_glyph.layer_for_source(source_source_id.clone()) {
                 if let Some(glyph_id) = font.glyph_id_by_name(source_glyph.name()) {
                     font.insert_glyph_layer(
                         glyph_id,
-                        source_layer.clone_with_identity(LayerId::new(), source_id),
+                        source_layer.clone_with_identity(LayerId::new(), source_id.clone()),
                     )?;
                 }
             }
@@ -435,11 +436,11 @@ fn move_glyph_layers_to_source(
     let layer_moves: Vec<_> = font
         .glyphs()
         .filter_map(|glyph| {
-            glyph.layer_for_source(from_source_id).map(|layer| {
+            glyph.layer_for_source(from_source_id.clone()).map(|layer| {
                 (
                     glyph.id(),
                     layer.id(),
-                    layer.clone_with_identity(LayerId::new(), to_source_id),
+                    layer.clone_with_identity(LayerId::new(), to_source_id.clone()),
                 )
             })
         })

--- a/crates/shift-backends/src/glyphs/reader.rs
+++ b/crates/shift-backends/src/glyphs/reader.rs
@@ -190,7 +190,7 @@ impl FontReader for GlyphsReader {
                 }
             }
             let source_id = font.add_source(Source::new(master.name.clone(), location));
-            source_by_master_id.insert(master.id.clone(), source_id);
+            source_by_master_id.insert(master.id.clone(), source_id.clone());
             if master_idx == glyphs_font.default_master_idx {
                 font.set_default_source_id(source_id);
             }
@@ -203,7 +203,7 @@ impl FontReader for GlyphsReader {
             }
 
             for layer in &glyph.layers {
-                let Some(source_id) = source_by_master_id.get(layer.master_id()).copied() else {
+                let Some(source_id) = source_by_master_id.get(layer.master_id()).cloned() else {
                     continue;
                 };
 

--- a/crates/shift-backends/src/ufo/reader.rs
+++ b/crates/shift-backends/src/ufo/reader.rs
@@ -248,17 +248,18 @@ impl FontReader for UfoReader {
         let norad_default_layer_name = norad_font.layers.default_layer().name().clone();
         for layer in norad_font.layers.iter() {
             let source_id = if layer.name() == &norad_default_layer_name {
-                default_source_id
+                default_source_id.clone()
             } else {
                 font.add_source(Source::new(layer.name().to_string(), Location::new()))
             };
 
             for norad_glyph in layer.iter() {
-                let glyph = Self::convert_glyph_layer(norad_glyph, LayerId::new(), source_id);
+                let glyph =
+                    Self::convert_glyph_layer(norad_glyph, LayerId::new(), source_id.clone());
 
                 if let Some(glyph_id) = font.glyph_id_by_name(glyph.name()) {
                     for layer_data in glyph.layers().values() {
-                        font.insert_glyph_layer(glyph_id, layer_data.as_ref().clone())?;
+                        font.insert_glyph_layer(glyph_id.clone(), layer_data.as_ref().clone())?;
                     }
                 } else {
                     font.insert_glyph(glyph)?;

--- a/crates/shift-backends/src/ufo/writer.rs
+++ b/crates/shift-backends/src/ufo/writer.rs
@@ -282,10 +282,10 @@ impl UfoWriter {
         let default_layer = norad_font.layers.default_layer_mut();
 
         for glyph in font.glyphs() {
-            let Some(source_id) = default_source_id else {
+            let Some(ref source_id) = default_source_id else {
                 continue;
             };
-            if let Some(layer_data) = glyph.layer_for_source(source_id) {
+            if let Some(layer_data) = glyph.layer_for_source(source_id.clone()) {
                 let norad_glyph = Self::convert_glyph(glyph, layer_data);
                 default_layer.insert_glyph(norad_glyph);
             }

--- a/crates/shift-backends/tests/round_trip/ufo.rs
+++ b/crates/shift-backends/tests/round_trip/ufo.rs
@@ -144,7 +144,7 @@ fn preserves_components_anchors_layers_and_kerning() {
         .layers()
         .iter()
         .max_by_key(|(_, layer)| layer.contours().len())
-        .map(|(layer_id, _)| *layer_id)
+        .map(|(layer_id, _)| layer_id.clone())
         .expect("E should have a main layer");
     original
         .layer_mut(e_layer_id)

--- a/crates/shift-bridge/__test__/index.spec.mjs
+++ b/crates/shift-bridge/__test__/index.spec.mjs
@@ -132,7 +132,7 @@ describe("Bridge", () => {
     expect(Array.from(change.values)).toEqual([500, 10, 20]);
   });
 
-  it("applies point positions through the sparse typed-array hot path", () => {
+  it("applies point positions through the sparse bridge patch path", () => {
     const glyphRef = createDefaultLayer();
     const contourId = bridge.addContour(glyphRef).changed.contourIds[0];
     const pointId = bridge.addPoint(glyphRef, contourId, 10, 20, "onCurve", false).changed
@@ -140,7 +140,7 @@ describe("Bridge", () => {
 
     bridge.applyPositionPatch(
       glyphRef,
-      new BigUint64Array([BigInt(pointId)]),
+      [pointId],
       new Float64Array([30, 40]),
       null,
       null,
@@ -181,11 +181,11 @@ describe("Bridge", () => {
     expect(() =>
       bridge.applyPositionPatch(
         glyphRef,
-        new BigUint64Array([1n]),
+        ["not-a-point"],
         new Float64Array([10]),
         null,
         null,
       ),
-    ).toThrow(/point positions/i);
+    ).toThrow(/point ID/i);
   });
 });

--- a/crates/shift-bridge/index.d.ts
+++ b/crates/shift-bridge/index.d.ts
@@ -44,10 +44,10 @@ export declare class Bridge {
   removePoints(glyphRef: GlyphLayerRef, pointIds: Array<PointId>): NapiGlyphStructureChange
   toggleSmooth(glyphRef: GlyphLayerRef, pointId: PointId): NapiGlyphStructureChange
   /**
-   * Bulk position sync. IDs use BigUint64Array to avoid lossy float packing.
+   * Bulk position sync. IDs are stable typed strings from the current glyph state.
    * Coords are interleaved [x0, y0, x1, y1, ...].
    */
-  applyPositionPatch(glyphRef: GlyphLayerRef, pointIds?: BigUint64Array | undefined | null, pointCoords?: Float64Array | undefined | null, anchorIds?: BigUint64Array | undefined | null, anchorCoords?: Float64Array | undefined | null): void
+  applyPositionPatch(glyphRef: GlyphLayerRef, pointIds?: Array<PointId> | null, pointCoords?: Float64Array | undefined | null, anchorIds?: Array<AnchorId> | null, anchorCoords?: Float64Array | undefined | null): void
   restoreState(glyphRef: GlyphLayerRef, structure: NapiGlyphStructure, values: Float64Array): NapiGlyphStructureChange
 }
 

--- a/crates/shift-bridge/src/bridge.rs
+++ b/crates/shift-bridge/src/bridge.rs
@@ -1,5 +1,5 @@
 use crate::errors::{self, BridgeError, BridgeResult};
-use crate::input::parse;
+use crate::input::{parse, BridgeParse};
 use napi::bindgen_prelude::*;
 use napi::{Error, Status};
 use napi_derive::napi;
@@ -788,7 +788,9 @@ impl Bridge {
   ) -> errors::Result<NapiGlyphStructureChange> {
     let contour_id = parse::<ContourId>(&contour_id)?;
     let layer_id = self.existing_layer_id(glyph_ref)?;
-    let layer = self.workspace_mut()?.open_contour(layer_id, contour_id)?;
+    let layer = self
+      .workspace_mut()?
+      .open_contour(layer_id, contour_id.clone())?;
     let changed = GlyphChangedEntities {
       contour_ids: vec![contour_id],
       ..Default::default()
@@ -807,7 +809,9 @@ impl Bridge {
   ) -> errors::Result<NapiGlyphStructureChange> {
     let contour_id = parse::<ContourId>(&contour_id)?;
     let layer_id = self.existing_layer_id(glyph_ref)?;
-    let layer = self.workspace_mut()?.close_contour(layer_id, contour_id)?;
+    let layer = self
+      .workspace_mut()?
+      .close_contour(layer_id, contour_id.clone())?;
     let changed = GlyphChangedEntities {
       contour_ids: vec![contour_id],
       ..Default::default()
@@ -828,7 +832,7 @@ impl Bridge {
     let layer_id = self.existing_layer_id(glyph_ref)?;
     let layer = self
       .workspace_mut()?
-      .reverse_contour(layer_id, contour_id)?;
+      .reverse_contour(layer_id, contour_id.clone())?;
     let changed = GlyphChangedEntities {
       contour_ids: vec![contour_id],
       ..Default::default()
@@ -904,7 +908,9 @@ impl Bridge {
   ) -> errors::Result<NapiGlyphStructureChange> {
     let parsed_id = parse::<PointId>(&point_id)?;
     let layer_id = self.existing_layer_id(glyph_ref)?;
-    let layer = self.workspace_mut()?.toggle_smooth(layer_id, parsed_id)?;
+    let layer = self
+      .workspace_mut()?
+      .toggle_smooth(layer_id, parsed_id.clone())?;
     let changed = GlyphChangedEntities {
       point_ids: vec![parsed_id],
       ..Default::default()
@@ -915,35 +921,31 @@ impl Bridge {
     Ok(change.into())
   }
 
-  /// Bulk position sync. IDs use BigUint64Array to avoid lossy float packing.
+  /// Bulk position sync. IDs are stable typed strings from the current glyph state.
   /// Coords are interleaved [x0, y0, x1, y1, ...].
   #[napi]
   pub fn apply_position_patch(
     &mut self,
     glyph_ref: GlyphLayerRef,
-    point_ids: Option<BigUint64Array>,
+    #[napi(ts_arg_type = "Array<PointId> | null")] point_ids: Option<Vec<String>>,
     point_coords: Option<Float64Array>,
-    anchor_ids: Option<BigUint64Array>,
+    #[napi(ts_arg_type = "Array<AnchorId> | null")] anchor_ids: Option<Vec<String>>,
     anchor_coords: Option<Float64Array>,
   ) -> errors::Result<()> {
-    let point_position_changes = read_point_position_changes(&point_ids, &point_coords)?;
+    let point_ids = parse_ids::<PointId>(point_ids.as_deref())?;
+    let anchor_ids = parse_ids::<shift_font::AnchorId>(anchor_ids.as_deref())?;
+    let point_position_changes = read_point_position_changes(point_ids.as_deref(), &point_coords)?;
     let has_anchor_updates = anchor_ids.as_ref().is_some_and(|ids| !ids.is_empty())
       || anchor_coords
         .as_ref()
         .is_some_and(|coords| !coords.is_empty());
     let layer_id = self.existing_layer_id(glyph_ref)?;
-    let point_id_slice = point_ids.as_ref().map(|ids| {
-      let ids: &[u64] = ids;
-      ids
-    });
+    let point_id_slice = point_ids.as_deref();
     let point_coord_slice = point_coords.as_ref().map(|coords| {
       let coords: &[f64] = coords;
       coords
     });
-    let anchor_id_slice = anchor_ids.as_ref().map(|ids| {
-      let ids: &[u64] = ids;
-      ids
-    });
+    let anchor_id_slice = anchor_ids.as_deref();
     let anchor_coord_slice = anchor_coords.as_ref().map(|coords| {
       let coords: &[f64] = coords;
       coords
@@ -977,11 +979,15 @@ impl Bridge {
     let layer_id = self.existing_layer_id(glyph_ref)?;
     let mut layer = self
       .font()?
-      .layer(layer_id)
-      .ok_or(shift_font::error::CoreError::LayerNotFound(layer_id))?
+      .layer(layer_id.clone())
+      .ok_or(shift_font::error::CoreError::LayerNotFound(
+        layer_id.clone(),
+      ))?
       .clone();
     apply_state_to_layer(&mut layer, &structure, values)?;
-    let layer = self.workspace_mut()?.replace_layer(layer_id, layer)?;
+    let layer = self
+      .workspace_mut()?
+      .replace_layer(layer_id.clone(), layer)?;
     let change = GlyphStructureChange::from_layer(&layer, Default::default());
 
     self.mark_font_changed();
@@ -989,15 +995,20 @@ impl Bridge {
   }
 }
 
+fn parse_ids<T: BridgeParse>(ids: Option<&[String]>) -> BridgeResult<Option<Vec<T>>> {
+  ids
+    .map(|ids| ids.iter().map(|id| parse::<T>(id)).collect())
+    .transpose()
+}
+
 fn read_point_position_changes(
-  point_ids: &Option<BigUint64Array>,
+  point_ids: Option<&[PointId]>,
   point_coords: &Option<Float64Array>,
 ) -> BridgeResult<Vec<shift_font::PointPosition>> {
-  let Some(point_ids) = point_ids.as_ref() else {
+  let Some(point_ids) = point_ids else {
     return Ok(Vec::new());
   };
 
-  let point_ids: &[u64] = point_ids;
   let point_coords = point_coords
     .as_ref()
     .ok_or_else(|| BridgeError::InvalidInput {
@@ -1021,7 +1032,7 @@ fn read_point_position_changes(
       .iter()
       .enumerate()
       .map(|(index, point_id)| shift_font::PointPosition {
-        point_id: PointId::from_raw(*point_id as u128),
+        point_id: point_id.clone(),
         x: point_coords[index * 2],
         y: point_coords[index * 2 + 1],
       })

--- a/crates/shift-font/Cargo.toml
+++ b/crates/shift-font/Cargo.toml
@@ -15,6 +15,7 @@ kurbo = "0.13.0"
 linesweeper = "0.3.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 thiserror = "2.0.18"
+uuid = { version = "1.17.0", features = ["v4"] }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/crates/shift-font/src/changes.rs
+++ b/crates/shift-font/src/changes.rs
@@ -32,6 +32,7 @@ impl From<FontChange> for FontChangeSet {
 pub enum FontChange {
     GlyphCreated(GlyphCreated),
     GlyphIdentityChanged(GlyphIdentityChanged),
+    GlyphLayerCreated(GlyphLayerCreated),
     LayerMetricsChanged(LayerMetricsChanged),
     ContourAdded(ContourAdded),
     ContourOpenClosedChanged(ContourOpenClosedChanged),
@@ -63,63 +64,60 @@ impl FontChange {
         })
     }
 
-    pub fn layer_metrics_changed(target: GlyphLayerChangeTarget, layer: &GlyphLayer) -> Self {
-        Self::LayerMetricsChanged(LayerMetricsChanged::from_layer(target, layer))
+    pub fn glyph_layer_created(
+        glyph_id: GlyphId,
+        name: Option<GlyphName>,
+        layer: &GlyphLayer,
+    ) -> Self {
+        Self::GlyphLayerCreated(GlyphLayerCreated::from_layer(glyph_id, name, layer))
     }
 
-    pub fn contour_added(target: GlyphLayerChangeTarget, contour: &Contour) -> Self {
+    pub fn layer_metrics_changed(layer: &GlyphLayer) -> Self {
+        Self::LayerMetricsChanged(LayerMetricsChanged::from_layer(layer))
+    }
+
+    pub fn contour_added(layer_id: LayerId, contour: &Contour) -> Self {
         Self::ContourAdded(ContourAdded {
-            target,
+            layer_id,
             contour: ContourValue::from(contour),
         })
     }
 
     pub fn contour_open_closed_changed(
-        target: GlyphLayerChangeTarget,
+        layer_id: LayerId,
         contour_id: ContourId,
         closed: bool,
     ) -> Self {
         Self::ContourOpenClosedChanged(ContourOpenClosedChanged {
-            target,
+            layer_id,
             contour_id,
             closed,
         })
     }
 
-    pub fn points_added(
-        target: GlyphLayerChangeTarget,
-        contour: &Contour,
-        point_ids: Vec<PointId>,
-    ) -> Self {
+    pub fn points_added(layer_id: LayerId, contour: &Contour, point_ids: Vec<PointId>) -> Self {
         Self::PointsAdded(PointsAdded {
-            target,
+            layer_id,
             contour: ContourValue::from(contour),
             point_ids,
         })
     }
 
-    pub fn point_smooth_changed(
-        target: GlyphLayerChangeTarget,
-        point_id: PointId,
-        smooth: bool,
-    ) -> Self {
+    pub fn point_smooth_changed(layer_id: LayerId, point_id: PointId, smooth: bool) -> Self {
         Self::PointSmoothChanged(PointSmoothChanged {
-            target,
+            layer_id,
             point_id,
             smooth,
         })
     }
 
-    pub fn point_positions_changed(
-        target: GlyphLayerChangeTarget,
-        points: Vec<PointPosition>,
-    ) -> Self {
-        Self::PointPositionsChanged(PointPositionsChanged { target, points })
+    pub fn point_positions_changed(layer_id: LayerId, points: Vec<PointPosition>) -> Self {
+        Self::PointPositionsChanged(PointPositionsChanged { layer_id, points })
     }
 
-    pub fn layer_geometry_replaced(target: GlyphLayerChangeTarget, layer: &GlyphLayer) -> Self {
+    pub fn layer_geometry_replaced(layer: &GlyphLayer) -> Self {
         Self::LayerGeometryReplaced(LayerGeometryReplaced {
-            target,
+            layer_id: layer.id(),
             layer: GlyphLayerValue::from(layer),
         })
     }
@@ -152,24 +150,39 @@ pub struct GlyphIdentityChanged {
 }
 
 #[derive(Clone, Debug)]
-pub struct GlyphLayerChangeTarget {
+pub struct GlyphLayerCreated {
     pub glyph_id: GlyphId,
-    pub glyph_name: GlyphName,
     pub source_id: SourceId,
     pub layer_id: LayerId,
+    pub name: Option<GlyphName>,
+    pub width: f64,
+    pub height: Option<f64>,
+}
+
+impl GlyphLayerCreated {
+    pub fn from_layer(glyph_id: GlyphId, name: Option<GlyphName>, layer: &GlyphLayer) -> Self {
+        Self {
+            glyph_id,
+            source_id: layer.source_id(),
+            layer_id: layer.id(),
+            name,
+            width: layer.width(),
+            height: layer.height(),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
 pub struct LayerMetricsChanged {
-    pub target: GlyphLayerChangeTarget,
+    pub layer_id: LayerId,
     pub width: f64,
     pub height: Option<f64>,
 }
 
 impl LayerMetricsChanged {
-    pub fn from_layer(target: GlyphLayerChangeTarget, layer: &GlyphLayer) -> Self {
+    pub fn from_layer(layer: &GlyphLayer) -> Self {
         Self {
-            target,
+            layer_id: layer.id(),
             width: layer.width(),
             height: layer.height(),
         }
@@ -178,41 +191,41 @@ impl LayerMetricsChanged {
 
 #[derive(Clone, Debug)]
 pub struct ContourAdded {
-    pub target: GlyphLayerChangeTarget,
+    pub layer_id: LayerId,
     pub contour: ContourValue,
 }
 
 #[derive(Clone, Debug)]
 pub struct ContourOpenClosedChanged {
-    pub target: GlyphLayerChangeTarget,
+    pub layer_id: LayerId,
     pub contour_id: ContourId,
     pub closed: bool,
 }
 
 #[derive(Clone, Debug)]
 pub struct PointsAdded {
-    pub target: GlyphLayerChangeTarget,
+    pub layer_id: LayerId,
     pub contour: ContourValue,
     pub point_ids: Vec<PointId>,
 }
 
 #[derive(Clone, Debug)]
 pub struct PointsDeleted {
-    pub target: GlyphLayerChangeTarget,
+    pub layer_id: LayerId,
     pub contour: ContourValue,
     pub point_ids: Vec<PointId>,
 }
 
 #[derive(Clone, Debug)]
 pub struct PointSmoothChanged {
-    pub target: GlyphLayerChangeTarget,
+    pub layer_id: LayerId,
     pub point_id: PointId,
     pub smooth: bool,
 }
 
 #[derive(Clone, Debug)]
 pub struct PointPositionsChanged {
-    pub target: GlyphLayerChangeTarget,
+    pub layer_id: LayerId,
     pub points: Vec<PointPosition>,
 }
 
@@ -225,7 +238,7 @@ pub struct PointPosition {
 
 #[derive(Clone, Debug)]
 pub struct LayerGeometryReplaced {
-    pub target: GlyphLayerChangeTarget,
+    pub layer_id: LayerId,
     pub layer: GlyphLayerValue,
 }
 

--- a/crates/shift-font/src/composite.rs
+++ b/crates/shift-font/src/composite.rs
@@ -227,10 +227,7 @@ fn flatten_component_named(
         }
 
         let mut placed_anchors = Vec::new();
-        let mut components: Vec<_> = layer.components().iter().collect();
-        components.sort_by_key(|(id, _)| id.raw());
-
-        for (_, component) in components {
+        for component in layer.components_iter() {
             let explicit_transform = component.matrix();
             let component_transform = resolve_component_transform(
                 provider,
@@ -291,10 +288,7 @@ pub fn resolve_component_instances_for_layer(
     visiting.insert(root_glyph_name.to_string());
 
     let mut placed_anchors = Vec::new();
-    let mut components: Vec<_> = layer.components().iter().collect();
-    components.sort_by_key(|(id, _)| id.raw());
-
-    for (_, component) in components {
+    for component in layer.components_iter() {
         let explicit_transform = component.matrix();
         let component_transform = resolve_component_transform(
             provider,
@@ -493,13 +487,13 @@ mod tests {
         let source_id = font.default_source_id().unwrap();
 
         let mut base = Glyph::new("base".to_string());
-        let mut base_layer = test_layer(source_id, 500.0);
+        let mut base_layer = test_layer(source_id.clone(), 500.0);
         base_layer.add_contour(two_point_contour(0.0, 0.0, 10.0, 10.0));
         base.set_layer(base_layer);
         font.insert_glyph(base).unwrap();
 
         let mut composite = Glyph::new("comp".to_string());
-        let mut composite_layer = test_layer(source_id, 500.0);
+        let mut composite_layer = test_layer(source_id.clone(), 500.0);
         let composite_layer_id = composite_layer.id();
         composite_layer.add_component(Component::new("base".to_string()));
         composite.set_layer(composite_layer);
@@ -522,7 +516,7 @@ mod tests {
         let source_id = font.default_source_id().unwrap();
 
         let mut a = Glyph::new("A".to_string());
-        let mut a_layer = test_layer(source_id, 500.0);
+        let mut a_layer = test_layer(source_id.clone(), 500.0);
         let a_layer_id = a_layer.id();
         a_layer.add_component(Component::new("B".to_string()));
         a_layer.add_component(Component::new("C".to_string()));
@@ -530,14 +524,14 @@ mod tests {
         font.insert_glyph(a).unwrap();
 
         let mut b = Glyph::new("B".to_string());
-        let mut b_layer = test_layer(source_id, 500.0);
+        let mut b_layer = test_layer(source_id.clone(), 500.0);
         b_layer.add_contour(two_point_contour(0.0, 0.0, 20.0, 20.0));
         b_layer.add_component(Component::new("A".to_string()));
         b.set_layer(b_layer);
         font.insert_glyph(b).unwrap();
 
         let mut c = Glyph::new("C".to_string());
-        let mut c_layer = test_layer(source_id, 500.0);
+        let mut c_layer = test_layer(source_id.clone(), 500.0);
         c_layer.add_contour(two_point_contour(10.0, 0.0, 30.0, 20.0));
         c.set_layer(c_layer);
         font.insert_glyph(c).unwrap();
@@ -558,21 +552,21 @@ mod tests {
         let source_id = font.default_source_id().unwrap();
 
         let mut base = Glyph::new("base".to_string());
-        let mut base_layer = test_layer(source_id, 500.0);
+        let mut base_layer = test_layer(source_id.clone(), 500.0);
         base_layer.add_contour(two_point_contour(0.0, 0.0, 10.0, 0.0));
         base_layer.add_anchor(Anchor::new(Some("top".to_string()), 100.0, 200.0));
         base.set_layer(base_layer);
         font.insert_glyph(base).unwrap();
 
         let mut mark = Glyph::new("mark".to_string());
-        let mut mark_layer = test_layer(source_id, 500.0);
+        let mut mark_layer = test_layer(source_id.clone(), 500.0);
         mark_layer.add_contour(two_point_contour(0.0, 0.0, 10.0, 0.0));
         mark_layer.add_anchor(Anchor::new(Some("_top".to_string()), 5.0, 0.0));
         mark.set_layer(mark_layer);
         font.insert_glyph(mark).unwrap();
 
         let mut comp = Glyph::new("comp".to_string());
-        let mut comp_layer = test_layer(source_id, 500.0);
+        let mut comp_layer = test_layer(source_id.clone(), 500.0);
         let comp_layer_id = comp_layer.id();
         comp_layer.add_component(Component::new("base".to_string()));
         comp_layer.add_component(Component::new("mark".to_string()));
@@ -600,14 +594,14 @@ mod tests {
         let source_id = font.default_source_id().unwrap();
 
         let mut mark = Glyph::new("mark".to_string());
-        let mut mark_layer = test_layer(source_id, 500.0);
+        let mut mark_layer = test_layer(source_id.clone(), 500.0);
         mark_layer.add_contour(two_point_contour(0.0, 0.0, 10.0, 0.0));
         mark_layer.add_anchor(Anchor::new(Some("top".to_string()), 5.0, 0.0));
         mark.set_layer(mark_layer);
         font.insert_glyph(mark).unwrap();
 
         let mut comp = Glyph::new("comp".to_string());
-        let mut comp_layer = test_layer(source_id, 500.0);
+        let mut comp_layer = test_layer(source_id.clone(), 500.0);
         let comp_layer_id = comp_layer.id();
         let matrix = Transform::translate(30.0, 40.0);
         comp_layer.add_component(Component::with_matrix("mark".to_string(), &matrix));
@@ -634,21 +628,21 @@ mod tests {
         let source_id = font.default_source_id().unwrap();
 
         let mut base = Glyph::new("base".to_string());
-        let mut base_layer = test_layer(source_id, 500.0);
+        let mut base_layer = test_layer(source_id.clone(), 500.0);
         base_layer.add_anchor(Anchor::new(Some("top".to_string()), 100.0, 200.0));
         base_layer.add_contour(two_point_contour(0.0, 0.0, 10.0, 0.0));
         base.set_layer(base_layer);
         font.insert_glyph(base).unwrap();
 
         let mut mark = Glyph::new("mark".to_string());
-        let mut mark_layer = test_layer(source_id, 500.0);
+        let mut mark_layer = test_layer(source_id.clone(), 500.0);
         mark_layer.add_anchor(Anchor::new(Some("top_extra".to_string()), 5.0, 0.0));
         mark_layer.add_contour(two_point_contour(0.0, 0.0, 10.0, 0.0));
         mark.set_layer(mark_layer);
         font.insert_glyph(mark).unwrap();
 
         let mut comp = Glyph::new("comp".to_string());
-        let mut comp_layer = test_layer(source_id, 500.0);
+        let mut comp_layer = test_layer(source_id.clone(), 500.0);
         let comp_layer_id = comp_layer.id();
         comp_layer.add_anchor(Anchor::new(Some("parent_top".to_string()), 0.0, 0.0));
         comp_layer.add_component(Component::new("base".to_string()));
@@ -677,14 +671,14 @@ mod tests {
         let source_id = font.default_source_id().unwrap();
 
         let mut base = Glyph::new("base".to_string());
-        let mut base_layer = test_layer(source_id, 500.0);
+        let mut base_layer = test_layer(source_id.clone(), 500.0);
         base_layer.add_anchor(Anchor::new(Some("top".to_string()), 100.0, 200.0));
         base_layer.add_contour(two_point_contour(0.0, 0.0, 10.0, 0.0));
         base.set_layer(base_layer);
         font.insert_glyph(base).unwrap();
 
         let mut mark = Glyph::new("mark".to_string());
-        let mut mark_layer = test_layer(source_id, 500.0);
+        let mut mark_layer = test_layer(source_id.clone(), 500.0);
         mark_layer.add_anchor(Anchor::new(Some("_top".to_string()), 5.0, 0.0));
         mark_layer.add_anchor(Anchor::new(Some("top".to_string()), 5.0, 20.0));
         mark_layer.add_contour(two_point_contour(0.0, 0.0, 10.0, 0.0));
@@ -692,7 +686,7 @@ mod tests {
         font.insert_glyph(mark).unwrap();
 
         let mut comp = Glyph::new("comp".to_string());
-        let mut comp_layer = test_layer(source_id, 500.0);
+        let mut comp_layer = test_layer(source_id.clone(), 500.0);
         let comp_layer_id = comp_layer.id();
         comp_layer.add_component(Component::new("base".to_string()));
         comp_layer.add_component(Component::new("mark".to_string()));

--- a/crates/shift-font/src/ir/anchor.rs
+++ b/crates/shift-font/src/ir/anchor.rs
@@ -29,7 +29,7 @@ impl Anchor {
     }
 
     pub fn id(&self) -> AnchorId {
-        self.id
+        self.id.clone()
     }
 
     pub fn name(&self) -> Option<&str> {
@@ -91,7 +91,7 @@ mod tests {
     #[test]
     fn anchor_with_id_roundtrip() {
         let id = AnchorId::new();
-        let a = Anchor::with_id(id, Some("top".to_string()), 1.0, 2.0);
+        let a = Anchor::with_id(id.clone(), Some("top".to_string()), 1.0, 2.0);
         assert_eq!(a.id(), id);
         assert_eq!(a.name(), Some("top"));
     }

--- a/crates/shift-font/src/ir/component.rs
+++ b/crates/shift-font/src/ir/component.rs
@@ -240,7 +240,7 @@ impl Component {
     }
 
     pub fn id(&self) -> ComponentId {
-        self.id
+        self.id.clone()
     }
 
     pub fn base_glyph(&self) -> &GlyphName {

--- a/crates/shift-font/src/ir/contour.rs
+++ b/crates/shift-font/src/ir/contour.rs
@@ -43,7 +43,7 @@ impl Contour {
     }
 
     pub fn id(&self) -> ContourId {
-        self.id
+        self.id.clone()
     }
 
     pub fn points(&self) -> &[Point] {
@@ -80,7 +80,7 @@ impl Contour {
 
     pub fn add_point(&mut self, x: f64, y: f64, point_type: PointType, smooth: bool) -> PointId {
         let id = PointId::new();
-        let point = Point::new(id, x, y, point_type, smooth);
+        let point = Point::new(id.clone(), x, y, point_type, smooth);
         self.points.push(point);
         id
     }
@@ -136,7 +136,7 @@ impl Contour {
     ) -> Option<PointId> {
         let index = self.points.iter().position(|p| p.id() == before_id)?;
         let id = PointId::new();
-        let point = Point::new(id, x, y, point_type, smooth);
+        let point = Point::new(id.clone(), x, y, point_type, smooth);
         self.points.insert(index, point);
         Some(id)
     }

--- a/crates/shift-font/src/ir/entity.rs
+++ b/crates/shift-font/src/ir/entity.rs
@@ -1,22 +1,19 @@
 use serde::{Deserialize, Serialize};
-use std::sync::atomic::{AtomicU64, Ordering};
 
-static ENTITY_COUNTER: AtomicU64 = AtomicU64::new(1);
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct EntityId(u64);
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct EntityId(String);
 
 impl EntityId {
     pub fn new() -> Self {
-        Self(ENTITY_COUNTER.fetch_add(1, Ordering::Relaxed))
+        Self(prefixed_id("entity"))
     }
 
-    pub fn raw(&self) -> u64 {
-        self.0
+    pub fn as_str(&self) -> &str {
+        &self.0
     }
 
-    pub fn from_raw(raw: u64) -> Self {
-        Self(raw)
+    pub fn from_raw(raw: impl std::fmt::Display) -> Self {
+        Self(format!("entity_{raw}"))
     }
 }
 
@@ -28,14 +25,14 @@ impl Default for EntityId {
 
 impl std::fmt::Display for EntityId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+        f.write_str(self.as_str())
     }
 }
 
 macro_rules! typed_id {
-    ($name:ident) => {
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-        pub struct $name(EntityId);
+    ($name:ident, $prefix:literal) => {
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
+        pub struct $name(String);
 
         impl Default for $name {
             fn default() -> Self {
@@ -45,49 +42,76 @@ macro_rules! typed_id {
 
         impl $name {
             pub fn new() -> Self {
-                Self(EntityId::new())
+                Self(prefixed_id($prefix))
             }
 
-            pub fn raw(&self) -> u64 {
-                self.0.raw()
+            pub fn as_str(&self) -> &str {
+                &self.0
             }
 
-            pub fn from_raw(raw: u128) -> Self {
-                Self(EntityId::from_raw(raw as u64))
-            }
-        }
-
-        impl From<$name> for u64 {
-            fn from(id: $name) -> u64 {
-                id.raw()
+            pub fn from_raw(raw: impl std::fmt::Display) -> Self {
+                let raw = raw.to_string();
+                if raw.starts_with(concat!($prefix, "_")) {
+                    Self(raw)
+                } else {
+                    Self(format!("{}_{raw}", $prefix))
+                }
             }
         }
 
         impl std::fmt::Display for $name {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                write!(f, "{}", self.0)
+                f.write_str(self.as_str())
             }
         }
 
         impl std::str::FromStr for $name {
-            type Err = std::num::ParseIntError;
+            type Err = InvalidEntityId;
 
             fn from_str(s: &str) -> Result<Self, Self::Err> {
-                let raw: u64 = s.parse()?;
-                Ok(Self::from_raw(raw as u128))
+                if s.starts_with(concat!($prefix, "_")) {
+                    Ok(Self(s.to_string()))
+                } else {
+                    Err(InvalidEntityId {
+                        expected_prefix: $prefix,
+                        value: s.to_string(),
+                    })
+                }
             }
         }
     };
 }
 
-typed_id!(PointId);
-typed_id!(ContourId);
-typed_id!(ComponentId);
-typed_id!(AnchorId);
-typed_id!(GuidelineId);
-typed_id!(LayerId);
-typed_id!(GlyphId);
-typed_id!(SourceId);
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidEntityId {
+    expected_prefix: &'static str,
+    value: String,
+}
+
+impl std::fmt::Display for InvalidEntityId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "expected ID with prefix '{}_', got '{}'",
+            self.expected_prefix, self.value
+        )
+    }
+}
+
+impl std::error::Error for InvalidEntityId {}
+
+fn prefixed_id(prefix: &str) -> String {
+    format!("{prefix}_{}", uuid::Uuid::new_v4().simple())
+}
+
+typed_id!(PointId, "point");
+typed_id!(ContourId, "contour");
+typed_id!(ComponentId, "component");
+typed_id!(AnchorId, "anchor");
+typed_id!(GuidelineId, "guideline");
+typed_id!(LayerId, "layer");
+typed_id!(GlyphId, "glyph");
+typed_id!(SourceId, "source");
 
 #[cfg(test)]
 mod tests {
@@ -103,16 +127,16 @@ mod tests {
     #[test]
     fn typed_id_from_raw_roundtrip() {
         let original = PointId::new();
-        let raw = original.raw();
-        let reconstructed = PointId::from_raw(raw as u128);
+        let raw = original.as_str();
+        let reconstructed = PointId::from_raw(raw);
         assert_eq!(original, reconstructed);
     }
 
     #[test]
     fn typed_id_display_and_parse() {
-        let id = ContourId::from_raw(12345u128);
-        assert_eq!(id.to_string(), "12345");
-        let parsed: ContourId = "12345".parse().unwrap();
+        let id = ContourId::from_raw("test");
+        assert_eq!(id.to_string(), "contour_test");
+        let parsed: ContourId = "contour_test".parse().unwrap();
         assert_eq!(id, parsed);
     }
 }

--- a/crates/shift-font/src/ir/font.rs
+++ b/crates/shift-font/src/ir/font.rs
@@ -118,14 +118,14 @@ impl FontIndex {
         for (glyph_id, glyph) in glyphs {
             if *glyph_id != glyph.id() {
                 return Err(CoreError::MismatchedGlyphId {
-                    key: *glyph_id,
+                    key: glyph_id.clone(),
                     glyph_id: glyph.id(),
                 });
             }
 
             if index
                 .glyph_by_name
-                .insert(glyph.glyph_name().clone(), *glyph_id)
+                .insert(glyph.glyph_name().clone(), glyph_id.clone())
                 .is_some()
             {
                 return Err(CoreError::DuplicateGlyphName(glyph.glyph_name().clone()));
@@ -136,21 +136,25 @@ impl FontIndex {
                     .glyphs_by_unicode
                     .entry(*unicode)
                     .or_default()
-                    .push(*glyph_id);
+                    .push(glyph_id.clone());
             }
 
             for layer in glyph.layers().values().map(Arc::as_ref) {
-                if index.layer_owner.insert(layer.id(), *glyph_id).is_some() {
+                if index
+                    .layer_owner
+                    .insert(layer.id(), glyph_id.clone())
+                    .is_some()
+                {
                     return Err(CoreError::DuplicateLayerId(layer.id()));
                 }
 
                 if index
                     .layer_by_glyph_source
-                    .insert((*glyph_id, layer.source_id()), layer.id())
+                    .insert((glyph_id.clone(), layer.source_id()), layer.id())
                     .is_some()
                 {
                     return Err(CoreError::DuplicateGlyphLayer {
-                        glyph_id: *glyph_id,
+                        glyph_id: glyph_id.clone(),
                         source_id: layer.source_id(),
                     });
                 }
@@ -180,11 +184,11 @@ impl FontIndex {
 
             if self
                 .layer_by_glyph_source
-                .contains_key(&(glyph_id, layer.source_id()))
+                .contains_key(&(glyph_id.clone(), layer.source_id()))
                 || !local_sources.insert(layer.source_id())
             {
                 return Err(CoreError::DuplicateGlyphLayer {
-                    glyph_id,
+                    glyph_id: glyph_id.clone(),
                     source_id: layer.source_id(),
                 });
             }
@@ -195,19 +199,19 @@ impl FontIndex {
 
     fn insert_glyph(&mut self, glyph_id: GlyphId, glyph: &Glyph) {
         self.glyph_by_name
-            .insert(glyph.glyph_name().clone(), glyph_id);
+            .insert(glyph.glyph_name().clone(), glyph_id.clone());
 
         for unicode in glyph.unicodes() {
             self.glyphs_by_unicode
                 .entry(*unicode)
                 .or_default()
-                .push(glyph_id);
+                .push(glyph_id.clone());
         }
 
         for layer in glyph.layers().values().map(Arc::as_ref) {
-            self.layer_owner.insert(layer.id(), glyph_id);
+            self.layer_owner.insert(layer.id(), glyph_id.clone());
             self.layer_by_glyph_source
-                .insert((glyph_id, layer.source_id()), layer.id());
+                .insert((glyph_id.clone(), layer.source_id()), layer.id());
         }
     }
 
@@ -226,7 +230,7 @@ impl FontIndex {
         for layer in glyph.layers().values().map(Arc::as_ref) {
             self.layer_owner.remove(&layer.id());
             self.layer_by_glyph_source
-                .remove(&(glyph_id, layer.source_id()));
+                .remove(&(glyph_id.clone(), layer.source_id()));
         }
     }
 }
@@ -363,7 +367,7 @@ impl Font {
         let source_id = source.id();
         let data = self.data_mut();
         if data.default_source_id.is_none() {
-            data.default_source_id = Some(source_id);
+            data.default_source_id = Some(source_id.clone());
         }
         data.sources.push(source);
         source_id
@@ -376,7 +380,7 @@ impl Font {
     }
 
     pub fn default_source_id(&self) -> Option<SourceId> {
-        self.data().default_source_id
+        self.data().default_source_id.clone()
     }
 
     pub fn set_default_source_id(&mut self, source_id: SourceId) {
@@ -384,7 +388,7 @@ impl Font {
     }
 
     pub fn default_source(&self) -> Option<&Source> {
-        let default_source_id = self.data().default_source_id?;
+        let default_source_id = self.data().default_source_id.clone()?;
         self.data()
             .sources
             .iter()
@@ -404,7 +408,7 @@ impl Font {
     }
 
     pub fn glyph_id_by_name(&self, name: &str) -> Option<GlyphId> {
-        self.index().glyph_by_name.get(name).copied()
+        self.index().glyph_by_name.get(name).cloned()
     }
 
     pub fn glyph_by_name(&self, name: &str) -> Option<&Glyph> {
@@ -417,11 +421,11 @@ impl Font {
             .get(&unicode)
             .into_iter()
             .flatten()
-            .filter_map(|glyph_id| self.glyph(*glyph_id))
+            .filter_map(|glyph_id| self.glyph(glyph_id.clone()))
     }
 
     pub fn glyph_id_by_layer(&self, layer_id: LayerId) -> Option<GlyphId> {
-        self.index().layer_owner.get(&layer_id).copied()
+        self.index().layer_owner.get(&layer_id).cloned()
     }
 
     pub fn layer_id_for_glyph_source(
@@ -432,16 +436,16 @@ impl Font {
         self.index()
             .layer_by_glyph_source
             .get(&(glyph_id, source_id))
-            .copied()
+            .cloned()
     }
 
     pub fn layer(&self, layer_id: LayerId) -> Option<&GlyphLayer> {
-        let glyph_id = self.glyph_id_by_layer(layer_id)?;
+        let glyph_id = self.glyph_id_by_layer(layer_id.clone())?;
         self.glyph(glyph_id)?.layer(layer_id)
     }
 
     pub fn layer_mut(&mut self, layer_id: LayerId) -> Option<&mut GlyphLayer> {
-        let glyph_id = self.glyph_id_by_layer(layer_id)?;
+        let glyph_id = self.glyph_id_by_layer(layer_id.clone())?;
         self.data_mut()
             .glyphs
             .get_mut(&glyph_id)
@@ -453,11 +457,12 @@ impl Font {
         if self.data().glyphs.contains_key(&glyph_id) {
             return Err(CoreError::DuplicateGlyphId(glyph_id));
         }
-        self.index().validate_glyph_insert(glyph_id, &glyph)?;
+        self.index()
+            .validate_glyph_insert(glyph_id.clone(), &glyph)?;
 
         let state = self.state_mut();
-        state.index.insert_glyph(glyph_id, &glyph);
-        state.data.glyphs.insert(glyph_id, Arc::new(glyph));
+        state.index.insert_glyph(glyph_id.clone(), &glyph);
+        state.data.glyphs.insert(glyph_id.clone(), Arc::new(glyph));
         Ok(glyph_id)
     }
 
@@ -511,7 +516,7 @@ impl Font {
             return Err(CoreError::SourceNotFound(source_id));
         }
         if self
-            .layer_id_for_glyph_source(glyph_id, source_id)
+            .layer_id_for_glyph_source(glyph_id.clone(), source_id.clone())
             .is_some()
         {
             return Err(CoreError::DuplicateGlyphLayer {
@@ -520,9 +525,9 @@ impl Font {
             });
         }
 
-        let layer = GlyphLayer::new(LayerId::new(), source_id);
+        let layer = GlyphLayer::new(LayerId::new(), source_id.clone());
         let layer_id = layer.id();
-        self.insert_glyph_layer(glyph_id, layer)?;
+        self.insert_glyph_layer(glyph_id.clone(), layer)?;
         Ok(layer_id)
     }
 
@@ -549,8 +554,8 @@ impl Font {
 
     pub fn remove_glyph_layer(&mut self, layer_id: LayerId) -> CoreResult<GlyphLayer> {
         let glyph_id = self
-            .glyph_id_by_layer(layer_id)
-            .ok_or(CoreError::LayerNotFound(layer_id))?;
+            .glyph_id_by_layer(layer_id.clone())
+            .ok_or(CoreError::LayerNotFound(layer_id.clone()))?;
         let mut state = (*self.state).clone();
         let glyph = state
             .data
@@ -558,7 +563,7 @@ impl Font {
             .get_mut(&glyph_id)
             .ok_or(CoreError::GlyphNotFound(glyph_id))?;
         let layer = Arc::make_mut(glyph)
-            .remove_layer(layer_id)
+            .remove_layer(layer_id.clone())
             .ok_or(CoreError::LayerNotFound(layer_id))?;
         state.rebuild_index()?;
         self.state = Arc::new(state);
@@ -625,8 +630,11 @@ mod tests {
 
         for glyph_index in 0..mark.glyphs {
             let mut glyph = Glyph::with_unicode(format!("g{glyph_index:05}"), glyph_index as u32);
-            let mut layer =
-                GlyphLayer::with_width(LayerId::new(), source_id, 500.0 + glyph_index as f64);
+            let mut layer = GlyphLayer::with_width(
+                LayerId::new(),
+                source_id.clone(),
+                500.0 + glyph_index as f64,
+            );
 
             for contour_index in 0..mark.contours_per_glyph {
                 let mut contour = Contour::new();
@@ -678,19 +686,22 @@ mod tests {
         let glyph_id = font.insert_glyph(glyph).unwrap();
 
         assert_eq!(font.glyph_count(), 1);
-        assert!(font.glyph(glyph_id).is_some());
-        assert_eq!(font.glyph_id_by_name("A"), Some(glyph_id));
+        assert!(font.glyph(glyph_id.clone()).is_some());
+        assert_eq!(font.glyph_id_by_name("A"), Some(glyph_id.clone()));
         assert!(font.glyph_by_name("A").is_some());
-        assert_eq!(font.glyph_id_by_layer(layer_id), Some(glyph_id));
         assert_eq!(
-            font.layer_id_for_glyph_source(glyph_id, font.default_source_id().unwrap()),
-            Some(layer_id)
+            font.glyph_id_by_layer(layer_id.clone()),
+            Some(glyph_id.clone())
+        );
+        assert_eq!(
+            font.layer_id_for_glyph_source(glyph_id.clone(), font.default_source_id().unwrap()),
+            Some(layer_id.clone())
         );
         assert_eq!(
             font.glyphs_by_unicode(65)
                 .map(Glyph::id)
                 .collect::<Vec<_>>(),
-            vec![glyph_id]
+            vec![glyph_id.clone()]
         );
     }
 
@@ -700,14 +711,14 @@ mod tests {
         let glyph = Glyph::with_unicode("A".to_string(), 65);
         let glyph_id = font.insert_glyph(glyph).unwrap();
 
-        let taken = font.remove_glyph(glyph_id);
+        let taken = font.remove_glyph(glyph_id.clone());
         assert!(taken.is_some());
         assert_eq!(font.glyph_count(), 0);
         assert_eq!(font.glyph_id_by_name("A"), None);
 
         font.insert_glyph(taken.unwrap()).unwrap();
         assert_eq!(font.glyph_count(), 1);
-        assert_eq!(font.glyph_id_by_name("A"), Some(glyph_id));
+        assert_eq!(font.glyph_id_by_name("A"), Some(glyph_id.clone()));
     }
 
     #[test]
@@ -739,12 +750,12 @@ mod tests {
         let mut font = Font::new();
         let glyph_id = font.insert_glyph(Glyph::new("A")).unwrap();
 
-        font.rename_glyph(glyph_id, GlyphName::from("A.alt"))
+        font.rename_glyph(glyph_id.clone(), GlyphName::from("A.alt"))
             .unwrap();
 
         assert_eq!(font.glyph_id_by_name("A"), None);
-        assert_eq!(font.glyph_id_by_name("A.alt"), Some(glyph_id));
-        assert_eq!(font.glyph(glyph_id).unwrap().name(), "A.alt");
+        assert_eq!(font.glyph_id_by_name("A.alt"), Some(glyph_id.clone()));
+        assert_eq!(font.glyph(glyph_id.clone()).unwrap().name(), "A.alt");
     }
 
     #[test]
@@ -765,7 +776,7 @@ mod tests {
         let mut font = Font::new();
         let source_id = font.default_source_id().unwrap();
         let mut glyph = Glyph::with_unicode("A", 0x41);
-        let layer = GlyphLayer::new(LayerId::new(), source_id);
+        let layer = GlyphLayer::new(LayerId::new(), source_id.clone());
         let layer_id = layer.id();
         glyph.set_layer(layer);
         let glyph_id = font.insert_glyph(glyph).unwrap();
@@ -773,18 +784,21 @@ mod tests {
         let json = serde_json::to_string(&font).unwrap();
         let decoded: Font = serde_json::from_str(&json).unwrap();
 
-        assert_eq!(decoded.glyph_id_by_name("A"), Some(glyph_id));
-        assert_eq!(decoded.glyph_id_by_layer(layer_id), Some(glyph_id));
+        assert_eq!(decoded.glyph_id_by_name("A"), Some(glyph_id.clone()));
         assert_eq!(
-            decoded.layer_id_for_glyph_source(glyph_id, source_id),
-            Some(layer_id)
+            decoded.glyph_id_by_layer(layer_id.clone()),
+            Some(glyph_id.clone())
+        );
+        assert_eq!(
+            decoded.layer_id_for_glyph_source(glyph_id.clone(), source_id.clone()),
+            Some(layer_id.clone())
         );
         assert_eq!(
             decoded
                 .glyphs_by_unicode(0x41)
                 .map(Glyph::id)
                 .collect::<Vec<_>>(),
-            vec![glyph_id]
+            vec![glyph_id.clone()]
         );
     }
 
@@ -794,8 +808,11 @@ mod tests {
         let source_id = font.default_source_id().unwrap();
         let glyph_id = font.insert_glyph(Glyph::new("A")).unwrap();
 
-        font.create_glyph_layer(glyph_id, source_id).unwrap();
-        let error = font.create_glyph_layer(glyph_id, source_id).unwrap_err();
+        font.create_glyph_layer(glyph_id.clone(), source_id.clone())
+            .unwrap();
+        let error = font
+            .create_glyph_layer(glyph_id.clone(), source_id.clone())
+            .unwrap_err();
 
         assert!(matches!(
             error,
@@ -811,26 +828,34 @@ mod tests {
         let mut font = Font::new();
         let source_id = font.default_source_id().unwrap();
         let glyph_id = font.insert_glyph(Glyph::new("A")).unwrap();
-        let layer_id = font.create_glyph_layer(glyph_id, source_id).unwrap();
+        let layer_id = font
+            .create_glyph_layer(glyph_id.clone(), source_id.clone())
+            .unwrap();
 
-        assert_eq!(font.glyph_id_by_layer(layer_id), Some(glyph_id));
         assert_eq!(
-            font.layer_id_for_glyph_source(glyph_id, source_id),
-            Some(layer_id)
+            font.glyph_id_by_layer(layer_id.clone()),
+            Some(glyph_id.clone())
+        );
+        assert_eq!(
+            font.layer_id_for_glyph_source(glyph_id.clone(), source_id.clone()),
+            Some(layer_id.clone())
         );
 
-        font.remove_glyph_layer(layer_id).unwrap();
+        font.remove_glyph_layer(layer_id.clone()).unwrap();
 
-        assert_eq!(font.glyph_id_by_layer(layer_id), None);
-        assert_eq!(font.layer_id_for_glyph_source(glyph_id, source_id), None);
+        assert_eq!(font.glyph_id_by_layer(layer_id.clone()), None);
+        assert_eq!(
+            font.layer_id_for_glyph_source(glyph_id.clone(), source_id.clone()),
+            None
+        );
     }
 
     #[test]
     fn index_validation_rejects_duplicate_layers_for_one_glyph_source() {
         let source_id = SourceId::new();
         let mut glyph = Glyph::new("A");
-        glyph.set_layer(GlyphLayer::new(LayerId::new(), source_id));
-        glyph.set_layer(GlyphLayer::new(LayerId::new(), source_id));
+        glyph.set_layer(GlyphLayer::new(LayerId::new(), source_id.clone()));
+        glyph.set_layer(GlyphLayer::new(LayerId::new(), source_id.clone()));
         let mut glyphs = IndexMap::new();
         glyphs.insert(glyph.id(), Arc::new(glyph));
 
@@ -873,10 +898,11 @@ mod tests {
             .unwrap();
         let snapshot = font.clone();
 
-        font.set_glyph_unicodes(a, vec![0x41, 0x00C1]).unwrap();
+        font.set_glyph_unicodes(a.clone(), vec![0x41, 0x00C1])
+            .unwrap();
 
-        assert_eq!(font.glyph(a).unwrap().unicodes(), &[0x41, 0x00C1]);
-        assert_eq!(snapshot.glyph(a).unwrap().unicodes(), &[0x41]);
+        assert_eq!(font.glyph(a.clone()).unwrap().unicodes(), &[0x41, 0x00C1]);
+        assert_eq!(snapshot.glyph(a.clone()).unwrap().unicodes(), &[0x41]);
         assert!(!Arc::ptr_eq(
             font.state.data.glyphs.get(&a).unwrap(),
             snapshot.state.data.glyphs.get(&a).unwrap()
@@ -944,26 +970,26 @@ mod tests {
         let default_source_id = font.default_source_id().unwrap();
         let glyph_id = font.glyph_id_by_name("g00000").unwrap();
         let layer_id = font
-            .layer_id_for_glyph_source(glyph_id, default_source_id)
+            .layer_id_for_glyph_source(glyph_id.clone(), default_source_id.clone())
             .unwrap();
         let other_glyph_id = font.glyph_id_by_name("g00001").unwrap();
         let start = Instant::now();
 
-        font.layer_mut(layer_id)
+        font.layer_mut(layer_id.clone())
             .expect("target glyph should exist")
             .set_width(777.0);
 
         let elapsed = start.elapsed();
 
         assert_eq!(
-            font.layer(layer_id)
+            font.layer(layer_id.clone())
                 .expect("target source layer should exist")
                 .width(),
             777.0
         );
         assert_ne!(
             snapshot
-                .layer(layer_id)
+                .layer(layer_id.clone())
                 .expect("target source layer should exist")
                 .width(),
             777.0
@@ -996,13 +1022,13 @@ mod tests {
         let glyph_id = font.glyph_id_by_name("g00000").unwrap();
         let start = Instant::now();
 
-        font.rename_glyph(glyph_id, GlyphName::from("g00000.alt"))
+        font.rename_glyph(glyph_id.clone(), GlyphName::from("g00000.alt"))
             .unwrap();
 
         let elapsed = start.elapsed();
 
         assert_eq!(font.glyph_id_by_name("g00000"), None);
-        assert_eq!(font.glyph_id_by_name("g00000.alt"), Some(glyph_id));
+        assert_eq!(font.glyph_id_by_name("g00000.alt"), Some(glyph_id.clone()));
         print_perf_mark("rename glyph and rebuild indexes", mark, elapsed);
         assert!(
             elapsed < Duration::from_secs(1),
@@ -1023,7 +1049,7 @@ mod tests {
         let unicode = 0xE000;
         let start = Instant::now();
 
-        font.set_glyph_unicodes(glyph_id, vec![0x41, unicode])
+        font.set_glyph_unicodes(glyph_id.clone(), vec![0x41, unicode])
             .unwrap();
 
         let elapsed = start.elapsed();
@@ -1032,7 +1058,7 @@ mod tests {
             font.glyphs_by_unicode(unicode)
                 .map(Glyph::id)
                 .collect::<Vec<_>>(),
-            vec![glyph_id]
+            vec![glyph_id.clone()]
         );
         print_perf_mark("set glyph unicodes and rebuild indexes", mark, elapsed);
         assert!(
@@ -1054,14 +1080,19 @@ mod tests {
         let source_id = font.add_source(Source::new("Bold".to_string(), Location::new()));
         let start = Instant::now();
 
-        let layer_id = font.create_glyph_layer(glyph_id, source_id).unwrap();
-        let removed = font.remove_glyph_layer(layer_id).unwrap();
+        let layer_id = font
+            .create_glyph_layer(glyph_id.clone(), source_id.clone())
+            .unwrap();
+        let removed = font.remove_glyph_layer(layer_id.clone()).unwrap();
 
         let elapsed = start.elapsed();
 
         assert_eq!(removed.id(), layer_id);
-        assert_eq!(font.glyph_id_by_layer(layer_id), None);
-        assert_eq!(font.layer_id_for_glyph_source(glyph_id, source_id), None);
+        assert_eq!(font.glyph_id_by_layer(layer_id.clone()), None);
+        assert_eq!(
+            font.layer_id_for_glyph_source(glyph_id.clone(), source_id.clone()),
+            None
+        );
         print_perf_mark("create/remove layer and rebuild indexes", mark, elapsed);
         assert!(
             elapsed < Duration::from_secs(1),

--- a/crates/shift-font/src/ir/glyph.rs
+++ b/crates/shift-font/src/ir/glyph.rs
@@ -26,7 +26,7 @@ pub struct GlyphLayer {
     width: f64,
     height: Option<f64>,
     contours: IndexMap<ContourId, Contour>,
-    components: HashMap<ComponentId, Component>,
+    components: IndexMap<ComponentId, Component>,
     anchors: Vec<Anchor>,
     guidelines: Vec<Guideline>,
     lib: LibData,
@@ -40,7 +40,7 @@ impl GlyphLayer {
             width: 0.0,
             height: None,
             contours: IndexMap::new(),
-            components: HashMap::new(),
+            components: IndexMap::new(),
             anchors: Vec::new(),
             guidelines: Vec::new(),
             lib: LibData::new(),
@@ -55,11 +55,11 @@ impl GlyphLayer {
     }
 
     pub fn id(&self) -> LayerId {
-        self.id
+        self.id.clone()
     }
 
     pub fn source_id(&self) -> SourceId {
-        self.source_id
+        self.source_id.clone()
     }
 
     pub fn clone_with_identity(&self, id: LayerId, source_id: SourceId) -> Self {
@@ -107,7 +107,7 @@ impl GlyphLayer {
 
     pub fn add_contour(&mut self, contour: Contour) -> ContourId {
         let id = contour.id();
-        self.contours.insert(id, contour);
+        self.contours.insert(id.clone(), contour);
         id
     }
 
@@ -119,7 +119,7 @@ impl GlyphLayer {
         self.contours.clear();
     }
 
-    pub fn components(&self) -> &HashMap<ComponentId, Component> {
+    pub fn components(&self) -> &IndexMap<ComponentId, Component> {
         &self.components
     }
 
@@ -133,12 +133,12 @@ impl GlyphLayer {
 
     pub fn add_component(&mut self, component: Component) -> ComponentId {
         let id = component.id();
-        self.components.insert(id, component);
+        self.components.insert(id.clone(), component);
         id
     }
 
     pub fn remove_component(&mut self, id: ComponentId) -> Option<Component> {
-        self.components.remove(&id)
+        self.components.shift_remove(&id)
     }
 
     pub fn clear_components(&mut self) {
@@ -191,9 +191,9 @@ impl GlyphLayer {
     pub fn move_anchors(&mut self, ids: &[AnchorId], dx: f64, dy: f64) -> Vec<AnchorId> {
         let mut moved = Vec::new();
         for id in ids {
-            if let Some(anchor) = self.anchor_mut(*id) {
+            if let Some(anchor) = self.anchor_mut(id.clone()) {
                 anchor.translate(dx, dy);
-                moved.push(*id);
+                moved.push(id.clone());
             }
         }
         moved
@@ -242,7 +242,7 @@ impl Glyph {
     }
 
     pub fn id(&self) -> GlyphId {
-        self.id
+        self.id.clone()
     }
 
     pub fn name(&self) -> &str {
@@ -303,7 +303,7 @@ impl Glyph {
 
         let layer = GlyphLayer::new(LayerId::new(), source_id);
         let layer_id = layer.id();
-        self.layers.insert(layer_id, Arc::new(layer));
+        self.layers.insert(layer_id.clone(), Arc::new(layer));
         self.layer_mut(layer_id).expect("layer was just inserted")
     }
 
@@ -356,12 +356,15 @@ mod tests {
         let mut g = Glyph::new("A".to_string());
         let source_id = SourceId::new();
 
-        let layer = g.ensure_layer_for_source(source_id);
+        let layer = g.ensure_layer_for_source(source_id.clone());
         let layer_id = layer.id();
         layer.set_width(600.0);
 
-        assert_eq!(g.layer(layer_id).unwrap().width(), 600.0);
-        assert_eq!(g.layer_for_source(source_id).unwrap().id(), layer_id);
+        assert_eq!(g.layer(layer_id.clone()).unwrap().width(), 600.0);
+        assert_eq!(
+            g.layer_for_source(source_id.clone()).unwrap().id(),
+            layer_id.clone()
+        );
     }
 
     #[test]
@@ -372,24 +375,27 @@ mod tests {
         let first_layer_id = LayerId::new();
         let second_layer_id = LayerId::new();
         glyph.set_layer(GlyphLayer::with_width(
-            first_layer_id,
-            first_source_id,
+            first_layer_id.clone(),
+            first_source_id.clone(),
             500.0,
         ));
         glyph.set_layer(GlyphLayer::with_width(
-            second_layer_id,
-            second_source_id,
+            second_layer_id.clone(),
+            second_source_id.clone(),
             600.0,
         ));
         let snapshot = glyph.clone();
 
         glyph
-            .layer_mut(first_layer_id)
+            .layer_mut(first_layer_id.clone())
             .expect("first layer should exist")
             .set_width(700.0);
 
-        assert_eq!(glyph.layer(first_layer_id).unwrap().width(), 700.0);
-        assert_eq!(snapshot.layer(first_layer_id).unwrap().width(), 500.0);
+        assert_eq!(glyph.layer(first_layer_id.clone()).unwrap().width(), 700.0);
+        assert_eq!(
+            snapshot.layer(first_layer_id.clone()).unwrap().width(),
+            500.0
+        );
         assert!(!Arc::ptr_eq(
             glyph.layers.get(&first_layer_id).unwrap(),
             snapshot.layers.get(&first_layer_id).unwrap()

--- a/crates/shift-font/src/ir/guideline.rs
+++ b/crates/shift-font/src/ir/guideline.rs
@@ -53,7 +53,7 @@ impl Guideline {
     }
 
     pub fn id(&self) -> GuidelineId {
-        self.id
+        self.id.clone()
     }
 
     pub fn x(&self) -> Option<f64> {

--- a/crates/shift-font/src/ir/point.rs
+++ b/crates/shift-font/src/ir/point.rs
@@ -23,7 +23,7 @@ impl std::str::FromStr for PointType {
     }
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Point {
     id: PointId,
     x: f64,
@@ -52,7 +52,7 @@ impl Point {
     }
 
     pub fn id(&self) -> PointId {
-        self.id
+        self.id.clone()
     }
 
     pub fn x(&self) -> f64 {

--- a/crates/shift-font/src/ir/source.rs
+++ b/crates/shift-font/src/ir/source.rs
@@ -31,7 +31,7 @@ impl Source {
     }
 
     pub fn id(&self) -> SourceId {
-        self.id
+        self.id.clone()
     }
 
     pub fn name(&self) -> &str {

--- a/crates/shift-font/src/layer_edit.rs
+++ b/crates/shift-font/src/layer_edit.rs
@@ -31,7 +31,7 @@ impl ChangedEntities {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum EditableNode {
     Point(PointId),
     Anchor(AnchorId),
@@ -45,9 +45,9 @@ struct NodePosition {
 
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct BulkNodePositionUpdates<'a> {
-    pub point_ids: Option<&'a [u64]>,
+    pub point_ids: Option<&'a [PointId]>,
     pub point_coords: Option<&'a [GlyphValue]>,
-    pub anchor_ids: Option<&'a [u64]>,
+    pub anchor_ids: Option<&'a [AnchorId]>,
     pub anchor_coords: Option<&'a [GlyphValue]>,
 }
 
@@ -76,7 +76,7 @@ impl BulkPositionUpdateReader {
 
     fn read_points(
         &mut self,
-        ids: Option<&[u64]>,
+        ids: Option<&[PointId]>,
         coords: Option<&[GlyphValue]>,
     ) -> CoreResult<()> {
         let Some(ids) = ids else {
@@ -90,9 +90,7 @@ impl BulkPositionUpdateReader {
 
         for id in ids {
             let (x, y) = coords.next()?;
-            self.groups
-                .points
-                .insert(PointId::from_raw(*id as u128), NodePosition { x, y });
+            self.groups.points.insert(id.clone(), NodePosition { x, y });
         }
 
         coords.finish()
@@ -100,7 +98,7 @@ impl BulkPositionUpdateReader {
 
     fn read_anchors(
         &mut self,
-        ids: Option<&[u64]>,
+        ids: Option<&[AnchorId]>,
         coords: Option<&[GlyphValue]>,
     ) -> CoreResult<()> {
         let Some(ids) = ids else {
@@ -116,7 +114,7 @@ impl BulkPositionUpdateReader {
             let (x, y) = coords.next()?;
             self.groups
                 .anchors
-                .insert(AnchorId::from_raw(*id as u128), NodePosition { x, y });
+                .insert(id.clone(), NodePosition { x, y });
         }
 
         coords.finish()
@@ -194,7 +192,9 @@ fn invalid_position_update_input(kind: &'static str, message: impl Into<String>)
 
 impl GlyphLayer {
     fn contour_mut_or_err(&mut self, id: ContourId) -> CoreResult<&mut Contour> {
-        let contour = self.contour_mut(id).ok_or(CoreError::ContourNotFound(id))?;
+        let contour = self
+            .contour_mut(id.clone())
+            .ok_or(CoreError::ContourNotFound(id))?;
 
         Ok(contour)
     }
@@ -206,22 +206,22 @@ impl GlyphLayer {
     ) -> CoreResult<&mut Point> {
         let contour = self.contour_mut_or_err(contour_id)?;
         contour
-            .get_point_mut(point_id)
+            .get_point_mut(point_id.clone())
             .ok_or(CoreError::PointNotFound(point_id))
     }
 
     fn point_contour_or_err(&self, point_id: PointId) -> CoreResult<ContourId> {
-        self.find_point_contour(point_id)
+        self.find_point_contour(point_id.clone())
             .ok_or(CoreError::PointInContourNotFound(point_id))
     }
 
     fn point_mut_by_id_or_err(&mut self, point_id: PointId) -> CoreResult<&mut Point> {
-        let contour_id = self.point_contour_or_err(point_id)?;
+        let contour_id = self.point_contour_or_err(point_id.clone())?;
         self.point_mut_or_err(contour_id, point_id)
     }
 
     fn anchor_mut_or_err(&mut self, anchor_id: AnchorId) -> CoreResult<&mut Anchor> {
-        self.anchor_mut(anchor_id)
+        self.anchor_mut(anchor_id.clone())
             .ok_or(CoreError::AnchorNotFound(anchor_id))
     }
 
@@ -231,16 +231,16 @@ impl GlyphLayer {
     ) -> CoreResult<Vec<(PointId, ContourId)>> {
         point_ids
             .iter()
-            .map(|&point_id| {
-                self.point_contour_or_err(point_id)
-                    .map(|contour_id| (point_id, contour_id))
+            .map(|point_id| {
+                self.point_contour_or_err(point_id.clone())
+                    .map(|contour_id| (point_id.clone(), contour_id))
             })
             .collect()
     }
 
     fn points_exist_or_err(&self, point_ids: &[PointId]) -> CoreResult<()> {
         for point_id in point_ids {
-            self.point_contour_or_err(*point_id)?;
+            self.point_contour_or_err(point_id.clone())?;
         }
         Ok(())
     }
@@ -250,15 +250,15 @@ impl GlyphLayer {
         updates: &HashMap<PointId, NodePosition>,
     ) -> CoreResult<()> {
         for point_id in updates.keys() {
-            self.point_contour_or_err(*point_id)?;
+            self.point_contour_or_err(point_id.clone())?;
         }
         Ok(())
     }
 
     fn anchors_exist_or_err(&self, anchor_ids: &[AnchorId]) -> CoreResult<()> {
         for anchor_id in anchor_ids {
-            if self.anchor(*anchor_id).is_none() {
-                return Err(CoreError::AnchorNotFound(*anchor_id));
+            if self.anchor(anchor_id.clone()).is_none() {
+                return Err(CoreError::AnchorNotFound(anchor_id.clone()));
             }
         }
         Ok(())
@@ -269,8 +269,8 @@ impl GlyphLayer {
         updates: &HashMap<AnchorId, NodePosition>,
     ) -> CoreResult<()> {
         for anchor_id in updates.keys() {
-            if self.anchor(*anchor_id).is_none() {
-                return Err(CoreError::AnchorNotFound(*anchor_id));
+            if self.anchor(anchor_id.clone()).is_none() {
+                return Err(CoreError::AnchorNotFound(anchor_id.clone()));
             }
         }
         Ok(())
@@ -283,7 +283,7 @@ impl GlyphLayer {
     ) -> CoreResult<()> {
         self.points_exist_or_err(point_ids)?;
 
-        let mut remaining: HashSet<PointId> = point_ids.iter().copied().collect();
+        let mut remaining: HashSet<PointId> = point_ids.iter().cloned().collect();
         if remaining.is_empty() {
             return Ok(());
         }
@@ -307,7 +307,7 @@ impl GlyphLayer {
         &mut self,
         updates: &HashMap<PointId, NodePosition>,
     ) -> CoreResult<()> {
-        let mut remaining: HashSet<PointId> = updates.keys().copied().collect();
+        let mut remaining: HashSet<PointId> = updates.keys().cloned().collect();
         if remaining.is_empty() {
             return Ok(());
         }
@@ -337,7 +337,7 @@ impl GlyphLayer {
         updates: &HashMap<AnchorId, NodePosition>,
     ) -> CoreResult<()> {
         for (anchor_id, position) in updates {
-            self.anchor_mut_or_err(*anchor_id)?
+            self.anchor_mut_or_err(anchor_id.clone())?
                 .set_position(position.x, position.y);
         }
         Ok(())
@@ -348,8 +348,8 @@ impl GlyphLayer {
 
         for node in nodes {
             match node {
-                EditableNode::Point(point_id) => groups.points.push(*point_id),
-                EditableNode::Anchor(anchor_id) => groups.anchors.push(*anchor_id),
+                EditableNode::Point(point_id) => groups.points.push(point_id.clone()),
+                EditableNode::Anchor(anchor_id) => groups.anchors.push(anchor_id.clone()),
             }
         }
 
@@ -413,7 +413,7 @@ impl GlyphLayer {
     }
 
     pub fn remove_contour_checked(&mut self, contour_id: ContourId) -> CoreResult<Contour> {
-        self.remove_contour(contour_id)
+        self.remove_contour(contour_id.clone())
             .ok_or(CoreError::ContourNotFound(contour_id))
     }
 
@@ -442,19 +442,19 @@ impl GlyphLayer {
         op: BooleanOp,
     ) -> CoreResult<Vec<ContourId>> {
         let a = self
-            .contour(contour_id_a)
-            .ok_or(CoreError::ContourNotFound(contour_id_a))?
+            .contour(contour_id_a.clone())
+            .ok_or(CoreError::ContourNotFound(contour_id_a.clone()))?
             .clone();
         let b = self
-            .contour(contour_id_b)
-            .ok_or(CoreError::ContourNotFound(contour_id_b))?
+            .contour(contour_id_b.clone())
+            .ok_or(CoreError::ContourNotFound(contour_id_b.clone()))?
             .clone();
 
         let result =
             boolean(op, &a, &b).map_err(|e| CoreError::BooleanOperationFailed(e.to_string()))?;
 
-        self.remove_contour_checked(contour_id_a)?;
-        self.remove_contour_checked(contour_id_b)?;
+        self.remove_contour_checked(contour_id_a.clone())?;
+        self.remove_contour_checked(contour_id_b.clone())?;
 
         let mut created_ids = Vec::new();
         for contour in result.0 {
@@ -467,7 +467,7 @@ impl GlyphLayer {
 
     pub fn find_point_contour(&self, point_id: PointId) -> Option<ContourId> {
         for contour in self.contours_iter() {
-            if contour.get_point(point_id).is_some() {
+            if contour.get_point(point_id.clone()).is_some() {
                 return Some(contour.id());
             }
         }
@@ -484,7 +484,7 @@ impl GlyphLayer {
         point_type: PointType,
         is_smooth: bool,
     ) -> CoreResult<AddedPoint> {
-        let contour = self.contour_mut_or_err(contour_id)?;
+        let contour = self.contour_mut_or_err(contour_id.clone())?;
         let point_id = contour.add_point(x, y, point_type, is_smooth);
 
         Ok(AddedPoint {
@@ -501,11 +501,11 @@ impl GlyphLayer {
         point_type: PointType,
         is_smooth: bool,
     ) -> CoreResult<AddedPoint> {
-        let contour_id = self.point_contour_or_err(before_id)?;
+        let contour_id = self.point_contour_or_err(before_id.clone())?;
         let contour = self.contour_mut_or_err(contour_id)?;
 
         let point_id = contour
-            .insert_point_before(before_id, x, y, point_type, is_smooth)
+            .insert_point_before(before_id.clone(), x, y, point_type, is_smooth)
             .ok_or(CoreError::PointNotFound(before_id))?;
 
         Ok(AddedPoint {
@@ -515,10 +515,10 @@ impl GlyphLayer {
     }
 
     pub fn remove_point(&mut self, point_id: PointId) -> CoreResult<()> {
-        let contour_id = self.point_contour_or_err(point_id)?;
+        let contour_id = self.point_contour_or_err(point_id.clone())?;
         let contour = self.contour_mut_or_err(contour_id)?;
         contour
-            .remove_point(point_id)
+            .remove_point(point_id.clone())
             .ok_or(CoreError::PointNotFound(point_id))?;
         Ok(())
     }
@@ -554,7 +554,7 @@ impl GlyphLayer {
     }
 
     pub fn toggle_smooth(&mut self, point_id: PointId) -> CoreResult<bool> {
-        let contour_id = self.point_contour_or_err(point_id)?;
+        let contour_id = self.point_contour_or_err(point_id.clone())?;
         let point = self.point_mut_or_err(contour_id, point_id)?;
 
         point.toggle_smooth();
@@ -568,7 +568,7 @@ impl GlyphLayer {
         for (point_id, contour_id) in point_contours {
             let contour = self.contour_mut_or_err(contour_id)?;
             contour
-                .remove_point(point_id)
+                .remove_point(point_id.clone())
                 .ok_or(CoreError::PointNotFound(point_id))?;
         }
 
@@ -597,7 +597,7 @@ impl GlyphLayer {
         self.anchors_exist_or_err(anchor_ids)?;
 
         for anchor_id in anchor_ids {
-            self.anchor_mut_or_err(*anchor_id)?.translate(dx, dy);
+            self.anchor_mut_or_err(anchor_id.clone())?.translate(dx, dy);
         }
         Ok(())
     }
@@ -610,7 +610,7 @@ impl GlyphLayer {
         self.anchors_exist_or_err(anchor_ids)?;
 
         for anchor_id in anchor_ids {
-            let anchor = self.anchor_mut_or_err(*anchor_id)?;
+            let anchor = self.anchor_mut_or_err(anchor_id.clone())?;
             let (x, y) = transform.transform_point(anchor.x(), anchor.y());
             anchor.set_position(x, y);
         }
@@ -645,8 +645,8 @@ impl GlyphLayer {
     ) -> CoreResult<ChangedEntities> {
         let groups = Self::bulk_node_position_updates(updates)?;
         let changed = ChangedEntities {
-            point_ids: groups.points.keys().copied().collect(),
-            anchor_ids: groups.anchors.keys().copied().collect(),
+            point_ids: groups.points.keys().cloned().collect(),
+            anchor_ids: groups.anchors.keys().cloned().collect(),
             ..Default::default()
         };
 
@@ -789,7 +789,7 @@ mod tests {
         let contour_id = ContourId::new();
 
         assert!(matches!(
-            session.remove_contour_checked(contour_id),
+            session.remove_contour_checked(contour_id.clone()),
             Err(CoreError::ContourNotFound(id)) if id == contour_id
         ));
     }
@@ -797,35 +797,38 @@ mod tests {
     #[test]
     fn move_nodes_moves_points_and_anchors() {
         let (mut session, contour_id) = session_with_contour();
-        let point_id = add_point(&mut session, contour_id, 10.0, 20.0);
+        let point_id = add_point(&mut session, contour_id.clone(), 10.0, 20.0);
         let anchor_id = add_anchor(&mut session, 100.0, 200.0);
 
         session
             .move_nodes(
                 &[
-                    EditableNode::Point(point_id),
-                    EditableNode::Anchor(anchor_id),
+                    EditableNode::Point(point_id.clone()),
+                    EditableNode::Anchor(anchor_id.clone()),
                 ],
                 5.0,
                 -10.0,
             )
             .unwrap();
 
-        assert_eq!(point_position(&session, contour_id, point_id), (15.0, 10.0));
-        assert_eq!(anchor_position(&session, anchor_id), (105.0, 190.0));
+        assert_eq!(
+            point_position(&session, contour_id.clone(), point_id.clone()),
+            (15.0, 10.0)
+        );
+        assert_eq!(anchor_position(&session, anchor_id.clone()), (105.0, 190.0));
     }
 
     #[test]
     fn transform_nodes_applies_affine_transform_to_points_and_anchors() {
         let (mut session, contour_id) = session_with_contour();
-        let point_id = add_point(&mut session, contour_id, 10.0, 20.0);
+        let point_id = add_point(&mut session, contour_id.clone(), 10.0, 20.0);
         let anchor_id = add_anchor(&mut session, 100.0, 200.0);
 
         session
             .transform_nodes(
                 &[
-                    EditableNode::Point(point_id),
-                    EditableNode::Anchor(anchor_id),
+                    EditableNode::Point(point_id.clone()),
+                    EditableNode::Anchor(anchor_id.clone()),
                 ],
                 Transform {
                     xx: 2.0,
@@ -838,18 +841,21 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(point_position(&session, contour_id, point_id), (25.0, 50.0));
-        assert_eq!(anchor_position(&session, anchor_id), (205.0, 590.0));
+        assert_eq!(
+            point_position(&session, contour_id.clone(), point_id.clone()),
+            (25.0, 50.0)
+        );
+        assert_eq!(anchor_position(&session, anchor_id.clone()), (205.0, 590.0));
     }
 
     #[test]
     fn set_bulk_node_positions_sets_points_and_anchors() {
         let (mut session, contour_id) = session_with_contour();
-        let point_id = add_point(&mut session, contour_id, 10.0, 20.0);
+        let point_id = add_point(&mut session, contour_id.clone(), 10.0, 20.0);
         let anchor_id = add_anchor(&mut session, 100.0, 200.0);
-        let point_ids = [point_id.raw()];
+        let point_ids = [point_id.clone()];
         let point_coords = [300.0, 400.0];
-        let anchor_ids = [anchor_id.raw()];
+        let anchor_ids = [anchor_id.clone()];
         let anchor_coords = [500.0, 600.0];
 
         session
@@ -862,20 +868,23 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            point_position(&session, contour_id, point_id),
+            point_position(&session, contour_id.clone(), point_id.clone()),
             (300.0, 400.0)
         );
-        assert_eq!(anchor_position(&session, anchor_id), (500.0, 600.0));
+        assert_eq!(anchor_position(&session, anchor_id.clone()), (500.0, 600.0));
     }
 
     #[test]
     fn move_point_sets_absolute_position() {
         let (mut session, contour_id) = session_with_contour();
-        let point_id = add_point(&mut session, contour_id, 0.0, 0.0);
+        let point_id = add_point(&mut session, contour_id.clone(), 0.0, 0.0);
 
-        session.move_point(point_id, 50.0, 75.0).unwrap();
+        session.move_point(point_id.clone(), 50.0, 75.0).unwrap();
 
-        assert_eq!(point_position(&session, contour_id, point_id), (50.0, 75.0));
+        assert_eq!(
+            point_position(&session, contour_id.clone(), point_id.clone()),
+            (50.0, 75.0)
+        );
     }
 
     #[test]
@@ -884,7 +893,7 @@ mod tests {
         let point_id = PointId::new();
 
         assert!(matches!(
-            session.move_point(point_id, 50.0, 75.0),
+            session.move_point(point_id.clone(), 50.0, 75.0),
             Err(CoreError::PointInContourNotFound(id)) if id == point_id
         ));
     }
@@ -895,7 +904,7 @@ mod tests {
         let contour_id = ContourId::new();
 
         assert!(matches!(
-            session.add_point_to_contour(contour_id, 1.0, 2.0, PointType::OnCurve, false),
+            session.add_point_to_contour(contour_id.clone(), 1.0, 2.0, PointType::OnCurve, false),
             Err(CoreError::ContourNotFound(id)) if id == contour_id
         ));
     }
@@ -903,13 +912,21 @@ mod tests {
     #[test]
     fn move_points_multiple() {
         let (mut session, contour_id) = session_with_contour();
-        let p1 = add_point(&mut session, contour_id, 0.0, 0.0);
-        let p2 = add_point(&mut session, contour_id, 100.0, 100.0);
+        let p1 = add_point(&mut session, contour_id.clone(), 0.0, 0.0);
+        let p2 = add_point(&mut session, contour_id.clone(), 100.0, 100.0);
 
-        session.move_points(&[p1, p2], 10.0, 20.0).unwrap();
+        session
+            .move_points(&[p1.clone(), p2.clone()], 10.0, 20.0)
+            .unwrap();
 
-        assert_eq!(point_position(&session, contour_id, p1), (10.0, 20.0));
-        assert_eq!(point_position(&session, contour_id, p2), (110.0, 120.0));
+        assert_eq!(
+            point_position(&session, contour_id.clone(), p1.clone()),
+            (10.0, 20.0)
+        );
+        assert_eq!(
+            point_position(&session, contour_id.clone(), p2.clone()),
+            (110.0, 120.0)
+        );
     }
 
     #[test]
@@ -917,38 +934,43 @@ mod tests {
         let mut session = create_session();
         let c1_id = session.add_empty_contour().id();
         let p1 = session
-            .add_point_to_contour(c1_id, 0.0, 0.0, PointType::OnCurve, false)
+            .add_point_to_contour(c1_id.clone(), 0.0, 0.0, PointType::OnCurve, false)
             .unwrap();
         let p1 = p1.point_id;
 
         let c2_id = session.add_empty_contour().id();
         let p2 = session
-            .add_point_to_contour(c2_id, 50.0, 50.0, PointType::OnCurve, false)
+            .add_point_to_contour(c2_id.clone(), 50.0, 50.0, PointType::OnCurve, false)
             .unwrap();
         let p2 = p2.point_id;
 
-        session.move_points(&[p1, p2], 5.0, 5.0).unwrap();
+        session
+            .move_points(&[p1.clone(), p2.clone()], 5.0, 5.0)
+            .unwrap();
 
-        let c1 = session.contour(c1_id).unwrap();
-        let c2 = session.contour(c2_id).unwrap();
+        let c1 = session.contour(c1_id.clone()).unwrap();
+        let c2 = session.contour(c2_id.clone()).unwrap();
 
-        assert_eq!(c1.get_point(p1).unwrap().x(), 5.0);
-        assert_eq!(c2.get_point(p2).unwrap().x(), 55.0);
+        assert_eq!(c1.get_point(p1.clone()).unwrap().x(), 5.0);
+        assert_eq!(c2.get_point(p2.clone()).unwrap().x(), 55.0);
     }
 
     #[test]
     fn move_points_missing_point_does_not_partially_move_existing_points() {
         let (mut session, contour_id) = session_with_contour();
-        let point_id = add_point(&mut session, contour_id, 0.0, 0.0);
+        let point_id = add_point(&mut session, contour_id.clone(), 0.0, 0.0);
         let missing_id = PointId::new();
 
-        let result = session.move_points(&[point_id, missing_id], 10.0, 20.0);
+        let result = session.move_points(&[point_id.clone(), missing_id.clone()], 10.0, 20.0);
 
         assert!(matches!(
             result,
             Err(CoreError::PointInContourNotFound(id)) if id == missing_id
         ));
-        assert_eq!(point_position(&session, contour_id, point_id), (0.0, 0.0));
+        assert_eq!(
+            point_position(&session, contour_id.clone(), point_id.clone()),
+            (0.0, 0.0)
+        );
     }
 
     #[test]
@@ -957,25 +979,26 @@ mod tests {
         let anchor_id = add_anchor(&mut session, 10.0, 20.0);
         let missing_id = AnchorId::new();
 
-        let result = session.move_anchors_checked(&[anchor_id, missing_id], 5.0, 6.0);
+        let result =
+            session.move_anchors_checked(&[anchor_id.clone(), missing_id.clone()], 5.0, 6.0);
 
         assert!(matches!(
             result,
             Err(CoreError::AnchorNotFound(id)) if id == missing_id
         ));
-        assert_eq!(anchor_position(&session, anchor_id), (10.0, 20.0));
+        assert_eq!(anchor_position(&session, anchor_id.clone()), (10.0, 20.0));
     }
 
     #[test]
     fn move_nodes_missing_anchor_does_not_move_points() {
         let (mut session, contour_id) = session_with_contour();
-        let point_id = add_point(&mut session, contour_id, 10.0, 20.0);
+        let point_id = add_point(&mut session, contour_id.clone(), 10.0, 20.0);
         let missing_id = AnchorId::new();
 
         let result = session.move_nodes(
             &[
-                EditableNode::Point(point_id),
-                EditableNode::Anchor(missing_id),
+                EditableNode::Point(point_id.clone()),
+                EditableNode::Anchor(missing_id.clone()),
             ],
             5.0,
             6.0,
@@ -985,17 +1008,20 @@ mod tests {
             result,
             Err(CoreError::AnchorNotFound(id)) if id == missing_id
         ));
-        assert_eq!(point_position(&session, contour_id, point_id), (10.0, 20.0));
+        assert_eq!(
+            point_position(&session, contour_id.clone(), point_id.clone()),
+            (10.0, 20.0)
+        );
     }
 
     #[test]
     fn set_bulk_node_positions_missing_anchor_does_not_move_points() {
         let (mut session, contour_id) = session_with_contour();
-        let point_id = add_point(&mut session, contour_id, 10.0, 20.0);
+        let point_id = add_point(&mut session, contour_id.clone(), 10.0, 20.0);
         let missing_id = AnchorId::new();
-        let point_ids = [point_id.raw()];
+        let point_ids = [point_id.clone()];
         let point_coords = [300.0, 400.0];
-        let anchor_ids = [missing_id.raw()];
+        let anchor_ids = [missing_id.clone()];
         let anchor_coords = [500.0, 600.0];
 
         let result = session.set_bulk_node_positions(BulkNodePositionUpdates {
@@ -1009,7 +1035,10 @@ mod tests {
             result,
             Err(CoreError::AnchorNotFound(id)) if id == missing_id
         ));
-        assert_eq!(point_position(&session, contour_id, point_id), (10.0, 20.0));
+        assert_eq!(
+            point_position(&session, contour_id.clone(), point_id.clone()),
+            (10.0, 20.0)
+        );
     }
 
     #[test]
@@ -1018,7 +1047,7 @@ mod tests {
         let original_width = session.width();
         let contour_id = session.add_empty_contour().id();
         let point_id = session
-            .add_point_to_contour(contour_id, 10.0, 20.0, PointType::OnCurve, false)
+            .add_point_to_contour(contour_id.clone(), 10.0, 20.0, PointType::OnCurve, false)
             .unwrap();
         let point_id = point_id.point_id;
         let anchor_id = session.add_anchor(Anchor::new(Some("top".to_string()), 30.0, 40.0));
@@ -1026,11 +1055,11 @@ mod tests {
         session.translate_layer(5.0, -3.0);
 
         let point = session
-            .contour(contour_id)
+            .contour(contour_id.clone())
             .unwrap()
-            .get_point(point_id)
+            .get_point(point_id.clone())
             .unwrap();
-        let anchor = session.anchor(anchor_id).unwrap();
+        let anchor = session.anchor(anchor_id.clone()).unwrap();
         assert_eq!(point.x(), 15.0);
         assert_eq!(point.y(), 17.0);
         assert_eq!(anchor.x(), 35.0);
@@ -1045,7 +1074,7 @@ mod tests {
 
         session.translate_layer(12.0, -7.0);
 
-        let component = session.component(component_id).unwrap();
+        let component = session.component(component_id.clone()).unwrap();
         let matrix = component.matrix();
         assert_eq!(matrix.dx, 12.0);
         assert_eq!(matrix.dy, -7.0);
@@ -1054,44 +1083,44 @@ mod tests {
     #[test]
     fn remove_points_removes_all_requested_points() {
         let (mut session, contour_id) = session_with_contour();
-        let p1 = add_point(&mut session, contour_id, 0.0, 0.0);
-        let p2 = add_point(&mut session, contour_id, 100.0, 100.0);
-        let p3 = add_point(&mut session, contour_id, 200.0, 200.0);
+        let p1 = add_point(&mut session, contour_id.clone(), 0.0, 0.0);
+        let p2 = add_point(&mut session, contour_id.clone(), 100.0, 100.0);
+        let p3 = add_point(&mut session, contour_id.clone(), 200.0, 200.0);
 
-        session.remove_points(&[p1, p3]).unwrap();
+        session.remove_points(&[p1.clone(), p3.clone()]).unwrap();
 
-        assert!(session.find_point_contour(p2).is_some());
-        assert!(session.find_point_contour(p1).is_none());
-        assert!(session.find_point_contour(p3).is_none());
+        assert!(session.find_point_contour(p2.clone()).is_some());
+        assert!(session.find_point_contour(p1.clone()).is_none());
+        assert!(session.find_point_contour(p3.clone()).is_none());
     }
 
     #[test]
     fn remove_points_missing_point_does_not_partially_remove_existing_points() {
         let (mut session, contour_id) = session_with_contour();
-        let point_id = add_point(&mut session, contour_id, 0.0, 0.0);
+        let point_id = add_point(&mut session, contour_id.clone(), 0.0, 0.0);
         let missing_id = PointId::new();
 
-        let result = session.remove_points(&[point_id, missing_id]);
+        let result = session.remove_points(&[point_id.clone(), missing_id.clone()]);
 
         assert!(matches!(
             result,
             Err(CoreError::PointInContourNotFound(id)) if id == missing_id
         ));
-        assert!(session.find_point_contour(point_id).is_some());
+        assert!(session.find_point_contour(point_id.clone()).is_some());
     }
 
     #[test]
     fn insert_point_before_creates_bezier_pattern() {
         let (mut session, contour_id) = session_with_contour();
-        let anchor1 = add_point(&mut session, contour_id, 0.0, 0.0);
-        let anchor2 = add_point(&mut session, contour_id, 100.0, 100.0);
+        let anchor1 = add_point(&mut session, contour_id.clone(), 0.0, 0.0);
+        let anchor2 = add_point(&mut session, contour_id.clone(), 100.0, 100.0);
 
         let control = session
-            .insert_point_before(anchor2, 50.0, 75.0, PointType::OffCurve, false)
+            .insert_point_before(anchor2.clone(), 50.0, 75.0, PointType::OffCurve, false)
             .unwrap();
         let control = control.point_id;
 
-        let contour = session.contour(contour_id).unwrap();
+        let contour = session.contour(contour_id.clone()).unwrap();
         let points: Vec<_> = contour.points().iter().collect();
 
         assert_eq!(points.len(), 3);
@@ -1107,11 +1136,11 @@ mod tests {
     #[test]
     fn insert_point_before_nonexistent_fails() {
         let (mut session, contour_id) = session_with_contour();
-        add_point(&mut session, contour_id, 0.0, 0.0);
+        add_point(&mut session, contour_id.clone(), 0.0, 0.0);
         let fake_id = PointId::new();
 
         assert!(matches!(
-            session.insert_point_before(fake_id, 50.0, 50.0, PointType::OffCurve, false),
+            session.insert_point_before(fake_id.clone(), 50.0, 50.0, PointType::OffCurve, false),
             Err(CoreError::PointInContourNotFound(id)) if id == fake_id
         ));
     }
@@ -1142,17 +1171,25 @@ mod tests {
             -10.0,
         );
 
-        let contour_id = result.created_contour_ids[0];
-        let contour = session.contour(contour_id).unwrap();
+        let contour_id = result.created_contour_ids[0].clone();
+        let contour = session.contour(contour_id.clone()).unwrap();
 
         assert!(contour.is_closed());
         assert_eq!(result.created_point_ids.len(), 2);
         assert_eq!(
-            point_position(&session, contour_id, result.created_point_ids[0]),
+            point_position(
+                &session,
+                contour_id.clone(),
+                result.created_point_ids[0].clone()
+            ),
             (15.0, 10.0)
         );
         assert_eq!(
-            point_position(&session, contour_id, result.created_point_ids[1]),
+            point_position(
+                &session,
+                contour_id.clone(),
+                result.created_point_ids[1].clone()
+            ),
             (35.0, 30.0)
         );
     }

--- a/crates/shift-store/src/change_set.rs
+++ b/crates/shift-store/src/change_set.rs
@@ -37,14 +37,16 @@ impl ShiftStore {
             replace_glyph_unicodes(&tx, glyph.id(), glyph.unicodes())?;
 
             for layer in glyph.layers().values().map(|layer| layer.as_ref()) {
-                let target = font::GlyphLayerChangeTarget {
-                    glyph_id: glyph.id(),
-                    glyph_name: glyph.glyph_name().clone(),
-                    source_id: layer.source_id(),
-                    layer_id: layer.id(),
-                };
-                upsert_layer(&tx, &target, layer.width(), layer.height())?;
-                replace_layer_geometry(&tx, &target, &font::GlyphLayerValue::from(layer))?;
+                upsert_layer(
+                    &tx,
+                    layer.id(),
+                    glyph.id(),
+                    layer.source_id(),
+                    Some(glyph.glyph_name()),
+                    layer.width(),
+                    layer.height(),
+                )?;
+                replace_layer_geometry(&tx, layer.id(), &font::GlyphLayerValue::from(layer))?;
             }
         }
 
@@ -63,25 +65,33 @@ fn apply_change(tx: &Transaction<'_>, change: &font::FontChange) -> Result<(), S
             upsert_glyph(tx, change.glyph_id, &change.to_name)?;
             replace_glyph_unicodes(tx, change.glyph_id, &change.to_unicodes)
         }
+        font::FontChange::GlyphLayerCreated(change) => upsert_layer(
+            tx,
+            change.layer_id,
+            change.glyph_id,
+            change.source_id,
+            change.name.as_ref(),
+            change.width,
+            change.height,
+        ),
         font::FontChange::LayerMetricsChanged(change) => {
-            ensure_target(tx, &change.target)?;
             let rows_changed = tx.execute(
                 "
                 UPDATE glyph_layers
                 SET width = ?2, height = ?3
                 WHERE id = ?1
                 ",
-                params![layer_row_id(&change.target), change.width, change.height,],
+                params![layer_row_id(change.layer_id), change.width, change.height,],
             )?;
-            require_changed(rows_changed, "glyph layer", layer_row_id(&change.target))?;
+            require_changed(rows_changed, "glyph layer", layer_row_id(change.layer_id))?;
             Ok(())
         }
         font::FontChange::ContourAdded(change) => {
-            ensure_target(tx, &change.target)?;
-            replace_contour(tx, &change.target, &change.contour)
+            require_layer_exists(tx, change.layer_id)?;
+            replace_contour(tx, change.layer_id, &change.contour)
         }
         font::FontChange::ContourOpenClosedChanged(change) => {
-            ensure_target(tx, &change.target)?;
+            require_layer_exists(tx, change.layer_id)?;
             let rows_changed = tx.execute(
                 "
                 UPDATE glyph_layer_contours
@@ -94,15 +104,15 @@ fn apply_change(tx: &Transaction<'_>, change: &font::FontChange) -> Result<(), S
             Ok(())
         }
         font::FontChange::PointsAdded(change) => {
-            ensure_target(tx, &change.target)?;
-            replace_contour(tx, &change.target, &change.contour)
+            require_layer_exists(tx, change.layer_id)?;
+            replace_contour(tx, change.layer_id, &change.contour)
         }
         font::FontChange::PointsDeleted(change) => {
-            ensure_target(tx, &change.target)?;
-            replace_contour(tx, &change.target, &change.contour)
+            require_layer_exists(tx, change.layer_id)?;
+            replace_contour(tx, change.layer_id, &change.contour)
         }
         font::FontChange::PointSmoothChanged(change) => {
-            ensure_target(tx, &change.target)?;
+            require_layer_exists(tx, change.layer_id)?;
             let rows_changed = tx.execute(
                 "
                 UPDATE glyph_layer_points
@@ -115,7 +125,7 @@ fn apply_change(tx: &Transaction<'_>, change: &font::FontChange) -> Result<(), S
             Ok(())
         }
         font::FontChange::PointPositionsChanged(change) => {
-            ensure_target(tx, &change.target)?;
+            require_layer_exists(tx, change.layer_id)?;
             for point in &change.points {
                 let rows_changed = tx.execute(
                     "
@@ -130,19 +140,10 @@ fn apply_change(tx: &Transaction<'_>, change: &font::FontChange) -> Result<(), S
             Ok(())
         }
         font::FontChange::LayerGeometryReplaced(change) => {
-            ensure_target(tx, &change.target)?;
-            replace_layer_geometry(tx, &change.target, &change.layer)
+            require_layer_exists(tx, change.layer_id)?;
+            replace_layer_geometry(tx, change.layer_id, &change.layer)
         }
     }
-}
-
-fn ensure_target(
-    tx: &Transaction<'_>,
-    target: &font::GlyphLayerChangeTarget,
-) -> Result<(), StoreError> {
-    upsert_source(tx, target.source_id, None)?;
-    upsert_glyph(tx, target.glyph_id, &target.glyph_name)?;
-    upsert_layer(tx, target, 0.0, None)
 }
 
 fn upsert_source(
@@ -204,7 +205,10 @@ fn replace_glyph_unicodes(
 
 fn upsert_layer(
     tx: &Transaction<'_>,
-    target: &font::GlyphLayerChangeTarget,
+    layer_id: font::LayerId,
+    glyph_id: font::GlyphId,
+    source_id: font::SourceId,
+    name: Option<&font::GlyphName>,
     width: f64,
     height: Option<f64>,
 ) -> Result<(), StoreError> {
@@ -218,10 +222,10 @@ fn upsert_layer(
             name = excluded.name
         ",
         params![
-            layer_row_id(target),
-            target.glyph_id.to_string(),
-            target.source_id.to_string(),
-            target.glyph_name.as_str(),
+            layer_row_id(layer_id),
+            glyph_id.to_string(),
+            source_id.to_string(),
+            name.map(font::GlyphName::as_str),
             width,
             height,
         ],
@@ -231,27 +235,28 @@ fn upsert_layer(
 
 fn replace_layer_geometry(
     tx: &Transaction<'_>,
-    target: &font::GlyphLayerChangeTarget,
+    layer_id: font::LayerId,
     layer: &font::GlyphLayerValue,
 ) -> Result<(), StoreError> {
-    tx.execute(
+    let rows_changed = tx.execute(
         "
         UPDATE glyph_layers
         SET width = ?2, height = ?3
         WHERE id = ?1
         ",
-        params![layer_row_id(target), layer.width, layer.height],
+        params![layer_row_id(layer_id), layer.width, layer.height],
     )?;
+    require_changed(rows_changed, "glyph layer", layer_row_id(layer_id))?;
     tx.execute(
         "
         DELETE FROM glyph_layer_contours
         WHERE layer_id = ?1
         ",
-        [layer_row_id(target)],
+        [layer_row_id(layer_id)],
     )?;
 
     for (order_index, contour) in layer.contours.iter().enumerate() {
-        insert_contour(tx, target, order_index, contour)?;
+        insert_contour(tx, layer_id, order_index, contour)?;
     }
 
     Ok(())
@@ -259,7 +264,7 @@ fn replace_layer_geometry(
 
 fn replace_contour(
     tx: &Transaction<'_>,
-    target: &font::GlyphLayerChangeTarget,
+    layer_id: font::LayerId,
     contour: &font::ContourValue,
 ) -> Result<(), StoreError> {
     tx.execute(
@@ -273,7 +278,11 @@ fn replace_contour(
             closed = excluded.closed,
             layer_id = excluded.layer_id
         ",
-        params![contour.id.to_string(), layer_row_id(target), contour.closed,],
+        params![
+            contour.id.to_string(),
+            layer_row_id(layer_id),
+            contour.closed,
+        ],
     )?;
     tx.execute(
         "DELETE FROM glyph_layer_points WHERE contour_id = ?1",
@@ -289,7 +298,7 @@ fn replace_contour(
 
 fn insert_contour(
     tx: &Transaction<'_>,
-    target: &font::GlyphLayerChangeTarget,
+    layer_id: font::LayerId,
     order_index: usize,
     contour: &font::ContourValue,
 ) -> Result<(), StoreError> {
@@ -300,7 +309,7 @@ fn insert_contour(
         ",
         params![
             contour.id.to_string(),
-            layer_row_id(target),
+            layer_row_id(layer_id),
             contour.closed,
             order_index as i64,
         ],
@@ -360,6 +369,22 @@ fn require_changed(rows_changed: usize, kind: &'static str, id: String) -> Resul
     }
 }
 
-fn layer_row_id(target: &font::GlyphLayerChangeTarget) -> String {
-    format!("{}:{}", target.glyph_id, target.layer_id)
+fn require_layer_exists(tx: &Transaction<'_>, layer_id: font::LayerId) -> Result<(), StoreError> {
+    let exists: bool = tx.query_row(
+        "SELECT EXISTS(SELECT 1 FROM glyph_layers WHERE id = ?1)",
+        [layer_row_id(layer_id)],
+        |row| row.get(0),
+    )?;
+    if exists {
+        Ok(())
+    } else {
+        Err(StoreError::MissingEntity {
+            kind: "glyph layer",
+            id: layer_row_id(layer_id),
+        })
+    }
+}
+
+fn layer_row_id(layer_id: font::LayerId) -> String {
+    layer_id.to_string()
 }

--- a/crates/shift-store/src/change_set.rs
+++ b/crates/shift-store/src/change_set.rs
@@ -29,24 +29,24 @@ impl ShiftStore {
         tx.execute("DELETE FROM axes", [])?;
 
         for source in font.sources() {
-            upsert_source(&tx, source.id(), Some(source.name()))?;
+            upsert_source(&tx, &source.id(), Some(source.name()))?;
         }
 
         for glyph in font.glyphs() {
-            upsert_glyph(&tx, glyph.id(), glyph.glyph_name())?;
-            replace_glyph_unicodes(&tx, glyph.id(), glyph.unicodes())?;
+            upsert_glyph(&tx, &glyph.id(), glyph.glyph_name())?;
+            replace_glyph_unicodes(&tx, &glyph.id(), glyph.unicodes())?;
 
             for layer in glyph.layers().values().map(|layer| layer.as_ref()) {
                 upsert_layer(
                     &tx,
-                    layer.id(),
-                    glyph.id(),
-                    layer.source_id(),
+                    &layer.id(),
+                    &glyph.id(),
+                    &layer.source_id(),
                     Some(glyph.glyph_name()),
                     layer.width(),
                     layer.height(),
                 )?;
-                replace_layer_geometry(&tx, layer.id(), &font::GlyphLayerValue::from(layer))?;
+                replace_layer_geometry(&tx, &layer.id(), &font::GlyphLayerValue::from(layer))?;
             }
         }
 
@@ -58,18 +58,18 @@ impl ShiftStore {
 fn apply_change(tx: &Transaction<'_>, change: &font::FontChange) -> Result<(), StoreError> {
     match change {
         font::FontChange::GlyphCreated(change) => {
-            upsert_glyph(tx, change.glyph_id, &change.name)?;
-            replace_glyph_unicodes(tx, change.glyph_id, &change.unicodes)
+            upsert_glyph(tx, &change.glyph_id, &change.name)?;
+            replace_glyph_unicodes(tx, &change.glyph_id, &change.unicodes)
         }
         font::FontChange::GlyphIdentityChanged(change) => {
-            upsert_glyph(tx, change.glyph_id, &change.to_name)?;
-            replace_glyph_unicodes(tx, change.glyph_id, &change.to_unicodes)
+            upsert_glyph(tx, &change.glyph_id, &change.to_name)?;
+            replace_glyph_unicodes(tx, &change.glyph_id, &change.to_unicodes)
         }
         font::FontChange::GlyphLayerCreated(change) => upsert_layer(
             tx,
-            change.layer_id,
-            change.glyph_id,
-            change.source_id,
+            &change.layer_id,
+            &change.glyph_id,
+            &change.source_id,
             change.name.as_ref(),
             change.width,
             change.height,
@@ -81,17 +81,17 @@ fn apply_change(tx: &Transaction<'_>, change: &font::FontChange) -> Result<(), S
                 SET width = ?2, height = ?3
                 WHERE id = ?1
                 ",
-                params![layer_row_id(change.layer_id), change.width, change.height,],
+                params![layer_row_id(&change.layer_id), change.width, change.height,],
             )?;
-            require_changed(rows_changed, "glyph layer", layer_row_id(change.layer_id))?;
+            require_changed(rows_changed, "glyph layer", layer_row_id(&change.layer_id))?;
             Ok(())
         }
         font::FontChange::ContourAdded(change) => {
-            require_layer_exists(tx, change.layer_id)?;
-            replace_contour(tx, change.layer_id, &change.contour)
+            require_layer_exists(tx, &change.layer_id)?;
+            replace_contour(tx, &change.layer_id, &change.contour)
         }
         font::FontChange::ContourOpenClosedChanged(change) => {
-            require_layer_exists(tx, change.layer_id)?;
+            require_layer_exists(tx, &change.layer_id)?;
             let rows_changed = tx.execute(
                 "
                 UPDATE glyph_layer_contours
@@ -104,15 +104,15 @@ fn apply_change(tx: &Transaction<'_>, change: &font::FontChange) -> Result<(), S
             Ok(())
         }
         font::FontChange::PointsAdded(change) => {
-            require_layer_exists(tx, change.layer_id)?;
-            replace_contour(tx, change.layer_id, &change.contour)
+            require_layer_exists(tx, &change.layer_id)?;
+            replace_contour(tx, &change.layer_id, &change.contour)
         }
         font::FontChange::PointsDeleted(change) => {
-            require_layer_exists(tx, change.layer_id)?;
-            replace_contour(tx, change.layer_id, &change.contour)
+            require_layer_exists(tx, &change.layer_id)?;
+            replace_contour(tx, &change.layer_id, &change.contour)
         }
         font::FontChange::PointSmoothChanged(change) => {
-            require_layer_exists(tx, change.layer_id)?;
+            require_layer_exists(tx, &change.layer_id)?;
             let rows_changed = tx.execute(
                 "
                 UPDATE glyph_layer_points
@@ -125,7 +125,7 @@ fn apply_change(tx: &Transaction<'_>, change: &font::FontChange) -> Result<(), S
             Ok(())
         }
         font::FontChange::PointPositionsChanged(change) => {
-            require_layer_exists(tx, change.layer_id)?;
+            require_layer_exists(tx, &change.layer_id)?;
             for point in &change.points {
                 let rows_changed = tx.execute(
                     "
@@ -140,15 +140,15 @@ fn apply_change(tx: &Transaction<'_>, change: &font::FontChange) -> Result<(), S
             Ok(())
         }
         font::FontChange::LayerGeometryReplaced(change) => {
-            require_layer_exists(tx, change.layer_id)?;
-            replace_layer_geometry(tx, change.layer_id, &change.layer)
+            require_layer_exists(tx, &change.layer_id)?;
+            replace_layer_geometry(tx, &change.layer_id, &change.layer)
         }
     }
 }
 
 fn upsert_source(
     tx: &Transaction<'_>,
-    source_id: font::SourceId,
+    source_id: &font::SourceId,
     name: Option<&str>,
 ) -> Result<(), StoreError> {
     tx.execute(
@@ -165,7 +165,7 @@ fn upsert_source(
 
 fn upsert_glyph(
     tx: &Transaction<'_>,
-    glyph_id: font::GlyphId,
+    glyph_id: &font::GlyphId,
     name: &font::GlyphName,
 ) -> Result<(), StoreError> {
     tx.execute(
@@ -182,7 +182,7 @@ fn upsert_glyph(
 
 fn replace_glyph_unicodes(
     tx: &Transaction<'_>,
-    glyph_id: font::GlyphId,
+    glyph_id: &font::GlyphId,
     unicodes: &[u32],
 ) -> Result<(), StoreError> {
     tx.execute(
@@ -205,9 +205,9 @@ fn replace_glyph_unicodes(
 
 fn upsert_layer(
     tx: &Transaction<'_>,
-    layer_id: font::LayerId,
-    glyph_id: font::GlyphId,
-    source_id: font::SourceId,
+    layer_id: &font::LayerId,
+    glyph_id: &font::GlyphId,
+    source_id: &font::SourceId,
     name: Option<&font::GlyphName>,
     width: f64,
     height: Option<f64>,
@@ -235,7 +235,7 @@ fn upsert_layer(
 
 fn replace_layer_geometry(
     tx: &Transaction<'_>,
-    layer_id: font::LayerId,
+    layer_id: &font::LayerId,
     layer: &font::GlyphLayerValue,
 ) -> Result<(), StoreError> {
     let rows_changed = tx.execute(
@@ -264,7 +264,7 @@ fn replace_layer_geometry(
 
 fn replace_contour(
     tx: &Transaction<'_>,
-    layer_id: font::LayerId,
+    layer_id: &font::LayerId,
     contour: &font::ContourValue,
 ) -> Result<(), StoreError> {
     tx.execute(
@@ -290,7 +290,7 @@ fn replace_contour(
     )?;
 
     for point in &contour.points {
-        insert_point(tx, contour.id, point)?;
+        insert_point(tx, &contour.id, point)?;
     }
 
     Ok(())
@@ -298,7 +298,7 @@ fn replace_contour(
 
 fn insert_contour(
     tx: &Transaction<'_>,
-    layer_id: font::LayerId,
+    layer_id: &font::LayerId,
     order_index: usize,
     contour: &font::ContourValue,
 ) -> Result<(), StoreError> {
@@ -316,7 +316,7 @@ fn insert_contour(
     )?;
 
     for point in &contour.points {
-        insert_point(tx, contour.id, point)?;
+        insert_point(tx, &contour.id, point)?;
     }
 
     Ok(())
@@ -324,7 +324,7 @@ fn insert_contour(
 
 fn insert_point(
     tx: &Transaction<'_>,
-    contour_id: font::ContourId,
+    contour_id: &font::ContourId,
     point: &font::PointValue,
 ) -> Result<(), StoreError> {
     tx.execute(
@@ -369,7 +369,7 @@ fn require_changed(rows_changed: usize, kind: &'static str, id: String) -> Resul
     }
 }
 
-fn require_layer_exists(tx: &Transaction<'_>, layer_id: font::LayerId) -> Result<(), StoreError> {
+fn require_layer_exists(tx: &Transaction<'_>, layer_id: &font::LayerId) -> Result<(), StoreError> {
     let exists: bool = tx.query_row(
         "SELECT EXISTS(SELECT 1 FROM glyph_layers WHERE id = ?1)",
         [layer_row_id(layer_id)],
@@ -385,6 +385,6 @@ fn require_layer_exists(tx: &Transaction<'_>, layer_id: font::LayerId) -> Result
     }
 }
 
-fn layer_row_id(layer_id: font::LayerId) -> String {
+fn layer_row_id(layer_id: &font::LayerId) -> String {
     layer_id.to_string()
 }

--- a/crates/shift-store/tests/store_test.rs
+++ b/crates/shift-store/tests/store_test.rs
@@ -291,22 +291,28 @@ fn applies_glyph_identity_change_set() {
 #[test]
 fn applies_layer_metrics_and_contour_point_changes() {
     let mut store = ShiftStore::open_memory_for_test().expect("memory store should open");
-    let (target, contour, point_id) = store_change_target_with_contour();
-    let store_layer_id = store_layer_id(&target);
+    let (glyph, layer, contour, point_id) = store_layer_with_contour();
+    create_regular_source_with_id(&mut store, layer.source_id());
 
     store
         .apply_change_set(&shift_font::FontChangeSet::new(vec![
+            shift_font::FontChange::glyph_created(&glyph),
+            shift_font::FontChange::glyph_layer_created(
+                glyph.id(),
+                Some(glyph.glyph_name().clone()),
+                &layer,
+            ),
             shift_font::FontChange::LayerMetricsChanged(shift_font::LayerMetricsChanged {
-                target: target.clone(),
+                layer_id: layer.id(),
                 width: 720.0,
                 height: None,
             }),
             shift_font::FontChange::ContourAdded(shift_font::ContourAdded {
-                target: target.clone(),
+                layer_id: layer.id(),
                 contour,
             }),
             shift_font::FontChange::PointPositionsChanged(shift_font::PointPositionsChanged {
-                target,
+                layer_id: layer.id(),
                 points: vec![shift_font::PointPosition {
                     point_id,
                     x: 40.0,
@@ -317,11 +323,11 @@ fn applies_layer_metrics_and_contour_point_changes() {
         .expect("change set should apply");
 
     let layer = store
-        .get_glyph_layer(&store_layer_id)
+        .get_glyph_layer(&LayerId::new(layer.id().to_string()))
         .expect("layer query should succeed")
         .expect("layer should exist");
     let contours = store
-        .list_contours_for_layer(&store_layer_id)
+        .list_contours_for_layer(&layer.id)
         .expect("contour query should succeed");
     let points = store
         .list_points_for_contour(&contours[0].id)
@@ -339,27 +345,32 @@ fn applies_layer_metrics_and_contour_point_changes() {
 #[test]
 fn applies_layer_geometry_replacement() {
     let mut store = ShiftStore::open_memory_for_test().expect("memory store should open");
-    let (target, first_contour, _) = store_change_target_with_contour();
-    let store_layer_id = store_layer_id(&target);
-    let mut layer =
-        shift_font::GlyphLayer::with_width(shift_font::LayerId::new(), target.source_id, 500.0);
-    layer.add_contour(contour_with_point(10.0, 20.0));
+    let (glyph, layer, first_contour, _) = store_layer_with_contour();
+    create_regular_source_with_id(&mut store, layer.source_id());
+    let mut replacement = shift_font::GlyphLayer::with_width(layer.id(), layer.source_id(), 500.0);
+    replacement.add_contour(contour_with_point(10.0, 20.0));
 
     store
         .apply_change_set(&shift_font::FontChangeSet::new(vec![
+            shift_font::FontChange::glyph_created(&glyph),
+            shift_font::FontChange::glyph_layer_created(
+                glyph.id(),
+                Some(glyph.glyph_name().clone()),
+                &layer,
+            ),
             shift_font::FontChange::ContourAdded(shift_font::ContourAdded {
-                target: target.clone(),
+                layer_id: layer.id(),
                 contour: first_contour,
             }),
             shift_font::FontChange::LayerGeometryReplaced(shift_font::LayerGeometryReplaced {
-                target: target.clone(),
-                layer: shift_font::GlyphLayerValue::from(&layer),
+                layer_id: layer.id(),
+                layer: shift_font::GlyphLayerValue::from(&replacement),
             }),
         ]))
         .expect("change set should apply");
 
     let contours = store
-        .list_contours_for_layer(&store_layer_id)
+        .list_contours_for_layer(&LayerId::new(layer.id().to_string()))
         .expect("contour query should succeed");
     let points = store
         .list_points_for_contour(&contours[0].id)
@@ -373,12 +384,19 @@ fn applies_layer_geometry_replacement() {
 #[test]
 fn rejects_incremental_change_for_missing_point_row() {
     let mut store = ShiftStore::open_memory_for_test().expect("memory store should open");
-    let (target, _, _) = store_change_target_with_contour();
+    let (glyph, layer, _, _) = store_layer_with_contour();
+    create_regular_source_with_id(&mut store, layer.source_id());
     let missing_point_id = shift_font::PointId::new();
 
     let result = store.apply_change_set(&shift_font::FontChangeSet::new(vec![
+        shift_font::FontChange::glyph_created(&glyph),
+        shift_font::FontChange::glyph_layer_created(
+            glyph.id(),
+            Some(glyph.glyph_name().clone()),
+            &layer,
+        ),
         shift_font::FontChange::PointPositionsChanged(shift_font::PointPositionsChanged {
-            target,
+            layer_id: layer.id(),
             points: vec![shift_font::PointPosition {
                 point_id: missing_point_id,
                 x: 1.0,
@@ -392,6 +410,27 @@ fn rejects_incremental_change_for_missing_point_row() {
             .expect_err("missing point should reject")
             .to_string()
             .contains(&missing_point_id.to_string())
+    );
+}
+
+#[test]
+fn rejects_layer_edit_for_missing_layer_row() {
+    let mut store = ShiftStore::open_memory_for_test().expect("memory store should open");
+    let missing_layer_id = shift_font::LayerId::new();
+
+    let result = store.apply_change_set(&shift_font::FontChangeSet::new(vec![
+        shift_font::FontChange::LayerMetricsChanged(shift_font::LayerMetricsChanged {
+            layer_id: missing_layer_id,
+            width: 600.0,
+            height: None,
+        }),
+    ]));
+
+    assert!(
+        result
+            .expect_err("missing layer should reject")
+            .to_string()
+            .contains(&missing_layer_id.to_string())
     );
 }
 
@@ -542,24 +581,33 @@ fn create_regular_source(store: &mut ShiftStore) -> SourceId {
     source_id
 }
 
-fn store_change_target_with_contour() -> (
-    shift_font::GlyphLayerChangeTarget,
+fn create_regular_source_with_id(store: &mut ShiftStore, source_id: shift_font::SourceId) {
+    store
+        .create_source(NewSource {
+            id: SourceId::new(source_id.to_string()),
+            name: Some("Regular".to_string()),
+            family_name: Some("Shift Sans".to_string()),
+            style_name: Some("Regular".to_string()),
+            kind: SourceKind::Master,
+        })
+        .expect("source should be created");
+}
+
+fn store_layer_with_contour() -> (
+    shift_font::Glyph,
+    shift_font::GlyphLayer,
     shift_font::ContourValue,
     shift_font::PointId,
 ) {
     let glyph = shift_font::Glyph::with_unicode("A", 65);
-    let layer_id = shift_font::LayerId::new();
     let source_id = shift_font::SourceId::new();
+    let layer = shift_font::GlyphLayer::with_width(shift_font::LayerId::new(), source_id, 500.0);
     let contour = contour_with_point(10.0, 20.0);
     let point_id = contour.points()[0].id();
 
     (
-        shift_font::GlyphLayerChangeTarget {
-            glyph_id: glyph.id(),
-            glyph_name: glyph.glyph_name().clone(),
-            source_id,
-            layer_id,
-        },
+        glyph,
+        layer,
         shift_font::ContourValue::from(&contour),
         point_id,
     )
@@ -569,8 +617,4 @@ fn contour_with_point(x: f64, y: f64) -> shift_font::Contour {
     let mut contour = shift_font::Contour::new();
     contour.add_point(x, y, shift_font::PointType::OnCurve, false);
     contour
-}
-
-fn store_layer_id(target: &shift_font::GlyphLayerChangeTarget) -> LayerId {
-    LayerId::new(format!("{}:{}", target.glyph_id, target.layer_id))
 }

--- a/crates/shift-store/tests/store_test.rs
+++ b/crates/shift-store/tests/store_test.rs
@@ -267,7 +267,7 @@ fn applies_glyph_identity_change_set() {
         .apply_change_set(&shift_font::FontChangeSet::new(vec![
             shift_font::FontChange::GlyphCreated(shift_font::GlyphCreated::from(&glyph)),
             shift_font::FontChange::GlyphIdentityChanged(shift_font::GlyphIdentityChanged {
-                glyph_id,
+                glyph_id: glyph_id.clone(),
                 from_name: shift_font::GlyphName::from("A"),
                 to_name: shift_font::GlyphName::from("A.alt"),
                 from_unicodes: vec![65],
@@ -314,7 +314,7 @@ fn applies_layer_metrics_and_contour_point_changes() {
             shift_font::FontChange::PointPositionsChanged(shift_font::PointPositionsChanged {
                 layer_id: layer.id(),
                 points: vec![shift_font::PointPosition {
-                    point_id,
+                    point_id: point_id.clone(),
                     x: 40.0,
                     y: 50.0,
                 }],
@@ -398,7 +398,7 @@ fn rejects_incremental_change_for_missing_point_row() {
         shift_font::FontChange::PointPositionsChanged(shift_font::PointPositionsChanged {
             layer_id: layer.id(),
             points: vec![shift_font::PointPosition {
-                point_id: missing_point_id,
+                point_id: missing_point_id.clone(),
                 x: 1.0,
                 y: 2.0,
             }],
@@ -420,7 +420,7 @@ fn rejects_layer_edit_for_missing_layer_row() {
 
     let result = store.apply_change_set(&shift_font::FontChangeSet::new(vec![
         shift_font::FontChange::LayerMetricsChanged(shift_font::LayerMetricsChanged {
-            layer_id: missing_layer_id,
+            layer_id: missing_layer_id.clone(),
             width: 600.0,
             height: None,
         }),

--- a/crates/shift-wire/src/lib.rs
+++ b/crates/shift-wire/src/lib.rs
@@ -207,10 +207,7 @@ impl From<&GlyphLayer> for GlyphStructure {
         Self {
             contours: layer.contours_iter().map(ContourData::from).collect(),
             anchors: layer.anchors_iter().map(AnchorData::from).collect(),
-            components: sorted_components(layer)
-                .into_iter()
-                .map(ComponentData::from)
-                .collect(),
+            components: layer.components_iter().map(ComponentData::from).collect(),
         }
     }
 }
@@ -466,19 +463,11 @@ pub fn values_from_layer(layer: &GlyphLayer) -> GlyphValues {
         values.push(anchor.y());
     }
 
-    for component in sorted_components(layer) {
+    for component in layer.components_iter() {
         push_transform_values(&mut values, component.transform());
     }
 
     values
-}
-
-/// Components live in a `HashMap` in the IR, but the values array needs stable
-/// ordering. Sort by component ID everywhere structure and values are exported.
-fn sorted_components(layer: &GlyphLayer) -> Vec<&IrComponent> {
-    let mut components: Vec<_> = layer.components_iter().collect();
-    components.sort_by_key(|component| component.id().raw());
-    components
 }
 
 fn push_transform_values(values: &mut Vec<f64>, transform: &IrTransform) {

--- a/crates/shift-wire/src/state.rs
+++ b/crates/shift-wire/src/state.rs
@@ -272,7 +272,7 @@ mod tests {
     }
 
     #[test]
-    fn glyph_structure_sorts_components_by_id() {
+    fn glyph_structure_preserves_component_order() {
         let mut layer = GlyphLayer::new(LayerId::new(), SourceId::new());
         layer.add_component(Component::with_id(
             ComponentId::from_raw(200),
@@ -287,8 +287,8 @@ mod tests {
 
         let structure = GlyphStructure::from(&layer);
 
-        assert_eq!(structure.components[0].id, "100");
-        assert_eq!(structure.components[1].id, "200");
+        assert_eq!(structure.components[0].id, "component_200");
+        assert_eq!(structure.components[1].id, "component_100");
     }
 
     #[test]

--- a/crates/shift-workspace/src/workspace.rs
+++ b/crates/shift-workspace/src/workspace.rs
@@ -126,12 +126,13 @@ impl FontWorkspace {
                     kind: "glyph name",
                     value: from_name.to_string(),
                 })?;
-        let existing = next_font
-            .glyph(glyph_id)
-            .ok_or_else(|| WorkspaceError::InvalidInput {
-                kind: "glyph name",
-                value: from_name.to_string(),
-            })?;
+        let existing =
+            next_font
+                .glyph(glyph_id.clone())
+                .ok_or_else(|| WorkspaceError::InvalidInput {
+                    kind: "glyph name",
+                    value: from_name.to_string(),
+                })?;
         if from_name == name && existing.unicodes() == unicodes.as_slice() {
             return Ok(());
         }
@@ -151,8 +152,8 @@ impl FontWorkspace {
         }
 
         let glyph = next_font
-            .glyph(glyph_id)
-            .ok_or(CoreError::GlyphNotFound(glyph_id))?;
+            .glyph(glyph_id.clone())
+            .ok_or(CoreError::GlyphNotFound(glyph_id.clone()))?;
         let from_name = glyph.glyph_name().clone();
         let from_unicodes = glyph.unicodes().to_vec();
         let glyph_name = shift_font::GlyphName::new(name.to_string()).map_err(|_| {
@@ -162,18 +163,18 @@ impl FontWorkspace {
             }
         })?;
 
-        next_font.rename_glyph(glyph_id, glyph_name)?;
-        next_font.set_glyph_unicodes(glyph_id, unicodes)?;
+        next_font.rename_glyph(glyph_id.clone(), glyph_name)?;
+        next_font.set_glyph_unicodes(glyph_id.clone(), unicodes)?;
         let glyph = next_font
-            .glyph(glyph_id)
-            .ok_or(CoreError::GlyphNotFound(glyph_id))?;
+            .glyph(glyph_id.clone())
+            .ok_or(CoreError::GlyphNotFound(glyph_id.clone()))?;
         let to_name = glyph.glyph_name().clone();
         let to_unicodes = glyph.unicodes().to_vec();
 
         self.commit_font(
             next_font,
             FontChange::glyph_identity_changed(
-                glyph_id,
+                glyph_id.clone(),
                 from_name,
                 to_name,
                 from_unicodes,
@@ -227,19 +228,19 @@ impl FontWorkspace {
     ) -> Result<GlyphLayer, WorkspaceError> {
         self.commit_edit(|font| {
             let glyph = font
-                .glyph(glyph_id)
-                .ok_or(CoreError::GlyphNotFound(glyph_id))?;
+                .glyph(glyph_id.clone())
+                .ok_or(CoreError::GlyphNotFound(glyph_id.clone()))?;
             let glyph_name = glyph.glyph_name().clone();
-            let layer = GlyphLayer::with_width(LayerId::new(), source_id, 500.0);
+            let layer = GlyphLayer::with_width(LayerId::new(), source_id.clone(), 500.0);
             let layer_id = layer.id();
 
-            font.insert_glyph_layer(glyph_id, layer)?;
+            font.insert_glyph_layer(glyph_id.clone(), layer)?;
             let layer = font
-                .layer(layer_id)
-                .ok_or(CoreError::LayerNotFound(layer_id))?
+                .layer(layer_id.clone())
+                .ok_or(CoreError::LayerNotFound(layer_id.clone()))?
                 .clone();
             let change_set =
-                FontChange::glyph_layer_created(glyph_id, Some(glyph_name), &layer).into();
+                FontChange::glyph_layer_created(glyph_id.clone(), Some(glyph_name), &layer).into();
 
             Ok((layer, change_set))
         })
@@ -252,8 +253,8 @@ impl FontWorkspace {
     ) -> Result<GlyphLayer, WorkspaceError> {
         self.commit_edit(|font| {
             let layer = font
-                .layer_mut(layer_id)
-                .ok_or(CoreError::LayerNotFound(layer_id))?;
+                .layer_mut(layer_id.clone())
+                .ok_or(CoreError::LayerNotFound(layer_id.clone()))?;
 
             layer.set_x_advance(width);
             let edited_layer = layer.clone();
@@ -286,14 +287,18 @@ impl FontWorkspace {
     ) -> Result<(GlyphLayer, PointId), WorkspaceError> {
         self.commit_edit(|font| {
             let layer = font
-                .layer_mut(layer_id)
-                .ok_or(CoreError::LayerNotFound(layer_id))?;
-            let added = layer.add_point_to_contour(contour_id, x, y, point_type, smooth)?;
+                .layer_mut(layer_id.clone())
+                .ok_or(CoreError::LayerNotFound(layer_id.clone()))?;
+            let added = layer.add_point_to_contour(contour_id.clone(), x, y, point_type, smooth)?;
             let edited_layer = layer.clone();
-            let change_set =
-                FontChange::points_added(layer_id, &added.contour, vec![added.point_id]).into();
+            let change_set = FontChange::points_added(
+                layer_id.clone(),
+                &added.contour,
+                vec![added.point_id.clone()],
+            )
+            .into();
 
-            Ok(((edited_layer, added.point_id), change_set))
+            Ok(((edited_layer, added.point_id.clone()), change_set))
         })
     }
 
@@ -308,14 +313,19 @@ impl FontWorkspace {
     ) -> Result<(GlyphLayer, PointId), WorkspaceError> {
         self.commit_edit(|font| {
             let layer = font
-                .layer_mut(layer_id)
-                .ok_or(CoreError::LayerNotFound(layer_id))?;
-            let added = layer.insert_point_before(before_point_id, x, y, point_type, smooth)?;
+                .layer_mut(layer_id.clone())
+                .ok_or(CoreError::LayerNotFound(layer_id.clone()))?;
+            let added =
+                layer.insert_point_before(before_point_id.clone(), x, y, point_type, smooth)?;
             let edited_layer = layer.clone();
-            let change_set =
-                FontChange::points_added(layer_id, &added.contour, vec![added.point_id]).into();
+            let change_set = FontChange::points_added(
+                layer_id.clone(),
+                &added.contour,
+                vec![added.point_id.clone()],
+            )
+            .into();
 
-            Ok(((edited_layer, added.point_id), change_set))
+            Ok(((edited_layer, added.point_id.clone()), change_set))
         })
     }
 
@@ -325,11 +335,11 @@ impl FontWorkspace {
     ) -> Result<(GlyphLayer, ContourId), WorkspaceError> {
         self.commit_edit(|font| {
             let layer = font
-                .layer_mut(layer_id)
-                .ok_or(CoreError::LayerNotFound(layer_id))?;
+                .layer_mut(layer_id.clone())
+                .ok_or(CoreError::LayerNotFound(layer_id.clone()))?;
             let contour = layer.add_empty_contour();
             let edited_layer = layer.clone();
-            let change_set = FontChange::contour_added(layer_id, &contour).into();
+            let change_set = FontChange::contour_added(layer_id.clone(), &contour).into();
 
             Ok(((edited_layer, contour.id()), change_set))
         })
@@ -392,11 +402,12 @@ impl FontWorkspace {
     ) -> Result<GlyphLayer, WorkspaceError> {
         self.commit_edit(|font| {
             let layer = font
-                .layer_mut(layer_id)
-                .ok_or(CoreError::LayerNotFound(layer_id))?;
-            let smooth = layer.toggle_smooth(point_id)?;
+                .layer_mut(layer_id.clone())
+                .ok_or(CoreError::LayerNotFound(layer_id.clone()))?;
+            let smooth = layer.toggle_smooth(point_id.clone())?;
             let edited_layer = layer.clone();
-            let change_set = FontChange::point_smooth_changed(layer_id, point_id, smooth).into();
+            let change_set =
+                FontChange::point_smooth_changed(layer_id.clone(), point_id.clone(), smooth).into();
 
             Ok((edited_layer, change_set))
         })
@@ -411,13 +422,17 @@ impl FontWorkspace {
     ) -> Result<(), WorkspaceError> {
         self.commit_edit(|font| {
             let layer = font
-                .layer_mut(layer_id)
-                .ok_or(CoreError::LayerNotFound(layer_id))?;
+                .layer_mut(layer_id.clone())
+                .ok_or(CoreError::LayerNotFound(layer_id.clone()))?;
             layer.apply_bulk_node_positions(updates)?;
             let change_set = if replace_geometry {
                 Self::layer_replaced_change_set(layer)
             } else {
-                FontChange::point_positions_changed(layer_id, point_position_changes).into()
+                FontChange::point_positions_changed(
+                    layer_id.clone(),
+                    point_position_changes.clone(),
+                )
+                .into()
             };
 
             Ok(((), change_set))
@@ -464,16 +479,20 @@ impl FontWorkspace {
     ) -> Result<GlyphLayer, WorkspaceError> {
         self.commit_edit(|font| {
             let layer = font
-                .layer_mut(layer_id)
-                .ok_or(CoreError::LayerNotFound(layer_id))?;
+                .layer_mut(layer_id.clone())
+                .ok_or(CoreError::LayerNotFound(layer_id.clone()))?;
             if closed {
-                layer.close_contour(contour_id)?;
+                layer.close_contour(contour_id.clone())?;
             } else {
-                layer.open_contour(contour_id)?;
+                layer.open_contour(contour_id.clone())?;
             }
             let edited_layer = layer.clone();
-            let change_set =
-                FontChange::contour_open_closed_changed(layer_id, contour_id, closed).into();
+            let change_set = FontChange::contour_open_closed_changed(
+                layer_id.clone(),
+                contour_id.clone(),
+                closed,
+            )
+            .into();
 
             Ok((edited_layer, change_set))
         })
@@ -498,8 +517,8 @@ impl FontWorkspace {
     ) -> Result<(GlyphLayer, R), WorkspaceError> {
         self.commit_edit(|font| {
             let layer = font
-                .layer_mut(layer_id)
-                .ok_or(CoreError::LayerNotFound(layer_id))?;
+                .layer_mut(layer_id.clone())
+                .ok_or(CoreError::LayerNotFound(layer_id.clone()))?;
             let result = edit(layer)?;
             let edited_layer = layer.clone();
             let change_set = Self::layer_replaced_change_set(layer);

--- a/crates/shift-workspace/src/workspace.rs
+++ b/crates/shift-workspace/src/workspace.rs
@@ -3,8 +3,7 @@ use std::path::{Path, PathBuf};
 use shift_backends::{FontExportRequest, FontExportResult, FontExporter, font_loader::FontLoader};
 use shift_font::{
     BooleanOp, BulkNodePositionUpdates, ContourId, FontChange, FontChangeSet, Glyph, GlyphId,
-    GlyphLayer, GlyphLayerChangeTarget, GlyphName, LayerId, PointId, PointPosition, PointType,
-    SourceId, error::CoreError,
+    GlyphLayer, GlyphName, LayerId, PointId, PointPosition, PointType, SourceId, error::CoreError,
 };
 use shift_source::ShiftSourcePackage;
 use shift_store::ShiftStore;
@@ -239,13 +238,8 @@ impl FontWorkspace {
                 .layer(layer_id)
                 .ok_or(CoreError::LayerNotFound(layer_id))?
                 .clone();
-            let target = GlyphLayerChangeTarget {
-                glyph_id,
-                glyph_name,
-                source_id,
-                layer_id,
-            };
-            let change_set = FontChange::layer_metrics_changed(target, &layer).into();
+            let change_set =
+                FontChange::glyph_layer_created(glyph_id, Some(glyph_name), &layer).into();
 
             Ok((layer, change_set))
         })
@@ -257,14 +251,13 @@ impl FontWorkspace {
         width: f64,
     ) -> Result<GlyphLayer, WorkspaceError> {
         self.commit_edit(|font| {
-            let target = Self::layer_change_target(font, layer_id)?;
             let layer = font
                 .layer_mut(layer_id)
                 .ok_or(CoreError::LayerNotFound(layer_id))?;
 
             layer.set_x_advance(width);
             let edited_layer = layer.clone();
-            let change_set = FontChange::layer_metrics_changed(target, layer).into();
+            let change_set = FontChange::layer_metrics_changed(layer).into();
 
             Ok((edited_layer, change_set))
         })
@@ -292,14 +285,13 @@ impl FontWorkspace {
         smooth: bool,
     ) -> Result<(GlyphLayer, PointId), WorkspaceError> {
         self.commit_edit(|font| {
-            let target = Self::layer_change_target(font, layer_id)?;
             let layer = font
                 .layer_mut(layer_id)
                 .ok_or(CoreError::LayerNotFound(layer_id))?;
             let added = layer.add_point_to_contour(contour_id, x, y, point_type, smooth)?;
             let edited_layer = layer.clone();
             let change_set =
-                FontChange::points_added(target, &added.contour, vec![added.point_id]).into();
+                FontChange::points_added(layer_id, &added.contour, vec![added.point_id]).into();
 
             Ok(((edited_layer, added.point_id), change_set))
         })
@@ -315,14 +307,13 @@ impl FontWorkspace {
         smooth: bool,
     ) -> Result<(GlyphLayer, PointId), WorkspaceError> {
         self.commit_edit(|font| {
-            let target = Self::layer_change_target(font, layer_id)?;
             let layer = font
                 .layer_mut(layer_id)
                 .ok_or(CoreError::LayerNotFound(layer_id))?;
             let added = layer.insert_point_before(before_point_id, x, y, point_type, smooth)?;
             let edited_layer = layer.clone();
             let change_set =
-                FontChange::points_added(target, &added.contour, vec![added.point_id]).into();
+                FontChange::points_added(layer_id, &added.contour, vec![added.point_id]).into();
 
             Ok(((edited_layer, added.point_id), change_set))
         })
@@ -333,13 +324,12 @@ impl FontWorkspace {
         layer_id: LayerId,
     ) -> Result<(GlyphLayer, ContourId), WorkspaceError> {
         self.commit_edit(|font| {
-            let target = Self::layer_change_target(font, layer_id)?;
             let layer = font
                 .layer_mut(layer_id)
                 .ok_or(CoreError::LayerNotFound(layer_id))?;
             let contour = layer.add_empty_contour();
             let edited_layer = layer.clone();
-            let change_set = FontChange::contour_added(target, &contour).into();
+            let change_set = FontChange::contour_added(layer_id, &contour).into();
 
             Ok(((edited_layer, contour.id()), change_set))
         })
@@ -401,13 +391,12 @@ impl FontWorkspace {
         point_id: PointId,
     ) -> Result<GlyphLayer, WorkspaceError> {
         self.commit_edit(|font| {
-            let target = Self::layer_change_target(font, layer_id)?;
             let layer = font
                 .layer_mut(layer_id)
                 .ok_or(CoreError::LayerNotFound(layer_id))?;
             let smooth = layer.toggle_smooth(point_id)?;
             let edited_layer = layer.clone();
-            let change_set = FontChange::point_smooth_changed(target, point_id, smooth).into();
+            let change_set = FontChange::point_smooth_changed(layer_id, point_id, smooth).into();
 
             Ok((edited_layer, change_set))
         })
@@ -421,15 +410,14 @@ impl FontWorkspace {
         replace_geometry: bool,
     ) -> Result<(), WorkspaceError> {
         self.commit_edit(|font| {
-            let target = Self::layer_change_target(font, layer_id)?;
             let layer = font
                 .layer_mut(layer_id)
                 .ok_or(CoreError::LayerNotFound(layer_id))?;
             layer.apply_bulk_node_positions(updates)?;
             let change_set = if replace_geometry {
-                Self::layer_replaced_change_set(target, layer)
+                Self::layer_replaced_change_set(layer)
             } else {
-                FontChange::point_positions_changed(target, point_position_changes).into()
+                FontChange::point_positions_changed(layer_id, point_position_changes).into()
             };
 
             Ok(((), change_set))
@@ -468,28 +456,6 @@ impl FontWorkspace {
         Ok(result)
     }
 
-    fn layer_change_target(
-        font: &shift_font::Font,
-        layer_id: LayerId,
-    ) -> Result<GlyphLayerChangeTarget, WorkspaceError> {
-        let glyph_id = font
-            .glyph_id_by_layer(layer_id)
-            .ok_or(CoreError::LayerNotFound(layer_id))?;
-        let glyph = font
-            .glyph(glyph_id)
-            .ok_or(CoreError::GlyphNotFound(glyph_id))?;
-        let layer = glyph
-            .layer(layer_id)
-            .ok_or(CoreError::LayerNotFound(layer_id))?;
-
-        Ok(GlyphLayerChangeTarget {
-            glyph_id,
-            glyph_name: glyph.glyph_name().clone(),
-            source_id: layer.source_id(),
-            layer_id,
-        })
-    }
-
     fn set_contour_closed(
         &mut self,
         layer_id: LayerId,
@@ -497,7 +463,6 @@ impl FontWorkspace {
         closed: bool,
     ) -> Result<GlyphLayer, WorkspaceError> {
         self.commit_edit(|font| {
-            let target = Self::layer_change_target(font, layer_id)?;
             let layer = font
                 .layer_mut(layer_id)
                 .ok_or(CoreError::LayerNotFound(layer_id))?;
@@ -508,7 +473,7 @@ impl FontWorkspace {
             }
             let edited_layer = layer.clone();
             let change_set =
-                FontChange::contour_open_closed_changed(target, contour_id, closed).into();
+                FontChange::contour_open_closed_changed(layer_id, contour_id, closed).into();
 
             Ok((edited_layer, change_set))
         })
@@ -532,23 +497,19 @@ impl FontWorkspace {
         edit: impl FnOnce(&mut GlyphLayer) -> Result<R, CoreError>,
     ) -> Result<(GlyphLayer, R), WorkspaceError> {
         self.commit_edit(|font| {
-            let target = Self::layer_change_target(font, layer_id)?;
             let layer = font
                 .layer_mut(layer_id)
                 .ok_or(CoreError::LayerNotFound(layer_id))?;
             let result = edit(layer)?;
             let edited_layer = layer.clone();
-            let change_set = Self::layer_replaced_change_set(target, layer);
+            let change_set = Self::layer_replaced_change_set(layer);
 
             Ok(((edited_layer, result), change_set))
         })
     }
 
-    fn layer_replaced_change_set(
-        target: GlyphLayerChangeTarget,
-        layer: &GlyphLayer,
-    ) -> FontChangeSet {
-        FontChange::layer_geometry_replaced(target, layer).into()
+    fn layer_replaced_change_set(layer: &GlyphLayer) -> FontChangeSet {
+        FontChange::layer_geometry_replaced(layer).into()
     }
 
     fn open_package(

--- a/crates/shift-workspace/tests/workspace_test.rs
+++ b/crates/shift-workspace/tests/workspace_test.rs
@@ -122,7 +122,7 @@ fn set_x_advance_updates_existing_layer() {
     let layer = workspace.create_glyph_layer(glyph.id(), source_id).unwrap();
     let layer_id = layer.id();
 
-    let edited_layer = workspace.set_x_advance(layer_id, 640.0).unwrap();
+    let edited_layer = workspace.set_x_advance(layer_id.clone(), 640.0).unwrap();
 
     assert_eq!(edited_layer.width(), 640.0);
     assert_eq!(workspace.font().layer(layer_id).unwrap().width(), 640.0);
@@ -137,7 +137,9 @@ fn set_x_advance_rejects_missing_layer() {
         FontWorkspace::create(&source_path, &store_path, NewWorkspace::new()).unwrap();
     let layer_id = LayerId::new();
 
-    let error = workspace.set_x_advance(layer_id, 640.0).unwrap_err();
+    let error = workspace
+        .set_x_advance(layer_id.clone(), 640.0)
+        .unwrap_err();
 
     assert!(matches!(
         error,

--- a/packages/types/src/bridge/generated.ts
+++ b/packages/types/src/bridge/generated.ts
@@ -49,10 +49,10 @@ export interface BridgeApi {
   removePoints(glyphRef: GlyphLayerRef, pointIds: Array<PointId>): GlyphStructureChange
   toggleSmooth(glyphRef: GlyphLayerRef, pointId: PointId): GlyphStructureChange
   /**
-   * Bulk position sync. IDs use BigUint64Array to avoid lossy float packing.
+   * Bulk position sync. IDs are stable typed strings from the current glyph state.
    * Coords are interleaved [x0, y0, x1, y1, ...].
    */
-  applyPositionPatch(glyphRef: GlyphLayerRef, pointIds?: BigUint64Array | undefined | null, pointCoords?: Float64Array | undefined | null, anchorIds?: BigUint64Array | undefined | null, anchorCoords?: Float64Array | undefined | null): void
+  applyPositionPatch(glyphRef: GlyphLayerRef, pointIds?: Array<PointId> | null, pointCoords?: Float64Array | undefined | null, anchorIds?: Array<AnchorId> | null, anchorCoords?: Float64Array | undefined | null): void
   restoreState(glyphRef: GlyphLayerRef, structure: GlyphStructure, values: Float64Array): GlyphStructureChange
 }
 


### PR DESCRIPTION
## Summary
- Add an explicit GlyphLayerCreated font change for layer row creation.
- Change existing layer edit changes to carry LayerId directly instead of GlyphLayerChangeTarget.
- Update shift-store to persist layer rows by the real LayerId and reject layer edits when the row is missing.
- Simplify shift-workspace change construction now that layer edits no longer need glyph/source/name target hydration.

## Checks
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- commit hook: cargo check/tests, cargo fmt, cargo clippy