### PR TITLE
feat: undoable font-level intents — one apply, one undo step

### DIFF
--- a/apps/desktop/src/renderer/src/components/editor/EditorView.tsx
+++ b/apps/desktop/src/renderer/src/components/editor/EditorView.tsx
@@ -4,7 +4,7 @@ import { CanvasContextProvider } from "@/context/CanvasContext";
 import { useDebugSafe } from "@/context/DebugContext";
 import { effect } from "@/lib/signals/signal";
 import { useSignalState } from "@/lib/signals";
-import { getEditor, getWorkspace } from "@/store/appStore";
+import { getEditor } from "@/store/appStore";
 import { zoomMultiplierFromWheel } from "@/lib/transform";
 import { InteractiveScene } from "./InteractiveScene";
 import { StaticScene } from "./StaticScene";
@@ -61,18 +61,7 @@ export const EditorView: FC<EditorViewProps> = ({ glyphId, glyphName }) => {
 
       // Glyph-name-first: opening a cell that has no committed record yet
       // creates the glyph in the workspace, then opens it.
-      let record = editor.font.recordForName(handle.name);
-      if (!record) {
-        const applied = await getWorkspace().apply([
-          {
-            kind: "createGlyph",
-            name: handle.name,
-            unicodes: handle.unicode === undefined ? [] : [handle.unicode],
-          },
-        ]);
-        record = applied.glyphs?.find((glyph) => glyph.name === handle.name) ?? null;
-      }
-      if (!record || cancelled) return;
+      const record = editor.font.recordForName(handle.name) ?? editor.createGlyph(handle.name);
 
       // Pull replace-grade state and materialize the editable model before
       // the session opens; folds keep it current afterwards.

--- a/apps/desktop/src/renderer/src/context/GlyphCatalogContext.tsx
+++ b/apps/desktop/src/renderer/src/context/GlyphCatalogContext.tsx
@@ -116,12 +116,12 @@ const useGlyphCatalogState = (): GlyphCatalogState => {
     selectedSubCategoryKey,
     setQuery,
     createQuickGlyph: () => {
-      const handle = getEditor().createGlyph("newGlyph");
+      const record = getEditor().createGlyph("newGlyph" as GlyphName);
       setQuery("");
       setSelectedCategory(null);
       setSelectedSubCategoryKey(null);
 
-      return handle.name;
+      return record.name;
     },
     selectAll: () => {
       setSelectedCategory(null);

--- a/apps/desktop/src/renderer/src/lib/editor/Editor.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/Editor.ts
@@ -1,5 +1,5 @@
 import type { CursorType, ToolRegistryItem } from "@/types/editor";
-import type { PointId, ContourId, Source, SourceId, GlyphName } from "@shift/types";
+import type { PointId, ContourId, Source, SourceId, GlyphName, GlyphRecord } from "@shift/types";
 import type { AxisLocation } from "@/types/variation";
 import type { Coordinates } from "@/types/coordinates";
 import type { Glyph, GlyphInstance, GlyphSource } from "@/lib/model/Glyph";
@@ -556,16 +556,13 @@ export class Editor {
   }
 
   /**
-   * Creates an empty committed glyph in the loaded font.
-   *
-   * @remarks
-   * This is the editor-level entry point for quick-add flows. It delegates
-   * naming and bridge commit semantics to {@link Font.createGlyph}.
+   * Creates an empty glyph in the loaded font.
    *
    * @param name - Preferred glyph name. Existing names are auto-incremented.
-   * @returns The handle for the glyph that was actually created.
+   * @returns The record for the glyph that was actually created.
+   * @see {@link Font.createGlyph}
    */
-  public createGlyph(name: GlyphName): GlyphHandle {
+  public createGlyph(name: GlyphName): GlyphRecord {
     return this.font.createGlyph(name);
   }
 

--- a/apps/desktop/src/renderer/src/lib/model/Font.test.ts
+++ b/apps/desktop/src/renderer/src/lib/model/Font.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { GlyphName, SourceId, Unicode } from "@shift/types";
+import { mintGlyphId, type GlyphName, type SourceId, type Unicode } from "@shift/types";
 import type { WorkspaceSnapshot } from "@shared/workspace/protocol";
 import { signal } from "@/lib/signals/signal";
 import { Font } from "./Font";
@@ -92,7 +92,10 @@ describe("font-level intents make the font variable", () => {
     const stack = createWorkspaceStack();
     await stack.client.create();
     await stack.client.apply([
-      { kind: "createGlyph", name: "A" as GlyphName, unicodes: [65 as Unicode] },
+      {
+        kind: "createGlyph",
+        createGlyph: { glyphId: mintGlyphId(), name: "A" as GlyphName, unicodes: [65 as Unicode] },
+      },
     ]);
     expect(stack.font.isVariable()).toBe(false);
 

--- a/apps/desktop/src/renderer/src/lib/model/Font.ts
+++ b/apps/desktop/src/renderer/src/lib/model/Font.ts
@@ -10,6 +10,7 @@ import type {
   SourceId,
   Unicode,
 } from "@shift/types";
+import { mintGlyphId } from "@shift/types";
 import { computed, type Signal } from "@/lib/signals/signal";
 import type { ChangeWriter } from "@/lib/workspace/ChangeWriter";
 import type { WorkspaceSnapshot } from "@shared/workspace/protocol";
@@ -429,12 +430,32 @@ export class Font {
   }
 
   /**
-   * Creates an empty committed glyph at the default source.
+   * Creates an empty glyph with one layer per source and returns its
+   * identity immediately.
    *
-   * @throws {Error} always — glyph mutations return with workspace change sets.
+   * @remarks
+   * The durable commit happens asynchronously; the committed record folds
+   * into the font's directory when the workspace echo lands. Reads that
+   * resolve glyph state (e.g. {@link openGlyph}) serialize behind pending
+   * writes, so they may follow this call without awaiting anything.
+   *
+   * @param name - Preferred glyph name. Existing names are auto-incremented
+   *   (`base`, `base.1`, …); Unicode assignment is inferred from the
+   *   resolved name.
+   * @returns The created glyph's record, carrying its freshly minted id.
    */
-  createGlyph(_name: GlyphName): GlyphHandle {
-    throw new Error("editing is not wired to the workspace yet");
+  createGlyph(name: GlyphName): GlyphRecord {
+    const finalName = this.nextAvailableGlyphName(name);
+    const handle = this.glyphHandleForName(finalName);
+    const unicodes = handle.unicode === undefined ? [] : [handle.unicode];
+    const glyphId = mintGlyphId();
+
+    this.writer.push({
+      kind: "createGlyph",
+      createGlyph: { glyphId, name: finalName, unicodes },
+    });
+
+    return { id: glyphId, name: finalName, unicodes, componentBaseGlyphNames: [] };
   }
 
   /**

--- a/apps/desktop/src/renderer/src/lib/model/variation.test.ts
+++ b/apps/desktop/src/renderer/src/lib/model/variation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeEach } from "vitest";
 import type { GlyphId, GlyphName, LayerId, Source, Unicode } from "@shift/types";
-import { mintContourId, mintPointId } from "@shift/types";
+import { mintContourId, mintGlyphId, mintPointId } from "@shift/types";
 import { defaultAxisLocation, withAxisValue } from "@/lib/variation/location";
 import { createWorkspaceStack, type WorkspaceStack } from "@/testing/workspaceStack";
 
@@ -55,7 +55,10 @@ async function variableFont(): Promise<{
   await stack.client.create();
 
   const created = await stack.client.apply([
-    { kind: "createGlyph", name: "A" as GlyphName, unicodes: [65 as Unicode] },
+    {
+      kind: "createGlyph",
+      createGlyph: { glyphId: mintGlyphId(), name: "A" as GlyphName, unicodes: [65 as Unicode] },
+    },
   ]);
   const glyphId = created.glyphs![0]!.id;
   const regularLayerId = created.layers[0]!.layerId;

--- a/apps/desktop/src/renderer/src/lib/text/layout/testUtils.ts
+++ b/apps/desktop/src/renderer/src/lib/text/layout/testUtils.ts
@@ -6,7 +6,7 @@
  * outline bounds flow through positioning. No fakes; tests assert against
  * values read back from the workspace, not hardcoded advances.
  */
-import type { GlyphName, Unicode } from "@shift/types";
+import { mintGlyphId, type GlyphName, type Unicode } from "@shift/types";
 import { signal } from "@/lib/signals/signal";
 import type { Font } from "@/lib/model/Font";
 import { createWorkspaceStack } from "@/testing/workspaceStack";
@@ -26,7 +26,10 @@ export async function layoutTestFont(): Promise<Font> {
 
   for (const [name, unicode, advance] of GLYPHS) {
     const applied = await stack.client.apply([
-      { kind: "createGlyph", name: name as GlyphName, unicodes: [unicode] },
+      {
+        kind: "createGlyph",
+        createGlyph: { glyphId: mintGlyphId(), name: name as GlyphName, unicodes: [unicode] },
+      },
     ]);
     const layerId = applied.layers[0]?.layerId;
     const record = applied.glyphs?.find((glyph) => glyph.name === name);

--- a/apps/desktop/src/renderer/src/lib/workspace/ledger.test.ts
+++ b/apps/desktop/src/renderer/src/lib/workspace/ledger.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import type { GlyphName } from "@shift/types";
 import { TestEditor } from "@/testing/TestEditor";
 
 /**
@@ -66,11 +67,15 @@ describe("workspace ledger semantics (via TestEditor)", () => {
     expect(source().allPoints.map(({ x }) => x)).toEqual([10, 30]);
   });
 
-  it("undo on an empty ledger leaves state untouched", async () => {
+  it("undoes the session's glyph creation, then stops at the empty ledger", async () => {
     await editor.undoAndSettle();
+    expect(editor.font.recordForName("A" as GlyphName)).toBe(null);
 
-    expect(editor.pointCount).toBe(0);
-    expect(editor.activeGlyphSource).not.toBe(null);
+    await editor.undoAndSettle();
+    expect(editor.font.recordForName("A" as GlyphName)).toBe(null);
+
+    await editor.redoAndSettle();
+    expect(editor.font.recordForName("A" as GlyphName)).not.toBe(null);
   });
 
   it("coalesces every intent in one tick into a single entry", async () => {

--- a/apps/desktop/src/renderer/src/perf/workspaceApply.bench.ts
+++ b/apps/desktop/src/renderer/src/perf/workspaceApply.bench.ts
@@ -1,6 +1,6 @@
 import { bench, describe } from "vitest";
 import type { GlyphName, PointType, Unicode } from "@shift/types";
-import { mintContourId, mintPointId } from "@shift/types";
+import { mintContourId, mintGlyphId, mintPointId } from "@shift/types";
 import { createWorkspaceStack } from "@/testing/workspaceStack";
 
 /**
@@ -13,7 +13,10 @@ const stack = createWorkspaceStack();
 await stack.client.create();
 
 const created = await stack.client.apply([
-  { kind: "createGlyph", name: "A" as GlyphName, unicodes: [65 as Unicode] },
+  {
+    kind: "createGlyph",
+    createGlyph: { glyphId: mintGlyphId(), name: "A" as GlyphName, unicodes: [65 as Unicode] },
+  },
 ]);
 const layerId = created.layers[0]!.layerId;
 const glyphId = created.glyphs![0]!.id;

--- a/apps/desktop/src/renderer/src/testing/TestEditor.ts
+++ b/apps/desktop/src/renderer/src/testing/TestEditor.ts
@@ -15,7 +15,7 @@ import { Editor } from "@/lib/editor/Editor";
 import type { Glyph } from "@/lib/model/Glyph";
 import type { ToolName } from "@/lib/tools/core";
 import { registerBuiltInTools } from "@/lib/tools/tools";
-import type { GlyphName } from "@shift/types";
+import { mintGlyphId, type GlyphName, type Unicode } from "@shift/types";
 import type { SystemClipboard } from "@/lib/clipboard";
 import { createWorkspaceStack, type WorkspaceStack } from "./workspaceStack";
 
@@ -73,8 +73,11 @@ export class TestEditor extends Editor {
     const applied = await this.#stack.client.apply([
       {
         kind: "createGlyph",
-        name: name as GlyphName,
-        unicodes: unicode === null ? [] : [unicode],
+        createGlyph: {
+          glyphId: mintGlyphId(),
+          name: name as GlyphName,
+          unicodes: (unicode === null ? [] : [unicode]) as Unicode[],
+        },
       },
     ]);
 

--- a/apps/desktop/src/utility/workspace/WorkspaceHost.test.ts
+++ b/apps/desktop/src/utility/workspace/WorkspaceHost.test.ts
@@ -4,7 +4,15 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { Channel, nodePortTransport, type Transport } from "../../shared/workspace/channel";
-import { mintContourId, mintPointId, type GlyphId, type PointType } from "@shift/types";
+import {
+  mintContourId,
+  mintGlyphId,
+  mintPointId,
+  type GlyphId,
+  type GlyphName,
+  type PointType,
+  type Unicode,
+} from "@shift/types";
 import type {
   ShellCallMap,
   ShellEventMap,
@@ -14,6 +22,15 @@ import type {
 import { WorkspaceHost } from "./WorkspaceHost";
 
 type ShellChannel = Channel<ShellCallMap, ShellEventMap>;
+
+const createGlyphA = () => ({
+  kind: "createGlyph",
+  createGlyph: {
+    glyphId: mintGlyphId(),
+    name: "A" as GlyphName,
+    unicodes: [65 as Unicode],
+  },
+});
 type SyncChannel = Channel<SyncCallMap, SyncEventMap>;
 
 describe("WorkspaceHost serves the workspace over transferred ports", () => {
@@ -131,7 +148,7 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     await sync.call("workspace.create", undefined);
 
     const applied = await sync.call("workspace.apply", {
-      intents: [{ kind: "createGlyph", name: "A", unicodes: [65] }],
+      intents: [createGlyphA()],
       label: "Add Glyph",
     });
 
@@ -143,11 +160,34 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     expect(snapshot?.glyphs.map((glyph) => glyph.name)).toEqual(["A"]);
   });
 
+  it("undo and redo createGlyph update glyph records", async () => {
+    const sync = await connectSyncLane();
+    const snapshot = await sync.call("workspace.create", undefined);
+    const sourceId = snapshot.sources[0].id;
+
+    const created = await sync.call("workspace.apply", {
+      intents: [createGlyphA()],
+      label: "Add Glyph",
+    });
+    const glyphId = created.glyphs?.[0].id;
+    if (!glyphId) throw new Error("createGlyph must echo the record id");
+
+    const undone = await sync.call("workspace.undo", undefined);
+    expect(undone?.glyphs?.map((glyph) => glyph.name)).toEqual([]);
+    expect(undone?.layers).toEqual([]);
+    await expect(sync.call("workspace.glyph", { glyphId, sourceId })).resolves.toBeNull();
+
+    const redone = await sync.call("workspace.redo", undefined);
+    expect(redone?.glyphs?.map((glyph) => glyph.name)).toEqual(["A"]);
+    expect(redone?.layers).toHaveLength(1);
+    await expect(sync.call("workspace.glyph", { glyphId, sourceId })).resolves.not.toBeNull();
+  });
+
   it("apply setXAdvance echoes values without structure or records", async () => {
     const sync = await connectSyncLane();
     await sync.call("workspace.create", undefined);
     const created = await sync.call("workspace.apply", {
-      intents: [{ kind: "createGlyph", name: "A", unicodes: [65] }],
+      intents: [createGlyphA()],
     });
     const layerId = created.layers[0].layerId;
 
@@ -174,7 +214,7 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     const sync = await connectSyncLane();
     await sync.call("workspace.create", undefined);
     const created = await sync.call("workspace.apply", {
-      intents: [{ kind: "createGlyph", name: "A", unicodes: [65] }],
+      intents: [createGlyphA()],
     });
     const layerId = created.layers[0].layerId;
 
@@ -214,7 +254,7 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     const sync = await connectSyncLane();
     await sync.call("workspace.create", undefined);
     const created = await sync.call("workspace.apply", {
-      intents: [{ kind: "createGlyph", name: "A", unicodes: [65] }],
+      intents: [createGlyphA()],
     });
     const layerId = created.layers[0].layerId;
     const contourId = mintContourId();
@@ -255,7 +295,7 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     const snapshot = await sync.call("workspace.create", undefined);
     const sourceId = snapshot.sources[0].id;
     const created = await sync.call("workspace.apply", {
-      intents: [{ kind: "createGlyph", name: "A", unicodes: [65] }],
+      intents: [createGlyphA()],
     });
     const glyphId = created.glyphs?.[0].id;
     if (!glyphId) throw new Error("createGlyph must echo the record id");
@@ -272,7 +312,7 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     const sync = await connectSyncLane();
     await sync.call("workspace.create", undefined);
     const created = await sync.call("workspace.apply", {
-      intents: [{ kind: "createGlyph", name: "A", unicodes: [65] }],
+      intents: [createGlyphA()],
     });
     const layerId = created.layers[0].layerId;
 

--- a/crates/shift-bridge/__test__/index.spec.mjs
+++ b/crates/shift-bridge/__test__/index.spec.mjs
@@ -28,7 +28,9 @@ describe("Bridge", () => {
   }
 
   function createGlyphLayer(name = "A", unicodes = [65]) {
-    const applied = bridge.apply([{ kind: "createGlyph", name, unicodes }]);
+    const applied = bridge.apply([
+      { kind: "createGlyph", createGlyph: { glyphId: mintId("glyph"), name, unicodes } },
+    ]);
     return applied.layers[0].layerId;
   }
 

--- a/crates/shift-bridge/index.d.ts
+++ b/crates/shift-bridge/index.d.ts
@@ -18,12 +18,10 @@ export declare class Bridge {
   getMetrics(): NapiFontMetrics
   getGlyphs(): Array<NapiGlyphRecord>
   /**
-   * Applies one intent set as a single atomic workspace apply.
-   *
-   * Editing kinds decode through `map_intent` into `Font::apply_intents`.
-   * Font-level kinds (createGlyph, createAxis, createSource) take the
-   * workspace-verb path and skip the ledger. Sets must be homogeneous:
-   * font-level and editing intents never share a tick.
+   * Applies one intent set as a single atomic workspace apply: every kind
+   * — editing and create alike — decodes through `map_intent` into one
+   * `FontWorkspace::apply` call. One call = one SQLite transaction = one
+   * undo step, however many intents the set batches.
    */
   apply(intents: Array<NapiFontIntent>, label?: string | undefined | null): NapiAppliedChange
   /**
@@ -158,6 +156,17 @@ export interface NapiCreateAxisIntent {
 }
 
 /**
+ * Font-level glyph creation. The glyph id is client-minted (decision 6:
+ * verbs return identity synchronously); Rust honors it and rejects
+ * duplicates.
+ */
+export interface NapiCreateGlyphIntent {
+  glyphId: GlyphId
+  name: GlyphName
+  unicodes: Array<Unicode>
+}
+
+/**
  * Font-level source creation. Rust mints the source id; the echo's
  * `sources` list carries it back.
  */
@@ -178,8 +187,8 @@ export interface NapiFontIntent {
    * "setPointSmooth" | "removePoints" | "addAnchors" | "moveAnchors" |
    * "removeAnchors" | "reverseContour" | "translatePoints" |
    * "setXAdvance" | "applyBooleanOp".
-   * Font-level kinds (never share a set with editing kinds, not undoable):
-   * "createGlyph" | "createAxis" | "createSource".
+   * Create kinds: "createGlyph" | "createAxis" | "createSource". Every
+   * kind shares the same apply path; one set = one undo step.
    */
   kind: string
   addPoints?: NapiAddPointsIntent
@@ -195,10 +204,9 @@ export interface NapiFontIntent {
   translatePoints?: NapiTranslatePointsIntent
   setXAdvance?: NapiSetXAdvanceIntent
   applyBooleanOp?: NapiBooleanOpIntent
+  createGlyph?: NapiCreateGlyphIntent
   createAxis?: NapiCreateAxisIntent
   createSource?: NapiCreateSourceIntent
-  name?: GlyphName
-  unicodes?: Array<Unicode>
 }
 
 export interface NapiFontMetadata {

--- a/crates/shift-bridge/src/bridge.rs
+++ b/crates/shift-bridge/src/bridge.rs
@@ -5,8 +5,8 @@ use napi::{Error, Status};
 use napi_derive::napi;
 use shift_backends::{ExportFormat, FontExportRequest, FontExportResult, FontExporter, FontView};
 use shift_font::{
-  AnchorId, AnchorSeed, Axis as FontAxis, BooleanOp, ContourId, Font, FontIntent, FontIntentSet,
-  Glyph, GlyphId, GlyphLayer, LayerId, Location as FontLocation, PointId, PointSeed, SourceId,
+  AnchorId, AnchorSeed, Axis as FontAxis, BooleanOp, ContourId, Font, FontChange, FontIntent,
+  FontIntentSet, Glyph, GlyphId, LayerId, Location as FontLocation, PointId, PointSeed, SourceId,
 };
 use shift_wire::{
   bridges::napi::{
@@ -256,154 +256,12 @@ impl Bridge {
     Ok(records)
   }
 
-  /// Applies one intent set as a single atomic workspace apply.
-  ///
-  /// Editing kinds decode through `map_intent` into `Font::apply_intents`.
-  /// Font-level kinds (createGlyph, createAxis, createSource) take the
-  /// workspace-verb path and skip the ledger. Sets must be homogeneous:
-  /// font-level and editing intents never share a tick.
+  /// Applies one intent set as a single atomic workspace apply: every kind
+  /// — editing and create alike — decodes through `map_intent` into one
+  /// `FontWorkspace::apply` call. One call = one SQLite transaction = one
+  /// undo step, however many intents the set batches.
   #[napi]
   pub fn apply(
-    &mut self,
-    intents: Vec<NapiFontIntent>,
-    label: Option<String>,
-  ) -> errors::Result<NapiAppliedChange> {
-    let (font_level, edits): (Vec<_>, Vec<_>) = intents.into_iter().partition(is_font_level);
-
-    if !font_level.is_empty() && !edits.is_empty() {
-      return Err(BridgeError::InvalidInput {
-        kind: "intent",
-        value: "font-level intents cannot share a set with editing intents".to_string(),
-      });
-    }
-
-    if font_level.is_empty() {
-      return self.apply_editing_intents(edits, label);
-    }
-
-    // Font-level verbs are not in the ledger; the label is part of the
-    // wire contract now.
-    let _ = label;
-
-    let mut layers = Vec::new();
-    let mut glyphs_changed = false;
-    let mut axes_changed = false;
-    let mut sources_changed = false;
-
-    for intent in font_level {
-      match intent.kind.as_str() {
-        "createGlyph" => {
-          layers.extend(self.apply_create_glyph(intent)?);
-          glyphs_changed = true;
-        }
-        "createAxis" => {
-          self.apply_create_axis(intent)?;
-          axes_changed = true;
-          // Axis creation reshapes every source location's design space.
-          sources_changed = true;
-        }
-        "createSource" => {
-          layers.extend(self.apply_create_source(intent)?);
-          sources_changed = true;
-        }
-        other => {
-          return Err(BridgeError::InvalidInput {
-            kind: "intent",
-            value: format!("unknown font-level intent kind \"{other}\""),
-          });
-        }
-      }
-    }
-
-    self.mark_font_changed();
-
-    Ok(NapiAppliedChange {
-      layers,
-      glyphs: glyphs_changed.then(|| self.get_glyphs()).transpose()?,
-      axes: axes_changed.then(|| self.get_axes()).transpose()?,
-      sources: sources_changed.then(|| self.get_sources()).transpose()?,
-      // Composites cannot depend on structure that did not exist yet.
-      dependents: Vec::new(),
-    })
-  }
-
-  /// Creates the glyph plus one layer per source (eager: every
-  /// (glyphId, sourceId) pair must resolve a layer).
-  fn apply_create_glyph(
-    &mut self,
-    intent: NapiFontIntent,
-  ) -> errors::Result<Vec<NapiLayerReplaced>> {
-    let name = intent.name.ok_or(BridgeError::InvalidInput {
-      kind: "intent",
-      value: "createGlyph requires name".to_string(),
-    })?;
-    let unicodes = intent.unicodes.unwrap_or_default();
-
-    let source_ids: Vec<SourceId> = self
-      .font()?
-      .sources()
-      .iter()
-      .map(|source| source.id())
-      .collect();
-    if source_ids.is_empty() {
-      return Err(BridgeError::InvalidInput {
-        kind: "intent",
-        value: "createGlyph requires a font with at least one source".to_string(),
-      });
-    }
-
-    let glyph = self.workspace_mut()?.create_glyph(name, unicodes)?;
-
-    let mut layers = Vec::with_capacity(source_ids.len());
-    for source_id in source_ids {
-      let layer = self
-        .workspace_mut()?
-        .create_glyph_layer(glyph.id(), source_id)?;
-      layers.push(layer_replaced(&layer));
-    }
-
-    Ok(layers)
-  }
-
-  fn apply_create_axis(&mut self, intent: NapiFontIntent) -> errors::Result<()> {
-    let payload = intent.create_axis.ok_or(BridgeError::InvalidInput {
-      kind: "intent",
-      value: "createAxis requires its payload field".to_string(),
-    })?;
-
-    let mut axis = FontAxis::new(
-      payload.tag,
-      payload.name,
-      payload.min,
-      payload.default,
-      payload.max,
-    );
-    axis.set_hidden(payload.hidden);
-
-    self.workspace_mut()?.create_axis(axis)?;
-    Ok(())
-  }
-
-  /// Creates the source plus one eager layer per existing glyph; echoes the
-  /// new layers replace-grade.
-  fn apply_create_source(
-    &mut self,
-    intent: NapiFontIntent,
-  ) -> errors::Result<Vec<NapiLayerReplaced>> {
-    let payload = intent.create_source.ok_or(BridgeError::InvalidInput {
-      kind: "intent",
-      value: "createSource requires its payload field".to_string(),
-    })?;
-
-    let location = FontLocation::from_map(payload.location.values);
-    let (_, layers) = self
-      .workspace_mut()?
-      .create_source(payload.name, location)?;
-
-    Ok(layers.iter().map(layer_replaced).collect())
-  }
-
-  fn apply_editing_intents(
     &mut self,
     intents: Vec<NapiFontIntent>,
     label: Option<String>,
@@ -430,8 +288,28 @@ impl Bridge {
   }
 
   /// Assembles the pure-state echo for an applied outcome: replace-grade
-  /// layers plus dependent composites. Shared by apply/undo/redo.
+  /// layers plus dependent composites. Shared by apply/undo/redo. The
+  /// records grain (glyphs/axes/sources lists) rides along whenever the
+  /// change set touched that structure.
   fn applied_echo(&self, outcome: shift_font::AppliedIntents) -> errors::Result<NapiAppliedChange> {
+    let mut glyphs_changed = false;
+    let mut axes_changed = false;
+    let mut sources_changed = false;
+    for change in &outcome.changes.changes {
+      match change {
+        FontChange::GlyphCreated(_)
+        | FontChange::GlyphDeleted(_)
+        | FontChange::GlyphIdentityChanged(_) => glyphs_changed = true,
+        // Axis structure reshapes every source location's design space.
+        FontChange::AxisCreated(_) | FontChange::AxisDeleted(_) => {
+          axes_changed = true;
+          sources_changed = true;
+        }
+        FontChange::SourceCreated(_) | FontChange::SourceDeleted(_) => sources_changed = true,
+        _ => {}
+      }
+    }
+
     let touched_layer_ids: Vec<LayerId> = outcome
       .layers
       .iter()
@@ -459,9 +337,9 @@ impl Bridge {
 
     Ok(NapiAppliedChange {
       layers,
-      glyphs: None,
-      axes: None,
-      sources: None,
+      glyphs: glyphs_changed.then(|| self.get_glyphs()).transpose()?,
+      axes: axes_changed.then(|| self.get_axes()).transpose()?,
+      sources: sources_changed.then(|| self.get_sources()).transpose()?,
       dependents,
     })
   }
@@ -604,21 +482,6 @@ fn parse_id_list<T: BridgeParse>(ids: &[String]) -> BridgeResult<Vec<T>> {
   ids.iter().map(|id| parse::<T>(id)).collect()
 }
 
-const FONT_LEVEL_KINDS: [&str; 3] = ["createGlyph", "createAxis", "createSource"];
-
-fn is_font_level(intent: &NapiFontIntent) -> bool {
-  FONT_LEVEL_KINDS.contains(&intent.kind.as_str())
-}
-
-fn layer_replaced(layer: &GlyphLayer) -> NapiLayerReplaced {
-  NapiLayerReplaced {
-    layer_id: layer.id().to_string(),
-    structure: Some(GlyphStructure::from(layer).into()),
-    values: shift_wire::values_from_layer(layer).into(),
-    changed: GlyphChangedEntities::default().into(),
-  }
-}
-
 fn map_intent(intent: NapiFontIntent) -> errors::Result<FontIntent> {
   let missing = |kind: &str| BridgeError::InvalidInput {
     kind: "intent",
@@ -753,6 +616,35 @@ fn map_intent(intent: NapiFontIntent) -> errors::Result<FontIntent> {
         operation: parse_boolean_op(&payload.operation)?,
       })
     }
+    "createGlyph" => {
+      let payload = intent.create_glyph.ok_or_else(|| missing("createGlyph"))?;
+      Ok(FontIntent::CreateGlyph {
+        glyph_id: Some(parse::<GlyphId>(&payload.glyph_id)?),
+        name: payload.name,
+        unicodes: payload.unicodes,
+      })
+    }
+    "createAxis" => {
+      let payload = intent.create_axis.ok_or_else(|| missing("createAxis"))?;
+      let mut axis = FontAxis::new(
+        payload.tag,
+        payload.name,
+        payload.min,
+        payload.default,
+        payload.max,
+      );
+      axis.set_hidden(payload.hidden);
+      Ok(FontIntent::CreateAxis { axis })
+    }
+    "createSource" => {
+      let payload = intent
+        .create_source
+        .ok_or_else(|| missing("createSource"))?;
+      Ok(FontIntent::CreateSource {
+        name: payload.name,
+        location: FontLocation::from_map(payload.location.values),
+      })
+    }
     other => Err(BridgeError::InvalidInput {
       kind: "intent",
       value: format!("unknown intent kind \"{other}\""),
@@ -797,10 +689,10 @@ mod tests {
   use super::*;
   use shift_wire::bridges::napi::{
     NapiAddAnchorsIntent, NapiAddContourIntent, NapiAddPointsIntent, NapiCreateAxisIntent,
-    NapiCreateSourceIntent, NapiLocation, NapiMoveAnchorsIntent, NapiMovePointsIntent,
-    NapiPointSeed, NapiPointType, NapiRemoveAnchorsIntent, NapiRemovePointsIntent,
-    NapiReverseContourIntent, NapiSetContourClosedIntent, NapiSetPointSmoothIntent,
-    NapiSetXAdvanceIntent, NapiTranslatePointsIntent,
+    NapiCreateGlyphIntent, NapiCreateSourceIntent, NapiLocation, NapiMoveAnchorsIntent,
+    NapiMovePointsIntent, NapiPointSeed, NapiPointType, NapiRemoveAnchorsIntent,
+    NapiRemovePointsIntent, NapiReverseContourIntent, NapiSetContourClosedIntent,
+    NapiSetPointSmoothIntent, NapiSetXAdvanceIntent, NapiTranslatePointsIntent,
   };
   use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -822,10 +714,20 @@ mod tests {
       translate_points: None,
       set_x_advance: None,
       apply_boolean_op: None,
+      create_glyph: None,
       create_axis: None,
       create_source: None,
-      name: None,
-      unicodes: None,
+    }
+  }
+
+  fn create_glyph_napi(name: &str, unicodes: Vec<u32>) -> NapiFontIntent {
+    NapiFontIntent {
+      create_glyph: Some(NapiCreateGlyphIntent {
+        glyph_id: GlyphId::new().to_string(),
+        name: name.to_string(),
+        unicodes,
+      }),
+      ..skeleton_intent("createGlyph")
     }
   }
 
@@ -835,11 +737,7 @@ mod tests {
 
     let applied = bridge
       .apply(
-        vec![NapiFontIntent {
-          name: Some("A".to_string()),
-          unicodes: Some(vec![65]),
-          ..skeleton_intent("createGlyph")
-        }],
+        vec![create_glyph_napi("A", vec![65])],
         Some("Add Glyph".to_string()),
       )
       .unwrap();
@@ -855,14 +753,7 @@ mod tests {
   fn apply_set_x_advance_echoes_values_without_structure() {
     let mut bridge = bridge_with_workspace();
     let created = bridge
-      .apply(
-        vec![NapiFontIntent {
-          name: Some("A".to_string()),
-          unicodes: Some(vec![65]),
-          ..skeleton_intent("createGlyph")
-        }],
-        None,
-      )
+      .apply(vec![create_glyph_napi("A", vec![65])], None)
       .unwrap();
     let layer_id = created.layers[0].layer_id.clone();
 
@@ -897,14 +788,7 @@ mod tests {
 
   fn pen_setup(bridge: &mut Bridge) -> (String, String) {
     let created = bridge
-      .apply(
-        vec![NapiFontIntent {
-          name: Some("A".to_string()),
-          unicodes: Some(vec![65]),
-          ..skeleton_intent("createGlyph")
-        }],
-        None,
-      )
+      .apply(vec![create_glyph_napi("A", vec![65])], None)
       .unwrap();
     let layer_id = created.layers[0].layer_id.clone();
 
@@ -1551,9 +1435,7 @@ mod tests {
   }
 
   fn create_default_glyph_layer(bridge: &mut Bridge, name: &str, unicode: Option<u32>) -> String {
-    let mut intent = skeleton_intent("createGlyph");
-    intent.name = Some(name.to_string());
-    intent.unicodes = Some(unicode.into_iter().collect());
+    let intent = create_glyph_napi(name, unicode.into_iter().collect());
 
     let applied = bridge.apply(vec![intent], None).unwrap();
     applied.layers[0].layer_id.clone()
@@ -1707,14 +1589,7 @@ mod tests {
       .unwrap();
 
     let applied = bridge
-      .apply(
-        vec![NapiFontIntent {
-          name: Some("A".to_string()),
-          unicodes: Some(vec![65]),
-          ..skeleton_intent("createGlyph")
-        }],
-        None,
-      )
+      .apply(vec![create_glyph_napi("A", vec![65])], None)
       .unwrap();
 
     assert_eq!(applied.layers.len(), 2);
@@ -1732,26 +1607,35 @@ mod tests {
   }
 
   #[test]
-  fn apply_rejects_editing_intents_mixed_with_font_level_kinds() {
+  fn apply_mixes_editing_and_create_intents_as_one_undo_step() {
     let mut bridge = bridge_with_workspace();
     let (layer_id, _) = pen_setup(&mut bridge);
 
-    let result = bridge.apply(
-      vec![
-        weight_axis_intent(),
-        NapiFontIntent {
-          set_x_advance: Some(NapiSetXAdvanceIntent {
-            layer_id,
-            width: 600.0,
-          }),
-          ..skeleton_intent("setXAdvance")
-        },
-      ],
-      None,
-    );
+    let applied = bridge
+      .apply(
+        vec![
+          weight_axis_intent(),
+          NapiFontIntent {
+            set_x_advance: Some(NapiSetXAdvanceIntent {
+              layer_id: layer_id.clone(),
+              width: 600.0,
+            }),
+            ..skeleton_intent("setXAdvance")
+          },
+        ],
+        Some("Add Weight".to_string()),
+      )
+      .unwrap();
 
-    assert!(result.is_err());
+    assert_eq!(applied.axes.expect("createAxis must echo axes").len(), 1);
+    assert!(applied
+      .layers
+      .iter()
+      .any(|layer| layer.layer_id == layer_id));
+
+    let undone = bridge.undo().unwrap().expect("mixed set should undo");
     assert!(bridge.get_axes().unwrap().is_empty());
+    assert_eq!(undone.axes.expect("undo must echo axes").len(), 0);
   }
 
   #[test]

--- a/crates/shift-font/src/changes.rs
+++ b/crates/shift-font/src/changes.rs
@@ -31,8 +31,11 @@ impl From<FontChange> for FontChangeSet {
 #[derive(Clone, Debug)]
 pub enum FontChange {
     AxisCreated(AxisCreated),
+    AxisDeleted(AxisDeleted),
     SourceCreated(SourceCreated),
+    SourceDeleted(SourceDeleted),
     GlyphCreated(GlyphCreated),
+    GlyphDeleted(GlyphDeleted),
     GlyphIdentityChanged(GlyphIdentityChanged),
     GlyphLayerCreated(GlyphLayerCreated),
     LayerMetricsChanged(LayerMetricsChanged),
@@ -51,12 +54,24 @@ impl FontChange {
         Self::AxisCreated(AxisCreated::from(axis))
     }
 
+    pub fn axis_deleted(tag: impl Into<String>) -> Self {
+        Self::AxisDeleted(AxisDeleted { tag: tag.into() })
+    }
+
     pub fn source_created(source: &Source) -> Self {
         Self::SourceCreated(SourceCreated::from(source))
     }
 
+    pub fn source_deleted(source_id: SourceId) -> Self {
+        Self::SourceDeleted(SourceDeleted { source_id })
+    }
+
     pub fn glyph_created(glyph: &Glyph) -> Self {
         Self::GlyphCreated(GlyphCreated::from(glyph))
+    }
+
+    pub fn glyph_deleted(glyph_id: GlyphId) -> Self {
+        Self::GlyphDeleted(GlyphDeleted { glyph_id })
     }
 
     pub fn glyph_identity_changed(
@@ -185,6 +200,17 @@ impl From<&Source> for SourceCreated {
     }
 }
 
+/// Axis rows are keyed by tag (the IR mints no axis id).
+#[derive(Clone, Debug)]
+pub struct AxisDeleted {
+    pub tag: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct SourceDeleted {
+    pub source_id: SourceId,
+}
+
 #[derive(Clone, Debug)]
 pub struct SourceAxisValue {
     pub axis_tag: String,
@@ -206,6 +232,11 @@ impl From<&Glyph> for GlyphCreated {
             unicodes: glyph.unicodes().to_vec(),
         }
     }
+}
+
+#[derive(Clone, Debug)]
+pub struct GlyphDeleted {
+    pub glyph_id: GlyphId,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/shift-font/src/error.rs
+++ b/crates/shift-font/src/error.rs
@@ -73,6 +73,24 @@ pub enum CoreError {
 
     #[error("glyph storage key {key} does not match glyph id {glyph_id}")]
     MismatchedGlyphId { key: GlyphId, glyph_id: GlyphId },
+
+    #[error("invalid glyph name {0:?}")]
+    InvalidGlyphName(String),
+
+    #[error("creating a glyph requires a font with at least one source")]
+    GlyphNeedsSource,
+
+    #[error("axis tag {0} already exists")]
+    DuplicateAxisTag(String),
+
+    #[error("axis {0} not found")]
+    AxisNotFound(String),
+
+    #[error("invalid source name {0:?}")]
+    InvalidSourceName(String),
+
+    #[error("source name {0} already exists")]
+    DuplicateSourceName(String),
 }
 
 pub type CoreResult<T> = Result<T, CoreError>;

--- a/crates/shift-font/src/intents.rs
+++ b/crates/shift-font/src/intents.rs
@@ -9,10 +9,14 @@
 use crate::changes::{AnchorPosition, FontChange, FontChangeSet, PointPosition};
 use crate::error::{CoreError, CoreResult};
 use crate::ir::{
-    Anchor, AnchorId, BooleanOp, Contour, ContourId, Font, GlyphId, GlyphLayer, GlyphName, LayerId,
-    PointId, PointType,
+    Anchor, AnchorId, Axis, BooleanOp, Contour, ContourId, Font, Glyph, GlyphId, GlyphLayer,
+    GlyphName, LayerId, Location, PointId, PointType, Source, SourceId,
 };
 use crate::layer_edit::BulkNodePositionUpdates;
+
+/// Advance width for layers minted by create intents, before any metrics
+/// edit lands.
+const DEFAULT_LAYER_WIDTH: f64 = 500.0;
 
 /// A point to create, with its caller-minted id.
 #[derive(Clone, Debug)]
@@ -107,10 +111,29 @@ pub enum FontIntent {
         contour_id_b: ContourId,
         operation: BooleanOp,
     },
+    /// Creates the glyph plus one layer per source (eager: every
+    /// (glyphId, sourceId) pair must resolve a layer).
+    CreateGlyph {
+        /// Caller-minted id so the verb returns identity synchronously;
+        /// `None` mints Rust-side.
+        glyph_id: Option<GlyphId>,
+        name: String,
+        unicodes: Vec<u32>,
+    },
+    CreateAxis {
+        axis: Axis,
+    },
+    /// Creates the source plus one eager layer per existing glyph.
+    CreateSource {
+        name: String,
+        location: Location,
+    },
 }
 
 impl FontIntent {
-    pub fn layer_id(&self) -> &LayerId {
+    /// The targeted layer for editing intents; `None` for create intents,
+    /// whose layers do not exist until the intent applies.
+    pub fn layer_id(&self) -> Option<&LayerId> {
         match self {
             Self::AddPoints { layer_id, .. }
             | Self::AddContour { layer_id, .. }
@@ -124,7 +147,9 @@ impl FontIntent {
             | Self::ReverseContour { layer_id, .. }
             | Self::TranslatePoints { layer_id, .. }
             | Self::SetXAdvance { layer_id, .. }
-            | Self::ApplyBooleanOp { layer_id, .. } => layer_id,
+            | Self::ApplyBooleanOp { layer_id, .. } => Some(layer_id),
+
+            Self::CreateGlyph { .. } | Self::CreateAxis { .. } | Self::CreateSource { .. } => None,
         }
     }
 
@@ -169,17 +194,30 @@ impl Font {
         let mut changes = FontChangeSet::default();
         let mut touched: Vec<(LayerId, bool)> = Vec::new();
 
+        let touch =
+            |touched: &mut Vec<(LayerId, bool)>, layer_id: LayerId, structural| match touched
+                .iter_mut()
+                .find(|(id, _)| *id == layer_id)
+            {
+                Some((_, flag)) => *flag |= structural,
+                None => touched.push((layer_id, structural)),
+            };
+
         for intent in &set.intents {
-            let layer_id = intent.layer_id().clone();
+            let Some(layer_id) = intent.layer_id() else {
+                for layer_id in self.apply_create_intent(intent, &mut changes)? {
+                    touch(&mut touched, layer_id, true);
+                }
+                continue;
+            };
+
+            let layer_id = layer_id.clone();
             let structural = intent.structural();
 
             let change = self.apply_intent(intent)?;
             changes.push(change);
 
-            match touched.iter_mut().find(|(id, _)| *id == layer_id) {
-                Some((_, flag)) => *flag |= structural,
-                None => touched.push((layer_id, structural)),
-            }
+            touch(&mut touched, layer_id, structural);
         }
 
         let layers = touched
@@ -194,6 +232,135 @@ impl Font {
             .collect::<CoreResult<Vec<_>>>()?;
 
         Ok(AppliedIntents { changes, layers })
+    }
+
+    /// Applies one create intent, pushing every change it produces.
+    /// Returns the created layer ids so the caller can mark them touched.
+    fn apply_create_intent(
+        &mut self,
+        intent: &FontIntent,
+        changes: &mut FontChangeSet,
+    ) -> CoreResult<Vec<LayerId>> {
+        match intent {
+            FontIntent::CreateGlyph {
+                glyph_id,
+                name,
+                unicodes,
+            } => self.apply_create_glyph(glyph_id.clone(), name, unicodes.clone(), changes),
+            FontIntent::CreateAxis { axis } => {
+                self.apply_create_axis(axis, changes)?;
+                Ok(Vec::new())
+            }
+            FontIntent::CreateSource { name, location } => {
+                self.apply_create_source(name, location, changes)
+            }
+            _ => unreachable!("editing intents take the layer path"),
+        }
+    }
+
+    fn apply_create_glyph(
+        &mut self,
+        glyph_id: Option<GlyphId>,
+        name: &str,
+        unicodes: Vec<u32>,
+        changes: &mut FontChangeSet,
+    ) -> CoreResult<Vec<LayerId>> {
+        let name = name.trim();
+        let glyph_name =
+            GlyphName::new(name).map_err(|_| CoreError::InvalidGlyphName(name.to_string()))?;
+        if self.glyph_id_by_name(name).is_some() {
+            return Err(CoreError::DuplicateGlyphName(glyph_name));
+        }
+
+        let source_ids: Vec<SourceId> = self.sources().iter().map(Source::id).collect();
+        if source_ids.is_empty() {
+            return Err(CoreError::GlyphNeedsSource);
+        }
+
+        let glyph_id = glyph_id.unwrap_or_default();
+        let mut glyph = Glyph::with_id(glyph_id, glyph_name.clone());
+        glyph.set_unicodes(unicodes);
+        let glyph_id = glyph.id();
+        changes.push(FontChange::glyph_created(&glyph));
+
+        let mut layer_ids = Vec::with_capacity(source_ids.len());
+        for source_id in source_ids {
+            let layer = GlyphLayer::with_width(LayerId::new(), source_id, DEFAULT_LAYER_WIDTH);
+            layer_ids.push(layer.id());
+            changes.push(FontChange::glyph_layer_created(
+                glyph_id.clone(),
+                Some(glyph_name.clone()),
+                &layer,
+            ));
+            glyph.set_layer(layer);
+        }
+
+        self.insert_glyph(glyph)?;
+        Ok(layer_ids)
+    }
+
+    fn apply_create_axis(&mut self, axis: &Axis, changes: &mut FontChangeSet) -> CoreResult<()> {
+        if self
+            .axes()
+            .iter()
+            .any(|existing| existing.tag() == axis.tag())
+        {
+            return Err(CoreError::DuplicateAxisTag(axis.tag().to_string()));
+        }
+
+        changes.push(FontChange::axis_created(axis));
+        self.add_axis(axis.clone());
+        Ok(())
+    }
+
+    fn apply_create_source(
+        &mut self,
+        name: &str,
+        location: &Location,
+        changes: &mut FontChangeSet,
+    ) -> CoreResult<Vec<LayerId>> {
+        let name = name.trim();
+        if name.is_empty() {
+            return Err(CoreError::InvalidSourceName(name.to_string()));
+        }
+        if self.sources().iter().any(|source| source.name() == name) {
+            return Err(CoreError::DuplicateSourceName(name.to_string()));
+        }
+
+        for (axis_tag, _) in location.iter() {
+            if !self
+                .axes()
+                .iter()
+                .any(|axis| axis.tag() == axis_tag.as_str())
+            {
+                return Err(CoreError::AxisNotFound(axis_tag.clone()));
+            }
+        }
+
+        let source = Source::new(name.to_string(), location.clone());
+        let source_id = source.id();
+        changes.push(FontChange::source_created(&source));
+        self.add_source(source);
+
+        let glyphs: Vec<(GlyphId, GlyphName)> = self
+            .glyphs()
+            .map(|glyph| (glyph.id(), glyph.glyph_name().clone()))
+            .collect();
+
+        let mut layer_ids = Vec::with_capacity(glyphs.len());
+        for (glyph_id, glyph_name) in glyphs {
+            let layer =
+                GlyphLayer::with_width(LayerId::new(), source_id.clone(), DEFAULT_LAYER_WIDTH);
+            layer_ids.push(layer.id());
+            changes.push(FontChange::glyph_layer_created(
+                glyph_id.clone(),
+                Some(glyph_name),
+                &layer,
+            ));
+            self.insert_glyph_layer(glyph_id, layer)?;
+        }
+
+        Ok(layer_ids)
     }
 
     fn apply_intent(&mut self, intent: &FontIntent) -> CoreResult<FontChange> {
@@ -473,6 +640,11 @@ impl Font {
                 layer.apply_boolean_op(contour_id_a.clone(), contour_id_b.clone(), *operation)?;
 
                 Ok(FontChange::layer_geometry_replaced(layer))
+            }
+            FontIntent::CreateGlyph { .. }
+            | FontIntent::CreateAxis { .. }
+            | FontIntent::CreateSource { .. } => {
+                unreachable!("create intents take the apply_create_intent path")
             }
         }
     }

--- a/crates/shift-font/src/ir/font.rs
+++ b/crates/shift-font/src/ir/font.rs
@@ -359,6 +359,12 @@ impl Font {
         self.data_mut().axes.push(axis);
     }
 
+    pub fn remove_axis(&mut self, tag: &str) -> Option<Axis> {
+        let data = self.data_mut();
+        let index = data.axes.iter().position(|axis| axis.tag() == tag)?;
+        Some(data.axes.remove(index))
+    }
+
     pub fn sources(&self) -> &[Source] {
         &self.data().sources
     }
@@ -371,6 +377,23 @@ impl Font {
         }
         data.sources.push(source);
         source_id
+    }
+
+    /// Removes a source record only; the caller removes the source's glyph
+    /// layers first so the layer index never points at a missing source.
+    pub fn remove_source(&mut self, source_id: SourceId) -> Option<Source> {
+        let data = self.data_mut();
+        let index = data
+            .sources
+            .iter()
+            .position(|source| source.id() == source_id)?;
+        let source = data.sources.remove(index);
+
+        if data.default_source_id == Some(source_id) {
+            data.default_source_id = data.sources.first().map(Source::id);
+        }
+
+        Some(source)
     }
 
     pub fn clear_sources(&mut self) {

--- a/crates/shift-font/src/ir/glyph.rs
+++ b/crates/shift-font/src/ir/glyph.rs
@@ -222,8 +222,14 @@ impl GlyphLayer {
 
 impl Glyph {
     pub fn new(name: impl Into<GlyphName>) -> Self {
+        Self::with_id(GlyphId::new(), name)
+    }
+
+    /// Constructs with a caller-minted id, so creating callers can hold the
+    /// glyph's identity before the glyph exists.
+    pub fn with_id(id: GlyphId, name: impl Into<GlyphName>) -> Self {
         Self {
-            id: GlyphId::new(),
+            id,
             name: name.into(),
             unicodes: Vec::new(),
             layers: HashMap::new(),

--- a/crates/shift-store/src/change_set.rs
+++ b/crates/shift-store/src/change_set.rs
@@ -74,6 +74,12 @@ impl ShiftStore {
 fn apply_change(tx: &Transaction<'_>, change: &font::FontChange) -> Result<(), StoreError> {
     match change {
         font::FontChange::AxisCreated(change) => insert_axis(tx, change),
+        font::FontChange::AxisDeleted(change) => {
+            // The axis row id doubles as the tag; source_locations cascade.
+            let rows_changed = tx.execute("DELETE FROM axes WHERE id = ?1", [&change.tag])?;
+            require_changed(rows_changed, "axis", change.tag.clone())?;
+            Ok(())
+        }
         font::FontChange::SourceCreated(change) => {
             upsert_source(tx, &change.source_id, Some(&change.name))?;
 
@@ -88,9 +94,26 @@ fn apply_change(tx: &Transaction<'_>, change: &font::FontChange) -> Result<(), S
 
             Ok(())
         }
+        font::FontChange::SourceDeleted(change) => {
+            // glyph_layers and source_locations cascade on the source row.
+            let rows_changed = tx.execute(
+                "DELETE FROM sources WHERE id = ?1",
+                [change.source_id.to_string()],
+            )?;
+            require_changed(rows_changed, "source", change.source_id.to_string())?;
+            Ok(())
+        }
         font::FontChange::GlyphCreated(change) => {
             upsert_glyph(tx, &change.glyph_id, &change.name)?;
             replace_glyph_unicodes(tx, &change.glyph_id, &change.unicodes)
+        }
+        font::FontChange::GlyphDeleted(change) => {
+            let rows_changed = tx.execute(
+                "DELETE FROM glyphs WHERE id = ?1",
+                [change.glyph_id.to_string()],
+            )?;
+            require_changed(rows_changed, "glyph", change.glyph_id.to_string())?;
+            Ok(())
         }
         font::FontChange::GlyphIdentityChanged(change) => {
             upsert_glyph(tx, &change.glyph_id, &change.to_name)?;

--- a/crates/shift-store/tests/store_test.rs
+++ b/crates/shift-store/tests/store_test.rs
@@ -289,6 +289,43 @@ fn applies_glyph_identity_change_set() {
 }
 
 #[test]
+fn applies_glyph_delete_change_set_and_cascades_layers() {
+    let mut store = ShiftStore::open_memory_for_test().expect("memory store should open");
+    let glyph = shift_font::Glyph::with_unicode("A", 65);
+    let glyph_id = glyph.id();
+    let source_id = shift_font::SourceId::new();
+    let layer =
+        shift_font::GlyphLayer::with_width(shift_font::LayerId::new(), source_id.clone(), 500.0);
+    create_regular_source_with_id(&mut store, source_id);
+
+    store
+        .apply_change_set(&shift_font::FontChangeSet::new(vec![
+            shift_font::FontChange::glyph_created(&glyph),
+            shift_font::FontChange::glyph_layer_created(
+                glyph.id(),
+                Some(glyph.glyph_name().clone()),
+                &layer,
+            ),
+            shift_font::FontChange::glyph_deleted(glyph.id()),
+        ]))
+        .expect("change set should apply");
+
+    let stored = store
+        .get_glyph(&GlyphId::new(glyph_id.to_string()))
+        .expect("glyph query should succeed");
+    let layers = store
+        .list_glyph_layers_for_glyph(&GlyphId::new(glyph_id.to_string()))
+        .expect("layer query should succeed");
+    let unicodes = store
+        .list_glyph_unicodes(&GlyphId::new(glyph_id.to_string()))
+        .expect("unicode query should succeed");
+
+    assert!(stored.is_none());
+    assert!(layers.is_empty());
+    assert!(unicodes.is_empty());
+}
+
+#[test]
 fn applies_layer_metrics_and_contour_point_changes() {
     let mut store = ShiftStore::open_memory_for_test().expect("memory store should open");
     let (glyph, layer, contour, point_id) = store_layer_with_contour();

--- a/crates/shift-wire/src/bridges/napi/mod.rs
+++ b/crates/shift-wire/src/bridges/napi/mod.rs
@@ -467,8 +467,8 @@ pub struct NapiFontIntent {
     /// "setPointSmooth" | "removePoints" | "addAnchors" | "moveAnchors" |
     /// "removeAnchors" | "reverseContour" | "translatePoints" |
     /// "setXAdvance" | "applyBooleanOp".
-    /// Font-level kinds (never share a set with editing kinds, not undoable):
-    /// "createGlyph" | "createAxis" | "createSource".
+    /// Create kinds: "createGlyph" | "createAxis" | "createSource". Every
+    /// kind shares the same apply path; one set = one undo step.
     pub kind: String,
     pub add_points: Option<NapiAddPointsIntent>,
     pub add_contour: Option<NapiAddContourIntent>,
@@ -483,12 +483,22 @@ pub struct NapiFontIntent {
     pub translate_points: Option<NapiTranslatePointsIntent>,
     pub set_x_advance: Option<NapiSetXAdvanceIntent>,
     pub apply_boolean_op: Option<NapiBooleanOpIntent>,
+    pub create_glyph: Option<NapiCreateGlyphIntent>,
     pub create_axis: Option<NapiCreateAxisIntent>,
     pub create_source: Option<NapiCreateSourceIntent>,
+}
+
+/// Font-level glyph creation. The glyph id is client-minted (decision 6:
+/// verbs return identity synchronously); Rust honors it and rejects
+/// duplicates.
+#[napi(object)]
+pub struct NapiCreateGlyphIntent {
+    #[napi(ts_type = "GlyphId")]
+    pub glyph_id: String,
     #[napi(ts_type = "GlyphName")]
-    pub name: Option<String>,
+    pub name: String,
     #[napi(ts_type = "Array<Unicode>")]
-    pub unicodes: Option<Vec<u32>>,
+    pub unicodes: Vec<u32>,
 }
 
 /// Font-level axis creation. Rust mints no id for axes; the tag is the

--- a/crates/shift-workspace/src/ledger.rs
+++ b/crates/shift-workspace/src/ledger.rs
@@ -1,16 +1,41 @@
 //! Undo ledger: state-pair entries replayed through the normal apply path.
 //!
-//! Each applied intent set records pre/post `GlyphLayer` snapshots for every
-//! touched layer. Undo restores the pre states, redo the post states — no
+//! One entry corresponds to one apply request and holds the request's steps
+//! in application order. Every step is a state pair — undo applies the `pre`
+//! side of each step in reverse order, redo the `post` side in order — no
 //! per-variant inversion algebra. The ledger is in-memory: history survives
 //! a renderer reload (it lives with the workspace process), not a utility
 //! crash; a SQLite ledger table is the later upgrade if that ever matters.
 
-use shift_font::GlyphLayer;
+use shift_font::{Axis, Glyph, GlyphId, GlyphLayer, Source};
 
 /// Generous bound so a marathon session cannot grow memory unboundedly;
 /// oldest entries fall off first.
 const MAX_ENTRIES: usize = 100;
+
+#[derive(Clone)]
+pub enum LedgerStep {
+    /// Edits to existing layers; pairs replay by substitution.
+    Layers(Vec<LayerPair>),
+    /// Glyph existence/identity: created (`pre` None), deleted (`post`
+    /// None), or replaced. Snapshots carry the glyph's layers.
+    Glyph {
+        pre: Option<Glyph>,
+        post: Option<Glyph>,
+    },
+    Axis {
+        pre: Option<Axis>,
+        post: Option<Axis>,
+    },
+    /// Source existence plus the eager per-glyph layers minted with it.
+    /// Layers owned by glyphs created in the same entry ride their
+    /// [`LedgerStep::Glyph`] snapshots instead.
+    Source {
+        pre: Option<Source>,
+        post: Option<Source>,
+        layers: Vec<(GlyphId, GlyphLayer)>,
+    },
+}
 
 #[derive(Clone)]
 pub struct LayerPair {
@@ -21,7 +46,7 @@ pub struct LayerPair {
 #[derive(Clone)]
 pub struct LedgerEntry {
     pub label: Option<String>,
-    pub layers: Vec<LayerPair>,
+    pub steps: Vec<LedgerStep>,
 }
 
 #[derive(Default)]

--- a/crates/shift-workspace/src/lib.rs
+++ b/crates/shift-workspace/src/lib.rs
@@ -2,6 +2,6 @@ mod ledger;
 mod new_workspace;
 mod workspace;
 
-pub use ledger::{LayerPair, Ledger, LedgerEntry};
+pub use ledger::{LayerPair, Ledger, LedgerEntry, LedgerStep};
 pub use new_workspace::NewWorkspace;
 pub use workspace::{FontWorkspace, WorkspaceError, WorkspaceSource};

--- a/crates/shift-workspace/src/workspace.rs
+++ b/crates/shift-workspace/src/workspace.rs
@@ -3,19 +3,16 @@ use std::path::{Path, PathBuf};
 use shift_backends::{FontExportRequest, FontExportResult, FontExporter, font_loader::FontLoader};
 use shift_font::{
     AppliedIntents, Axis, FontChange, FontChangeSet, FontIntentSet, Glyph, GlyphId, GlyphLayer,
-    GlyphName, LayerId, Location, Source, SourceId, TouchedLayer, error::CoreError,
+    Source, TouchedLayer, error::CoreError,
 };
 use shift_source::ShiftSourcePackage;
 use shift_store::ShiftStore;
 
 use crate::NewWorkspace;
-use crate::ledger::{LayerPair, Ledger, LedgerEntry};
+use crate::ledger::{LayerPair, Ledger, LedgerEntry, LedgerStep};
 
 #[derive(Debug, thiserror::Error)]
 pub enum WorkspaceError {
-    #[error("invalid {kind}: {value}")]
-    InvalidInput { kind: &'static str, value: String },
-
     #[error(transparent)]
     Font(#[from] CoreError),
 
@@ -125,141 +122,10 @@ impl FontWorkspace {
             .map_err(WorkspaceError::from)
     }
 
-    pub fn create_glyph(
-        &mut self,
-        name: String,
-        unicodes: Vec<u32>,
-    ) -> Result<Glyph, WorkspaceError> {
-        self.commit_edit(|font| {
-            let name = name.trim();
-            if name.is_empty() {
-                return Err(WorkspaceError::InvalidInput {
-                    kind: "glyph name",
-                    value: name.to_string(),
-                });
-            }
-            if font.glyph_id_by_name(name).is_some() {
-                return Err(WorkspaceError::InvalidInput {
-                    kind: "glyph name",
-                    value: format!("{name} already exists"),
-                });
-            }
-
-            let glyph_name =
-                GlyphName::new(name.to_string()).map_err(|_| WorkspaceError::InvalidInput {
-                    kind: "glyph name",
-                    value: name.to_string(),
-                })?;
-            let mut glyph = Glyph::new(glyph_name);
-            glyph.set_unicodes(unicodes);
-            let created_glyph = glyph.clone();
-            let change_set = FontChange::glyph_created(&glyph).into();
-
-            font.insert_glyph(glyph)?;
-
-            Ok((created_glyph, change_set))
-        })
-    }
-
-    pub fn create_axis(&mut self, axis: Axis) -> Result<Axis, WorkspaceError> {
-        self.commit_edit(|font| {
-            if font
-                .axes()
-                .iter()
-                .any(|existing| existing.tag() == axis.tag())
-            {
-                return Err(WorkspaceError::InvalidInput {
-                    kind: "axis tag",
-                    value: format!("{} already exists", axis.tag()),
-                });
-            }
-
-            let change_set = FontChange::axis_created(&axis).into();
-            font.add_axis(axis.clone());
-
-            Ok((axis, change_set))
-        })
-    }
-
-    /// Adds a source and eagerly creates one layer per existing glyph, so
-    /// every (glyphId, sourceId) pair resolves a layer.
-    pub fn create_source(
-        &mut self,
-        name: String,
-        location: Location,
-    ) -> Result<(Source, Vec<GlyphLayer>), WorkspaceError> {
-        let source = self.commit_edit(|font| {
-            let name = name.trim();
-            if name.is_empty() {
-                return Err(WorkspaceError::InvalidInput {
-                    kind: "source name",
-                    value: name.to_string(),
-                });
-            }
-            if font.sources().iter().any(|source| source.name() == name) {
-                return Err(WorkspaceError::InvalidInput {
-                    kind: "source name",
-                    value: format!("{name} already exists"),
-                });
-            }
-
-            for (axis_tag, _) in location.iter() {
-                if !font
-                    .axes()
-                    .iter()
-                    .any(|axis| axis.tag() == axis_tag.as_str())
-                {
-                    return Err(WorkspaceError::InvalidInput {
-                        kind: "axis tag",
-                        value: format!("{axis_tag} is not a font axis"),
-                    });
-                }
-            }
-
-            let source = Source::new(name.to_string(), location.clone());
-            let change_set = FontChange::source_created(&source).into();
-            font.add_source(source.clone());
-
-            Ok((source, change_set))
-        })?;
-
-        let glyph_ids: Vec<GlyphId> = self.font.glyphs().map(Glyph::id).collect();
-        let mut layers = Vec::with_capacity(glyph_ids.len());
-        for glyph_id in glyph_ids {
-            layers.push(self.create_glyph_layer(glyph_id, source.id())?);
-        }
-
-        Ok((source, layers))
-    }
-
-    pub fn create_glyph_layer(
-        &mut self,
-        glyph_id: GlyphId,
-        source_id: SourceId,
-    ) -> Result<GlyphLayer, WorkspaceError> {
-        self.commit_edit(|font| {
-            let glyph = font
-                .glyph(glyph_id.clone())
-                .ok_or(CoreError::GlyphNotFound(glyph_id.clone()))?;
-            let glyph_name = glyph.glyph_name().clone();
-            let layer = GlyphLayer::with_width(LayerId::new(), source_id.clone(), 500.0);
-            let layer_id = layer.id();
-
-            font.insert_glyph_layer(glyph_id.clone(), layer)?;
-            let layer = font
-                .layer(layer_id.clone())
-                .ok_or(CoreError::LayerNotFound(layer_id.clone()))?
-                .clone();
-            let change_set =
-                FontChange::glyph_layer_created(glyph_id.clone(), Some(glyph_name), &layer).into();
-
-            Ok((layer, change_set))
-        })
-    }
-
     /// Applies a renderer intent set: validate + mutate via shift-font,
     /// persist the canonical records, swap the live font, record one ledger
-    /// entry. One call = one SQLite transaction = one undo step.
+    /// entry. One call = one SQLite transaction = one undo step — including
+    /// sets that batch several create intents.
     pub fn apply(
         &mut self,
         set: FontIntentSet,
@@ -267,7 +133,9 @@ impl FontWorkspace {
     ) -> Result<AppliedIntents, WorkspaceError> {
         let mut pre: Vec<GlyphLayer> = Vec::new();
         for intent in &set.intents {
-            let layer_id = intent.layer_id();
+            let Some(layer_id) = intent.layer_id() else {
+                continue;
+            };
             if pre.iter().any(|layer| layer.id() == *layer_id) {
                 continue;
             }
@@ -282,7 +150,17 @@ impl FontWorkspace {
             Ok((outcome, changes))
         })?;
 
-        let layers = outcome
+        let steps = self.ledger_steps(&pre, &outcome);
+        self.ledger.push(LedgerEntry { label, steps });
+        Ok(outcome)
+    }
+
+    /// Derives the entry's state-pair steps from the applied change set,
+    /// snapshotting post states from the committed font.
+    fn ledger_steps(&self, pre: &[GlyphLayer], outcome: &AppliedIntents) -> Vec<LedgerStep> {
+        let mut steps = Vec::new();
+
+        let pairs: Vec<LayerPair> = outcome
             .layers
             .iter()
             .filter_map(|touched| {
@@ -295,30 +173,88 @@ impl FontWorkspace {
                     })
             })
             .collect();
+        if !pairs.is_empty() {
+            steps.push(LedgerStep::Layers(pairs));
+        }
 
-        self.ledger.push(LedgerEntry { label, layers });
-        Ok(outcome)
+        let mut created_glyphs: Vec<GlyphId> = Vec::new();
+        for change in &outcome.changes.changes {
+            match change {
+                FontChange::GlyphCreated(change) => {
+                    created_glyphs.push(change.glyph_id.clone());
+                    steps.push(LedgerStep::Glyph {
+                        pre: None,
+                        post: self.font.glyph(change.glyph_id.clone()).cloned(),
+                    });
+                }
+                FontChange::AxisCreated(change) => steps.push(LedgerStep::Axis {
+                    pre: None,
+                    post: self
+                        .font
+                        .axes()
+                        .iter()
+                        .find(|axis| axis.tag() == change.tag)
+                        .cloned(),
+                }),
+                FontChange::SourceCreated(change) => steps.push(LedgerStep::Source {
+                    pre: None,
+                    post: self
+                        .font
+                        .sources()
+                        .iter()
+                        .find(|source| source.id() == change.source_id)
+                        .cloned(),
+                    layers: Vec::new(),
+                }),
+                FontChange::GlyphLayerCreated(change) => {
+                    // A created glyph's layers ride its Glyph snapshot; the
+                    // rest are eager layers belonging to a source step.
+                    if created_glyphs.contains(&change.glyph_id) {
+                        continue;
+                    }
+                    let Some(layer) = self.font.layer(change.layer_id.clone()) else {
+                        continue;
+                    };
+                    for step in steps.iter_mut().rev() {
+                        if let LedgerStep::Source {
+                            post: Some(source),
+                            layers,
+                            ..
+                        } = step
+                            && source.id() == change.source_id
+                        {
+                            layers.push((change.glyph_id.clone(), layer.clone()));
+                            break;
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        steps
     }
 
-    /// Replays the most recent entry's pre states. `None` when the undo
-    /// stack is empty. The echo is the same replace-grade shape as `apply`.
+    /// Replays the most recent entry's pre states in reverse step order.
+    /// `None` when the undo stack is empty. The echo is the same
+    /// replace-grade shape as `apply`.
     pub fn undo(&mut self) -> Result<Option<AppliedIntents>, WorkspaceError> {
         let Some(entry) = self.ledger.pop_undo() else {
             return Ok(None);
         };
 
-        let outcome = self.replay(&entry, |pair| &pair.pre)?;
+        let outcome = self.replay(&entry, ReplaySide::Pre)?;
         self.ledger.record_undone(entry);
         Ok(Some(outcome))
     }
 
-    /// Replays the most recent undone entry's post states.
+    /// Replays the most recent undone entry's post states in step order.
     pub fn redo(&mut self) -> Result<Option<AppliedIntents>, WorkspaceError> {
         let Some(entry) = self.ledger.pop_redo() else {
             return Ok(None);
         };
 
-        let outcome = self.replay(&entry, |pair| &pair.post)?;
+        let outcome = self.replay(&entry, ReplaySide::Post)?;
         self.ledger.record_redone(entry);
         Ok(Some(outcome))
     }
@@ -326,35 +262,40 @@ impl FontWorkspace {
     fn replay(
         &mut self,
         entry: &LedgerEntry,
-        side: impl Fn(&LayerPair) -> &GlyphLayer,
+        side: ReplaySide,
     ) -> Result<AppliedIntents, WorkspaceError> {
-        let restored: Vec<GlyphLayer> =
-            entry.layers.iter().map(|pair| side(pair).clone()).collect();
+        let mut steps = entry.steps.clone();
+        if side == ReplaySide::Pre {
+            steps.reverse();
+        }
 
         self.commit_edit(move |font| {
             let mut changes = FontChangeSet::default();
-            let mut layers = Vec::with_capacity(restored.len());
+            let mut touched: Vec<TouchedLayer> = Vec::new();
 
-            for replacement in restored {
-                let layer_id = replacement.id();
-                let layer = font
-                    .layer_mut(layer_id.clone())
-                    .ok_or(CoreError::LayerNotFound(layer_id))?;
-                *layer = replacement;
-
-                // Geometry replace persists contours only; metrics ride their
-                // own change so width/height restores reach SQLite too.
-                changes.push(FontChange::layer_geometry_replaced(layer));
-                changes.push(FontChange::layer_metrics_changed(layer));
-                layers.push(TouchedLayer {
-                    layer: layer.clone(),
-                    structural: true,
-                });
+            for step in steps {
+                match step {
+                    LedgerStep::Layers(pairs) => {
+                        replay_layer_pairs(font, pairs, side, &mut changes, &mut touched)?;
+                    }
+                    LedgerStep::Glyph { pre, post } => {
+                        let (from, to) = side.orient(pre, post);
+                        replay_glyph(font, from, to, &mut changes, &mut touched)?;
+                    }
+                    LedgerStep::Axis { pre, post } => {
+                        let (from, to) = side.orient(pre, post);
+                        replay_axis(font, from, to, &mut changes)?;
+                    }
+                    LedgerStep::Source { pre, post, layers } => {
+                        let (from, to) = side.orient(pre, post);
+                        replay_source(font, from, to, layers, &mut changes, &mut touched)?;
+                    }
+                }
             }
 
             let outcome = AppliedIntents {
                 changes: changes.clone(),
-                layers,
+                layers: touched,
             };
             Ok((outcome, changes))
         })
@@ -450,6 +391,153 @@ impl FontWorkspace {
     pub fn font_info(&self) -> Result<Option<shift_store::FontInfo>, WorkspaceError> {
         self.store.get_font_info().map_err(WorkspaceError::from)
     }
+}
+
+/// Which side of every state pair a replay applies: undo restores `Pre`,
+/// redo restores `Post`.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ReplaySide {
+    Pre,
+    Post,
+}
+
+impl ReplaySide {
+    /// Orients a state pair into (from, to) for this side.
+    fn orient<T>(self, pre: Option<T>, post: Option<T>) -> (Option<T>, Option<T>) {
+        match self {
+            Self::Pre => (post, pre),
+            Self::Post => (pre, post),
+        }
+    }
+}
+
+fn replay_layer_pairs(
+    font: &mut shift_font::Font,
+    pairs: Vec<LayerPair>,
+    side: ReplaySide,
+    changes: &mut FontChangeSet,
+    touched: &mut Vec<TouchedLayer>,
+) -> Result<(), WorkspaceError> {
+    for pair in pairs {
+        let replacement = match side {
+            ReplaySide::Pre => pair.pre,
+            ReplaySide::Post => pair.post,
+        };
+        let layer_id = replacement.id();
+        let layer = font
+            .layer_mut(layer_id.clone())
+            .ok_or(CoreError::LayerNotFound(layer_id))?;
+        *layer = replacement;
+
+        // Geometry replace persists contours only; metrics ride their
+        // own change so width/height restores reach SQLite too.
+        changes.push(FontChange::layer_geometry_replaced(layer));
+        changes.push(FontChange::layer_metrics_changed(layer));
+        touched.push(TouchedLayer {
+            layer: layer.clone(),
+            structural: true,
+        });
+    }
+
+    Ok(())
+}
+
+fn replay_glyph(
+    font: &mut shift_font::Font,
+    from: Option<Glyph>,
+    to: Option<Glyph>,
+    changes: &mut FontChangeSet,
+    touched: &mut Vec<TouchedLayer>,
+) -> Result<(), WorkspaceError> {
+    if let Some(glyph) = from {
+        font.remove_glyph(glyph.id())
+            .ok_or(CoreError::GlyphNotFound(glyph.id()))?;
+        changes.push(FontChange::glyph_deleted(glyph.id()));
+    }
+
+    if let Some(glyph) = to {
+        font.insert_glyph(glyph.clone())?;
+        changes.push(FontChange::glyph_created(&glyph));
+
+        for layer in glyph.layers().values() {
+            let layer = layer.as_ref().clone();
+            changes.push(FontChange::glyph_layer_created(
+                glyph.id(),
+                Some(glyph.glyph_name().clone()),
+                &layer,
+            ));
+            touched.push(TouchedLayer {
+                layer,
+                structural: true,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn replay_axis(
+    font: &mut shift_font::Font,
+    from: Option<Axis>,
+    to: Option<Axis>,
+    changes: &mut FontChangeSet,
+) -> Result<(), WorkspaceError> {
+    if let Some(axis) = from {
+        font.remove_axis(axis.tag())
+            .ok_or_else(|| CoreError::AxisNotFound(axis.tag().to_string()))?;
+        changes.push(FontChange::axis_deleted(axis.tag()));
+    }
+
+    if let Some(axis) = to {
+        changes.push(FontChange::axis_created(&axis));
+        font.add_axis(axis);
+    }
+
+    Ok(())
+}
+
+fn replay_source(
+    font: &mut shift_font::Font,
+    from: Option<Source>,
+    to: Option<Source>,
+    eager_layers: Vec<(GlyphId, GlyphLayer)>,
+    changes: &mut FontChangeSet,
+    touched: &mut Vec<TouchedLayer>,
+) -> Result<(), WorkspaceError> {
+    if let Some(source) = from {
+        // Layers go first so the layer index never points at a missing
+        // source; the store side cascades them off the source row.
+        for (_, layer) in &eager_layers {
+            font.remove_glyph_layer(layer.id())?;
+        }
+
+        font.remove_source(source.id())
+            .ok_or(CoreError::SourceNotFound(source.id()))?;
+        changes.push(FontChange::source_deleted(source.id()));
+    }
+
+    if let Some(source) = to {
+        changes.push(FontChange::source_created(&source));
+        font.add_source(source);
+
+        for (glyph_id, layer) in eager_layers {
+            let glyph_name = font
+                .glyph(glyph_id.clone())
+                .map(|glyph| glyph.glyph_name().clone());
+            changes.push(FontChange::glyph_layer_created(
+                glyph_id.clone(),
+                glyph_name,
+                &layer,
+            ));
+            font.insert_glyph_layer(glyph_id, layer.clone())?;
+            touched.push(TouchedLayer {
+                layer,
+                structural: true,
+            });
+        }
+    }
+
+    Ok(())
 }
 
 fn font_info_from_font(font: &shift_font::Font) -> shift_store::FontInfo {

--- a/crates/shift-workspace/tests/workspace_test.rs
+++ b/crates/shift-workspace/tests/workspace_test.rs
@@ -1,7 +1,30 @@
 use std::path::PathBuf;
 
-use shift_font::{FontIntent, FontIntentSet, LayerId, error::CoreError};
+use shift_font::{
+    Axis, FontChange, FontIntent, FontIntentSet, GlyphId, LayerId, Location, error::CoreError,
+};
 use shift_workspace::{FontWorkspace, NewWorkspace, WorkspaceError, WorkspaceSource};
+
+fn create_glyph_intent(name: &str, unicodes: Vec<u32>) -> FontIntent {
+    FontIntent::CreateGlyph {
+        glyph_id: None,
+        name: name.to_string(),
+        unicodes,
+    }
+}
+
+fn create_glyph(workspace: &mut FontWorkspace, name: &str, unicodes: Vec<u32>) -> GlyphId {
+    workspace
+        .apply(
+            FontIntentSet {
+                intents: vec![create_glyph_intent(name, unicodes)],
+            },
+            None,
+        )
+        .unwrap();
+
+    workspace.font().glyph_id_by_name(name).unwrap()
+}
 
 #[test]
 fn creates_untitled_workspace_with_working_store_only() {
@@ -158,9 +181,11 @@ fn apply_set_x_advance_updates_existing_layer() {
     let store_path = temp.path().join("working.sqlite");
     let mut workspace = FontWorkspace::create_untitled(&store_path, NewWorkspace::new()).unwrap();
     let source_id = workspace.font().default_source_id().unwrap();
-    let glyph = workspace.create_glyph("A".to_string(), vec![65]).unwrap();
-    let layer = workspace.create_glyph_layer(glyph.id(), source_id).unwrap();
-    let layer_id = layer.id();
+    let glyph_id = create_glyph(&mut workspace, "A", vec![65]);
+    let layer_id = workspace
+        .font()
+        .layer_id_for_glyph_source(glyph_id, source_id)
+        .unwrap();
 
     let outcome = workspace
         .apply(set_x_advance_intents(layer_id.clone(), 640.0), None)
@@ -168,6 +193,126 @@ fn apply_set_x_advance_updates_existing_layer() {
 
     assert_eq!(outcome.layers[0].layer.width(), 640.0);
     assert_eq!(workspace.font().layer(layer_id).unwrap().width(), 640.0);
+}
+
+#[test]
+fn create_glyph_undo_redo_removes_and_restores_glyph_with_layers() {
+    let temp = tempfile::tempdir().unwrap();
+    let store_path = temp.path().join("working.sqlite");
+    let mut workspace = FontWorkspace::create_untitled(&store_path, NewWorkspace::new()).unwrap();
+    let source_count = workspace.font().sources().len();
+
+    let applied = workspace
+        .apply(
+            FontIntentSet {
+                intents: vec![create_glyph_intent("A", vec![65])],
+            },
+            Some("Add Glyph".to_string()),
+        )
+        .unwrap();
+    let glyph_id = workspace.font().glyph_id_by_name("A").unwrap();
+
+    assert_eq!(workspace.font().glyph_count(), 1);
+    assert_eq!(applied.layers.len(), source_count);
+
+    let undone = workspace.undo().unwrap().expect("createGlyph should undo");
+    assert_eq!(workspace.font().glyph_count(), 0);
+    assert!(undone.changes.changes.iter().any(
+        |change| matches!(change, FontChange::GlyphDeleted(change) if change.glyph_id == glyph_id)
+    ));
+
+    let redone = workspace.redo().unwrap().expect("createGlyph should redo");
+    assert_eq!(workspace.font().glyph_count(), 1);
+    assert_eq!(redone.layers.len(), source_count);
+    assert!(workspace.font().glyph(glyph_id).is_some());
+}
+
+#[test]
+fn batched_create_glyphs_undo_as_one_step() {
+    let temp = tempfile::tempdir().unwrap();
+    let store_path = temp.path().join("working.sqlite");
+    let mut workspace = FontWorkspace::create_untitled(&store_path, NewWorkspace::new()).unwrap();
+
+    workspace
+        .apply(
+            FontIntentSet {
+                intents: vec![
+                    create_glyph_intent("A", vec![65]),
+                    create_glyph_intent("B", vec![66]),
+                    create_glyph_intent("C", vec![67]),
+                ],
+            },
+            Some("Add Glyphs".to_string()),
+        )
+        .unwrap();
+    assert_eq!(workspace.font().glyph_count(), 3);
+
+    workspace.undo().unwrap().expect("batch should undo");
+    assert_eq!(workspace.font().glyph_count(), 0);
+    assert!(workspace.undo().unwrap().is_none());
+
+    workspace.redo().unwrap().expect("batch should redo");
+    assert_eq!(workspace.font().glyph_count(), 3);
+    assert!(workspace.font().glyph_id_by_name("B").is_some());
+}
+
+#[test]
+fn mixed_font_level_batch_undoes_axis_source_and_glyph_together() {
+    let temp = tempfile::tempdir().unwrap();
+    let store_path = temp.path().join("working.sqlite");
+    let mut workspace = FontWorkspace::create_untitled(&store_path, NewWorkspace::new()).unwrap();
+    create_glyph(&mut workspace, "A", vec![65]);
+    let base_sources = workspace.font().sources().len();
+
+    let mut location = Location::new();
+    location.set("wght".to_string(), 700.0);
+    workspace
+        .apply(
+            FontIntentSet {
+                intents: vec![
+                    FontIntent::CreateAxis {
+                        axis: Axis::new(
+                            "wght".to_string(),
+                            "Weight".to_string(),
+                            100.0,
+                            400.0,
+                            900.0,
+                        ),
+                    },
+                    FontIntent::CreateSource {
+                        name: "Bold".to_string(),
+                        location,
+                    },
+                    create_glyph_intent("B", vec![66]),
+                ],
+            },
+            Some("Add Weight".to_string()),
+        )
+        .unwrap();
+
+    assert_eq!(workspace.font().axes().len(), 1);
+    assert_eq!(workspace.font().sources().len(), base_sources + 1);
+    assert_eq!(workspace.font().glyph_count(), 2);
+    // The pre-existing glyph gained an eager layer; the new glyph has one
+    // layer per source.
+    let glyph_a = workspace.font().glyph_by_name("A").unwrap();
+    assert_eq!(glyph_a.layers().len(), base_sources + 1);
+    let glyph_b = workspace.font().glyph_by_name("B").unwrap();
+    assert_eq!(glyph_b.layers().len(), base_sources + 1);
+
+    workspace.undo().unwrap().expect("batch should undo");
+    assert_eq!(workspace.font().axes().len(), 0);
+    assert_eq!(workspace.font().sources().len(), base_sources);
+    assert_eq!(workspace.font().glyph_count(), 1);
+    let glyph_a = workspace.font().glyph_by_name("A").unwrap();
+    assert_eq!(glyph_a.layers().len(), base_sources);
+
+    workspace.redo().unwrap().expect("batch should redo");
+    assert_eq!(workspace.font().axes().len(), 1);
+    assert_eq!(workspace.font().sources().len(), base_sources + 1);
+    assert_eq!(workspace.font().glyph_count(), 2);
+    let glyph_a = workspace.font().glyph_by_name("A").unwrap();
+    assert_eq!(glyph_a.layers().len(), base_sources + 1);
 }
 
 #[test]

--- a/packages/types/src/bridge/generated.ts
+++ b/packages/types/src/bridge/generated.ts
@@ -23,12 +23,10 @@ export interface BridgeApi {
   getMetrics(): FontMetrics
   getGlyphs(): Array<GlyphRecord>
   /**
-   * Applies one intent set as a single atomic workspace apply.
-   *
-   * Editing kinds decode through `map_intent` into `Font::apply_intents`.
-   * Font-level kinds (createGlyph, createAxis, createSource) take the
-   * workspace-verb path and skip the ledger. Sets must be homogeneous:
-   * font-level and editing intents never share a tick.
+   * Applies one intent set as a single atomic workspace apply: every kind
+   * — editing and create alike — decodes through `map_intent` into one
+   * `FontWorkspace::apply` call. One call = one SQLite transaction = one
+   * undo step, however many intents the set batches.
    */
   apply(intents: Array<FontIntent>, label?: string | undefined | null): AppliedChange
   /**
@@ -163,6 +161,17 @@ export interface CreateAxisIntent {
 }
 
 /**
+ * Font-level glyph creation. The glyph id is client-minted (decision 6:
+ * verbs return identity synchronously); Rust honors it and rejects
+ * duplicates.
+ */
+export interface CreateGlyphIntent {
+  glyphId: GlyphId
+  name: GlyphName
+  unicodes: Array<Unicode>
+}
+
+/**
  * Font-level source creation. Rust mints the source id; the echo's
  * `sources` list carries it back.
  */
@@ -183,8 +192,8 @@ export interface FontIntent {
    * "setPointSmooth" | "removePoints" | "addAnchors" | "moveAnchors" |
    * "removeAnchors" | "reverseContour" | "translatePoints" |
    * "setXAdvance" | "applyBooleanOp".
-   * Font-level kinds (never share a set with editing kinds, not undoable):
-   * "createGlyph" | "createAxis" | "createSource".
+   * Create kinds: "createGlyph" | "createAxis" | "createSource". Every
+   * kind shares the same apply path; one set = one undo step.
    */
   kind: string
   addPoints?: AddPointsIntent
@@ -200,10 +209,9 @@ export interface FontIntent {
   translatePoints?: TranslatePointsIntent
   setXAdvance?: SetXAdvanceIntent
   applyBooleanOp?: BooleanOpIntent
+  createGlyph?: CreateGlyphIntent
   createAxis?: CreateAxisIntent
   createSource?: CreateSourceIntent
-  name?: GlyphName
-  unicodes?: Array<Unicode>
 }
 
 export interface FontMetadata {

--- a/packages/types/src/ids.ts
+++ b/packages/types/src/ids.ts
@@ -217,3 +217,8 @@ export function mintContourId(): ContourId {
 export function mintAnchorId(): AnchorId {
   return `anchor_${crypto.randomUUID()}` as AnchorId;
 }
+
+/** Mints a new glyph id. See {@link mintPointId}. */
+export function mintGlyphId(): GlyphId {
+  return `glyph_${crypto.randomUUID()}` as GlyphId;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -33,6 +33,7 @@ export {
   mintContourId,
   mintAnchorId,
   mintPointId,
+  mintGlyphId,
 } from "./ids";
 
 export type {


### PR DESCRIPTION
## Summary

`createGlyph`/`createAxis`/`createSource` join the `FontIntent` vocabulary and ride the same ledgered apply path as editing intents. This fixes the review finding that batched `createGlyph` intents became multiple ledger entries (and multiple SQLite transactions), violating the one-apply-one-undo-step contract — and removes the partially-ledgered apply path where `createAxis`/`createSource` corrupted undo history by skipping the ledger entirely.

## Rust

- **One intent vocabulary.** `FontIntent` gains `CreateGlyph`/`CreateAxis`/`CreateSource`; `Font::apply_intents` applies them with domain validation as `CoreError` variants. The bridge's font-level partition/loop is deleted — every kind decodes through `map_intent` into one `FontWorkspace::apply` = one transaction = one ledger entry. Mixed editing+create sets are legal.
- **Composite, state-pair ledger.** `LedgerEntry` holds `steps: Vec<LedgerStep>` with `Glyph`/`Axis`/`Source { pre, post }` pairs. Undo replays pre sides in reverse order, redo post sides in order, through one symmetric replay function — the bespoke `undo_glyph_created`/`redo_glyph_created` inversion code is gone. The `Glyph` pair gives deleteGlyph/renameGlyph the same machinery for free.
- **Persistence for replays.** New `AxisDeleted`/`SourceDeleted` changes alongside `GlyphDeleted`; child rows (layers, unicodes, locations) ride the store's existing FK cascades.
- The per-verb workspace mutation surfaces (`create_glyph`, `create_glyph_with_layers`, `create_glyph_layer`, `create_axis`, `create_source`) are deleted — `apply` is the single door, so the undo invariant has no back doors.

## Renderer

- **Client-minted glyph ids** (`mintGlyphId`, mirroring point/contour/anchor ids) make `Font.createGlyph(name)` synchronous like every other verb: resolve the name, infer unicodes, push the intent, return the record immediately. Dependent reads (`openGlyph`) serialize behind pending writes, so no awaiting is needed.
- The wire intent gets a proper `CreateGlyphIntent { glyphId, name, unicodes }` payload, replacing the top-level `name`/`unicodes` fields on `FontIntent`.
- `EditorView` and the glyph-catalog quick-add (previously calling a throwing stub) route through `editor.createGlyph` → `Font.createGlyph` → `ChangeWriter`, so same-microtask pushes coalesce into one apply and one undo step.

## Tests

- Rust: batched creates undo as one step; a mixed axis+source+glyph batch undoes/redoes atomically with eager-layer coverage; store cascade test for glyph deletion.
- TS: ledger semantics updated for createGlyph now being undoable; WorkspaceHost undo/redo echo test; all intent call sites migrated to the new wire shape.

Follow-up filed separately: #75 (migrate post-commit editor/text state from name-keyed `GlyphHandle` to `GlyphId`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)