### PR TITLE
[codex] Make bridge edits target layer ids

### DIFF
--- a/apps/desktop/src/renderer/src/lib/model/Glyph.ts
+++ b/apps/desktop/src/renderer/src/lib/model/Glyph.ts
@@ -3,12 +3,12 @@ import type {
   ContourData,
   ContourId,
   GlyphName,
-  GlyphLayerRef,
   GlyphState,
   GlyphStructure,
   GlyphStructureChange,
   GlyphValueChange,
   GlyphVariationData,
+  LayerId,
   PointId,
   Source,
   Unicode,
@@ -99,14 +99,12 @@ export interface GlyphInstanceGeometry {
 
 class GlyphEditSession {
   readonly #font: Font;
-  readonly #handle: GlyphHandle;
-  readonly #source: Source;
+  readonly #layerId: LayerId;
   readonly #state: GlyphEditState;
 
-  constructor(font: Font, handle: GlyphHandle, source: Source, state: GlyphEditState) {
+  constructor(font: Font, layerId: LayerId, state: GlyphEditState) {
     this.#font = font;
-    this.#handle = handle;
-    this.#source = source;
+    this.#layerId = layerId;
     this.#state = state;
   }
 
@@ -119,14 +117,14 @@ class GlyphEditSession {
   }
 
   setXAdvance(width: number): void {
-    this.#applyValueChange(this.#font.bridge.setXAdvance(this.#glyphRef(), width));
+    this.#applyValueChange(this.#font.bridge.setXAdvance(this.#layerId, width));
   }
 
   applyPositionPatch(updates: SourcePositions): void {
     const patch = SourcePositionPatch.from(updates);
     if (patch.isEmpty) return;
 
-    this.#font.bridge.applyPositionPatch(this.#glyphRef(), ...patch.toBridgePayload());
+    this.#font.bridge.applyPositionPatch(this.#layerId, ...patch.toBridgePayload());
     this.#applyPositionPatchLocally(patch.positions);
   }
 
@@ -134,11 +132,11 @@ class GlyphEditSession {
     const patch = SourcePositionPatch.from(updates);
     if (patch.isEmpty) return;
 
-    this.#font.bridge.applyPositionPatch(this.#glyphRef(), ...patch.toBridgePayload());
+    this.#font.bridge.applyPositionPatch(this.#layerId, ...patch.toBridgePayload());
   }
 
   translateLayer(dx: number, dy: number): void {
-    this.#applyValueChange(this.#font.bridge.translateLayer(this.#glyphRef(), dx, dy));
+    this.#applyValueChange(this.#font.bridge.translateLayer(this.#layerId, dx, dy));
   }
 
   previewPositionPatch(updates: SourcePositions): void {
@@ -151,7 +149,7 @@ class GlyphEditSession {
   }
 
   addContour(): ContourId {
-    const change = this.#font.bridge.addContour(this.#glyphRef());
+    const change = this.#font.bridge.addContour(this.#layerId);
     this.#applyStructureChange(change);
     const contourId = change.changed.contourIds[0];
     if (!contourId) throw new Error("Bridge did not return a created contour ID");
@@ -160,7 +158,7 @@ class GlyphEditSession {
 
   addPoint(contourId: ContourId, edit: NewPoint): PointId {
     const change = this.#font.bridge.addPoint(
-      this.#glyphRef(),
+      this.#layerId,
       contourId,
       edit.x,
       edit.y,
@@ -178,7 +176,7 @@ class GlyphEditSession {
 
   insertPointBefore(beforePointId: PointId, edit: NewPoint): PointId {
     const change = this.#font.bridge.insertPointBefore(
-      this.#glyphRef(),
+      this.#layerId,
       beforePointId,
       edit.x,
       edit.y,
@@ -192,15 +190,15 @@ class GlyphEditSession {
   }
 
   openContour(contourId: ContourId): void {
-    this.#applyStructureChange(this.#font.bridge.openContour(this.#glyphRef(), contourId));
+    this.#applyStructureChange(this.#font.bridge.openContour(this.#layerId, contourId));
   }
 
   closeContour(contourId: ContourId): void {
-    this.#applyStructureChange(this.#font.bridge.closeContour(this.#glyphRef(), contourId));
+    this.#applyStructureChange(this.#font.bridge.closeContour(this.#layerId, contourId));
   }
 
   reverseContour(contourId: ContourId): void {
-    this.#applyStructureChange(this.#font.bridge.reverseContour(this.#glyphRef(), contourId));
+    this.#applyStructureChange(this.#font.bridge.reverseContour(this.#layerId, contourId));
   }
 
   applyBooleanOp(
@@ -209,34 +207,28 @@ class GlyphEditSession {
     operation: "union" | "subtract" | "intersect" | "difference",
   ): void {
     this.#applyStructureChange(
-      this.#font.bridge.applyBooleanOp(this.#glyphRef(), contourIdA, contourIdB, operation),
+      this.#font.bridge.applyBooleanOp(this.#layerId, contourIdA, contourIdB, operation),
     );
   }
 
   removePoints(pointIds: readonly PointId[]): void {
     if (pointIds.length === 0) return;
-    this.#applyStructureChange(this.#font.bridge.removePoints(this.#glyphRef(), [...pointIds]));
+    this.#applyStructureChange(this.#font.bridge.removePoints(this.#layerId, [...pointIds]));
   }
 
   toggleSmooth(pointId: PointId): void {
-    this.#applyStructureChange(this.#font.bridge.toggleSmooth(this.#glyphRef(), pointId));
+    this.#applyStructureChange(this.#font.bridge.toggleSmooth(this.#layerId, pointId));
   }
 
   restore(state: GlyphState): void {
     this.#applyStructureChange(
-      this.#font.bridge.restoreState(this.#glyphRef(), state.structure, state.values),
+      this.#font.bridge.restoreState(this.#layerId, state.structure, state.values),
     );
-  }
-
-  #glyphRef(): GlyphLayerRef {
-    return {
-      glyphHandle: this.#handle,
-      sourceId: this.#source.id,
-    };
   }
 
   #applyStructureChange(change: GlyphStructureChange): void {
     this.#state.state.replace({
+      layerId: this.#layerId,
       structure: change.structure,
       values: change.values,
     });
@@ -252,7 +244,7 @@ class GlyphEditSession {
  *
  * A source is the authored glyph at a designspace location. `GlyphSource`
  * exposes the reactive geometry for that source and forwards mutations to the
- * bridge with an explicit glyph-layer reference. Preview methods update the
+ * bridge with the source layer's stable ID. Preview methods update the
  * renderer-facing reactive data; commit methods also produce bridge changes.
  */
 export class GlyphSource {
@@ -1653,7 +1645,7 @@ export class Glyph {
 
     this.#xAdvance = computed(() => this.#sourceState.coordinateBuffersCell.value.xAdvance.value);
 
-    this.#edit = new GlyphEditSession(font, handle, source, {
+    this.#edit = new GlyphEditSession(font, state.layerId, {
       state: this.#sourceState,
       geometry: this.#geometry,
     });
@@ -1816,7 +1808,7 @@ export class Glyph {
 
     const sourceState = new GlyphSourceState(state);
     const geometry = computed(() => sourceState.geometryCell.value);
-    const edit = new GlyphEditSession(this.#font, this.handle, source, {
+    const edit = new GlyphEditSession(this.#font, state.layerId, {
       state: sourceState,
       geometry,
     });
@@ -1849,6 +1841,7 @@ export class Glyph {
     if (!variationData) return state;
 
     return {
+      layerId: state.layerId,
       structure: state.structure,
       values: state.values,
       variationData,

--- a/apps/desktop/src/renderer/src/lib/model/GlyphSourceState.test.ts
+++ b/apps/desktop/src/renderer/src/lib/model/GlyphSourceState.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, it } from "vitest";
-import type { AnchorId, ContourId, GlyphState, PointId } from "@shift/types";
+import type { AnchorId, ContourId, GlyphState, LayerId, PointId } from "@shift/types";
 import { GlyphSourceState } from "./GlyphSourceState";
 
 const contourId = (index: number): ContourId => `contour-${index}` as ContourId;
 const pointId = (index: number): PointId => `point-${index}` as PointId;
 const anchorId = (index: number): AnchorId => `anchor-${index}` as AnchorId;
+const layerId = (index: number): LayerId => `layer-${index}` as LayerId;
 
 function sourceState(): GlyphState {
   return {
+    layerId: layerId(1),
     structure: {
       contours: [
         {

--- a/apps/desktop/src/renderer/src/lib/model/GlyphSourceState.ts
+++ b/apps/desktop/src/renderer/src/lib/model/GlyphSourceState.ts
@@ -1,4 +1,11 @@
-import type { AnchorId, ContourId, GlyphState, GlyphStructure, PointId } from "@shift/types";
+import type {
+  AnchorId,
+  ContourId,
+  GlyphState,
+  GlyphStructure,
+  LayerId,
+  PointId,
+} from "@shift/types";
 import { Bounds, Mat, type Bounds as BoundsType, type MatModel } from "@shift/geo";
 import {
   GlyphStateGeometry as GlyphGeometry,
@@ -29,6 +36,7 @@ interface PointBufferLocation {
  * update a touched contour without invalidating every contour path.
  */
 export class GlyphSourceState {
+  readonly #layerId: LayerId;
   readonly #structure: WritableSignal<GlyphStructure>;
   readonly #coordinates: WritableSignal<SourceCoordinateBuffers>;
   readonly #xAdvance: ComputedSignal<number>;
@@ -37,6 +45,7 @@ export class GlyphSourceState {
   readonly #geometry: ComputedSignal<GlyphGeometry>;
 
   constructor(state: GlyphState) {
+    this.#layerId = state.layerId;
     this.#structure = signal(state.structure, {
       name: "glyphSource.structure",
     });
@@ -133,6 +142,7 @@ export class GlyphSourceState {
 
   get state(): GlyphState {
     return {
+      layerId: this.#layerId,
       structure: this.#structure.peek(),
       values: this.#coordinates.peek().snapshot.peek(),
     };
@@ -156,6 +166,7 @@ export class GlyphSourceState {
   replaceValues(values: Float64Array): void {
     this.#coordinates.set(
       SourceCoordinateBuffers.fromState({
+        layerId: this.#layerId,
         structure: this.#structure.peek(),
         values,
       }),

--- a/crates/shift-bridge/__test__/index.spec.mjs
+++ b/crates/shift-bridge/__test__/index.spec.mjs
@@ -29,19 +29,11 @@ describe("Bridge", () => {
     return unicode ?? (name === "A" ? 65 : undefined);
   }
 
-  function defaultLayerRef(name = "A", unicode) {
-    return {
-      glyphHandle: { name, unicode: defaultUnicode(name, unicode) },
-      sourceId: defaultSourceId(),
-    };
-  }
-
   function createDefaultLayer(name = "A", unicode) {
     const resolvedUnicode = defaultUnicode(name, unicode);
     const unicodes = resolvedUnicode === undefined ? [] : [resolvedUnicode];
     const glyphId = bridge.createGlyph(name, unicodes);
-    bridge.createGlyphLayer(glyphId, defaultSourceId());
-    return defaultLayerRef(name, resolvedUnicode);
+    return bridge.createGlyphLayer(glyphId, defaultSourceId());
   }
 
   it("creates a workspace with default committed font metadata", () => {
@@ -73,9 +65,9 @@ describe("Bridge", () => {
   });
 
   it("saves direct glyph layer edits to a shift source package target", () => {
-    const glyphRef = createDefaultLayer();
-    const contourId = bridge.addContour(glyphRef).changed.contourIds[0];
-    bridge.addPoint(glyphRef, contourId, 10, 20, "onCurve", false);
+    const layerId = createDefaultLayer();
+    const contourId = bridge.addContour(layerId).changed.contourIds[0];
+    bridge.addPoint(layerId, contourId, 10, 20, "onCurve", false);
 
     const outputPath = join(tempDir, "output.shift");
     const savedVersion = bridge.saveWorkspaceAs(outputPath);
@@ -98,9 +90,9 @@ describe("Bridge", () => {
 
   it("exports the live workspace font through an explicit export path", async () => {
     createDefaultLayer(".notdef", undefined);
-    const glyphRef = createDefaultLayer();
-    const contourId = bridge.addContour(glyphRef).changed.contourIds[0];
-    bridge.addPoint(glyphRef, contourId, 10, 20, "onCurve", false);
+    const layerId = createDefaultLayer();
+    const contourId = bridge.addContour(layerId).changed.contourIds[0];
+    bridge.addPoint(layerId, contourId, 10, 20, "onCurve", false);
 
     const outputPath = join(tempDir, "output.ttf");
     const result = await bridge.exportWorkspace({ path: outputPath, format: "ttf" });
@@ -110,11 +102,11 @@ describe("Bridge", () => {
   });
 
   it("adds a point to a contour and returns structure, values, and changed ids", () => {
-    const glyphRef = createDefaultLayer();
-    const contourChange = bridge.addContour(glyphRef);
+    const layerId = createDefaultLayer();
+    const contourChange = bridge.addContour(layerId);
     const contourId = contourChange.changed.contourIds[0];
 
-    const change = bridge.addPoint(glyphRef, contourId, 10, 20, "onCurve", false);
+    const change = bridge.addPoint(layerId, contourId, 10, 20, "onCurve", false);
 
     expect(change.changed.pointIds).toHaveLength(1);
     expect(change.structure.contours).toHaveLength(1);
@@ -133,13 +125,13 @@ describe("Bridge", () => {
   });
 
   it("applies point positions through the sparse bridge patch path", () => {
-    const glyphRef = createDefaultLayer();
-    const contourId = bridge.addContour(glyphRef).changed.contourIds[0];
-    const pointId = bridge.addPoint(glyphRef, contourId, 10, 20, "onCurve", false).changed
+    const layerId = createDefaultLayer();
+    const contourId = bridge.addContour(layerId).changed.contourIds[0];
+    const pointId = bridge.addPoint(layerId, contourId, 10, 20, "onCurve", false).changed
       .pointIds[0];
 
     bridge.applyPositionPatch(
-      glyphRef,
+      layerId,
       [pointId],
       new Float64Array([30, 40]),
       null,
@@ -150,17 +142,18 @@ describe("Bridge", () => {
       { name: "A", unicode: 65 },
       defaultSourceId(),
     );
+    expect(state.layerId).toBe(layerId);
     expect(Array.from(state.values)).toEqual([500, 30, 40]);
   });
 
   it("restores structure and values into a glyph layer", () => {
-    const glyphRef = createDefaultLayer();
-    const contourId = bridge.addContour(glyphRef).changed.contourIds[0];
-    const before = bridge.addPoint(glyphRef, contourId, 10, 20, "onCurve", false);
+    const layerId = createDefaultLayer();
+    const contourId = bridge.addContour(layerId).changed.contourIds[0];
+    const before = bridge.addPoint(layerId, contourId, 10, 20, "onCurve", false);
     const pointId = before.changed.pointIds[0];
 
     const change = bridge.restoreState(
-      glyphRef,
+      layerId,
       before.structure,
       new Float64Array([700, 90, 120]),
     );
@@ -171,16 +164,16 @@ describe("Bridge", () => {
 
   it("surfaces typed bridge errors at the NAPI boundary", () => {
     expect(() =>
-      bridge.addContour({ glyphHandle: { name: "A", unicode: 65 }, sourceId: "not-a-source" }),
-    ).toThrow(/source ID/i);
+      bridge.addContour("not-a-layer"),
+    ).toThrow(/layer ID/i);
 
-    const glyphRef = createDefaultLayer();
+    const layerId = createDefaultLayer();
     expect(() =>
-      bridge.addPoint(glyphRef, "not-a-contour", 10, 20, "onCurve", false),
+      bridge.addPoint(layerId, "not-a-contour", 10, 20, "onCurve", false),
     ).toThrow(/contour ID/i);
     expect(() =>
       bridge.applyPositionPatch(
-        glyphRef,
+        layerId,
         ["not-a-point"],
         new Float64Array([10]),
         null,

--- a/crates/shift-bridge/docs/DOCS.md
+++ b/crates/shift-bridge/docs/DOCS.md
@@ -29,7 +29,7 @@ crates/shift-bridge/
 ## Key Types
 
 - `Bridge` -- the exported `#[napi]` class holding the current `FontWorkspace` and document versions.
-- `GlyphLayerRef` -- boundary identity for the glyph layer being mutated.
+- `LayerId` -- mutation-side identity for the glyph layer being edited.
 - `FontSaveSnapshot` -- clone/COW export view of the current workspace font.
 - `ExportFontTask` -- NAPI `Task` implementation for async font export.
 - `BridgeError` -- typed bridge error enum converted once at the NAPI boundary.
@@ -38,9 +38,9 @@ crates/shift-bridge/
 
 ## How it works
 
-1. The renderer chooses the active glyph/source and builds a `GlyphLayerRef`.
-2. JS calls a mutation such as `closeContour(glyphRef, contourId)`.
-3. `Bridge` parses boundary strings and asks `FontWorkspace` to run the edit against the target glyph layer.
+1. The renderer resolves glyph state with `GlyphHandle + SourceId` and receives a stable `layerId`.
+2. JS calls a mutation such as `closeContour(layerId, contourId)`.
+3. `Bridge` parses boundary strings and asks `FontWorkspace` to run the edit against that layer.
 4. The bridge returns a `shift-wire` change DTO and bumps the live version.
 5. `saveWorkspace()` / `saveWorkspaceAs(path)` update the `.shift` source package target and record the persisted version.
 6. `exportWorkspace(request)` creates a `FontSaveSnapshot` and exports asynchronously through `shift-backends`.
@@ -59,7 +59,7 @@ crates/shift-bridge/
 2. Add or reuse a canonical DTO in `shift-wire`.
 3. Add a NAPI adapter in `shift-wire::bridges::napi` only if NAPI needs a different representation.
 4. Add the `#[napi]` method on `Bridge`.
-5. Accept `GlyphLayerRef` when the operation targets glyph outline state, parse string IDs through `input.rs`, call the model method, then return the appropriate wire change.
+5. Accept `LayerId` when the operation targets glyph outline state, parse string IDs through `input.rs`, call the workspace method, then return the appropriate wire change.
 6. Run `cargo check -p shift-bridge` and rebuild the native module before regenerating bridge types.
 
 ### Adding a new read-only query

--- a/crates/shift-bridge/index.d.ts
+++ b/crates/shift-bridge/index.d.ts
@@ -32,33 +32,28 @@ export declare class Bridge {
   isDirty(): boolean
   createGlyph(name: GlyphName, unicodes: Array<Unicode>): GlyphId
   createGlyphLayer(glyphId: GlyphId, sourceId: SourceId): LayerId
-  setXAdvance(glyphRef: GlyphLayerRef, width: number): NapiGlyphValueChange
-  translateLayer(glyphRef: GlyphLayerRef, dx: number, dy: number): NapiGlyphValueChange
-  addPoint(glyphRef: GlyphLayerRef, contourId: ContourId, x: number, y: number, pointType: NapiPointType, smooth: boolean): NapiGlyphStructureChange
-  insertPointBefore(glyphRef: GlyphLayerRef, beforePointId: PointId, x: number, y: number, pointType: NapiPointType, smooth: boolean): NapiGlyphStructureChange
-  addContour(glyphRef: GlyphLayerRef): NapiGlyphStructureChange
-  openContour(glyphRef: GlyphLayerRef, contourId: ContourId): NapiGlyphStructureChange
-  closeContour(glyphRef: GlyphLayerRef, contourId: ContourId): NapiGlyphStructureChange
-  reverseContour(glyphRef: GlyphLayerRef, contourId: ContourId): NapiGlyphStructureChange
-  applyBooleanOp(glyphRef: GlyphLayerRef, contourIdA: ContourId, contourIdB: ContourId, operation: string): NapiGlyphStructureChange
-  removePoints(glyphRef: GlyphLayerRef, pointIds: Array<PointId>): NapiGlyphStructureChange
-  toggleSmooth(glyphRef: GlyphLayerRef, pointId: PointId): NapiGlyphStructureChange
+  setXAdvance(layerId: LayerId, width: number): NapiGlyphValueChange
+  translateLayer(layerId: LayerId, dx: number, dy: number): NapiGlyphValueChange
+  addPoint(layerId: LayerId, contourId: ContourId, x: number, y: number, pointType: NapiPointType, smooth: boolean): NapiGlyphStructureChange
+  insertPointBefore(layerId: LayerId, beforePointId: PointId, x: number, y: number, pointType: NapiPointType, smooth: boolean): NapiGlyphStructureChange
+  addContour(layerId: LayerId): NapiGlyphStructureChange
+  openContour(layerId: LayerId, contourId: ContourId): NapiGlyphStructureChange
+  closeContour(layerId: LayerId, contourId: ContourId): NapiGlyphStructureChange
+  reverseContour(layerId: LayerId, contourId: ContourId): NapiGlyphStructureChange
+  applyBooleanOp(layerId: LayerId, contourIdA: ContourId, contourIdB: ContourId, operation: string): NapiGlyphStructureChange
+  removePoints(layerId: LayerId, pointIds: Array<PointId>): NapiGlyphStructureChange
+  toggleSmooth(layerId: LayerId, pointId: PointId): NapiGlyphStructureChange
   /**
    * Bulk position sync. IDs are stable typed strings from the current glyph state.
    * Coords are interleaved [x0, y0, x1, y1, ...].
    */
-  applyPositionPatch(glyphRef: GlyphLayerRef, pointIds?: Array<PointId> | null, pointCoords?: Float64Array | undefined | null, anchorIds?: Array<AnchorId> | null, anchorCoords?: Float64Array | undefined | null): void
-  restoreState(glyphRef: GlyphLayerRef, structure: NapiGlyphStructure, values: Float64Array): NapiGlyphStructureChange
+  applyPositionPatch(layerId: LayerId, pointIds?: Array<PointId> | null, pointCoords?: Float64Array | undefined | null, anchorIds?: Array<AnchorId> | null, anchorCoords?: Float64Array | undefined | null): void
+  restoreState(layerId: LayerId, structure: NapiGlyphStructure, values: Float64Array): NapiGlyphStructureChange
 }
 
 export interface GlyphHandle {
   name: GlyphName
   unicode?: Unicode
-}
-
-export interface GlyphLayerRef {
-  glyphHandle: GlyphHandle
-  sourceId: SourceId
 }
 
 export interface NapiFontExportRequest {
@@ -184,6 +179,7 @@ export interface NapiGlyphRecord {
 }
 
 export interface NapiGlyphState {
+  layerId: LayerId
   structure: NapiGlyphStructure
   /** Numeric glyph state ordered to match `GlyphStructure`. */
   values: Float64Array

--- a/crates/shift-bridge/src/bridge.rs
+++ b/crates/shift-bridge/src/bridge.rs
@@ -6,8 +6,7 @@ use napi_derive::napi;
 use serde::{Deserialize, Serialize};
 use shift_backends::{ExportFormat, FontExportRequest, FontExportResult, FontExporter, FontView};
 use shift_font::{
-  BooleanOp, BulkNodePositionUpdates, ContourId, Font, Glyph, GlyphId, GlyphLayer, LayerId,
-  PointId, SourceId,
+  BooleanOp, BulkNodePositionUpdates, ContourId, Font, Glyph, GlyphId, LayerId, PointId, SourceId,
 };
 use shift_wire::{
   bridges::napi::{
@@ -32,14 +31,6 @@ pub struct GlyphHandle {
   pub name: String,
   #[napi(ts_type = "Unicode")]
   pub unicode: Option<u32>,
-}
-
-#[napi(object)]
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct GlyphLayerRef {
-  pub glyph_handle: GlyphHandle,
-  #[napi(ts_type = "SourceId")]
-  pub source_id: String,
 }
 
 #[napi(object)]
@@ -475,24 +466,6 @@ impl Bridge {
     Ok(self.font()?.glyph_by_name(glyph_name).cloned())
   }
 
-  fn existing_layer_id(&self, glyph_ref: GlyphLayerRef) -> BridgeResult<LayerId> {
-    let source_id = parse::<SourceId>(&glyph_ref.source_id)?;
-    let layer_id = self
-      .font()?
-      .glyph_by_name(&glyph_ref.glyph_handle.name)
-      .and_then(|glyph| glyph.layer_for_source(source_id))
-      .map(GlyphLayer::id)
-      .ok_or_else(|| BridgeError::InvalidInput {
-        kind: "glyph layer",
-        value: format!(
-          "{} at source {}",
-          glyph_ref.glyph_handle.name, glyph_ref.source_id
-        ),
-      })?;
-
-    Ok(layer_id)
-  }
-
   fn variation_build_for_glyph(
     &self,
     glyph: &Glyph,
@@ -678,10 +651,10 @@ impl Bridge {
   #[napi]
   pub fn set_x_advance(
     &mut self,
-    glyph_ref: GlyphLayerRef,
+    #[napi(ts_arg_type = "LayerId")] layer_id: String,
     width: f64,
   ) -> errors::Result<NapiGlyphValueChange> {
-    let layer_id = self.existing_layer_id(glyph_ref)?;
+    let layer_id = parse::<LayerId>(&layer_id)?;
     let layer = self.workspace_mut()?.set_x_advance(layer_id, width)?;
     let change = GlyphValueChange::from_layer(&layer, Default::default());
 
@@ -692,11 +665,11 @@ impl Bridge {
   #[napi]
   pub fn translate_layer(
     &mut self,
-    glyph_ref: GlyphLayerRef,
+    #[napi(ts_arg_type = "LayerId")] layer_id: String,
     dx: f64,
     dy: f64,
   ) -> errors::Result<NapiGlyphValueChange> {
-    let layer_id = self.existing_layer_id(glyph_ref)?;
+    let layer_id = parse::<LayerId>(&layer_id)?;
     let layer = self.workspace_mut()?.translate_layer(layer_id, dx, dy)?;
     let change = GlyphValueChange::from_layer(&layer, Default::default());
 
@@ -707,7 +680,7 @@ impl Bridge {
   #[napi]
   pub fn add_point(
     &mut self,
-    glyph_ref: GlyphLayerRef,
+    #[napi(ts_arg_type = "LayerId")] layer_id: String,
     #[napi(ts_arg_type = "ContourId")] contour_id: String,
     x: f64,
     y: f64,
@@ -717,7 +690,7 @@ impl Bridge {
     let contour_id = parse::<ContourId>(&contour_id)?;
     let point_type = point_type.into();
 
-    let layer_id = self.existing_layer_id(glyph_ref)?;
+    let layer_id = parse::<LayerId>(&layer_id)?;
     let (layer, point_id) = self
       .workspace_mut()?
       .add_point(layer_id, contour_id, x, y, point_type, smooth)?;
@@ -734,7 +707,7 @@ impl Bridge {
   #[napi]
   pub fn insert_point_before(
     &mut self,
-    glyph_ref: GlyphLayerRef,
+    #[napi(ts_arg_type = "LayerId")] layer_id: String,
     #[napi(ts_arg_type = "PointId")] before_point_id: String,
     x: f64,
     y: f64,
@@ -744,7 +717,7 @@ impl Bridge {
     let before_point_id = parse::<PointId>(&before_point_id)?;
     let point_type = point_type.into();
 
-    let layer_id = self.existing_layer_id(glyph_ref)?;
+    let layer_id = parse::<LayerId>(&layer_id)?;
     let (layer, point_id) = self.workspace_mut()?.insert_point_before(
       layer_id,
       before_point_id,
@@ -766,9 +739,9 @@ impl Bridge {
   #[napi]
   pub fn add_contour(
     &mut self,
-    glyph_ref: GlyphLayerRef,
+    #[napi(ts_arg_type = "LayerId")] layer_id: String,
   ) -> errors::Result<NapiGlyphStructureChange> {
-    let layer_id = self.existing_layer_id(glyph_ref)?;
+    let layer_id = parse::<LayerId>(&layer_id)?;
     let (layer, contour_id) = self.workspace_mut()?.add_contour(layer_id)?;
     let changed = GlyphChangedEntities {
       contour_ids: vec![contour_id],
@@ -783,11 +756,11 @@ impl Bridge {
   #[napi]
   pub fn open_contour(
     &mut self,
-    glyph_ref: GlyphLayerRef,
+    #[napi(ts_arg_type = "LayerId")] layer_id: String,
     #[napi(ts_arg_type = "ContourId")] contour_id: String,
   ) -> errors::Result<NapiGlyphStructureChange> {
     let contour_id = parse::<ContourId>(&contour_id)?;
-    let layer_id = self.existing_layer_id(glyph_ref)?;
+    let layer_id = parse::<LayerId>(&layer_id)?;
     let layer = self
       .workspace_mut()?
       .open_contour(layer_id, contour_id.clone())?;
@@ -804,11 +777,11 @@ impl Bridge {
   #[napi]
   pub fn close_contour(
     &mut self,
-    glyph_ref: GlyphLayerRef,
+    #[napi(ts_arg_type = "LayerId")] layer_id: String,
     #[napi(ts_arg_type = "ContourId")] contour_id: String,
   ) -> errors::Result<NapiGlyphStructureChange> {
     let contour_id = parse::<ContourId>(&contour_id)?;
-    let layer_id = self.existing_layer_id(glyph_ref)?;
+    let layer_id = parse::<LayerId>(&layer_id)?;
     let layer = self
       .workspace_mut()?
       .close_contour(layer_id, contour_id.clone())?;
@@ -825,11 +798,11 @@ impl Bridge {
   #[napi]
   pub fn reverse_contour(
     &mut self,
-    glyph_ref: GlyphLayerRef,
+    #[napi(ts_arg_type = "LayerId")] layer_id: String,
     #[napi(ts_arg_type = "ContourId")] contour_id: String,
   ) -> errors::Result<NapiGlyphStructureChange> {
     let contour_id = parse::<ContourId>(&contour_id)?;
-    let layer_id = self.existing_layer_id(glyph_ref)?;
+    let layer_id = parse::<LayerId>(&layer_id)?;
     let layer = self
       .workspace_mut()?
       .reverse_contour(layer_id, contour_id.clone())?;
@@ -846,7 +819,7 @@ impl Bridge {
   #[napi]
   pub fn apply_boolean_op(
     &mut self,
-    glyph_ref: GlyphLayerRef,
+    #[napi(ts_arg_type = "LayerId")] layer_id: String,
     #[napi(ts_arg_type = "ContourId")] contour_id_a: String,
     #[napi(ts_arg_type = "ContourId")] contour_id_b: String,
     operation: String,
@@ -867,7 +840,7 @@ impl Bridge {
       }
     };
 
-    let layer_id = self.existing_layer_id(glyph_ref)?;
+    let layer_id = parse::<LayerId>(&layer_id)?;
     let (layer, contour_ids) = self
       .workspace_mut()?
       .apply_boolean_op(layer_id, cid_a, cid_b, op)?;
@@ -884,13 +857,13 @@ impl Bridge {
   #[napi]
   pub fn remove_points(
     &mut self,
-    glyph_ref: GlyphLayerRef,
+    #[napi(ts_arg_type = "LayerId")] layer_id: String,
     #[napi(ts_arg_type = "Array<PointId>")] point_ids: Vec<String>,
   ) -> errors::Result<NapiGlyphStructureChange> {
     let point_ids: BridgeResult<Vec<_>> = point_ids.iter().map(|id| parse::<PointId>(id)).collect();
     let point_ids = point_ids?;
 
-    let layer_id = self.existing_layer_id(glyph_ref)?;
+    let layer_id = parse::<LayerId>(&layer_id)?;
     let layer = self
       .workspace_mut()?
       .remove_points(layer_id, point_ids.clone())?;
@@ -903,11 +876,11 @@ impl Bridge {
   #[napi]
   pub fn toggle_smooth(
     &mut self,
-    glyph_ref: GlyphLayerRef,
+    #[napi(ts_arg_type = "LayerId")] layer_id: String,
     #[napi(ts_arg_type = "PointId")] point_id: String,
   ) -> errors::Result<NapiGlyphStructureChange> {
     let parsed_id = parse::<PointId>(&point_id)?;
-    let layer_id = self.existing_layer_id(glyph_ref)?;
+    let layer_id = parse::<LayerId>(&layer_id)?;
     let layer = self
       .workspace_mut()?
       .toggle_smooth(layer_id, parsed_id.clone())?;
@@ -926,7 +899,7 @@ impl Bridge {
   #[napi]
   pub fn apply_position_patch(
     &mut self,
-    glyph_ref: GlyphLayerRef,
+    #[napi(ts_arg_type = "LayerId")] layer_id: String,
     #[napi(ts_arg_type = "Array<PointId> | null")] point_ids: Option<Vec<String>>,
     point_coords: Option<Float64Array>,
     #[napi(ts_arg_type = "Array<AnchorId> | null")] anchor_ids: Option<Vec<String>>,
@@ -939,7 +912,7 @@ impl Bridge {
       || anchor_coords
         .as_ref()
         .is_some_and(|coords| !coords.is_empty());
-    let layer_id = self.existing_layer_id(glyph_ref)?;
+    let layer_id = parse::<LayerId>(&layer_id)?;
     let point_id_slice = point_ids.as_deref();
     let point_coord_slice = point_coords.as_ref().map(|coords| {
       let coords: &[f64] = coords;
@@ -970,13 +943,13 @@ impl Bridge {
   #[napi]
   pub fn restore_state(
     &mut self,
-    glyph_ref: GlyphLayerRef,
+    #[napi(ts_arg_type = "LayerId")] layer_id: String,
     structure: NapiGlyphStructure,
     values: Float64Array,
   ) -> errors::Result<NapiGlyphStructureChange> {
     let structure = GlyphStructure::from(structure);
     let values: &[f64] = &values;
-    let layer_id = self.existing_layer_id(glyph_ref)?;
+    let layer_id = parse::<LayerId>(&layer_id)?;
     let mut layer = self
       .font()?
       .layer(layer_id.clone())
@@ -1078,26 +1051,11 @@ mod tests {
     bridge.get_sources().unwrap()[0].id.clone()
   }
 
-  fn default_layer_ref(bridge: &Bridge, name: &str, unicode: Option<u32>) -> GlyphLayerRef {
-    GlyphLayerRef {
-      glyph_handle: glyph_handle(name, unicode),
-      source_id: bridge.get_sources().unwrap()[0].id.clone(),
-    }
-  }
-
-  fn create_default_glyph_layer(
-    bridge: &mut Bridge,
-    name: &str,
-    unicode: Option<u32>,
-  ) -> GlyphLayerRef {
-    let glyph_ref = default_layer_ref(bridge, name, unicode);
+  fn create_default_glyph_layer(bridge: &mut Bridge, name: &str, unicode: Option<u32>) -> String {
+    let source_id = bridge.get_sources().unwrap()[0].id.clone();
     let unicodes = unicode.into_iter().collect();
     let glyph_id = bridge.create_glyph(name.to_string(), unicodes).unwrap();
-    bridge
-      .create_glyph_layer(glyph_id, glyph_ref.source_id.clone())
-      .unwrap();
-
-    glyph_ref
+    bridge.create_glyph_layer(glyph_id, source_id).unwrap()
   }
 
   #[test]
@@ -1133,8 +1091,8 @@ mod tests {
   #[test]
   fn create_workspace_resets_to_fresh_font_state() {
     let mut bridge = bridge_with_workspace();
-    let glyph_ref = create_default_glyph_layer(&mut bridge, "A", Some(65));
-    bridge.add_contour(glyph_ref).unwrap();
+    let layer_id = create_default_glyph_layer(&mut bridge, "A", Some(65));
+    bridge.add_contour(layer_id).unwrap();
 
     let (source_path, store_path) = test_paths("reset");
     bridge
@@ -1150,9 +1108,9 @@ mod tests {
   #[test]
   fn add_contour_returns_structure_change() {
     let mut bridge = bridge_with_workspace();
-    let glyph_ref = create_default_glyph_layer(&mut bridge, "A", Some(65));
+    let layer_id = create_default_glyph_layer(&mut bridge, "A", Some(65));
 
-    let change = bridge.add_contour(glyph_ref).unwrap();
+    let change = bridge.add_contour(layer_id).unwrap();
 
     assert_eq!(change.structure.contours.len(), 1);
     assert_eq!(change.changed.contour_ids.len(), 1);
@@ -1164,21 +1122,18 @@ mod tests {
   }
 
   #[test]
-  fn set_x_advance_requires_existing_glyph_layer() {
+  fn set_x_advance_requires_existing_layer_id() {
     let mut bridge = bridge_with_workspace();
-    let glyph_ref = default_layer_ref(&bridge, "A", Some(65));
+    let missing_layer_id = LayerId::new().to_string();
 
-    let error = match bridge.set_x_advance(glyph_ref, 640.0) {
+    let error = match bridge.set_x_advance(missing_layer_id, 640.0) {
       Ok(_) => panic!("set_x_advance should require an existing glyph layer"),
       Err(error) => error,
     };
 
     assert!(matches!(
       error,
-      BridgeError::InvalidInput {
-        kind: "glyph layer",
-        ..
-      }
+      BridgeError::Workspace(_) | BridgeError::Core(_)
     ));
     assert_eq!(bridge.get_glyph_count().unwrap(), 0);
   }
@@ -1186,9 +1141,9 @@ mod tests {
   #[test]
   fn set_x_advance_updates_existing_glyph_layer() {
     let mut bridge = bridge_with_workspace();
-    let glyph_ref = create_default_glyph_layer(&mut bridge, "A", Some(65));
+    let layer_id = create_default_glyph_layer(&mut bridge, "A", Some(65));
 
-    let change = bridge.set_x_advance(glyph_ref, 640.0).unwrap();
+    let change = bridge.set_x_advance(layer_id, 640.0).unwrap();
 
     assert_eq!(&change.values[..], &[640.0]);
     assert!(change.changed.contour_ids.is_empty());
@@ -1198,16 +1153,16 @@ mod tests {
   #[test]
   fn save_snapshot_includes_direct_glyph_layer_edit() {
     let mut bridge = bridge_with_workspace();
-    let glyph_ref = create_default_glyph_layer(&mut bridge, "A", Some(65));
+    let layer_id = create_default_glyph_layer(&mut bridge, "A", Some(65));
     let contour_id = bridge
-      .add_contour(glyph_ref.clone())
+      .add_contour(layer_id.clone())
       .unwrap()
       .changed
       .contour_ids[0]
       .clone();
     let point_id = bridge
       .add_point(
-        glyph_ref,
+        layer_id,
         contour_id,
         10.0,
         20.0,
@@ -1257,9 +1212,9 @@ mod tests {
   #[test]
   fn persisted_older_snapshot_keeps_document_dirty_after_new_edit() {
     let mut bridge = bridge_with_workspace();
-    let glyph_ref = create_default_glyph_layer(&mut bridge, "A", Some(65));
+    let layer_id = create_default_glyph_layer(&mut bridge, "A", Some(65));
     let contour_id = bridge
-      .add_contour(glyph_ref.clone())
+      .add_contour(layer_id.clone())
       .unwrap()
       .changed
       .contour_ids[0]
@@ -1268,7 +1223,7 @@ mod tests {
 
     bridge
       .add_point(
-        glyph_ref,
+        layer_id,
         contour_id,
         10.0,
         20.0,
@@ -1290,8 +1245,8 @@ mod tests {
   #[test]
   fn opening_workspace_resets_persisted_version_handle_for_old_saves() {
     let mut bridge = bridge_with_workspace();
-    let glyph_ref = create_default_glyph_layer(&mut bridge, "A", Some(65));
-    bridge.add_contour(glyph_ref).unwrap();
+    let layer_id = create_default_glyph_layer(&mut bridge, "A", Some(65));
+    bridge.add_contour(layer_id).unwrap();
     let old_persisted_version = bridge.persisted_version.clone();
 
     let (source_path, store_path) = test_paths("reopen");
@@ -1307,9 +1262,9 @@ mod tests {
   #[test]
   fn add_point_returns_structure_and_changed_point() {
     let mut bridge = bridge_with_workspace();
-    let glyph_ref = create_default_glyph_layer(&mut bridge, "A", Some(65));
+    let layer_id = create_default_glyph_layer(&mut bridge, "A", Some(65));
     let contour_id = bridge
-      .add_contour(glyph_ref.clone())
+      .add_contour(layer_id.clone())
       .unwrap()
       .changed
       .contour_ids[0]
@@ -1317,7 +1272,7 @@ mod tests {
 
     let change = bridge
       .add_point(
-        glyph_ref,
+        layer_id,
         contour_id,
         10.0,
         20.0,
@@ -1337,16 +1292,16 @@ mod tests {
   #[test]
   fn get_glyph_state_reads_direct_glyph_layer_edit() {
     let mut bridge = bridge_with_workspace();
-    let glyph_ref = create_default_glyph_layer(&mut bridge, "A", Some(65));
+    let layer_id = create_default_glyph_layer(&mut bridge, "A", Some(65));
     let contour_id = bridge
-      .add_contour(glyph_ref.clone())
+      .add_contour(layer_id.clone())
       .unwrap()
       .changed
       .contour_ids[0]
       .clone();
     bridge
       .add_point(
-        glyph_ref,
+        layer_id.clone(),
         contour_id,
         10.0,
         20.0,
@@ -1361,6 +1316,7 @@ mod tests {
       .expect("edited glyph should be readable");
 
     assert_eq!(bridge.get_glyphs().unwrap().len(), 1);
+    assert_eq!(state.layer_id, layer_id);
     assert_eq!(state.structure.contours.len(), 1);
     assert_eq!(state.structure.contours[0].points.len(), 1);
     assert_eq!(&state.values[..], &[500.0, 10.0, 20.0]);
@@ -1377,18 +1333,15 @@ mod tests {
   }
 
   #[test]
-  fn edit_methods_require_valid_layer_ref() {
+  fn edit_methods_require_valid_layer_id() {
     let mut bridge = bridge_with_workspace();
 
-    let result = bridge.add_contour(GlyphLayerRef {
-      glyph_handle: glyph_handle("A", Some(65)),
-      source_id: "not-a-source-id".to_string(),
-    });
+    let result = bridge.add_contour("not-a-layer-id".to_string());
 
     assert!(matches!(
       result.err().unwrap(),
       BridgeError::InvalidInput {
-        kind: "source ID",
+        kind: "layer ID",
         ..
       }
     ));

--- a/crates/shift-wire/src/bridges/napi/mod.rs
+++ b/crates/shift-wire/src/bridges/napi/mod.rs
@@ -180,6 +180,8 @@ impl From<GlyphRecord> for NapiGlyphRecord {
 
 #[napi(object)]
 pub struct NapiGlyphState {
+    #[napi(ts_type = "LayerId")]
+    pub layer_id: String,
     pub structure: NapiGlyphStructure,
     /// Numeric glyph state ordered to match `GlyphStructure`.
     pub values: Float64Array,
@@ -189,6 +191,7 @@ pub struct NapiGlyphState {
 impl From<GlyphState> for NapiGlyphState {
     fn from(state: GlyphState) -> Self {
         Self {
+            layer_id: state.layer_id.to_string(),
             structure: state.structure.into(),
             values: state.values.into(),
             variation_data: state.variation_data.map(Into::into),

--- a/crates/shift-wire/src/lib.rs
+++ b/crates/shift-wire/src/lib.rs
@@ -10,7 +10,7 @@ use shift_font::{
     Anchor as IrAnchor, AnchorId, Axis as IrAxis, Component as IrComponent, ComponentId,
     Contour as IrContour, ContourId, DecomposedTransform as IrTransform,
     FontMetadata as IrFontMetadata, FontMetrics as IrFontMetrics, Glyph as IrGlyph, GlyphLayer,
-    GlyphName, GuidelineId, Location as IrLocation, Point as IrPoint, PointId,
+    GlyphName, GuidelineId, LayerId, Location as IrLocation, Point as IrPoint, PointId,
     PointType as IrPointType, Source as IrSource, SourceId,
 };
 
@@ -178,6 +178,7 @@ impl From<&IrGlyph> for GlyphRecord {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GlyphState {
+    pub layer_id: LayerId,
     pub structure: GlyphStructure,
     /// Numeric glyph state ordered to match `GlyphStructure`.
     pub values: GlyphValues,
@@ -187,6 +188,7 @@ pub struct GlyphState {
 impl GlyphState {
     pub fn from_layer(layer: &GlyphLayer, variation_data: Option<GlyphVariationData>) -> Self {
         Self {
+            layer_id: layer.id(),
             structure: GlyphStructure::from(layer),
             values: values_from_layer(layer),
             variation_data,

--- a/packages/types/src/bridge/generated.ts
+++ b/packages/types/src/bridge/generated.ts
@@ -37,33 +37,28 @@ export interface BridgeApi {
   isDirty(): boolean
   createGlyph(name: GlyphName, unicodes: Array<Unicode>): GlyphId
   createGlyphLayer(glyphId: GlyphId, sourceId: SourceId): LayerId
-  setXAdvance(glyphRef: GlyphLayerRef, width: number): GlyphValueChange
-  translateLayer(glyphRef: GlyphLayerRef, dx: number, dy: number): GlyphValueChange
-  addPoint(glyphRef: GlyphLayerRef, contourId: ContourId, x: number, y: number, pointType: PointType, smooth: boolean): GlyphStructureChange
-  insertPointBefore(glyphRef: GlyphLayerRef, beforePointId: PointId, x: number, y: number, pointType: PointType, smooth: boolean): GlyphStructureChange
-  addContour(glyphRef: GlyphLayerRef): GlyphStructureChange
-  openContour(glyphRef: GlyphLayerRef, contourId: ContourId): GlyphStructureChange
-  closeContour(glyphRef: GlyphLayerRef, contourId: ContourId): GlyphStructureChange
-  reverseContour(glyphRef: GlyphLayerRef, contourId: ContourId): GlyphStructureChange
-  applyBooleanOp(glyphRef: GlyphLayerRef, contourIdA: ContourId, contourIdB: ContourId, operation: string): GlyphStructureChange
-  removePoints(glyphRef: GlyphLayerRef, pointIds: Array<PointId>): GlyphStructureChange
-  toggleSmooth(glyphRef: GlyphLayerRef, pointId: PointId): GlyphStructureChange
+  setXAdvance(layerId: LayerId, width: number): GlyphValueChange
+  translateLayer(layerId: LayerId, dx: number, dy: number): GlyphValueChange
+  addPoint(layerId: LayerId, contourId: ContourId, x: number, y: number, pointType: PointType, smooth: boolean): GlyphStructureChange
+  insertPointBefore(layerId: LayerId, beforePointId: PointId, x: number, y: number, pointType: PointType, smooth: boolean): GlyphStructureChange
+  addContour(layerId: LayerId): GlyphStructureChange
+  openContour(layerId: LayerId, contourId: ContourId): GlyphStructureChange
+  closeContour(layerId: LayerId, contourId: ContourId): GlyphStructureChange
+  reverseContour(layerId: LayerId, contourId: ContourId): GlyphStructureChange
+  applyBooleanOp(layerId: LayerId, contourIdA: ContourId, contourIdB: ContourId, operation: string): GlyphStructureChange
+  removePoints(layerId: LayerId, pointIds: Array<PointId>): GlyphStructureChange
+  toggleSmooth(layerId: LayerId, pointId: PointId): GlyphStructureChange
   /**
    * Bulk position sync. IDs are stable typed strings from the current glyph state.
    * Coords are interleaved [x0, y0, x1, y1, ...].
    */
-  applyPositionPatch(glyphRef: GlyphLayerRef, pointIds?: Array<PointId> | null, pointCoords?: Float64Array | undefined | null, anchorIds?: Array<AnchorId> | null, anchorCoords?: Float64Array | undefined | null): void
-  restoreState(glyphRef: GlyphLayerRef, structure: GlyphStructure, values: Float64Array): GlyphStructureChange
+  applyPositionPatch(layerId: LayerId, pointIds?: Array<PointId> | null, pointCoords?: Float64Array | undefined | null, anchorIds?: Array<AnchorId> | null, anchorCoords?: Float64Array | undefined | null): void
+  restoreState(layerId: LayerId, structure: GlyphStructure, values: Float64Array): GlyphStructureChange
 }
 
 export interface GlyphHandle {
   name: GlyphName
   unicode?: Unicode
-}
-
-export interface GlyphLayerRef {
-  glyphHandle: GlyphHandle
-  sourceId: SourceId
 }
 
 export interface FontExportRequest {
@@ -189,6 +184,7 @@ export interface GlyphRecord {
 }
 
 export interface GlyphState {
+  layerId: LayerId
   structure: GlyphStructure
   /** Numeric glyph state ordered to match `GlyphStructure`. */
   values: Float64Array

--- a/packages/types/src/bridge/index.ts
+++ b/packages/types/src/bridge/index.ts
@@ -9,7 +9,6 @@ export type {
   FontMetrics,
   GlyphChangedEntities,
   GlyphHandle,
-  GlyphLayerRef,
   GlyphMaster,
   GlyphName,
   GlyphRecord,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -43,7 +43,6 @@ export type {
   FontMetrics,
   GlyphChangedEntities,
   GlyphHandle,
-  GlyphLayerRef,
   GlyphMaster,
   GlyphName,
   GlyphRecord,


### PR DESCRIPTION
## Summary

- Adds `layerId` to the shared glyph state wire DTO so the renderer receives the stable layer identity during hydration.
- Changes bridge mutation methods to accept `LayerId` directly instead of resolving the old glyph/source edit reference on every call.
- Updates the renderer glyph edit session to store and use the hydrated `LayerId`, and removes `GlyphLayerRef` from the shared TypeScript bridge facade.

## Why

Workspace edits already operate on explicit layers. The bridge was still carrying the older glyph-name/source identity shape for mutations, which kept hidden resolution in the edit path and made the future utility-process workspace API less clear.

This PR splits the boundary cleanly: read state by `GlyphHandle + SourceId`, then edit by `LayerId`.

## Validation

- `pnpm --filter shift-bridge run build:debug`
- `pnpm generate:bridge-types`
- `cargo test -p shift-wire -p shift-bridge`
- `pnpm --filter shift-bridge run test`
- `pnpm --filter @shift/desktop run typecheck`
- `pnpm --filter @shift/desktop run test -- src/renderer/src/lib/model/GlyphSourceState.test.ts src/renderer/src/lib/model/Glyph.test.ts` (package script ran the full desktop Vitest suite: 46 files, 517 passed, 6 todo)
- `cargo clippy --workspace --all-targets -- -D warnings`
- commit hooks: cargo check/fmt/clippy/test, oxfmt, oxlint, tsgo typecheck, strict deadcode, vitest
