### PR TITLE
[codex] Move edit result shaping into workspace

### DIFF
--- a/crates/shift-bridge/src/bridge.rs
+++ b/crates/shift-bridge/src/bridge.rs
@@ -18,7 +18,9 @@ use shift_wire::{
   Axis, FontMetadata, FontMetrics, GlyphChangedEntities, GlyphRecord, GlyphState, GlyphStructure,
   GlyphStructureChange, GlyphValueChange, Source,
 };
-use shift_workspace::{FontWorkspace, NewWorkspace};
+use shift_workspace::{
+  FontWorkspace, GlyphEditEntities, GlyphStructureEdit, GlyphValueEdit, NewWorkspace,
+};
 use std::sync::{
   atomic::{AtomicU64, Ordering},
   Arc,
@@ -655,8 +657,7 @@ impl Bridge {
     width: f64,
   ) -> errors::Result<NapiGlyphValueChange> {
     let layer_id = parse::<LayerId>(&layer_id)?;
-    let layer = self.workspace_mut()?.set_x_advance(layer_id, width)?;
-    let change = GlyphValueChange::from_layer(&layer, Default::default());
+    let change = glyph_value_change(self.workspace_mut()?.set_x_advance(layer_id, width)?);
 
     self.mark_font_changed();
     Ok(change.into())
@@ -670,8 +671,7 @@ impl Bridge {
     dy: f64,
   ) -> errors::Result<NapiGlyphValueChange> {
     let layer_id = parse::<LayerId>(&layer_id)?;
-    let layer = self.workspace_mut()?.translate_layer(layer_id, dx, dy)?;
-    let change = GlyphValueChange::from_layer(&layer, Default::default());
+    let change = glyph_value_change(self.workspace_mut()?.translate_layer(layer_id, dx, dy)?);
 
     self.mark_font_changed();
     Ok(change.into())
@@ -691,14 +691,11 @@ impl Bridge {
     let point_type = point_type.into();
 
     let layer_id = parse::<LayerId>(&layer_id)?;
-    let (layer, point_id) = self
-      .workspace_mut()?
-      .add_point(layer_id, contour_id, x, y, point_type, smooth)?;
-    let changed = GlyphChangedEntities {
-      point_ids: vec![point_id],
-      ..Default::default()
-    };
-    let change = GlyphStructureChange::from_layer(&layer, changed);
+    let change = glyph_structure_change(
+      self
+        .workspace_mut()?
+        .add_point(layer_id, contour_id, x, y, point_type, smooth)?,
+    );
 
     self.mark_font_changed();
     Ok(change.into())
@@ -718,19 +715,14 @@ impl Bridge {
     let point_type = point_type.into();
 
     let layer_id = parse::<LayerId>(&layer_id)?;
-    let (layer, point_id) = self.workspace_mut()?.insert_point_before(
+    let change = glyph_structure_change(self.workspace_mut()?.insert_point_before(
       layer_id,
       before_point_id,
       x,
       y,
       point_type,
       smooth,
-    )?;
-    let changed = GlyphChangedEntities {
-      point_ids: vec![point_id],
-      ..Default::default()
-    };
-    let change = GlyphStructureChange::from_layer(&layer, changed);
+    )?);
 
     self.mark_font_changed();
     Ok(change.into())
@@ -742,12 +734,7 @@ impl Bridge {
     #[napi(ts_arg_type = "LayerId")] layer_id: String,
   ) -> errors::Result<NapiGlyphStructureChange> {
     let layer_id = parse::<LayerId>(&layer_id)?;
-    let (layer, contour_id) = self.workspace_mut()?.add_contour(layer_id)?;
-    let changed = GlyphChangedEntities {
-      contour_ids: vec![contour_id],
-      ..Default::default()
-    };
-    let change = GlyphStructureChange::from_layer(&layer, changed);
+    let change = glyph_structure_change(self.workspace_mut()?.add_contour(layer_id)?);
 
     self.mark_font_changed();
     Ok(change.into())
@@ -761,14 +748,7 @@ impl Bridge {
   ) -> errors::Result<NapiGlyphStructureChange> {
     let contour_id = parse::<ContourId>(&contour_id)?;
     let layer_id = parse::<LayerId>(&layer_id)?;
-    let layer = self
-      .workspace_mut()?
-      .open_contour(layer_id, contour_id.clone())?;
-    let changed = GlyphChangedEntities {
-      contour_ids: vec![contour_id],
-      ..Default::default()
-    };
-    let change = GlyphStructureChange::from_layer(&layer, changed);
+    let change = glyph_structure_change(self.workspace_mut()?.open_contour(layer_id, contour_id)?);
 
     self.mark_font_changed();
     Ok(change.into())
@@ -782,14 +762,7 @@ impl Bridge {
   ) -> errors::Result<NapiGlyphStructureChange> {
     let contour_id = parse::<ContourId>(&contour_id)?;
     let layer_id = parse::<LayerId>(&layer_id)?;
-    let layer = self
-      .workspace_mut()?
-      .close_contour(layer_id, contour_id.clone())?;
-    let changed = GlyphChangedEntities {
-      contour_ids: vec![contour_id],
-      ..Default::default()
-    };
-    let change = GlyphStructureChange::from_layer(&layer, changed);
+    let change = glyph_structure_change(self.workspace_mut()?.close_contour(layer_id, contour_id)?);
 
     self.mark_font_changed();
     Ok(change.into())
@@ -803,14 +776,11 @@ impl Bridge {
   ) -> errors::Result<NapiGlyphStructureChange> {
     let contour_id = parse::<ContourId>(&contour_id)?;
     let layer_id = parse::<LayerId>(&layer_id)?;
-    let layer = self
-      .workspace_mut()?
-      .reverse_contour(layer_id, contour_id.clone())?;
-    let changed = GlyphChangedEntities {
-      contour_ids: vec![contour_id],
-      ..Default::default()
-    };
-    let change = GlyphStructureChange::from_layer(&layer, changed);
+    let change = glyph_structure_change(
+      self
+        .workspace_mut()?
+        .reverse_contour(layer_id, contour_id)?,
+    );
 
     self.mark_font_changed();
     Ok(change.into())
@@ -841,14 +811,11 @@ impl Bridge {
     };
 
     let layer_id = parse::<LayerId>(&layer_id)?;
-    let (layer, contour_ids) = self
-      .workspace_mut()?
-      .apply_boolean_op(layer_id, cid_a, cid_b, op)?;
-    let changed = GlyphChangedEntities {
-      contour_ids,
-      ..Default::default()
-    };
-    let change = GlyphStructureChange::from_layer(&layer, changed);
+    let change = glyph_structure_change(
+      self
+        .workspace_mut()?
+        .apply_boolean_op(layer_id, cid_a, cid_b, op)?,
+    );
 
     self.mark_font_changed();
     Ok(change.into())
@@ -864,10 +831,7 @@ impl Bridge {
     let point_ids = point_ids?;
 
     let layer_id = parse::<LayerId>(&layer_id)?;
-    let layer = self
-      .workspace_mut()?
-      .remove_points(layer_id, point_ids.clone())?;
-    let change = GlyphStructureChange::from_layer(&layer, GlyphChangedEntities::points(point_ids));
+    let change = glyph_structure_change(self.workspace_mut()?.remove_points(layer_id, point_ids)?);
 
     self.mark_font_changed();
     Ok(change.into())
@@ -881,14 +845,7 @@ impl Bridge {
   ) -> errors::Result<NapiGlyphStructureChange> {
     let parsed_id = parse::<PointId>(&point_id)?;
     let layer_id = parse::<LayerId>(&layer_id)?;
-    let layer = self
-      .workspace_mut()?
-      .toggle_smooth(layer_id, parsed_id.clone())?;
-    let changed = GlyphChangedEntities {
-      point_ids: vec![parsed_id],
-      ..Default::default()
-    };
-    let change = GlyphStructureChange::from_layer(&layer, changed);
+    let change = glyph_structure_change(self.workspace_mut()?.toggle_smooth(layer_id, parsed_id)?);
 
     self.mark_font_changed();
     Ok(change.into())
@@ -958,13 +915,32 @@ impl Bridge {
       ))?
       .clone();
     apply_state_to_layer(&mut layer, &structure, values)?;
-    let layer = self
-      .workspace_mut()?
-      .replace_layer(layer_id.clone(), layer)?;
-    let change = GlyphStructureChange::from_layer(&layer, Default::default());
+    let change = glyph_structure_change(
+      self
+        .workspace_mut()?
+        .replace_layer(layer_id.clone(), layer)?,
+    );
 
     self.mark_font_changed();
     Ok(change.into())
+  }
+}
+
+fn glyph_value_change(edit: GlyphValueEdit) -> GlyphValueChange {
+  GlyphValueChange::from_layer(&edit.layer, glyph_changed_entities(edit.changed))
+}
+
+fn glyph_structure_change(edit: GlyphStructureEdit) -> GlyphStructureChange {
+  GlyphStructureChange::from_layer(&edit.layer, glyph_changed_entities(edit.changed))
+}
+
+fn glyph_changed_entities(changed: GlyphEditEntities) -> GlyphChangedEntities {
+  GlyphChangedEntities {
+    point_ids: changed.point_ids,
+    contour_ids: changed.contour_ids,
+    anchor_ids: changed.anchor_ids,
+    guideline_ids: changed.guideline_ids,
+    component_ids: changed.component_ids,
   }
 }
 

--- a/crates/shift-workspace/src/lib.rs
+++ b/crates/shift-workspace/src/lib.rs
@@ -2,4 +2,7 @@ mod new_workspace;
 mod workspace;
 
 pub use new_workspace::NewWorkspace;
-pub use workspace::{FontWorkspace, WorkspaceError, WorkspaceSource};
+pub use workspace::{
+    FontWorkspace, GlyphEditEntities, GlyphStructureEdit, GlyphValueEdit, WorkspaceError,
+    WorkspaceSource,
+};

--- a/crates/shift-workspace/src/workspace.rs
+++ b/crates/shift-workspace/src/workspace.rs
@@ -2,8 +2,9 @@ use std::path::{Path, PathBuf};
 
 use shift_backends::{FontExportRequest, FontExportResult, FontExporter, font_loader::FontLoader};
 use shift_font::{
-    BooleanOp, BulkNodePositionUpdates, ContourId, FontChange, FontChangeSet, Glyph, GlyphId,
-    GlyphLayer, GlyphName, LayerId, PointId, PointPosition, PointType, SourceId, error::CoreError,
+    AnchorId, BooleanOp, BulkNodePositionUpdates, ComponentId, ContourId, FontChange,
+    FontChangeSet, Glyph, GlyphId, GlyphLayer, GlyphName, GuidelineId, LayerId, PointId,
+    PointPosition, PointType, SourceId, error::CoreError,
 };
 use shift_source::ShiftSourcePackage;
 use shift_store::ShiftStore;
@@ -47,6 +48,75 @@ pub struct FontWorkspace {
     font: shift_font::Font,
     source: WorkspaceSource,
     store: ShiftStore,
+}
+
+#[derive(Clone, Debug)]
+pub struct GlyphValueEdit {
+    pub layer: GlyphLayer,
+    pub changed: GlyphEditEntities,
+}
+
+impl GlyphValueEdit {
+    fn new(layer: &GlyphLayer, changed: GlyphEditEntities) -> Self {
+        Self {
+            layer: layer.clone(),
+            changed,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct GlyphStructureEdit {
+    pub layer: GlyphLayer,
+    pub changed: GlyphEditEntities,
+}
+
+impl GlyphStructureEdit {
+    fn new(layer: &GlyphLayer, changed: GlyphEditEntities) -> Self {
+        Self {
+            layer: layer.clone(),
+            changed,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct GlyphEditEntities {
+    pub point_ids: Vec<PointId>,
+    pub contour_ids: Vec<ContourId>,
+    pub anchor_ids: Vec<AnchorId>,
+    pub guideline_ids: Vec<GuidelineId>,
+    pub component_ids: Vec<ComponentId>,
+}
+
+impl GlyphEditEntities {
+    fn point(id: PointId) -> Self {
+        Self {
+            point_ids: vec![id],
+            ..Default::default()
+        }
+    }
+
+    fn points(ids: Vec<PointId>) -> Self {
+        Self {
+            point_ids: ids,
+            ..Default::default()
+        }
+    }
+
+    fn contour(id: ContourId) -> Self {
+        Self {
+            contour_ids: vec![id],
+            ..Default::default()
+        }
+    }
+
+    fn contours(ids: Vec<ContourId>) -> Self {
+        Self {
+            contour_ids: ids,
+            ..Default::default()
+        }
+    }
 }
 
 impl FontWorkspace {
@@ -250,17 +320,17 @@ impl FontWorkspace {
         &mut self,
         layer_id: LayerId,
         width: f64,
-    ) -> Result<GlyphLayer, WorkspaceError> {
+    ) -> Result<GlyphValueEdit, WorkspaceError> {
         self.commit_edit(|font| {
             let layer = font
                 .layer_mut(layer_id.clone())
                 .ok_or(CoreError::LayerNotFound(layer_id.clone()))?;
 
             layer.set_x_advance(width);
-            let edited_layer = layer.clone();
+            let edit_change = GlyphValueEdit::new(layer, Default::default());
             let change_set = FontChange::layer_metrics_changed(layer).into();
 
-            Ok((edited_layer, change_set))
+            Ok((edit_change, change_set))
         })
     }
 
@@ -269,11 +339,13 @@ impl FontWorkspace {
         layer_id: LayerId,
         dx: f64,
         dy: f64,
-    ) -> Result<GlyphLayer, WorkspaceError> {
-        self.replace_layer_geometry(layer_id, |layer| {
+    ) -> Result<GlyphValueEdit, WorkspaceError> {
+        let layer = self.replace_layer_geometry(layer_id, |layer| {
             layer.translate_layer(dx, dy);
             Ok(())
-        })
+        })?;
+
+        Ok(GlyphValueEdit::new(&layer, Default::default()))
     }
 
     pub fn add_point(
@@ -284,13 +356,14 @@ impl FontWorkspace {
         y: f64,
         point_type: PointType,
         smooth: bool,
-    ) -> Result<(GlyphLayer, PointId), WorkspaceError> {
+    ) -> Result<GlyphStructureEdit, WorkspaceError> {
         self.commit_edit(|font| {
             let layer = font
                 .layer_mut(layer_id.clone())
                 .ok_or(CoreError::LayerNotFound(layer_id.clone()))?;
             let added = layer.add_point_to_contour(contour_id.clone(), x, y, point_type, smooth)?;
-            let edited_layer = layer.clone();
+            let edit_change =
+                GlyphStructureEdit::new(layer, GlyphEditEntities::point(added.point_id.clone()));
             let change_set = FontChange::points_added(
                 layer_id.clone(),
                 &added.contour,
@@ -298,7 +371,7 @@ impl FontWorkspace {
             )
             .into();
 
-            Ok(((edited_layer, added.point_id.clone()), change_set))
+            Ok((edit_change, change_set))
         })
     }
 
@@ -310,14 +383,15 @@ impl FontWorkspace {
         y: f64,
         point_type: PointType,
         smooth: bool,
-    ) -> Result<(GlyphLayer, PointId), WorkspaceError> {
+    ) -> Result<GlyphStructureEdit, WorkspaceError> {
         self.commit_edit(|font| {
             let layer = font
                 .layer_mut(layer_id.clone())
                 .ok_or(CoreError::LayerNotFound(layer_id.clone()))?;
             let added =
                 layer.insert_point_before(before_point_id.clone(), x, y, point_type, smooth)?;
-            let edited_layer = layer.clone();
+            let edit_change =
+                GlyphStructureEdit::new(layer, GlyphEditEntities::point(added.point_id.clone()));
             let change_set = FontChange::points_added(
                 layer_id.clone(),
                 &added.contour,
@@ -325,23 +399,21 @@ impl FontWorkspace {
             )
             .into();
 
-            Ok(((edited_layer, added.point_id.clone()), change_set))
+            Ok((edit_change, change_set))
         })
     }
 
-    pub fn add_contour(
-        &mut self,
-        layer_id: LayerId,
-    ) -> Result<(GlyphLayer, ContourId), WorkspaceError> {
+    pub fn add_contour(&mut self, layer_id: LayerId) -> Result<GlyphStructureEdit, WorkspaceError> {
         self.commit_edit(|font| {
             let layer = font
                 .layer_mut(layer_id.clone())
                 .ok_or(CoreError::LayerNotFound(layer_id.clone()))?;
             let contour = layer.add_empty_contour();
-            let edited_layer = layer.clone();
+            let edit_change =
+                GlyphStructureEdit::new(layer, GlyphEditEntities::contour(contour.id()));
             let change_set = FontChange::contour_added(layer_id.clone(), &contour).into();
 
-            Ok(((edited_layer, contour.id()), change_set))
+            Ok((edit_change, change_set))
         })
     }
 
@@ -349,7 +421,7 @@ impl FontWorkspace {
         &mut self,
         layer_id: LayerId,
         contour_id: ContourId,
-    ) -> Result<GlyphLayer, WorkspaceError> {
+    ) -> Result<GlyphStructureEdit, WorkspaceError> {
         self.set_contour_closed(layer_id, contour_id, false)
     }
 
@@ -357,7 +429,7 @@ impl FontWorkspace {
         &mut self,
         layer_id: LayerId,
         contour_id: ContourId,
-    ) -> Result<GlyphLayer, WorkspaceError> {
+    ) -> Result<GlyphStructureEdit, WorkspaceError> {
         self.set_contour_closed(layer_id, contour_id, true)
     }
 
@@ -365,11 +437,17 @@ impl FontWorkspace {
         &mut self,
         layer_id: LayerId,
         contour_id: ContourId,
-    ) -> Result<GlyphLayer, WorkspaceError> {
-        self.replace_layer_geometry(layer_id, |layer| {
+    ) -> Result<GlyphStructureEdit, WorkspaceError> {
+        let contour_id_for_change = contour_id.clone();
+        let layer = self.replace_layer_geometry(layer_id, |layer| {
             layer.reverse_contour(contour_id)?;
             Ok(())
-        })
+        })?;
+
+        Ok(GlyphStructureEdit::new(
+            &layer,
+            GlyphEditEntities::contour(contour_id_for_change),
+        ))
     }
 
     pub fn apply_boolean_op(
@@ -378,38 +456,50 @@ impl FontWorkspace {
         contour_id_a: ContourId,
         contour_id_b: ContourId,
         operation: BooleanOp,
-    ) -> Result<(GlyphLayer, Vec<ContourId>), WorkspaceError> {
-        self.replace_layer_geometry_with_result(layer_id, |layer| {
+    ) -> Result<GlyphStructureEdit, WorkspaceError> {
+        let (layer, contour_ids) = self.replace_layer_geometry_with_result(layer_id, |layer| {
             layer.apply_boolean_op(contour_id_a, contour_id_b, operation)
-        })
+        })?;
+
+        Ok(GlyphStructureEdit::new(
+            &layer,
+            GlyphEditEntities::contours(contour_ids),
+        ))
     }
 
     pub fn remove_points(
         &mut self,
         layer_id: LayerId,
         point_ids: Vec<PointId>,
-    ) -> Result<GlyphLayer, WorkspaceError> {
-        self.replace_layer_geometry(layer_id, |layer| {
+    ) -> Result<GlyphStructureEdit, WorkspaceError> {
+        let point_ids_for_change = point_ids.clone();
+        let layer = self.replace_layer_geometry(layer_id, |layer| {
             layer.remove_points(&point_ids)?;
             Ok(())
-        })
+        })?;
+
+        Ok(GlyphStructureEdit::new(
+            &layer,
+            GlyphEditEntities::points(point_ids_for_change),
+        ))
     }
 
     pub fn toggle_smooth(
         &mut self,
         layer_id: LayerId,
         point_id: PointId,
-    ) -> Result<GlyphLayer, WorkspaceError> {
+    ) -> Result<GlyphStructureEdit, WorkspaceError> {
         self.commit_edit(|font| {
             let layer = font
                 .layer_mut(layer_id.clone())
                 .ok_or(CoreError::LayerNotFound(layer_id.clone()))?;
             let smooth = layer.toggle_smooth(point_id.clone())?;
-            let edited_layer = layer.clone();
+            let edit_change =
+                GlyphStructureEdit::new(layer, GlyphEditEntities::point(point_id.clone()));
             let change_set =
                 FontChange::point_smooth_changed(layer_id.clone(), point_id.clone(), smooth).into();
 
-            Ok((edited_layer, change_set))
+            Ok((edit_change, change_set))
         })
     }
 
@@ -443,11 +533,13 @@ impl FontWorkspace {
         &mut self,
         layer_id: LayerId,
         replacement: GlyphLayer,
-    ) -> Result<GlyphLayer, WorkspaceError> {
-        self.replace_layer_geometry(layer_id, |layer| {
+    ) -> Result<GlyphStructureEdit, WorkspaceError> {
+        let layer = self.replace_layer_geometry(layer_id, |layer| {
             *layer = replacement;
             Ok(())
-        })
+        })?;
+
+        Ok(GlyphStructureEdit::new(&layer, Default::default()))
     }
 
     fn commit_font(
@@ -476,7 +568,7 @@ impl FontWorkspace {
         layer_id: LayerId,
         contour_id: ContourId,
         closed: bool,
-    ) -> Result<GlyphLayer, WorkspaceError> {
+    ) -> Result<GlyphStructureEdit, WorkspaceError> {
         self.commit_edit(|font| {
             let layer = font
                 .layer_mut(layer_id.clone())
@@ -486,7 +578,8 @@ impl FontWorkspace {
             } else {
                 layer.open_contour(contour_id.clone())?;
             }
-            let edited_layer = layer.clone();
+            let edit_change =
+                GlyphStructureEdit::new(layer, GlyphEditEntities::contour(contour_id.clone()));
             let change_set = FontChange::contour_open_closed_changed(
                 layer_id.clone(),
                 contour_id.clone(),
@@ -494,7 +587,7 @@ impl FontWorkspace {
             )
             .into();
 
-            Ok((edited_layer, change_set))
+            Ok((edit_change, change_set))
         })
     }
 

--- a/crates/shift-workspace/tests/workspace_test.rs
+++ b/crates/shift-workspace/tests/workspace_test.rs
@@ -122,9 +122,9 @@ fn set_x_advance_updates_existing_layer() {
     let layer = workspace.create_glyph_layer(glyph.id(), source_id).unwrap();
     let layer_id = layer.id();
 
-    let edited_layer = workspace.set_x_advance(layer_id.clone(), 640.0).unwrap();
+    let change = workspace.set_x_advance(layer_id.clone(), 640.0).unwrap();
 
-    assert_eq!(edited_layer.width(), 640.0);
+    assert_eq!(change.layer.width(), 640.0);
     assert_eq!(workspace.font().layer(layer_id).unwrap().width(), 640.0);
 }
 


### PR DESCRIPTION
## Summary

- Adds workspace-domain edit result structs for glyph value and structure edits.
- Moves changed-entity ownership into `shift-workspace`, so workspace edit methods return the edited layer plus touched IDs.
- Simplifies bridge mutation methods so they parse NAPI inputs, call workspace, convert the workspace edit result to `shift-wire`, bump the live version, and return.

## Why

PR A makes edits target `LayerId` directly. This stacked PR tightens the next boundary: bridge should not decide which point/contour IDs changed for a domain edit. That belongs beside the workspace mutation because it is part of the edit semantics and persistence path.

The dependency direction stays clean: `shift-workspace` does not depend on `shift-wire` or NAPI. Bridge remains the wire/NAPI adapter.

## Validation

- `cargo check -p shift-workspace -p shift-bridge`
- `cargo test -p shift-workspace -p shift-bridge`
- `pnpm --filter shift-bridge run test`
- `cargo clippy -p shift-workspace -p shift-bridge --all-targets -- -D warnings`
- commit hooks: cargo check/fmt/clippy/test
