### PR TITLE
[codex] Add shift source package serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,6 +329,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,6 +419,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2163a0e204a148662b6b6816d4b5d5668a5f2f8df498ccbd5cd0e864e78fecba"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1698,6 +1727,7 @@ dependencies = [
  "plist",
  "quick-xml",
  "shift-font",
+ "shift-source",
  "skrifa",
  "tempfile",
  "thiserror 2.0.18",
@@ -1737,8 +1767,12 @@ dependencies = [
 name = "shift-source"
 version = "0.1.0"
 dependencies = [
+ "serde",
+ "serde_json",
+ "shift-font",
  "tempfile",
  "thiserror 2.0.18",
+ "zip",
 ]
 
 [[package]]
@@ -2401,4 +2435,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.18",
 ]

--- a/crates/shift-backends/Cargo.toml
+++ b/crates/shift-backends/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["rlib"]
 
 [dependencies]
 shift-font = { workspace = true }
+shift-source = { workspace = true }
 
 norad = "0.16.0"
 skrifa = "0.32.0"

--- a/crates/shift-backends/src/errors.rs
+++ b/crates/shift-backends/src/errors.rs
@@ -66,6 +66,9 @@ pub enum FormatBackendError {
     #[error(transparent)]
     Font(#[from] shift_font::CoreError),
 
+    #[error(transparent)]
+    Shift(#[from] shift_source::SourcePackageError),
+
     #[error("UFO backend error: {0}")]
     Ufo(String),
 

--- a/crates/shift-backends/src/font_loader.rs
+++ b/crates/shift-backends/src/font_loader.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use shift_font::Font;
+use shift_source::ShiftSourcePackage;
 
 use crate::designspace::{DesignspaceReader, DesignspaceWriter};
 use crate::errors::{BackendError, BackendResult, FormatBackendError, FormatBackendResult};
@@ -20,6 +21,19 @@ pub trait FontAdaptor {
 struct UfoFontAdaptor;
 struct GlyphsFontAdaptor;
 struct DesignspaceFontAdaptor;
+struct ShiftFontAdaptor;
+
+impl FontAdaptor for ShiftFontAdaptor {
+    fn read_font(&self, path: &str) -> FormatBackendResult<Font> {
+        ShiftSourcePackage::load_font(path).map_err(FormatBackendError::from)
+    }
+
+    fn write_font(&self, font: &Font, path: &str) -> FormatBackendResult<()> {
+        ShiftSourcePackage::save_font(path, font)
+            .map(|_| ())
+            .map_err(FormatBackendError::from)
+    }
+}
 
 impl FontAdaptor for UfoFontAdaptor {
     fn read_font(&self, path: &str) -> FormatBackendResult<Font> {
@@ -63,6 +77,7 @@ impl Default for FontLoader {
 
 fn format_from_extension(ext: &str) -> BackendResult<FontFormat> {
     match ext.to_ascii_lowercase().as_str() {
+        "shift" => Ok(FontFormat::Shift),
         "ufo" => Ok(FontFormat::Ufo),
         "glyphs" => Ok(FontFormat::Glyphs),
         "glyphspackage" => Ok(FontFormat::Glyphs),
@@ -89,6 +104,7 @@ fn extension_from_path(path: &Path) -> BackendResult<&str> {
 impl FontLoader {
     pub fn new() -> Self {
         let mut adaptors: HashMap<FontFormat, Box<dyn FontAdaptor>> = HashMap::new();
+        adaptors.insert(FontFormat::Shift, Box::new(ShiftFontAdaptor));
         adaptors.insert(FontFormat::Ufo, Box::new(UfoFontAdaptor));
         adaptors.insert(FontFormat::Glyphs, Box::new(GlyphsFontAdaptor));
         adaptors.insert(FontFormat::Designspace, Box::new(DesignspaceFontAdaptor));
@@ -125,7 +141,7 @@ impl FontLoader {
         let format = format_from_extension(ext)?;
 
         match format {
-            FontFormat::Ufo | FontFormat::Designspace => {}
+            FontFormat::Ufo | FontFormat::Designspace | FontFormat::Shift => {}
             _ => {
                 return Err(BackendError::UnsupportedWriteFormat {
                     extension: ext.to_string(),
@@ -173,8 +189,20 @@ mod tests {
     }
 
     #[test]
+    fn supports_shift_extension() {
+        assert!(matches!(
+            format_from_extension("shift"),
+            Ok(FontFormat::Shift)
+        ));
+    }
+
+    #[test]
     fn extension_matching_is_case_insensitive() {
         assert!(matches!(format_from_extension("UFO"), Ok(FontFormat::Ufo)));
+        assert!(matches!(
+            format_from_extension("SHIFT"),
+            Ok(FontFormat::Shift)
+        ));
         assert!(matches!(
             format_from_extension("GLYPHS"),
             Ok(FontFormat::Glyphs)

--- a/crates/shift-backends/src/format.rs
+++ b/crates/shift-backends/src/format.rs
@@ -3,6 +3,7 @@ pub enum FontFormat {
     Ufo,
     Glyphs,
     Designspace,
+    Shift,
     Ttf,
     Otf,
 }
@@ -10,6 +11,7 @@ pub enum FontFormat {
 impl FontFormat {
     pub fn name(self) -> &'static str {
         match self {
+            FontFormat::Shift => "shift",
             FontFormat::Ufo => "ufo",
             FontFormat::Glyphs => "glyphs",
             FontFormat::Designspace => "designspace",

--- a/crates/shift-backends/tests/loading.rs
+++ b/crates/shift-backends/tests/loading.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use shift_backends::font_loader::FontLoader;
-use shift_font::{Font, Glyph, GlyphLayer, PointType};
+use shift_font::{Contour, Font, Glyph, GlyphLayer, LayerId, PointType};
 
 fn fixtures_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -49,6 +49,22 @@ fn main_layer(glyph: &Glyph) -> &GlyphLayer {
         .values()
         .max_by_key(|layer| layer.contours().len())
         .expect("glyph should have at least one layer")
+}
+
+fn simple_geometry_font() -> Font {
+    let mut font = Font::new();
+    let source_id = font.default_source_id().unwrap();
+    let mut glyph = Glyph::with_unicode("A".to_string(), 0x0041);
+    let mut layer = GlyphLayer::with_width(LayerId::from_raw("A_regular"), source_id, 640.0);
+    let mut contour = Contour::new();
+    contour.add_point(100.0, 0.0, PointType::OnCurve, false);
+    contour.add_point(320.0, 700.0, PointType::OnCurve, false);
+    contour.add_point(540.0, 0.0, PointType::OnCurve, false);
+    contour.close();
+    layer.add_contour(contour);
+    glyph.set_layer(layer);
+    font.insert_glyph(glyph).unwrap();
+    font
 }
 
 #[test]
@@ -223,4 +239,25 @@ fn loads_designspace_sources_axes_and_default_metadata() {
 
     let glyph_a = font.glyph_by_name("A").expect("A glyph should exist");
     assert!(glyph_a.layers().len() >= 4);
+}
+
+#[test]
+fn round_trips_shift_source_through_font_loader() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("Dogfood.shift");
+    let original = simple_geometry_font();
+
+    FontLoader::new()
+        .write_font(&original, path.to_str().unwrap())
+        .unwrap();
+    let loaded = load_font(&path);
+
+    let glyph = loaded.glyph_by_name("A").expect("A glyph should exist");
+    let layer = main_layer(glyph);
+
+    assert_eq!(glyph.unicodes(), &[0x0041]);
+    assert_eq!(layer.width(), 640.0);
+    assert_eq!(layer.contours().len(), 1);
+    assert!(layer.contours().values().next().unwrap().is_closed());
+    assert_eq!(layer.contours().values().next().unwrap().points().len(), 3);
 }

--- a/crates/shift-font/src/ir/guideline.rs
+++ b/crates/shift-font/src/ir/guideline.rs
@@ -19,6 +19,24 @@ pub struct Guideline {
 }
 
 impl Guideline {
+    pub fn with_id(
+        id: GuidelineId,
+        x: Option<f64>,
+        y: Option<f64>,
+        angle: Option<f64>,
+        name: Option<String>,
+        color: Option<String>,
+    ) -> Self {
+        Self {
+            id,
+            x,
+            y,
+            angle,
+            name,
+            color,
+        }
+    }
+
     pub fn horizontal(y: f64) -> Self {
         Self {
             id: GuidelineId::new(),

--- a/crates/shift-font/src/ir/source.rs
+++ b/crates/shift-font/src/ir/source.rs
@@ -30,6 +30,20 @@ impl Source {
         }
     }
 
+    pub fn with_id(
+        id: SourceId,
+        name: String,
+        location: Location,
+        filename: Option<String>,
+    ) -> Self {
+        Self {
+            id,
+            name,
+            location,
+            filename,
+        }
+    }
+
     pub fn id(&self) -> SourceId {
         self.id.clone()
     }

--- a/crates/shift-source/Cargo.toml
+++ b/crates/shift-source/Cargo.toml
@@ -4,7 +4,11 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+shift-font = { workspace = true }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 thiserror = "2"
+zip = { version = "2", default-features = false }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/shift-source/docs/DOCS.md
+++ b/crates/shift-source/docs/DOCS.md
@@ -1,38 +1,83 @@
 # shift-source
 
-Placeholder source-package crate for Shift's user-authored `.shift` format.
+Source-package crate for Shift's user-authored `.shift` format.
 
 ## Architecture Invariants
 
-- **Architecture Invariant:** `.shift` is the user-selected source package path. It is separate from the working SQLite store path.
-- **Architecture Invariant:** This crate owns source-package file-system layout, not the live font object model or incremental working DB.
-- **Architecture Invariant:** The current package is intentionally minimal: a directory ending in `.shift` with a `manifest.json` file.
+- **Architecture Invariant:** `.shift` is a single zip file containing deterministic JSON entries. `manifest.json` is stored uncompressed as the first zip entry.
+- **Architecture Invariant:** This crate owns the stable source schema DTOs and converts to/from `shift_font::Font`. It does not expose serde for private `shift-font` storage structs as the file contract.
+- **Architecture Invariant:** Serialization is tree-first: `font_to_tree` emits `Vec<(path, bytes)>`; `write_tree_atomic` is the zip container layer. A future loose-directory container can reuse the same tree schema.
+- **Architecture Invariant:** `.shift` is separate from the app-managed SQLite working store. SQLite import/export wiring belongs in `shift-workspace`, not here.
 
 ## Codemap
 
-```
+```text
 crates/shift-source/src/
   lib.rs      -- public API barrel
-  package.rs  -- package creation/opening and path validation
+  package.rs  -- DTOs, tree serialization, zip IO, package validation
 ```
 
 ## Key Types
 
-- `ShiftSourcePackage` -- opened or newly created `.shift` package directory.
-- `SourcePackageError` -- typed source-package file-system and validation failures.
+- `ShiftSourcePackage` -- opened or newly written `.shift` zip file.
+- `SourcePackageError` -- typed package IO, zip, JSON, schema, and conversion failures.
+- `PackageTree` -- deterministic file tree as `(path, bytes)` entries.
 
-## How it works
+## Package Shape
 
-`ShiftSourcePackage::create_empty(path)` validates that the path ends in `.shift`, creates the directory, and writes a placeholder `manifest.json`.
+```text
+Family.shift
+  manifest.json
+  font.json
+  axes.json
+  sources.json
+  features.fea                    # optional verbatim OpenType feature text
+  kerning.json                    # optional, glyph references use stable glyph ids
+  glyphs/
+    glyph_<id>.json
+  modules/
+    shift.libData.json            # optional Shift-owned compatibility module for IR lib data
+```
 
-`ShiftSourcePackage::open(path)` validates that the directory and manifest exist.
+`glyphs/glyph_<id>.json` must contain the same `id`; a mismatch is a load error.
+
+Font-level guidelines live in `font.json`. Layer guidelines live in the owning
+`glyphs/glyph_<id>.json` entry so a future loose-directory writer can still keep
+guideline edits narrow.
+
+`features.fea` is stored as text, not JSON, and is absent when the font has no
+feature source.
+
+`kerning.json` stores kerning pairs and groups with stable glyph IDs plus glyph
+names as label caches. The serializer rejects kerning that references a glyph
+name that cannot resolve to a current glyph ID, because `.shift` references must
+not become name-keyed source truth.
+
+Current `shift_font::LibData` is preserved in `modules/shift.libData.json`, a
+Shift-owned, schema-versioned module. Core font/glyph/layer JSON documents do
+not grow arbitrary `lib` fields.
+
+## How It Works
+
+`font_to_tree(font)` converts the live `Font` projection into deterministic JSON entries. `tree_to_font(tree)` validates the manifest and rebuilds a `Font` through public `shift-font` constructors and mutators.
+
+`ShiftSourcePackage::save_font(path, font)` writes `path.tmp`, syncs it, then atomically renames it to `path`. `ShiftSourcePackage::load_font(path)` reads the zip tree and returns a rebuilt `Font`.
+
+`ShiftSourcePackage::create_empty(path)` writes an empty default `Font` package and refuses to overwrite an existing path.
+
+## Backend Integration
+
+`shift-source` intentionally does not depend on `shift-backends`. To expose `.shift` through `FontLoader`, add a thin `shift-backends` adaptor that delegates to `ShiftSourcePackage::load_font` and `ShiftSourcePackage::save_font`.
 
 ## Verification
 
-- `cargo test -p shift-source`
+```bash
+cargo fmt --all --check
+cargo test -p shift-source
+```
 
 ## Related
 
-- `shift-workspace` -- composes source package, working store, and live font model.
-- `shift-store` -- working SQLite store.
-- `shift-font` -- live font object model.
+- `shift-font` -- live authoring model converted at the boundary.
+- `shift-backends` -- extension-dispatch layer that can register `.shift` as a font backend.
+- `shift-workspace` -- composes source package IO with the SQLite working store.

--- a/crates/shift-source/docs/DOCS.md
+++ b/crates/shift-source/docs/DOCS.md
@@ -34,15 +34,15 @@ Family.shift
   features.fea                    # optional verbatim OpenType feature text
   kerning.json                    # optional, glyph references use stable glyph ids
   glyphs/
-    glyph_<id>.json
+    <glyphId>.json
   modules/
     shift.libData.json            # optional Shift-owned compatibility module for IR lib data
 ```
 
-`glyphs/glyph_<id>.json` must contain the same `id`; a mismatch is a load error.
+`glyphs/<glyphId>.json` must contain the same `id`; a mismatch is a load error.
 
 Font-level guidelines live in `font.json`. Layer guidelines live in the owning
-`glyphs/glyph_<id>.json` entry so a future loose-directory writer can still keep
+`glyphs/<glyphId>.json` entry so a future loose-directory writer can still keep
 guideline edits narrow.
 
 `features.fea` is stored as text, not JSON, and is absent when the font has no

--- a/crates/shift-source/src/lib.rs
+++ b/crates/shift-source/src/lib.rs
@@ -1,3 +1,7 @@
 mod package;
 
-pub use package::{MANIFEST_FILE, ShiftSourcePackage, SourcePackageError};
+pub use package::{
+    AXES_FILE, FEATURES_FILE, FONT_FILE, GLYPHS_DIR, KERNING_FILE, LIB_MODULE_FILE, MANIFEST_FILE,
+    MODULES_DIR, PackageTree, SOURCES_FILE, ShiftSourcePackage, SourcePackageError, font_to_tree,
+    read_tree, tree_to_font, write_tree_atomic,
+};

--- a/crates/shift-source/src/package.rs
+++ b/crates/shift-source/src/package.rs
@@ -1,15 +1,38 @@
 use std::{
-    fs, io,
+    collections::{BTreeMap, HashMap},
+    fs::{self, File},
+    io::{self, Read, Seek, Write},
     path::{Path, PathBuf},
+    str::FromStr,
+    string::FromUtf8Error,
 };
 
-pub const MANIFEST_FILE: &str = "manifest.json";
+use serde::{Deserialize, Serialize};
+use shift_font::{
+    Anchor, Axis, Component, ComponentId, Contour, DecomposedTransform, FeatureData, Font,
+    FontMetadata, FontMetrics, Glyph, GlyphLayer, GlyphName, Guideline, KerningData, KerningPair,
+    KerningSide, LibData, LibValue, Location, Point, PointType, Source, SourceId,
+};
+use zip::{CompressionMethod, ZipArchive, ZipWriter, result::ZipError, write::SimpleFileOptions};
 
-const EMPTY_MANIFEST: &str = r#"{
-  "format": "shift-source",
-  "version": 1
-}
-"#;
+pub const MANIFEST_FILE: &str = "manifest.json";
+pub const FONT_FILE: &str = "font.json";
+pub const AXES_FILE: &str = "axes.json";
+pub const SOURCES_FILE: &str = "sources.json";
+pub const FEATURES_FILE: &str = "features.fea";
+pub const KERNING_FILE: &str = "kerning.json";
+pub const GLYPHS_DIR: &str = "glyphs";
+pub const MODULES_DIR: &str = "modules";
+pub const LIB_MODULE_FILE: &str = "modules/shift.libData.json";
+
+const FORMAT_ID: &str = "shift-source";
+const SCHEMA_VERSION: u32 = 1;
+const KERNING_SCHEMA_VERSION: u32 = 1;
+const LIB_MODULE_OWNER: &str = "shift";
+const LIB_MODULE_NAME: &str = "libData";
+const LIB_MODULE_SCHEMA_VERSION: u32 = 1;
+
+pub type PackageTree = Vec<(String, Vec<u8>)>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum SourcePackageError {
@@ -19,14 +42,77 @@ pub enum SourcePackageError {
     #[error("source package does not exist: {0}")]
     MissingPackage(PathBuf),
 
-    #[error("source package manifest does not exist: {0}")]
-    MissingManifest(PathBuf),
-
     #[error("source package already exists: {0}")]
     AlreadyExists(PathBuf),
 
+    #[error("source package is not a file: {0}")]
+    NotAFile(PathBuf),
+
+    #[error("source package missing entry: {0}")]
+    MissingEntry(String),
+
+    #[error("source package manifest must be the first zip entry")]
+    ManifestNotFirst,
+
+    #[error("source package manifest must be stored uncompressed")]
+    ManifestCompressed,
+
+    #[error("unsupported source package format: {0}")]
+    UnsupportedFormat(String),
+
+    #[error("unsupported source package schema version: {0}")]
+    UnsupportedSchemaVersion(u32),
+
+    #[error("glyph file path {path} does not match glyph id {id}")]
+    MismatchedGlyphFileId { path: String, id: String },
+
+    #[error("invalid unicode scalar value: {0}")]
+    InvalidUnicode(String),
+
+    #[error("invalid {kind} id {value}: {message}")]
+    InvalidId {
+        kind: &'static str,
+        value: String,
+        message: String,
+    },
+
+    #[error("invalid glyph name {0:?}")]
+    InvalidGlyphName(String),
+
+    #[error("unresolved glyph name {name:?} in {field}")]
+    UnresolvedGlyphName { field: &'static str, name: String },
+
+    #[error("dangling {field} reference to {id}")]
+    DanglingReference { field: &'static str, id: String },
+
+    #[error("unexpected source package entry: {0}")]
+    UnexpectedEntry(String),
+
+    #[error("invalid source package module {path}: {message}")]
+    InvalidModule { path: String, message: String },
+
+    #[error("source package JSON error in {path}")]
+    Json {
+        path: String,
+        #[source]
+        source: serde_json::Error,
+    },
+
+    #[error("source package text error in {path}")]
+    Text {
+        path: String,
+        #[source]
+        source: FromUtf8Error,
+    },
+
+    #[error("source package zip error")]
+    Zip(#[from] ZipError),
+
     #[error("source package file-system error")]
     Io(#[from] io::Error),
+
+    #[error("font model error")]
+    Font(#[from] shift_font::CoreError),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -39,7 +125,7 @@ impl ShiftSourcePackage {
         path.as_ref()
             .extension()
             .and_then(|extension| extension.to_str())
-            == Some("shift")
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("shift"))
     }
 
     pub fn create_empty(path: impl AsRef<Path>) -> Result<Self, SourcePackageError> {
@@ -50,9 +136,13 @@ impl ShiftSourcePackage {
             return Err(SourcePackageError::AlreadyExists(path.to_path_buf()));
         }
 
-        fs::create_dir_all(path)?;
-        fs::write(path.join(MANIFEST_FILE), EMPTY_MANIFEST)?;
+        Self::save_font(path, &Font::new())
+    }
 
+    pub fn save_font(path: impl AsRef<Path>, font: &Font) -> Result<Self, SourcePackageError> {
+        let path = path.as_ref();
+        validate_shift_extension(path)?;
+        write_tree_atomic(path, font_to_tree(font)?)?;
         Ok(Self {
             path: path.to_path_buf(),
         })
@@ -61,28 +151,524 @@ impl ShiftSourcePackage {
     pub fn open(path: impl AsRef<Path>) -> Result<Self, SourcePackageError> {
         let path = path.as_ref();
         validate_shift_extension(path)?;
-
-        if !path.is_dir() {
-            return Err(SourcePackageError::MissingPackage(path.to_path_buf()));
-        }
-
-        let manifest_path = path.join(MANIFEST_FILE);
-        if !manifest_path.is_file() {
-            return Err(SourcePackageError::MissingManifest(manifest_path));
-        }
-
+        validate_package(path)?;
         Ok(Self {
             path: path.to_path_buf(),
         })
     }
 
+    pub fn load_font(path: impl AsRef<Path>) -> Result<Font, SourcePackageError> {
+        let path = path.as_ref();
+        validate_shift_extension(path)?;
+        tree_to_font(read_tree(path)?)
+    }
+
     pub fn path(&self) -> &Path {
         &self.path
     }
+}
 
-    pub fn manifest_path(&self) -> PathBuf {
-        self.path.join(MANIFEST_FILE)
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ManifestDoc {
+    format: String,
+    schema_version: u32,
+    default_source_id: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FontDoc {
+    metadata: MetadataDoc,
+    metrics: MetricsDoc,
+    #[serde(default)]
+    guidelines: Vec<GuidelineDoc>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct MetadataDoc {
+    family_name: Option<String>,
+    style_name: Option<String>,
+    version_major: Option<i32>,
+    version_minor: Option<i32>,
+    copyright: Option<String>,
+    trademark: Option<String>,
+    designer: Option<String>,
+    designer_url: Option<String>,
+    manufacturer: Option<String>,
+    manufacturer_url: Option<String>,
+    license: Option<String>,
+    license_url: Option<String>,
+    description: Option<String>,
+    note: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct MetricsDoc {
+    units_per_em: f64,
+    ascender: f64,
+    descender: f64,
+    cap_height: Option<f64>,
+    x_height: Option<f64>,
+    line_gap: Option<f64>,
+    italic_angle: Option<f64>,
+    underline_position: Option<f64>,
+    underline_thickness: Option<f64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AxesDoc {
+    axes: Vec<AxisDoc>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AxisDoc {
+    tag: String,
+    name: String,
+    minimum: f64,
+    default: f64,
+    maximum: f64,
+    hidden: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SourcesDoc {
+    sources: Vec<SourceDoc>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SourceDoc {
+    id: String,
+    name: String,
+    location: BTreeMap<String, f64>,
+    filename: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GlyphDoc {
+    id: String,
+    name: String,
+    unicodes: Vec<String>,
+    layers: BTreeMap<String, LayerDoc>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LayerDoc {
+    id: String,
+    advance: f64,
+    height: Option<f64>,
+    contours: Vec<ContourDoc>,
+    components: BTreeMap<String, ComponentDoc>,
+    anchors: Vec<AnchorDoc>,
+    #[serde(default)]
+    guidelines: Vec<GuidelineDoc>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GuidelineDoc {
+    id: String,
+    x: Option<f64>,
+    y: Option<f64>,
+    angle: Option<f64>,
+    name: Option<String>,
+    color: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ContourDoc {
+    id: String,
+    closed: bool,
+    points: Vec<PointDoc>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PointDoc {
+    id: String,
+    x: f64,
+    y: f64,
+    point_type: String,
+    smooth: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ComponentDoc {
+    base_glyph: String,
+    transform: TransformDoc,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TransformDoc {
+    translate_x: f64,
+    translate_y: f64,
+    rotation: f64,
+    scale_x: f64,
+    scale_y: f64,
+    skew_x: f64,
+    skew_y: f64,
+    t_center_x: f64,
+    t_center_y: f64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AnchorDoc {
+    id: String,
+    name: Option<String>,
+    x: f64,
+    y: f64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct KerningDoc {
+    schema_version: u32,
+    pairs: Vec<KerningPairDoc>,
+    groups1: BTreeMap<String, Vec<GlyphRefDoc>>,
+    groups2: BTreeMap<String, Vec<GlyphRefDoc>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct KerningPairDoc {
+    first: KerningSideDoc,
+    second: KerningSideDoc,
+    value: f64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "type")]
+enum KerningSideDoc {
+    Glyph { glyph_id: String, name: String },
+    Group { group_id: String },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GlyphRefDoc {
+    glyph_id: String,
+    name: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LibModuleDoc {
+    owner: String,
+    module: String,
+    schema_version: u32,
+    font: BTreeMap<String, LibValueDoc>,
+    glyphs: BTreeMap<String, GlyphLibDoc>,
+    layers: BTreeMap<String, LayerLibDoc>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GlyphLibDoc {
+    name: String,
+    lib: BTreeMap<String, LibValueDoc>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LayerLibDoc {
+    glyph_id: String,
+    glyph_name: String,
+    source_id: String,
+    lib: BTreeMap<String, LibValueDoc>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "type", content = "value")]
+enum LibValueDoc {
+    String(String),
+    Integer(i64),
+    Float(f64),
+    Boolean(bool),
+    Array(Vec<LibValueDoc>),
+    Dict(BTreeMap<String, LibValueDoc>),
+    Data(Vec<u8>),
+}
+
+pub fn font_to_tree(font: &Font) -> Result<PackageTree, SourcePackageError> {
+    let manifest = ManifestDoc {
+        format: FORMAT_ID.to_string(),
+        schema_version: SCHEMA_VERSION,
+        default_source_id: font.default_source_id().map(|id| id.to_string()),
+    };
+
+    let font_doc = FontDoc {
+        metadata: MetadataDoc::from(font.metadata()),
+        metrics: MetricsDoc::from(*font.metrics()),
+        guidelines: font.guidelines().iter().map(GuidelineDoc::from).collect(),
+    };
+
+    let axes_doc = AxesDoc {
+        axes: font.axes().iter().map(AxisDoc::from).collect(),
+    };
+
+    let sources_doc = SourcesDoc {
+        sources: font.sources().iter().map(SourceDoc::from).collect(),
+    };
+
+    let mut tree = vec![
+        json_entry(MANIFEST_FILE, &manifest)?,
+        json_entry(FONT_FILE, &font_doc)?,
+        json_entry(AXES_FILE, &axes_doc)?,
+        json_entry(SOURCES_FILE, &sources_doc)?,
+    ];
+
+    if let Some(features) = features_entry(font.features()) {
+        tree.push(features);
     }
+
+    if kerning_has_data(font.kerning()) {
+        tree.push(json_entry(KERNING_FILE, &KerningDoc::from_font(font)?)?);
+    }
+
+    if let Some(lib_module_doc) = LibModuleDoc::from_font(font) {
+        tree.push(json_entry(LIB_MODULE_FILE, &lib_module_doc)?);
+    }
+
+    let mut glyph_entries = font
+        .glyphs()
+        .map(|glyph| {
+            let glyph_doc = GlyphDoc::from(glyph);
+            let path = format!("{GLYPHS_DIR}/glyph_{}.json", glyph.id());
+            json_entry(&path, &glyph_doc)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    glyph_entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+    tree.extend(glyph_entries);
+
+    Ok(tree)
+}
+
+pub fn tree_to_font(tree: PackageTree) -> Result<Font, SourcePackageError> {
+    let mut entries: HashMap<String, Vec<u8>> = tree.into_iter().collect();
+
+    let manifest: ManifestDoc = take_json(&mut entries, MANIFEST_FILE)?;
+    validate_manifest(&manifest)?;
+
+    let font_doc: FontDoc = take_json(&mut entries, FONT_FILE)?;
+    let axes_doc: AxesDoc = take_json(&mut entries, AXES_FILE)?;
+    let sources_doc: SourcesDoc = take_json(&mut entries, SOURCES_FILE)?;
+    let features = take_optional_text(&mut entries, FEATURES_FILE)?;
+    let kerning_doc: Option<KerningDoc> = take_optional_json(&mut entries, KERNING_FILE)?;
+    let mut lib_module_doc: Option<LibModuleDoc> =
+        take_optional_json(&mut entries, LIB_MODULE_FILE)?;
+    if let Some(module_doc) = &lib_module_doc {
+        validate_lib_module(module_doc)?;
+    }
+
+    let mut font = Font::empty();
+    *font.metadata_mut() = FontMetadata::from(font_doc.metadata);
+    *font.metrics_mut() = FontMetrics::from(font_doc.metrics);
+    let mut feature_data = FeatureData::new();
+    feature_data.set_fea_source(features);
+    *font.features_mut() = feature_data;
+
+    for guideline_doc in font_doc.guidelines {
+        font.add_guideline(Guideline::try_from(guideline_doc)?);
+    }
+
+    if let Some(module_doc) = &mut lib_module_doc {
+        *font.lib_mut() = lib_from_doc(std::mem::take(&mut module_doc.font))?;
+    }
+
+    for axis_doc in axes_doc.axes {
+        font.add_axis(Axis::from(axis_doc));
+    }
+
+    for source_doc in sources_doc.sources {
+        font.add_source(Source::try_from(source_doc)?);
+    }
+
+    if let Some(default_source_id) = manifest.default_source_id {
+        font.set_default_source_id(parse_id("source", &default_source_id)?);
+    }
+
+    let mut glyph_entries = Vec::new();
+    for (path, bytes) in entries {
+        if path.starts_with(&format!("{GLYPHS_DIR}/glyph_")) {
+            glyph_entries.push((path, bytes));
+        } else {
+            return Err(SourcePackageError::UnexpectedEntry(path));
+        }
+    }
+    glyph_entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+
+    for (path, bytes) in glyph_entries {
+        let glyph_doc: GlyphDoc = from_json(&path, &bytes)?;
+        validate_glyph_path_id(&path, &glyph_doc.id)?;
+        let mut glyph = Glyph::try_from(glyph_doc)?;
+        if let Some(module_doc) = &mut lib_module_doc {
+            apply_lib_module_to_glyph(&mut glyph, module_doc)?;
+        }
+        font.insert_glyph(glyph)?;
+    }
+
+    if let Some(module_doc) = lib_module_doc {
+        ensure_lib_module_consumed(module_doc)?;
+    }
+
+    if let Some(kerning_doc) = kerning_doc {
+        *font.kerning_mut() = kerning_from_doc(kerning_doc, &font)?;
+    }
+
+    Ok(font)
+}
+
+fn validate_package(path: &Path) -> Result<(), SourcePackageError> {
+    let mut archive = open_archive(path)?;
+    validate_archive_manifest(&mut archive)?;
+    Ok(())
+}
+
+pub fn read_tree(path: impl AsRef<Path>) -> Result<PackageTree, SourcePackageError> {
+    let path = path.as_ref();
+    let mut archive = open_archive(path)?;
+    validate_archive_manifest(&mut archive)?;
+
+    let mut tree = Vec::with_capacity(archive.len());
+    for index in 0..archive.len() {
+        let mut file = archive.by_index(index)?;
+        if file.is_dir() {
+            continue;
+        }
+
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes)?;
+        tree.push((file.name().to_string(), bytes));
+    }
+
+    Ok(tree)
+}
+
+pub fn write_tree_atomic(
+    path: impl AsRef<Path>,
+    tree: PackageTree,
+) -> Result<(), SourcePackageError> {
+    let path = path.as_ref();
+    validate_shift_extension(path)?;
+    if path.is_dir() {
+        return Err(SourcePackageError::NotAFile(path.to_path_buf()));
+    }
+
+    let tmp_path = tmp_path_for(path);
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent)?;
+    }
+
+    let file = File::create(&tmp_path)?;
+    let mut zip = ZipWriter::new(file);
+    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+
+    for (entry_path, bytes) in tree {
+        zip.start_file(entry_path, options)?;
+        zip.write_all(&bytes)?;
+    }
+
+    let file = zip.finish()?;
+    file.sync_all()?;
+    fs::rename(&tmp_path, path)?;
+    sync_parent(path)?;
+    Ok(())
+}
+
+fn open_archive(path: &Path) -> Result<ZipArchive<File>, SourcePackageError> {
+    validate_shift_extension(path)?;
+
+    if !path.exists() {
+        return Err(SourcePackageError::MissingPackage(path.to_path_buf()));
+    }
+
+    if !path.is_file() {
+        return Err(SourcePackageError::NotAFile(path.to_path_buf()));
+    }
+
+    Ok(ZipArchive::new(File::open(path)?)?)
+}
+
+fn validate_archive_manifest<R: Read + Seek>(
+    archive: &mut ZipArchive<R>,
+) -> Result<(), SourcePackageError> {
+    if archive.is_empty() {
+        return Err(SourcePackageError::MissingEntry(MANIFEST_FILE.to_string()));
+    }
+
+    let mut manifest_file = archive.by_index(0)?;
+    if manifest_file.name() != MANIFEST_FILE {
+        return Err(SourcePackageError::ManifestNotFirst);
+    }
+
+    if manifest_file.compression() != CompressionMethod::Stored {
+        return Err(SourcePackageError::ManifestCompressed);
+    }
+
+    let mut bytes = Vec::new();
+    manifest_file.read_to_end(&mut bytes)?;
+    let manifest: ManifestDoc = from_json(MANIFEST_FILE, &bytes)?;
+    validate_manifest(&manifest)
+}
+
+fn validate_manifest(manifest: &ManifestDoc) -> Result<(), SourcePackageError> {
+    if manifest.format != FORMAT_ID {
+        return Err(SourcePackageError::UnsupportedFormat(
+            manifest.format.clone(),
+        ));
+    }
+
+    if manifest.schema_version != SCHEMA_VERSION {
+        return Err(SourcePackageError::UnsupportedSchemaVersion(
+            manifest.schema_version,
+        ));
+    }
+
+    Ok(())
+}
+
+fn validate_glyph_path_id(path: &str, id: &str) -> Result<(), SourcePackageError> {
+    let expected_path = format!("{GLYPHS_DIR}/glyph_{id}.json");
+    if path == expected_path {
+        Ok(())
+    } else {
+        Err(SourcePackageError::MismatchedGlyphFileId {
+            path: path.to_string(),
+            id: id.to_string(),
+        })
+    }
+}
+
+fn tmp_path_for(path: &Path) -> PathBuf {
+    let filename = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| format!("{name}.tmp"))
+        .unwrap_or_else(|| "shift-source.tmp".to_string());
+    path.with_file_name(filename)
+}
+
+fn sync_parent(path: &Path) -> Result<(), SourcePackageError> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        File::open(parent)?.sync_all()?;
+    }
+    Ok(())
 }
 
 fn validate_shift_extension(path: &Path) -> Result<(), SourcePackageError> {
@@ -90,5 +676,890 @@ fn validate_shift_extension(path: &Path) -> Result<(), SourcePackageError> {
         Ok(())
     } else {
         Err(SourcePackageError::InvalidExtension(path.to_path_buf()))
+    }
+}
+
+fn json_entry<T: Serialize>(
+    path: &str,
+    value: &T,
+) -> Result<(String, Vec<u8>), SourcePackageError> {
+    let mut bytes =
+        serde_json::to_vec_pretty(value).map_err(|source| SourcePackageError::Json {
+            path: path.to_string(),
+            source,
+        })?;
+    bytes.push(b'\n');
+    Ok((path.to_string(), bytes))
+}
+
+fn take_json<T: for<'de> Deserialize<'de>>(
+    entries: &mut HashMap<String, Vec<u8>>,
+    path: &str,
+) -> Result<T, SourcePackageError> {
+    let bytes = entries
+        .remove(path)
+        .ok_or_else(|| SourcePackageError::MissingEntry(path.to_string()))?;
+    from_json(path, &bytes)
+}
+
+fn take_optional_json<T: for<'de> Deserialize<'de>>(
+    entries: &mut HashMap<String, Vec<u8>>,
+    path: &str,
+) -> Result<Option<T>, SourcePackageError> {
+    entries
+        .remove(path)
+        .map(|bytes| from_json(path, &bytes))
+        .transpose()
+}
+
+fn take_optional_text(
+    entries: &mut HashMap<String, Vec<u8>>,
+    path: &str,
+) -> Result<Option<String>, SourcePackageError> {
+    entries
+        .remove(path)
+        .map(|bytes| {
+            String::from_utf8(bytes).map_err(|source| SourcePackageError::Text {
+                path: path.to_string(),
+                source,
+            })
+        })
+        .transpose()
+}
+
+fn from_json<T: for<'de> Deserialize<'de>>(
+    path: &str,
+    bytes: &[u8],
+) -> Result<T, SourcePackageError> {
+    serde_json::from_slice(bytes).map_err(|source| SourcePackageError::Json {
+        path: path.to_string(),
+        source,
+    })
+}
+
+fn parse_id<T>(kind: &'static str, value: &str) -> Result<T, SourcePackageError>
+where
+    T: FromStr,
+    T::Err: std::fmt::Display,
+{
+    value
+        .parse()
+        .map_err(|error: T::Err| SourcePackageError::InvalidId {
+            kind,
+            value: value.to_string(),
+            message: error.to_string(),
+        })
+}
+
+fn unicode_to_hex(unicode: u32) -> String {
+    format!("{unicode:04X}")
+}
+
+fn unicode_from_hex(value: &str) -> Result<u32, SourcePackageError> {
+    u32::from_str_radix(value, 16)
+        .ok()
+        .filter(|unicode| char::from_u32(*unicode).is_some())
+        .ok_or_else(|| SourcePackageError::InvalidUnicode(value.to_string()))
+}
+
+fn point_type_name(point_type: PointType) -> &'static str {
+    match point_type {
+        PointType::OnCurve => "onCurve",
+        PointType::OffCurve => "offCurve",
+        PointType::QCurve => "qCurve",
+    }
+}
+
+fn kerning_has_data(kerning: &KerningData) -> bool {
+    !kerning.pairs().is_empty() || !kerning.groups1().is_empty() || !kerning.groups2().is_empty()
+}
+
+fn features_entry(features: &FeatureData) -> Option<(String, Vec<u8>)> {
+    features
+        .fea_source()
+        .map(|source| (FEATURES_FILE.to_string(), source.as_bytes().to_vec()))
+}
+
+fn validate_lib_module(module_doc: &LibModuleDoc) -> Result<(), SourcePackageError> {
+    if module_doc.owner != LIB_MODULE_OWNER {
+        return Err(SourcePackageError::InvalidModule {
+            path: LIB_MODULE_FILE.to_string(),
+            message: format!("expected owner {LIB_MODULE_OWNER:?}"),
+        });
+    }
+
+    if module_doc.module != LIB_MODULE_NAME {
+        return Err(SourcePackageError::InvalidModule {
+            path: LIB_MODULE_FILE.to_string(),
+            message: format!("expected module {LIB_MODULE_NAME:?}"),
+        });
+    }
+
+    if module_doc.schema_version != LIB_MODULE_SCHEMA_VERSION {
+        return Err(SourcePackageError::InvalidModule {
+            path: LIB_MODULE_FILE.to_string(),
+            message: format!("unsupported schema version {}", module_doc.schema_version),
+        });
+    }
+
+    Ok(())
+}
+
+fn apply_lib_module_to_glyph(
+    glyph: &mut Glyph,
+    module_doc: &mut LibModuleDoc,
+) -> Result<(), SourcePackageError> {
+    let glyph_id = glyph.id().to_string();
+
+    if let Some(glyph_doc) = module_doc.glyphs.remove(&glyph_id) {
+        if glyph_doc.name != glyph.name() {
+            return Err(SourcePackageError::InvalidModule {
+                path: LIB_MODULE_FILE.to_string(),
+                message: format!(
+                    "glyph lib name cache {:?} does not match glyph {:?}",
+                    glyph_doc.name,
+                    glyph.name()
+                ),
+            });
+        }
+        *glyph.lib_mut() = lib_from_doc(glyph_doc.lib)?;
+    }
+
+    let layer_ids = glyph.layers().keys().cloned().collect::<Vec<_>>();
+    for layer_id in layer_ids {
+        let Some(layer_doc) = module_doc.layers.remove(&layer_id.to_string()) else {
+            continue;
+        };
+
+        if layer_doc.glyph_id != glyph_id {
+            return Err(SourcePackageError::InvalidModule {
+                path: LIB_MODULE_FILE.to_string(),
+                message: format!(
+                    "layer lib owner {:?} does not match glyph {:?}",
+                    layer_doc.glyph_id, glyph_id
+                ),
+            });
+        }
+
+        if layer_doc.glyph_name != glyph.name() {
+            return Err(SourcePackageError::InvalidModule {
+                path: LIB_MODULE_FILE.to_string(),
+                message: format!(
+                    "layer lib glyph name cache {:?} does not match glyph {:?}",
+                    layer_doc.glyph_name,
+                    glyph.name()
+                ),
+            });
+        }
+
+        let layer = glyph.layer_mut(layer_id.clone()).ok_or_else(|| {
+            SourcePackageError::DanglingReference {
+                field: "lib layer",
+                id: layer_id.to_string(),
+            }
+        })?;
+
+        if layer_doc.source_id != layer.source_id().to_string() {
+            return Err(SourcePackageError::InvalidModule {
+                path: LIB_MODULE_FILE.to_string(),
+                message: format!(
+                    "layer lib source {:?} does not match layer source {:?}",
+                    layer_doc.source_id,
+                    layer.source_id()
+                ),
+            });
+        }
+
+        *layer.lib_mut() = lib_from_doc(layer_doc.lib)?;
+    }
+
+    Ok(())
+}
+
+fn ensure_lib_module_consumed(module_doc: LibModuleDoc) -> Result<(), SourcePackageError> {
+    if let Some(glyph_id) = module_doc.glyphs.keys().next() {
+        return Err(SourcePackageError::DanglingReference {
+            field: "lib glyph",
+            id: glyph_id.clone(),
+        });
+    }
+
+    if let Some(layer_id) = module_doc.layers.keys().next() {
+        return Err(SourcePackageError::DanglingReference {
+            field: "lib layer",
+            id: layer_id.clone(),
+        });
+    }
+
+    Ok(())
+}
+
+fn lib_to_doc(lib: &LibData) -> BTreeMap<String, LibValueDoc> {
+    lib.iter()
+        .map(|(key, value)| (key.clone(), LibValueDoc::from(value)))
+        .collect()
+}
+
+fn lib_from_doc(doc: BTreeMap<String, LibValueDoc>) -> Result<LibData, SourcePackageError> {
+    Ok(LibData::from_map(
+        doc.into_iter()
+            .map(|(key, value)| value.try_into().map(|value| (key, value)))
+            .collect::<Result<HashMap<_, _>, _>>()?,
+    ))
+}
+
+impl LibModuleDoc {
+    fn from_font(font: &Font) -> Option<Self> {
+        let font_lib = lib_to_doc(font.lib());
+        let mut glyphs = BTreeMap::new();
+        let mut layers = BTreeMap::new();
+
+        for glyph in font.glyphs() {
+            if !glyph.lib().is_empty() {
+                glyphs.insert(
+                    glyph.id().to_string(),
+                    GlyphLibDoc {
+                        name: glyph.name().to_string(),
+                        lib: lib_to_doc(glyph.lib()),
+                    },
+                );
+            }
+
+            for layer in glyph.layers().values() {
+                if layer.lib().is_empty() {
+                    continue;
+                }
+
+                layers.insert(
+                    layer.id().to_string(),
+                    LayerLibDoc {
+                        glyph_id: glyph.id().to_string(),
+                        glyph_name: glyph.name().to_string(),
+                        source_id: layer.source_id().to_string(),
+                        lib: lib_to_doc(layer.lib()),
+                    },
+                );
+            }
+        }
+
+        if font_lib.is_empty() && glyphs.is_empty() && layers.is_empty() {
+            return None;
+        }
+
+        Some(Self {
+            owner: LIB_MODULE_OWNER.to_string(),
+            module: LIB_MODULE_NAME.to_string(),
+            schema_version: LIB_MODULE_SCHEMA_VERSION,
+            font: font_lib,
+            glyphs,
+            layers,
+        })
+    }
+}
+
+impl From<&LibValue> for LibValueDoc {
+    fn from(value: &LibValue) -> Self {
+        match value {
+            LibValue::String(value) => Self::String(value.clone()),
+            LibValue::Integer(value) => Self::Integer(*value),
+            LibValue::Float(value) => Self::Float(*value),
+            LibValue::Boolean(value) => Self::Boolean(*value),
+            LibValue::Array(values) => Self::Array(values.iter().map(Self::from).collect()),
+            LibValue::Dict(values) => Self::Dict(
+                values
+                    .iter()
+                    .map(|(key, value)| (key.clone(), Self::from(value)))
+                    .collect(),
+            ),
+            LibValue::Data(value) => Self::Data(value.clone()),
+        }
+    }
+}
+
+impl TryFrom<LibValueDoc> for LibValue {
+    type Error = SourcePackageError;
+
+    fn try_from(doc: LibValueDoc) -> Result<Self, Self::Error> {
+        Ok(match doc {
+            LibValueDoc::String(value) => Self::String(value),
+            LibValueDoc::Integer(value) => Self::Integer(value),
+            LibValueDoc::Float(value) => Self::Float(value),
+            LibValueDoc::Boolean(value) => Self::Boolean(value),
+            LibValueDoc::Array(values) => Self::Array(
+                values
+                    .into_iter()
+                    .map(Self::try_from)
+                    .collect::<Result<Vec<_>, _>>()?,
+            ),
+            LibValueDoc::Dict(values) => Self::Dict(
+                values
+                    .into_iter()
+                    .map(|(key, value)| value.try_into().map(|value| (key, value)))
+                    .collect::<Result<HashMap<_, _>, _>>()?,
+            ),
+            LibValueDoc::Data(value) => Self::Data(value),
+        })
+    }
+}
+
+impl KerningDoc {
+    fn from_font(font: &Font) -> Result<Self, SourcePackageError> {
+        let mut groups1 = BTreeMap::new();
+        for (group_id, members) in font.kerning().groups1() {
+            groups1.insert(
+                group_id.clone(),
+                members
+                    .iter()
+                    .map(|name| glyph_ref_for_name(font, "kerning.groups1", name))
+                    .collect::<Result<Vec<_>, _>>()?,
+            );
+        }
+
+        let mut groups2 = BTreeMap::new();
+        for (group_id, members) in font.kerning().groups2() {
+            groups2.insert(
+                group_id.clone(),
+                members
+                    .iter()
+                    .map(|name| glyph_ref_for_name(font, "kerning.groups2", name))
+                    .collect::<Result<Vec<_>, _>>()?,
+            );
+        }
+
+        let pairs = font
+            .kerning()
+            .pairs()
+            .iter()
+            .map(|pair| KerningPairDoc::from_pair(font, pair))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Self {
+            schema_version: KERNING_SCHEMA_VERSION,
+            pairs,
+            groups1,
+            groups2,
+        })
+    }
+}
+
+impl KerningPairDoc {
+    fn from_pair(font: &Font, pair: &KerningPair) -> Result<Self, SourcePackageError> {
+        Ok(Self {
+            first: KerningSideDoc::from_side(font, &pair.first, "kerning.pairs.first")?,
+            second: KerningSideDoc::from_side(font, &pair.second, "kerning.pairs.second")?,
+            value: pair.value,
+        })
+    }
+}
+
+impl KerningSideDoc {
+    fn from_side(
+        font: &Font,
+        side: &KerningSide,
+        field: &'static str,
+    ) -> Result<Self, SourcePackageError> {
+        Ok(match side {
+            KerningSide::Glyph(name) => {
+                let glyph_ref = glyph_ref_for_name(font, field, name)?;
+                Self::Glyph {
+                    glyph_id: glyph_ref.glyph_id,
+                    name: glyph_ref.name,
+                }
+            }
+            KerningSide::Group(group_id) => Self::Group {
+                group_id: group_id.clone(),
+            },
+        })
+    }
+
+    fn into_side(
+        self,
+        names_by_id: &HashMap<String, GlyphName>,
+        field: &'static str,
+    ) -> Result<KerningSide, SourcePackageError> {
+        Ok(match self {
+            Self::Glyph { glyph_id, name } => {
+                KerningSide::Glyph(glyph_name_from_ref(glyph_id, name, names_by_id, field)?)
+            }
+            Self::Group { group_id } => KerningSide::Group(group_id),
+        })
+    }
+}
+
+fn kerning_from_doc(doc: KerningDoc, font: &Font) -> Result<KerningData, SourcePackageError> {
+    if doc.schema_version != KERNING_SCHEMA_VERSION {
+        return Err(SourcePackageError::UnsupportedSchemaVersion(
+            doc.schema_version,
+        ));
+    }
+
+    let names_by_id = glyph_names_by_id(font);
+    let mut kerning = KerningData::new();
+
+    for (group_id, members) in doc.groups1 {
+        kerning.set_group1(
+            group_id,
+            members
+                .into_iter()
+                .map(|glyph_ref| glyph_ref.into_name(&names_by_id, "kerning.groups1"))
+                .collect::<Result<Vec<_>, _>>()?,
+        );
+    }
+
+    for (group_id, members) in doc.groups2 {
+        kerning.set_group2(
+            group_id,
+            members
+                .into_iter()
+                .map(|glyph_ref| glyph_ref.into_name(&names_by_id, "kerning.groups2"))
+                .collect::<Result<Vec<_>, _>>()?,
+        );
+    }
+
+    for pair_doc in doc.pairs {
+        kerning.add_pair(KerningPair::new(
+            pair_doc
+                .first
+                .into_side(&names_by_id, "kerning.pairs.first")?,
+            pair_doc
+                .second
+                .into_side(&names_by_id, "kerning.pairs.second")?,
+            pair_doc.value,
+        ));
+    }
+
+    Ok(kerning)
+}
+
+impl GlyphRefDoc {
+    fn into_name(
+        self,
+        names_by_id: &HashMap<String, GlyphName>,
+        field: &'static str,
+    ) -> Result<GlyphName, SourcePackageError> {
+        glyph_name_from_ref(self.glyph_id, self.name, names_by_id, field)
+    }
+}
+
+fn glyph_ref_for_name(
+    font: &Font,
+    field: &'static str,
+    name: &GlyphName,
+) -> Result<GlyphRefDoc, SourcePackageError> {
+    let glyph_id = font.glyph_id_by_name(name.as_str()).ok_or_else(|| {
+        SourcePackageError::UnresolvedGlyphName {
+            field,
+            name: name.to_string(),
+        }
+    })?;
+
+    Ok(GlyphRefDoc {
+        glyph_id: glyph_id.to_string(),
+        name: name.to_string(),
+    })
+}
+
+fn glyph_names_by_id(font: &Font) -> HashMap<String, GlyphName> {
+    font.glyphs()
+        .map(|glyph| (glyph.id().to_string(), glyph.glyph_name().clone()))
+        .collect()
+}
+
+fn glyph_name_from_ref(
+    glyph_id: String,
+    name: String,
+    names_by_id: &HashMap<String, GlyphName>,
+    field: &'static str,
+) -> Result<GlyphName, SourcePackageError> {
+    let glyph_name =
+        names_by_id
+            .get(&glyph_id)
+            .ok_or_else(|| SourcePackageError::DanglingReference {
+                field,
+                id: glyph_id.clone(),
+            })?;
+
+    if glyph_name.as_str() != name {
+        return Err(SourcePackageError::InvalidId {
+            kind: "glyphNameCache",
+            value: name,
+            message: format!("expected current name {:?}", glyph_name.as_str()),
+        });
+    }
+
+    Ok(glyph_name.clone())
+}
+
+impl From<&Guideline> for GuidelineDoc {
+    fn from(guideline: &Guideline) -> Self {
+        Self {
+            id: guideline.id().to_string(),
+            x: guideline.x(),
+            y: guideline.y(),
+            angle: guideline.angle(),
+            name: guideline.name().map(str::to_string),
+            color: guideline.color().map(str::to_string),
+        }
+    }
+}
+
+impl TryFrom<GuidelineDoc> for Guideline {
+    type Error = SourcePackageError;
+
+    fn try_from(doc: GuidelineDoc) -> Result<Self, Self::Error> {
+        Ok(Self::with_id(
+            parse_id("guideline", &doc.id)?,
+            doc.x,
+            doc.y,
+            doc.angle,
+            doc.name,
+            doc.color,
+        ))
+    }
+}
+
+impl From<&FontMetadata> for MetadataDoc {
+    fn from(metadata: &FontMetadata) -> Self {
+        Self {
+            family_name: metadata.family_name.clone(),
+            style_name: metadata.style_name.clone(),
+            version_major: metadata.version_major,
+            version_minor: metadata.version_minor,
+            copyright: metadata.copyright.clone(),
+            trademark: metadata.trademark.clone(),
+            designer: metadata.designer.clone(),
+            designer_url: metadata.designer_url.clone(),
+            manufacturer: metadata.manufacturer.clone(),
+            manufacturer_url: metadata.manufacturer_url.clone(),
+            license: metadata.license.clone(),
+            license_url: metadata.license_url.clone(),
+            description: metadata.description.clone(),
+            note: metadata.note.clone(),
+        }
+    }
+}
+
+impl From<MetadataDoc> for FontMetadata {
+    fn from(doc: MetadataDoc) -> Self {
+        Self {
+            family_name: doc.family_name,
+            style_name: doc.style_name,
+            version_major: doc.version_major,
+            version_minor: doc.version_minor,
+            copyright: doc.copyright,
+            trademark: doc.trademark,
+            designer: doc.designer,
+            designer_url: doc.designer_url,
+            manufacturer: doc.manufacturer,
+            manufacturer_url: doc.manufacturer_url,
+            license: doc.license,
+            license_url: doc.license_url,
+            description: doc.description,
+            note: doc.note,
+        }
+    }
+}
+
+impl From<FontMetrics> for MetricsDoc {
+    fn from(metrics: FontMetrics) -> Self {
+        Self {
+            units_per_em: metrics.units_per_em,
+            ascender: metrics.ascender,
+            descender: metrics.descender,
+            cap_height: metrics.cap_height,
+            x_height: metrics.x_height,
+            line_gap: metrics.line_gap,
+            italic_angle: metrics.italic_angle,
+            underline_position: metrics.underline_position,
+            underline_thickness: metrics.underline_thickness,
+        }
+    }
+}
+
+impl From<MetricsDoc> for FontMetrics {
+    fn from(doc: MetricsDoc) -> Self {
+        Self {
+            units_per_em: doc.units_per_em,
+            ascender: doc.ascender,
+            descender: doc.descender,
+            cap_height: doc.cap_height,
+            x_height: doc.x_height,
+            line_gap: doc.line_gap,
+            italic_angle: doc.italic_angle,
+            underline_position: doc.underline_position,
+            underline_thickness: doc.underline_thickness,
+        }
+    }
+}
+
+impl From<&Axis> for AxisDoc {
+    fn from(axis: &Axis) -> Self {
+        Self {
+            tag: axis.tag().to_string(),
+            name: axis.name().to_string(),
+            minimum: axis.minimum(),
+            default: axis.default(),
+            maximum: axis.maximum(),
+            hidden: axis.is_hidden(),
+        }
+    }
+}
+
+impl From<AxisDoc> for Axis {
+    fn from(doc: AxisDoc) -> Self {
+        let mut axis = Axis::new(doc.tag, doc.name, doc.minimum, doc.default, doc.maximum);
+        axis.set_hidden(doc.hidden);
+        axis
+    }
+}
+
+impl From<&Source> for SourceDoc {
+    fn from(source: &Source) -> Self {
+        Self {
+            id: source.id().to_string(),
+            name: source.name().to_string(),
+            location: source
+                .location()
+                .iter()
+                .map(|(tag, value)| (tag.clone(), *value))
+                .collect(),
+            filename: source.filename().map(str::to_string),
+        }
+    }
+}
+
+impl TryFrom<SourceDoc> for Source {
+    type Error = SourcePackageError;
+
+    fn try_from(doc: SourceDoc) -> Result<Self, Self::Error> {
+        Ok(Self::with_id(
+            parse_id("source", &doc.id)?,
+            doc.name,
+            Location::from_map(doc.location.into_iter().collect()),
+            doc.filename,
+        ))
+    }
+}
+
+impl From<&Glyph> for GlyphDoc {
+    fn from(glyph: &Glyph) -> Self {
+        let mut layers = BTreeMap::new();
+        for layer in glyph.layers().values() {
+            layers.insert(
+                layer.source_id().to_string(),
+                LayerDoc::from(layer.as_ref()),
+            );
+        }
+
+        Self {
+            id: glyph.id().to_string(),
+            name: glyph.name().to_string(),
+            unicodes: glyph
+                .unicodes()
+                .iter()
+                .map(|u| unicode_to_hex(*u))
+                .collect(),
+            layers,
+        }
+    }
+}
+
+impl TryFrom<GlyphDoc> for Glyph {
+    type Error = SourcePackageError;
+
+    fn try_from(doc: GlyphDoc) -> Result<Self, Self::Error> {
+        let glyph_name = GlyphName::new(doc.name.clone())
+            .map_err(|_| SourcePackageError::InvalidGlyphName(doc.name.clone()))?;
+        let mut glyph = Glyph::with_id(parse_id("glyph", &doc.id)?, glyph_name);
+        glyph.set_unicodes(
+            doc.unicodes
+                .iter()
+                .map(|value| unicode_from_hex(value))
+                .collect::<Result<Vec<_>, _>>()?,
+        );
+
+        for (source_id, layer_doc) in doc.layers {
+            glyph.set_layer(layer_doc.into_layer(parse_id("source", &source_id)?)?);
+        }
+
+        Ok(glyph)
+    }
+}
+
+impl From<&GlyphLayer> for LayerDoc {
+    fn from(layer: &GlyphLayer) -> Self {
+        Self {
+            id: layer.id().to_string(),
+            advance: layer.width(),
+            height: layer.height(),
+            contours: layer.contours_iter().map(ContourDoc::from).collect(),
+            components: layer
+                .components()
+                .iter()
+                .map(|(id, component)| (id.to_string(), ComponentDoc::from(component)))
+                .collect(),
+            anchors: layer.anchors_iter().map(AnchorDoc::from).collect(),
+            guidelines: layer.guidelines().iter().map(GuidelineDoc::from).collect(),
+        }
+    }
+}
+
+impl LayerDoc {
+    fn into_layer(self, source_id: SourceId) -> Result<GlyphLayer, SourcePackageError> {
+        let mut layer =
+            GlyphLayer::with_width(parse_id("layer", &self.id)?, source_id, self.advance);
+        layer.set_height(self.height);
+
+        for contour_doc in self.contours {
+            layer.add_contour(Contour::try_from(contour_doc)?);
+        }
+
+        for (component_id, component_doc) in self.components {
+            layer.add_component(
+                component_doc.into_component(parse_id("component", &component_id)?)?,
+            );
+        }
+
+        for anchor_doc in self.anchors {
+            layer.add_anchor(Anchor::try_from(anchor_doc)?);
+        }
+
+        for guideline_doc in self.guidelines {
+            layer.add_guideline(Guideline::try_from(guideline_doc)?);
+        }
+
+        Ok(layer)
+    }
+}
+
+impl From<&Contour> for ContourDoc {
+    fn from(contour: &Contour) -> Self {
+        Self {
+            id: contour.id().to_string(),
+            closed: contour.is_closed(),
+            points: contour.points().iter().map(PointDoc::from).collect(),
+        }
+    }
+}
+
+impl TryFrom<ContourDoc> for Contour {
+    type Error = SourcePackageError;
+
+    fn try_from(doc: ContourDoc) -> Result<Self, Self::Error> {
+        let mut contour = Contour::with_id(parse_id("contour", &doc.id)?);
+        if doc.closed {
+            contour.close();
+        }
+
+        for point_doc in doc.points {
+            contour.push_point(Point::try_from(point_doc)?);
+        }
+
+        Ok(contour)
+    }
+}
+
+impl From<&Point> for PointDoc {
+    fn from(point: &Point) -> Self {
+        Self {
+            id: point.id().to_string(),
+            x: point.x(),
+            y: point.y(),
+            point_type: point_type_name(point.point_type()).to_string(),
+            smooth: point.is_smooth(),
+        }
+    }
+}
+
+impl TryFrom<PointDoc> for Point {
+    type Error = SourcePackageError;
+
+    fn try_from(doc: PointDoc) -> Result<Self, Self::Error> {
+        Ok(Point::new(
+            parse_id("point", &doc.id)?,
+            doc.x,
+            doc.y,
+            doc.point_type
+                .parse()
+                .map_err(|message| SourcePackageError::InvalidId {
+                    kind: "pointType",
+                    value: doc.point_type.clone(),
+                    message,
+                })?,
+            doc.smooth,
+        ))
+    }
+}
+
+impl From<&Component> for ComponentDoc {
+    fn from(component: &Component) -> Self {
+        Self {
+            base_glyph: component.base_glyph().as_str().to_string(),
+            transform: TransformDoc::from(*component.transform()),
+        }
+    }
+}
+
+impl ComponentDoc {
+    fn into_component(self, id: ComponentId) -> Result<Component, SourcePackageError> {
+        let base_glyph = GlyphName::new(self.base_glyph.clone())
+            .map_err(|_| SourcePackageError::InvalidGlyphName(self.base_glyph.clone()))?;
+        Ok(Component::with_id(id, base_glyph, self.transform.into()))
+    }
+}
+
+impl From<DecomposedTransform> for TransformDoc {
+    fn from(transform: DecomposedTransform) -> Self {
+        Self {
+            translate_x: transform.translate_x,
+            translate_y: transform.translate_y,
+            rotation: transform.rotation,
+            scale_x: transform.scale_x,
+            scale_y: transform.scale_y,
+            skew_x: transform.skew_x,
+            skew_y: transform.skew_y,
+            t_center_x: transform.t_center_x,
+            t_center_y: transform.t_center_y,
+        }
+    }
+}
+
+impl From<TransformDoc> for DecomposedTransform {
+    fn from(doc: TransformDoc) -> Self {
+        Self {
+            translate_x: doc.translate_x,
+            translate_y: doc.translate_y,
+            rotation: doc.rotation,
+            scale_x: doc.scale_x,
+            scale_y: doc.scale_y,
+            skew_x: doc.skew_x,
+            skew_y: doc.skew_y,
+            t_center_x: doc.t_center_x,
+            t_center_y: doc.t_center_y,
+        }
+    }
+}
+
+impl From<&Anchor> for AnchorDoc {
+    fn from(anchor: &Anchor) -> Self {
+        Self {
+            id: anchor.id().to_string(),
+            name: anchor.name().map(str::to_string),
+            x: anchor.x(),
+            y: anchor.y(),
+        }
+    }
+}
+
+impl TryFrom<AnchorDoc> for Anchor {
+    type Error = SourcePackageError;
+
+    fn try_from(doc: AnchorDoc) -> Result<Self, Self::Error> {
+        Ok(Anchor::with_id(
+            parse_id("anchor", &doc.id)?,
+            doc.name,
+            doc.x,
+            doc.y,
+        ))
     }
 }

--- a/crates/shift-source/src/package.rs
+++ b/crates/shift-source/src/package.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet},
     fs::{self, File},
     io::{self, Read, Seek, Write},
     path::{Path, PathBuf},
@@ -84,6 +84,19 @@ pub enum SourcePackageError {
 
     #[error("dangling {field} reference to {id}")]
     DanglingReference { field: &'static str, id: String },
+
+    #[error("non-finite number in {field}")]
+    NonFiniteNumber { field: String },
+
+    #[error(
+        "invalid axis range for {tag}: expected minimum <= default <= maximum, got {minimum} <= {default} <= {maximum}"
+    )]
+    InvalidAxisRange {
+        tag: String,
+        minimum: f64,
+        default: f64,
+        maximum: f64,
+    },
 
     #[error("unexpected source package entry: {0}")]
     UnexpectedEntry(String),
@@ -410,16 +423,28 @@ pub fn font_to_tree(font: &Font) -> Result<PackageTree, SourcePackageError> {
 
     let font_doc = FontDoc {
         metadata: MetadataDoc::from(font.metadata()),
-        metrics: MetricsDoc::from(*font.metrics()),
-        guidelines: font.guidelines().iter().map(GuidelineDoc::from).collect(),
+        metrics: MetricsDoc::try_from(*font.metrics())?,
+        guidelines: font
+            .guidelines()
+            .iter()
+            .map(GuidelineDoc::try_from)
+            .collect::<Result<Vec<_>, _>>()?,
     };
 
     let axes_doc = AxesDoc {
-        axes: font.axes().iter().map(AxisDoc::from).collect(),
+        axes: font
+            .axes()
+            .iter()
+            .map(AxisDoc::try_from)
+            .collect::<Result<Vec<_>, _>>()?,
     };
 
     let sources_doc = SourcesDoc {
-        sources: font.sources().iter().map(SourceDoc::from).collect(),
+        sources: font
+            .sources()
+            .iter()
+            .map(SourceDoc::try_from)
+            .collect::<Result<Vec<_>, _>>()?,
     };
 
     let mut tree = vec![
@@ -444,8 +469,8 @@ pub fn font_to_tree(font: &Font) -> Result<PackageTree, SourcePackageError> {
     let mut glyph_entries = font
         .glyphs()
         .map(|glyph| {
-            let glyph_doc = GlyphDoc::from(glyph);
-            let path = format!("{GLYPHS_DIR}/glyph_{}.json", glyph.id());
+            let glyph_doc = GlyphDoc::try_from(glyph)?;
+            let path = format!("{GLYPHS_DIR}/{}.json", glyph.id());
             json_entry(&path, &glyph_doc)
         })
         .collect::<Result<Vec<_>, _>>()?;
@@ -474,7 +499,7 @@ pub fn tree_to_font(tree: PackageTree) -> Result<Font, SourcePackageError> {
 
     let mut font = Font::empty();
     *font.metadata_mut() = FontMetadata::from(font_doc.metadata);
-    *font.metrics_mut() = FontMetrics::from(font_doc.metrics);
+    *font.metrics_mut() = FontMetrics::try_from(font_doc.metrics)?;
     let mut feature_data = FeatureData::new();
     feature_data.set_fea_source(features);
     *font.features_mut() = feature_data;
@@ -488,15 +513,23 @@ pub fn tree_to_font(tree: PackageTree) -> Result<Font, SourcePackageError> {
     }
 
     for axis_doc in axes_doc.axes {
-        font.add_axis(Axis::from(axis_doc));
+        font.add_axis(Axis::try_from(axis_doc)?);
     }
 
     for source_doc in sources_doc.sources {
         font.add_source(Source::try_from(source_doc)?);
     }
 
+    let source_ids = font
+        .sources()
+        .iter()
+        .map(Source::id)
+        .collect::<HashSet<_>>();
+
     if let Some(default_source_id) = manifest.default_source_id {
-        font.set_default_source_id(parse_id("source", &default_source_id)?);
+        let source_id = parse_id("source", &default_source_id)?;
+        validate_source_reference(&source_ids, &source_id, "manifest.defaultSourceId")?;
+        font.set_default_source_id(source_id);
     }
 
     let mut glyph_entries = Vec::new();
@@ -512,6 +545,7 @@ pub fn tree_to_font(tree: PackageTree) -> Result<Font, SourcePackageError> {
     for (path, bytes) in glyph_entries {
         let glyph_doc: GlyphDoc = from_json(&path, &bytes)?;
         validate_glyph_path_id(&path, &glyph_doc.id)?;
+        validate_glyph_source_references(&glyph_doc, &source_ids)?;
         let mut glyph = Glyph::try_from(glyph_doc)?;
         if let Some(module_doc) = &mut lib_module_doc {
             apply_lib_module_to_glyph(&mut glyph, module_doc)?;
@@ -642,13 +676,70 @@ fn validate_manifest(manifest: &ManifestDoc) -> Result<(), SourcePackageError> {
 }
 
 fn validate_glyph_path_id(path: &str, id: &str) -> Result<(), SourcePackageError> {
-    let expected_path = format!("{GLYPHS_DIR}/glyph_{id}.json");
+    let expected_path = format!("{GLYPHS_DIR}/{id}.json");
     if path == expected_path {
         Ok(())
     } else {
         Err(SourcePackageError::MismatchedGlyphFileId {
             path: path.to_string(),
             id: id.to_string(),
+        })
+    }
+}
+
+fn validate_source_reference(
+    source_ids: &HashSet<SourceId>,
+    source_id: &SourceId,
+    field: &'static str,
+) -> Result<(), SourcePackageError> {
+    if source_ids.contains(source_id) {
+        Ok(())
+    } else {
+        Err(SourcePackageError::DanglingReference {
+            field,
+            id: source_id.to_string(),
+        })
+    }
+}
+
+fn validate_glyph_source_references(
+    glyph_doc: &GlyphDoc,
+    source_ids: &HashSet<SourceId>,
+) -> Result<(), SourcePackageError> {
+    for source_id in glyph_doc.layers.keys() {
+        let parsed_source_id = parse_id("source", source_id)?;
+        validate_source_reference(source_ids, &parsed_source_id, "glyph.layers.sourceId")?;
+    }
+
+    Ok(())
+}
+
+fn ensure_finite(field: impl Into<String>, value: f64) -> Result<f64, SourcePackageError> {
+    if value.is_finite() {
+        Ok(value)
+    } else {
+        Err(SourcePackageError::NonFiniteNumber {
+            field: field.into(),
+        })
+    }
+}
+
+fn ensure_optional_finite(
+    field: impl Into<String>,
+    value: Option<f64>,
+) -> Result<Option<f64>, SourcePackageError> {
+    value.map(|value| ensure_finite(field, value)).transpose()
+}
+
+fn ensure_axis_range(doc: &AxisDoc) -> Result<(), SourcePackageError> {
+    if doc.minimum <= doc.default && doc.default <= doc.maximum {
+        Ok(())
+    } else {
+        Err(SourcePackageError::InvalidAxisRange {
+            tag: doc.tag.clone(),
+            minimum: doc.minimum,
+            default: doc.default,
+            maximum: doc.maximum,
         })
     }
 }
@@ -1047,7 +1138,7 @@ impl KerningPairDoc {
         Ok(Self {
             first: KerningSideDoc::from_side(font, &pair.first, "kerning.pairs.first")?,
             second: KerningSideDoc::from_side(font, &pair.second, "kerning.pairs.second")?,
-            value: pair.value,
+            value: ensure_finite("kerning.pairs.value", pair.value)?,
         })
     }
 }
@@ -1124,7 +1215,7 @@ fn kerning_from_doc(doc: KerningDoc, font: &Font) -> Result<KerningData, SourceP
             pair_doc
                 .second
                 .into_side(&names_by_id, "kerning.pairs.second")?,
-            pair_doc.value,
+            ensure_finite("kerning.pairs.value", pair_doc.value)?,
         ));
     }
 
@@ -1190,16 +1281,18 @@ fn glyph_name_from_ref(
     Ok(glyph_name.clone())
 }
 
-impl From<&Guideline> for GuidelineDoc {
-    fn from(guideline: &Guideline) -> Self {
-        Self {
+impl TryFrom<&Guideline> for GuidelineDoc {
+    type Error = SourcePackageError;
+
+    fn try_from(guideline: &Guideline) -> Result<Self, Self::Error> {
+        Ok(Self {
             id: guideline.id().to_string(),
-            x: guideline.x(),
-            y: guideline.y(),
-            angle: guideline.angle(),
+            x: ensure_optional_finite("guideline.x", guideline.x())?,
+            y: ensure_optional_finite("guideline.y", guideline.y())?,
+            angle: ensure_optional_finite("guideline.angle", guideline.angle())?,
             name: guideline.name().map(str::to_string),
             color: guideline.color().map(str::to_string),
-        }
+        })
     }
 }
 
@@ -1209,9 +1302,9 @@ impl TryFrom<GuidelineDoc> for Guideline {
     fn try_from(doc: GuidelineDoc) -> Result<Self, Self::Error> {
         Ok(Self::with_id(
             parse_id("guideline", &doc.id)?,
-            doc.x,
-            doc.y,
-            doc.angle,
+            ensure_optional_finite("guideline.x", doc.x)?,
+            ensure_optional_finite("guideline.y", doc.y)?,
+            ensure_optional_finite("guideline.angle", doc.angle)?,
             doc.name,
             doc.color,
         ))
@@ -1260,71 +1353,104 @@ impl From<MetadataDoc> for FontMetadata {
     }
 }
 
-impl From<FontMetrics> for MetricsDoc {
-    fn from(metrics: FontMetrics) -> Self {
-        Self {
-            units_per_em: metrics.units_per_em,
-            ascender: metrics.ascender,
-            descender: metrics.descender,
-            cap_height: metrics.cap_height,
-            x_height: metrics.x_height,
-            line_gap: metrics.line_gap,
-            italic_angle: metrics.italic_angle,
-            underline_position: metrics.underline_position,
-            underline_thickness: metrics.underline_thickness,
-        }
+impl TryFrom<FontMetrics> for MetricsDoc {
+    type Error = SourcePackageError;
+
+    fn try_from(metrics: FontMetrics) -> Result<Self, Self::Error> {
+        Ok(Self {
+            units_per_em: ensure_finite("font.metrics.unitsPerEm", metrics.units_per_em)?,
+            ascender: ensure_finite("font.metrics.ascender", metrics.ascender)?,
+            descender: ensure_finite("font.metrics.descender", metrics.descender)?,
+            cap_height: ensure_optional_finite("font.metrics.capHeight", metrics.cap_height)?,
+            x_height: ensure_optional_finite("font.metrics.xHeight", metrics.x_height)?,
+            line_gap: ensure_optional_finite("font.metrics.lineGap", metrics.line_gap)?,
+            italic_angle: ensure_optional_finite("font.metrics.italicAngle", metrics.italic_angle)?,
+            underline_position: ensure_optional_finite(
+                "font.metrics.underlinePosition",
+                metrics.underline_position,
+            )?,
+            underline_thickness: ensure_optional_finite(
+                "font.metrics.underlineThickness",
+                metrics.underline_thickness,
+            )?,
+        })
     }
 }
 
-impl From<MetricsDoc> for FontMetrics {
-    fn from(doc: MetricsDoc) -> Self {
-        Self {
-            units_per_em: doc.units_per_em,
-            ascender: doc.ascender,
-            descender: doc.descender,
-            cap_height: doc.cap_height,
-            x_height: doc.x_height,
-            line_gap: doc.line_gap,
-            italic_angle: doc.italic_angle,
-            underline_position: doc.underline_position,
-            underline_thickness: doc.underline_thickness,
-        }
+impl TryFrom<MetricsDoc> for FontMetrics {
+    type Error = SourcePackageError;
+
+    fn try_from(doc: MetricsDoc) -> Result<Self, Self::Error> {
+        Ok(Self {
+            units_per_em: ensure_finite("font.metrics.unitsPerEm", doc.units_per_em)?,
+            ascender: ensure_finite("font.metrics.ascender", doc.ascender)?,
+            descender: ensure_finite("font.metrics.descender", doc.descender)?,
+            cap_height: ensure_optional_finite("font.metrics.capHeight", doc.cap_height)?,
+            x_height: ensure_optional_finite("font.metrics.xHeight", doc.x_height)?,
+            line_gap: ensure_optional_finite("font.metrics.lineGap", doc.line_gap)?,
+            italic_angle: ensure_optional_finite("font.metrics.italicAngle", doc.italic_angle)?,
+            underline_position: ensure_optional_finite(
+                "font.metrics.underlinePosition",
+                doc.underline_position,
+            )?,
+            underline_thickness: ensure_optional_finite(
+                "font.metrics.underlineThickness",
+                doc.underline_thickness,
+            )?,
+        })
     }
 }
 
-impl From<&Axis> for AxisDoc {
-    fn from(axis: &Axis) -> Self {
-        Self {
+impl TryFrom<&Axis> for AxisDoc {
+    type Error = SourcePackageError;
+
+    fn try_from(axis: &Axis) -> Result<Self, Self::Error> {
+        let doc = Self {
             tag: axis.tag().to_string(),
             name: axis.name().to_string(),
-            minimum: axis.minimum(),
-            default: axis.default(),
-            maximum: axis.maximum(),
+            minimum: ensure_finite("axes[].minimum", axis.minimum())?,
+            default: ensure_finite("axes[].default", axis.default())?,
+            maximum: ensure_finite("axes[].maximum", axis.maximum())?,
             hidden: axis.is_hidden(),
-        }
+        };
+        ensure_axis_range(&doc)?;
+        Ok(doc)
     }
 }
 
-impl From<AxisDoc> for Axis {
-    fn from(doc: AxisDoc) -> Self {
+impl TryFrom<AxisDoc> for Axis {
+    type Error = SourcePackageError;
+
+    fn try_from(doc: AxisDoc) -> Result<Self, Self::Error> {
+        ensure_finite("axes[].minimum", doc.minimum)?;
+        ensure_finite("axes[].default", doc.default)?;
+        ensure_finite("axes[].maximum", doc.maximum)?;
+        ensure_axis_range(&doc)?;
         let mut axis = Axis::new(doc.tag, doc.name, doc.minimum, doc.default, doc.maximum);
         axis.set_hidden(doc.hidden);
-        axis
+        Ok(axis)
     }
 }
 
-impl From<&Source> for SourceDoc {
-    fn from(source: &Source) -> Self {
-        Self {
+impl TryFrom<&Source> for SourceDoc {
+    type Error = SourcePackageError;
+
+    fn try_from(source: &Source) -> Result<Self, Self::Error> {
+        let id = source.id().to_string();
+        let mut location = BTreeMap::new();
+        for (tag, value) in source.location().iter() {
+            location.insert(
+                tag.clone(),
+                ensure_finite(format!("sources[{id}].location[{tag}]"), *value)?,
+            );
+        }
+
+        Ok(Self {
             id: source.id().to_string(),
             name: source.name().to_string(),
-            location: source
-                .location()
-                .iter()
-                .map(|(tag, value)| (tag.clone(), *value))
-                .collect(),
+            location,
             filename: source.filename().map(str::to_string),
-        }
+        })
     }
 }
 
@@ -1332,26 +1458,36 @@ impl TryFrom<SourceDoc> for Source {
     type Error = SourcePackageError;
 
     fn try_from(doc: SourceDoc) -> Result<Self, Self::Error> {
+        let mut location = HashMap::new();
+        for (tag, value) in doc.location {
+            location.insert(
+                tag.clone(),
+                ensure_finite(format!("sources[{}].location[{tag}]", doc.id), value)?,
+            );
+        }
+
         Ok(Self::with_id(
             parse_id("source", &doc.id)?,
             doc.name,
-            Location::from_map(doc.location.into_iter().collect()),
+            Location::from_map(location),
             doc.filename,
         ))
     }
 }
 
-impl From<&Glyph> for GlyphDoc {
-    fn from(glyph: &Glyph) -> Self {
+impl TryFrom<&Glyph> for GlyphDoc {
+    type Error = SourcePackageError;
+
+    fn try_from(glyph: &Glyph) -> Result<Self, Self::Error> {
         let mut layers = BTreeMap::new();
         for layer in glyph.layers().values() {
             layers.insert(
                 layer.source_id().to_string(),
-                LayerDoc::from(layer.as_ref()),
+                LayerDoc::try_from(layer.as_ref())?,
             );
         }
 
-        Self {
+        Ok(Self {
             id: glyph.id().to_string(),
             name: glyph.name().to_string(),
             unicodes: glyph
@@ -1360,7 +1496,7 @@ impl From<&Glyph> for GlyphDoc {
                 .map(|u| unicode_to_hex(*u))
                 .collect(),
             layers,
-        }
+        })
     }
 }
 
@@ -1386,29 +1522,49 @@ impl TryFrom<GlyphDoc> for Glyph {
     }
 }
 
-impl From<&GlyphLayer> for LayerDoc {
-    fn from(layer: &GlyphLayer) -> Self {
-        Self {
+impl TryFrom<&GlyphLayer> for LayerDoc {
+    type Error = SourcePackageError;
+
+    fn try_from(layer: &GlyphLayer) -> Result<Self, Self::Error> {
+        Ok(Self {
             id: layer.id().to_string(),
-            advance: layer.width(),
-            height: layer.height(),
-            contours: layer.contours_iter().map(ContourDoc::from).collect(),
+            advance: ensure_finite("glyph.layers[].advance", layer.width())?,
+            height: ensure_optional_finite("glyph.layers[].height", layer.height())?,
+            contours: layer
+                .contours_iter()
+                .map(ContourDoc::try_from)
+                .collect::<Result<Vec<_>, _>>()?,
             components: layer
                 .components()
                 .iter()
-                .map(|(id, component)| (id.to_string(), ComponentDoc::from(component)))
-                .collect(),
-            anchors: layer.anchors_iter().map(AnchorDoc::from).collect(),
-            guidelines: layer.guidelines().iter().map(GuidelineDoc::from).collect(),
-        }
+                .map(|(id, component)| {
+                    ComponentDoc::try_from(component).map(|doc| (id.to_string(), doc))
+                })
+                .collect::<Result<BTreeMap<_, _>, _>>()?,
+            anchors: layer
+                .anchors_iter()
+                .map(AnchorDoc::try_from)
+                .collect::<Result<Vec<_>, _>>()?,
+            guidelines: layer
+                .guidelines()
+                .iter()
+                .map(GuidelineDoc::try_from)
+                .collect::<Result<Vec<_>, _>>()?,
+        })
     }
 }
 
 impl LayerDoc {
     fn into_layer(self, source_id: SourceId) -> Result<GlyphLayer, SourcePackageError> {
-        let mut layer =
-            GlyphLayer::with_width(parse_id("layer", &self.id)?, source_id, self.advance);
-        layer.set_height(self.height);
+        let mut layer = GlyphLayer::with_width(
+            parse_id("layer", &self.id)?,
+            source_id,
+            ensure_finite("glyph.layers[].advance", self.advance)?,
+        );
+        layer.set_height(ensure_optional_finite(
+            "glyph.layers[].height",
+            self.height,
+        )?);
 
         for contour_doc in self.contours {
             layer.add_contour(Contour::try_from(contour_doc)?);
@@ -1432,13 +1588,19 @@ impl LayerDoc {
     }
 }
 
-impl From<&Contour> for ContourDoc {
-    fn from(contour: &Contour) -> Self {
-        Self {
+impl TryFrom<&Contour> for ContourDoc {
+    type Error = SourcePackageError;
+
+    fn try_from(contour: &Contour) -> Result<Self, Self::Error> {
+        Ok(Self {
             id: contour.id().to_string(),
             closed: contour.is_closed(),
-            points: contour.points().iter().map(PointDoc::from).collect(),
-        }
+            points: contour
+                .points()
+                .iter()
+                .map(PointDoc::try_from)
+                .collect::<Result<Vec<_>, _>>()?,
+        })
     }
 }
 
@@ -1459,15 +1621,17 @@ impl TryFrom<ContourDoc> for Contour {
     }
 }
 
-impl From<&Point> for PointDoc {
-    fn from(point: &Point) -> Self {
-        Self {
+impl TryFrom<&Point> for PointDoc {
+    type Error = SourcePackageError;
+
+    fn try_from(point: &Point) -> Result<Self, Self::Error> {
+        Ok(Self {
             id: point.id().to_string(),
-            x: point.x(),
-            y: point.y(),
+            x: ensure_finite("glyph.layers[].contours[].points[].x", point.x())?,
+            y: ensure_finite("glyph.layers[].contours[].points[].y", point.y())?,
             point_type: point_type_name(point.point_type()).to_string(),
             smooth: point.is_smooth(),
-        }
+        })
     }
 }
 
@@ -1477,8 +1641,8 @@ impl TryFrom<PointDoc> for Point {
     fn try_from(doc: PointDoc) -> Result<Self, Self::Error> {
         Ok(Point::new(
             parse_id("point", &doc.id)?,
-            doc.x,
-            doc.y,
+            ensure_finite("glyph.layers[].contours[].points[].x", doc.x)?,
+            ensure_finite("glyph.layers[].contours[].points[].y", doc.y)?,
             doc.point_type
                 .parse()
                 .map_err(|message| SourcePackageError::InvalidId {
@@ -1491,12 +1655,14 @@ impl TryFrom<PointDoc> for Point {
     }
 }
 
-impl From<&Component> for ComponentDoc {
-    fn from(component: &Component) -> Self {
-        Self {
+impl TryFrom<&Component> for ComponentDoc {
+    type Error = SourcePackageError;
+
+    fn try_from(component: &Component) -> Result<Self, Self::Error> {
+        Ok(Self {
             base_glyph: component.base_glyph().as_str().to_string(),
-            transform: TransformDoc::from(*component.transform()),
-        }
+            transform: TransformDoc::try_from(*component.transform())?,
+        })
     }
 }
 
@@ -1504,50 +1670,60 @@ impl ComponentDoc {
     fn into_component(self, id: ComponentId) -> Result<Component, SourcePackageError> {
         let base_glyph = GlyphName::new(self.base_glyph.clone())
             .map_err(|_| SourcePackageError::InvalidGlyphName(self.base_glyph.clone()))?;
-        Ok(Component::with_id(id, base_glyph, self.transform.into()))
+        Ok(Component::with_id(
+            id,
+            base_glyph,
+            DecomposedTransform::try_from(self.transform)?,
+        ))
     }
 }
 
-impl From<DecomposedTransform> for TransformDoc {
-    fn from(transform: DecomposedTransform) -> Self {
-        Self {
-            translate_x: transform.translate_x,
-            translate_y: transform.translate_y,
-            rotation: transform.rotation,
-            scale_x: transform.scale_x,
-            scale_y: transform.scale_y,
-            skew_x: transform.skew_x,
-            skew_y: transform.skew_y,
-            t_center_x: transform.t_center_x,
-            t_center_y: transform.t_center_y,
-        }
+impl TryFrom<DecomposedTransform> for TransformDoc {
+    type Error = SourcePackageError;
+
+    fn try_from(transform: DecomposedTransform) -> Result<Self, Self::Error> {
+        Ok(Self {
+            translate_x: ensure_finite("component.transform.translateX", transform.translate_x)?,
+            translate_y: ensure_finite("component.transform.translateY", transform.translate_y)?,
+            rotation: ensure_finite("component.transform.rotation", transform.rotation)?,
+            scale_x: ensure_finite("component.transform.scaleX", transform.scale_x)?,
+            scale_y: ensure_finite("component.transform.scaleY", transform.scale_y)?,
+            skew_x: ensure_finite("component.transform.skewX", transform.skew_x)?,
+            skew_y: ensure_finite("component.transform.skewY", transform.skew_y)?,
+            t_center_x: ensure_finite("component.transform.tCenterX", transform.t_center_x)?,
+            t_center_y: ensure_finite("component.transform.tCenterY", transform.t_center_y)?,
+        })
     }
 }
 
-impl From<TransformDoc> for DecomposedTransform {
-    fn from(doc: TransformDoc) -> Self {
-        Self {
-            translate_x: doc.translate_x,
-            translate_y: doc.translate_y,
-            rotation: doc.rotation,
-            scale_x: doc.scale_x,
-            scale_y: doc.scale_y,
-            skew_x: doc.skew_x,
-            skew_y: doc.skew_y,
-            t_center_x: doc.t_center_x,
-            t_center_y: doc.t_center_y,
-        }
+impl TryFrom<TransformDoc> for DecomposedTransform {
+    type Error = SourcePackageError;
+
+    fn try_from(doc: TransformDoc) -> Result<Self, Self::Error> {
+        Ok(Self {
+            translate_x: ensure_finite("component.transform.translateX", doc.translate_x)?,
+            translate_y: ensure_finite("component.transform.translateY", doc.translate_y)?,
+            rotation: ensure_finite("component.transform.rotation", doc.rotation)?,
+            scale_x: ensure_finite("component.transform.scaleX", doc.scale_x)?,
+            scale_y: ensure_finite("component.transform.scaleY", doc.scale_y)?,
+            skew_x: ensure_finite("component.transform.skewX", doc.skew_x)?,
+            skew_y: ensure_finite("component.transform.skewY", doc.skew_y)?,
+            t_center_x: ensure_finite("component.transform.tCenterX", doc.t_center_x)?,
+            t_center_y: ensure_finite("component.transform.tCenterY", doc.t_center_y)?,
+        })
     }
 }
 
-impl From<&Anchor> for AnchorDoc {
-    fn from(anchor: &Anchor) -> Self {
-        Self {
+impl TryFrom<&Anchor> for AnchorDoc {
+    type Error = SourcePackageError;
+
+    fn try_from(anchor: &Anchor) -> Result<Self, Self::Error> {
+        Ok(Self {
             id: anchor.id().to_string(),
             name: anchor.name().map(str::to_string),
-            x: anchor.x(),
-            y: anchor.y(),
-        }
+            x: ensure_finite("glyph.layers[].anchors[].x", anchor.x())?,
+            y: ensure_finite("glyph.layers[].anchors[].y", anchor.y())?,
+        })
     }
 }
 
@@ -1558,8 +1734,8 @@ impl TryFrom<AnchorDoc> for Anchor {
         Ok(Anchor::with_id(
             parse_id("anchor", &doc.id)?,
             doc.name,
-            doc.x,
-            doc.y,
+            ensure_finite("glyph.layers[].anchors[].x", doc.x)?,
+            ensure_finite("glyph.layers[].anchors[].y", doc.y)?,
         ))
     }
 }

--- a/crates/shift-source/tests/package_test.rs
+++ b/crates/shift-source/tests/package_test.rs
@@ -7,7 +7,7 @@ use shift_font::{
 };
 use shift_source::{
     AXES_FILE, FEATURES_FILE, FONT_FILE, GLYPHS_DIR, KERNING_FILE, LIB_MODULE_FILE, MANIFEST_FILE,
-    SOURCES_FILE, ShiftSourcePackage, SourcePackageError, font_to_tree, tree_to_font,
+    PackageTree, SOURCES_FILE, ShiftSourcePackage, SourcePackageError, font_to_tree, tree_to_font,
     write_tree_atomic,
 };
 use zip::{CompressionMethod, ZipArchive};
@@ -161,6 +161,19 @@ fn sample_font() -> Font {
     font
 }
 
+fn replace_tree_entry(tree: &mut PackageTree, path: &str, from: &str, to: &str) {
+    let entry = tree
+        .iter_mut()
+        .find(|(entry_path, _)| entry_path == path)
+        .unwrap_or_else(|| panic!("missing tree entry {path}"));
+    let json = String::from_utf8(entry.1.clone()).unwrap();
+    assert!(
+        json.contains(from),
+        "tree entry {path} did not contain {from:?}"
+    );
+    entry.1 = json.replacen(from, to, 1).into_bytes();
+}
+
 #[test]
 fn creates_zip_package_with_manifest_first_and_stored() {
     let temp = tempfile::tempdir().unwrap();
@@ -282,7 +295,7 @@ fn serializes_same_font_to_byte_identical_tree() {
             FEATURES_FILE,
             KERNING_FILE,
             LIB_MODULE_FILE,
-            &format!("{GLYPHS_DIR}/glyph_glyph_A.json")
+            &format!("{GLYPHS_DIR}/glyph_A.json")
         ]
     );
 }
@@ -407,7 +420,110 @@ fn rejects_glyph_file_id_mismatch() {
     assert!(matches!(
         error,
         SourcePackageError::MismatchedGlyphFileId { path, id }
-            if path == "glyphs/glyph_glyph_A.json" && id == "glyph_B"
+            if path == "glyphs/glyph_A.json" && id == "glyph_B"
+    ));
+}
+
+#[test]
+fn rejects_non_finite_metric_values_before_json_serialization() {
+    let mut font = sample_font();
+    font.metrics_mut().ascender = f64::NAN;
+
+    let error = font_to_tree(&font).unwrap_err();
+
+    assert!(matches!(
+        error,
+        SourcePackageError::NonFiniteNumber { field } if field == "font.metrics.ascender"
+    ));
+}
+
+#[test]
+fn rejects_non_finite_source_location_values() {
+    let mut font = Font::empty();
+    let mut location = Location::new();
+    location.set("wght".to_string(), f64::INFINITY);
+    font.add_source(Source::with_id(
+        SourceId::from_raw("bad"),
+        "Bad".to_string(),
+        location,
+        None,
+    ));
+
+    let error = font_to_tree(&font).unwrap_err();
+
+    assert!(matches!(
+        error,
+        SourcePackageError::NonFiniteNumber { field }
+            if field == "sources[source_bad].location[wght]"
+    ));
+}
+
+#[test]
+fn rejects_invalid_axis_ranges_on_load() {
+    let mut tree = font_to_tree(&Font::new()).unwrap();
+    let axes_entry = tree
+        .iter_mut()
+        .find(|(path, _)| path == AXES_FILE)
+        .expect("axes entry");
+    axes_entry.1 = br#"{
+  "axes": [
+    {
+      "tag": "wght",
+      "name": "Weight",
+      "minimum": 900.0,
+      "default": 400.0,
+      "maximum": 100.0,
+      "hidden": false
+    }
+  ]
+}
+"#
+    .to_vec();
+
+    let error = tree_to_font(tree).unwrap_err();
+
+    assert!(matches!(
+        error,
+        SourcePackageError::InvalidAxisRange { tag, .. } if tag == "wght"
+    ));
+}
+
+#[test]
+fn rejects_dangling_default_source_id() {
+    let mut tree = font_to_tree(&sample_font()).unwrap();
+    replace_tree_entry(
+        &mut tree,
+        MANIFEST_FILE,
+        r#""defaultSourceId": "source_regular""#,
+        r#""defaultSourceId": "source_missing""#,
+    );
+
+    let error = tree_to_font(tree).unwrap_err();
+
+    assert!(matches!(
+        error,
+        SourcePackageError::DanglingReference { field, id }
+            if field == "manifest.defaultSourceId" && id == "source_missing"
+    ));
+}
+
+#[test]
+fn rejects_glyph_layers_that_reference_missing_sources() {
+    let mut tree = font_to_tree(&sample_font()).unwrap();
+    let glyph_path = format!("{GLYPHS_DIR}/glyph_A.json");
+    replace_tree_entry(
+        &mut tree,
+        &glyph_path,
+        r#""source_regular": {"#,
+        r#""source_missing": {"#,
+    );
+
+    let error = tree_to_font(tree).unwrap_err();
+
+    assert!(matches!(
+        error,
+        SourcePackageError::DanglingReference { field, id }
+            if field == "glyph.layers.sourceId" && id == "source_missing"
     ));
 }
 

--- a/crates/shift-source/tests/package_test.rs
+++ b/crates/shift-source/tests/package_test.rs
@@ -1,38 +1,420 @@
-use std::fs;
+use std::fs::File;
 
-use shift_source::{MANIFEST_FILE, ShiftSourcePackage, SourcePackageError};
+use shift_font::{
+    Anchor, AnchorId, Axis, Component, ComponentId, Contour, ContourId, DecomposedTransform, Font,
+    Glyph, GlyphId, GlyphLayer, Guideline, GuidelineId, KerningPair, KerningSide, LayerId,
+    LibValue, Location, Point, PointId, PointType, Source, SourceId,
+};
+use shift_source::{
+    AXES_FILE, FEATURES_FILE, FONT_FILE, GLYPHS_DIR, KERNING_FILE, LIB_MODULE_FILE, MANIFEST_FILE,
+    SOURCES_FILE, ShiftSourcePackage, SourcePackageError, font_to_tree, tree_to_font,
+    write_tree_atomic,
+};
+use zip::{CompressionMethod, ZipArchive};
 
-#[test]
-fn creates_empty_shift_package_directory_with_manifest() {
-    let temp = tempfile::tempdir().unwrap();
-    let package_path = temp.path().join("TestFont.shift");
+fn sample_font() -> Font {
+    let mut font = Font::empty();
+    font.metadata_mut().family_name = Some("Dogfood Sans".to_string());
+    font.metadata_mut().style_name = Some("Regular".to_string());
+    font.metrics_mut().units_per_em = 2048.0;
+    font.metrics_mut().ascender = 1500.0;
+    font.metrics_mut().descender = -500.0;
+    font.features_mut()
+        .set_fea_source(Some("feature kern { pos A A -80; } kern;".to_string()));
+    font.kerning_mut()
+        .set_group1("public.kern1.A".to_string(), vec!["A".into()]);
+    font.kerning_mut()
+        .set_group2("public.kern2.A".to_string(), vec!["A".into()]);
+    font.kerning_mut().add_pair(KerningPair::new(
+        KerningSide::Group("public.kern1.A".to_string()),
+        KerningSide::Group("public.kern2.A".to_string()),
+        -80.0,
+    ));
+    let mut font_guideline = Guideline::with_id(
+        GuidelineId::from_raw("cap_height"),
+        None,
+        Some(700.0),
+        None,
+        Some("Cap Height".to_string()),
+        Some("blue".to_string()),
+    );
+    font_guideline.set_color(Some("green".to_string()));
+    font.add_guideline(font_guideline);
+    font.lib_mut().set(
+        "com.shift.note".to_string(),
+        LibValue::String("font note".to_string()),
+    );
 
-    let package = ShiftSourcePackage::create_empty(&package_path).unwrap();
+    let mut weight = Axis::new(
+        "wght".to_string(),
+        "Weight".to_string(),
+        100.0,
+        400.0,
+        900.0,
+    );
+    weight.set_hidden(true);
+    font.add_axis(weight);
 
-    assert_eq!(package.path(), package_path.as_path());
-    assert!(package.path().is_dir());
-    assert!(package.manifest_path().is_file());
-    assert_eq!(package.manifest_path(), package_path.join(MANIFEST_FILE));
+    let regular_id = SourceId::from_raw("regular");
+    let bold_id = SourceId::from_raw("bold");
+    let mut bold_location = Location::new();
+    bold_location.set("wght".to_string(), 900.0);
+    font.add_source(Source::with_id(
+        regular_id.clone(),
+        "Regular".to_string(),
+        Location::new(),
+        Some("Regular.ufo".to_string()),
+    ));
+    font.add_source(Source::with_id(
+        bold_id.clone(),
+        "Bold".to_string(),
+        bold_location,
+        None,
+    ));
+    font.set_default_source_id(regular_id.clone());
 
-    let manifest = fs::read_to_string(package.manifest_path()).unwrap();
-    assert!(manifest.contains("\"format\": \"shift-source\""));
+    let glyph_id = GlyphId::from_raw("A");
+    let mut glyph = Glyph::with_id(glyph_id, "A");
+    glyph.set_unicodes(vec![0x0041, 0x00C1]);
+
+    let mut regular_layer =
+        GlyphLayer::with_width(LayerId::from_raw("A_regular"), regular_id, 600.0);
+    regular_layer.set_height(Some(700.0));
+    let mut contour = Contour::with_id(ContourId::from_raw("A_outer"));
+    contour.push_point(Point::new(
+        PointId::from_raw("A_0"),
+        100.0,
+        0.0,
+        PointType::OnCurve,
+        false,
+    ));
+    contour.push_point(Point::new(
+        PointId::from_raw("A_1"),
+        300.0,
+        700.0,
+        PointType::OffCurve,
+        true,
+    ));
+    contour.push_point(Point::new(
+        PointId::from_raw("A_2"),
+        500.0,
+        0.0,
+        PointType::OnCurve,
+        false,
+    ));
+    contour.close();
+    regular_layer.add_contour(contour);
+    regular_layer.add_anchor(Anchor::with_id(
+        AnchorId::from_raw("A_top"),
+        Some("top".to_string()),
+        300.0,
+        700.0,
+    ));
+    regular_layer.add_component(Component::with_id(
+        ComponentId::from_raw("acute_component"),
+        "acute",
+        DecomposedTransform {
+            translate_x: 10.0,
+            translate_y: 20.0,
+            rotation: 5.0,
+            scale_x: 1.1,
+            scale_y: 0.9,
+            ..Default::default()
+        },
+    ));
+    regular_layer.add_guideline(Guideline::with_id(
+        GuidelineId::from_raw("baseline"),
+        None,
+        Some(0.0),
+        None,
+        Some("Baseline".to_string()),
+        None,
+    ));
+    regular_layer
+        .lib_mut()
+        .set("com.shift.layer".to_string(), LibValue::Integer(42));
+    glyph.set_layer(regular_layer);
+
+    let mut bold_layer = GlyphLayer::with_width(LayerId::from_raw("A_bold"), bold_id, 650.0);
+    let mut bold_contour = Contour::with_id(ContourId::from_raw("A_bold_outer"));
+    bold_contour.push_point(Point::new(
+        PointId::from_raw("A_bold_0"),
+        90.0,
+        0.0,
+        PointType::OnCurve,
+        false,
+    ));
+    bold_contour.push_point(Point::new(
+        PointId::from_raw("A_bold_1"),
+        310.0,
+        720.0,
+        PointType::OnCurve,
+        false,
+    ));
+    bold_layer.add_contour(bold_contour);
+    glyph.set_layer(bold_layer);
+    glyph
+        .lib_mut()
+        .set("com.shift.glyph".to_string(), LibValue::Boolean(true));
+
+    font.insert_glyph(glyph).unwrap();
+    font
 }
 
 #[test]
-fn opens_existing_shift_package() {
+fn creates_zip_package_with_manifest_first_and_stored() {
     let temp = tempfile::tempdir().unwrap();
-    let package_path = temp.path().join("TestFont.shift");
-    ShiftSourcePackage::create_empty(&package_path).unwrap();
-
-    let package = ShiftSourcePackage::open(&package_path).unwrap();
+    let package_path = temp.path().join("Dogfood.shift");
+    let package = ShiftSourcePackage::save_font(&package_path, &sample_font()).unwrap();
 
     assert_eq!(package.path(), package_path.as_path());
+    assert!(package.path().is_file());
+
+    let mut archive = ZipArchive::new(File::open(&package_path).unwrap()).unwrap();
+    let manifest = archive.by_index(0).unwrap();
+    assert_eq!(manifest.name(), MANIFEST_FILE);
+    assert_eq!(manifest.compression(), CompressionMethod::Stored);
+}
+
+#[test]
+fn roundtrips_geometry_font_through_zip_package() {
+    let temp = tempfile::tempdir().unwrap();
+    let package_path = temp.path().join("Dogfood.shift");
+    let original = sample_font();
+
+    ShiftSourcePackage::save_font(&package_path, &original).unwrap();
+    let loaded = ShiftSourcePackage::load_font(&package_path).unwrap();
+
+    assert_eq!(
+        loaded.metadata().family_name.as_deref(),
+        Some("Dogfood Sans")
+    );
+    assert_eq!(loaded.metrics().units_per_em, 2048.0);
+    assert_eq!(loaded.axes().len(), 1);
+    assert_eq!(loaded.axes()[0].tag(), "wght");
+    assert!(loaded.axes()[0].is_hidden());
+    assert_eq!(loaded.kerning().get_kerning("A", "A"), Some(-80.0));
+    assert!(
+        loaded
+            .features()
+            .fea_source()
+            .is_some_and(|source| source.contains("feature kern"))
+    );
+    assert_eq!(loaded.guidelines().len(), 1);
+    assert_eq!(
+        loaded.guidelines()[0].id(),
+        GuidelineId::from_raw("cap_height")
+    );
+    assert_eq!(loaded.guidelines()[0].name(), Some("Cap Height"));
+    assert_eq!(loaded.guidelines()[0].color(), Some("green"));
+    assert!(matches!(
+        loaded.lib().get("com.shift.note"),
+        Some(LibValue::String(value)) if value == "font note"
+    ));
+    assert_eq!(loaded.sources().len(), 2);
+    assert_eq!(
+        loaded.default_source_id(),
+        Some(SourceId::from_raw("regular"))
+    );
+
+    let glyph = loaded.glyph(GlyphId::from_raw("A")).unwrap();
+    assert_eq!(glyph.name(), "A");
+    assert_eq!(glyph.unicodes(), &[0x0041, 0x00C1]);
+    assert!(matches!(
+        glyph.lib().get("com.shift.glyph"),
+        Some(LibValue::Boolean(true))
+    ));
+
+    let regular_layer = glyph.layer(LayerId::from_raw("A_regular")).unwrap();
+    assert_eq!(regular_layer.source_id(), SourceId::from_raw("regular"));
+    assert_eq!(regular_layer.width(), 600.0);
+    assert_eq!(regular_layer.height(), Some(700.0));
+    assert_eq!(regular_layer.contours().len(), 1);
+    assert_eq!(regular_layer.components().len(), 1);
+    assert_eq!(regular_layer.anchors().len(), 1);
+    assert_eq!(regular_layer.guidelines().len(), 1);
+    assert_eq!(
+        regular_layer.guidelines()[0].id(),
+        GuidelineId::from_raw("baseline")
+    );
+    assert!(matches!(
+        regular_layer.lib().get("com.shift.layer"),
+        Some(LibValue::Integer(42))
+    ));
+
+    let contour = regular_layer
+        .contour(ContourId::from_raw("A_outer"))
+        .unwrap();
+    assert!(contour.is_closed());
+    assert_eq!(contour.points().len(), 3);
+    assert_eq!(contour.points()[1].point_type(), PointType::OffCurve);
+    assert!(contour.points()[1].is_smooth());
+
+    let component = regular_layer
+        .component(ComponentId::from_raw("acute_component"))
+        .unwrap();
+    assert_eq!(component.base_glyph().as_str(), "acute");
+    assert_eq!(component.transform().translate_x, 10.0);
+
+    let bold_layer = glyph.layer(LayerId::from_raw("A_bold")).unwrap();
+    assert_eq!(bold_layer.source_id(), SourceId::from_raw("bold"));
+    assert_eq!(bold_layer.width(), 650.0);
+}
+
+#[test]
+fn serializes_same_font_to_byte_identical_tree() {
+    let font = sample_font();
+
+    let first = font_to_tree(&font).unwrap();
+    let second = font_to_tree(&font).unwrap();
+
+    assert_eq!(first, second);
+    assert_eq!(
+        first
+            .iter()
+            .map(|(path, _)| path.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            MANIFEST_FILE,
+            FONT_FILE,
+            AXES_FILE,
+            SOURCES_FILE,
+            FEATURES_FILE,
+            KERNING_FILE,
+            LIB_MODULE_FILE,
+            &format!("{GLYPHS_DIR}/glyph_glyph_A.json")
+        ]
+    );
+}
+
+#[test]
+fn rejects_kerning_references_to_unknown_glyph_names() {
+    let mut font = Font::new();
+    font.kerning_mut().add_pair(KerningPair::glyph_pair(
+        "A".to_string(),
+        "Missing".to_string(),
+        -80.0,
+    ));
+
+    let error = font_to_tree(&font).unwrap_err();
+
+    assert!(matches!(
+        error,
+        SourcePackageError::UnresolvedGlyphName {
+            field: "kerning.pairs.first",
+            name
+        } if name == "A"
+    ));
+}
+
+#[test]
+fn parses_minimal_handwritten_tree() {
+    let tree = vec![
+        (
+            MANIFEST_FILE.to_string(),
+            br#"{
+  "format": "shift-source",
+  "schemaVersion": 1,
+  "defaultSourceId": "source_regular"
+}
+"#
+            .to_vec(),
+        ),
+        (
+            FONT_FILE.to_string(),
+            br#"{
+  "metadata": {
+    "familyName": "Minimal Sans",
+    "styleName": "Regular",
+    "versionMajor": 1,
+    "versionMinor": 0,
+    "copyright": null,
+    "trademark": null,
+    "designer": null,
+    "designerUrl": null,
+    "manufacturer": null,
+    "manufacturerUrl": null,
+    "license": null,
+    "licenseUrl": null,
+    "description": null,
+    "note": null
+  },
+  "metrics": {
+    "unitsPerEm": 1000.0,
+    "ascender": 800.0,
+    "descender": -200.0,
+    "capHeight": 700.0,
+    "xHeight": 500.0,
+    "lineGap": null,
+    "italicAngle": null,
+    "underlinePosition": null,
+    "underlineThickness": null
+  }
+}
+"#
+            .to_vec(),
+        ),
+        (
+            AXES_FILE.to_string(),
+            br#"{
+  "axes": []
+}
+"#
+            .to_vec(),
+        ),
+        (
+            SOURCES_FILE.to_string(),
+            br#"{
+  "sources": [
+    {
+      "id": "source_regular",
+      "name": "Regular",
+      "location": {},
+      "filename": null
+    }
+  ]
+}
+"#
+            .to_vec(),
+        ),
+    ];
+
+    let font = tree_to_font(tree).unwrap();
+
+    assert_eq!(font.metadata().family_name.as_deref(), Some("Minimal Sans"));
+    assert_eq!(font.sources().len(), 1);
+    assert_eq!(
+        font.default_source_id(),
+        Some(SourceId::from_raw("regular"))
+    );
+    assert_eq!(font.glyph_count(), 0);
+}
+
+#[test]
+fn rejects_glyph_file_id_mismatch() {
+    let mut tree = font_to_tree(&sample_font()).unwrap();
+    let glyph_entry = tree
+        .iter_mut()
+        .find(|(path, _)| path.starts_with(GLYPHS_DIR))
+        .unwrap();
+    let json = String::from_utf8(glyph_entry.1.clone())
+        .unwrap()
+        .replace("\"id\": \"glyph_A\"", "\"id\": \"glyph_B\"");
+    glyph_entry.1 = json.into_bytes();
+
+    let error = tree_to_font(tree).unwrap_err();
+
+    assert!(matches!(
+        error,
+        SourcePackageError::MismatchedGlyphFileId { path, id }
+            if path == "glyphs/glyph_glyph_A.json" && id == "glyph_B"
+    ));
 }
 
 #[test]
 fn rejects_non_shift_package_paths() {
     let temp = tempfile::tempdir().unwrap();
-    let package_path = temp.path().join("TestFont");
+    let package_path = temp.path().join("Dogfood");
 
     let error = ShiftSourcePackage::create_empty(&package_path).unwrap_err();
 
@@ -40,12 +422,23 @@ fn rejects_non_shift_package_paths() {
 }
 
 #[test]
-fn does_not_overwrite_existing_shift_package() {
+fn does_not_overwrite_existing_package_when_creating_empty() {
     let temp = tempfile::tempdir().unwrap();
-    let package_path = temp.path().join("TestFont.shift");
+    let package_path = temp.path().join("Dogfood.shift");
     ShiftSourcePackage::create_empty(&package_path).unwrap();
 
     let error = ShiftSourcePackage::create_empty(&package_path).unwrap_err();
 
     assert!(matches!(error, SourcePackageError::AlreadyExists(_)));
+}
+
+#[test]
+fn writes_handwritten_tree_as_openable_zip() {
+    let temp = tempfile::tempdir().unwrap();
+    let package_path = temp.path().join("Minimal.shift");
+    let tree = font_to_tree(&Font::new()).unwrap();
+
+    write_tree_atomic(&package_path, tree).unwrap();
+
+    ShiftSourcePackage::open(&package_path).unwrap();
 }

--- a/crates/shift-workspace/tests/workspace_test.rs
+++ b/crates/shift-workspace/tests/workspace_test.rs
@@ -70,7 +70,7 @@ fn creates_package_workspace_with_source_package_and_working_store() {
         }
     );
     assert_eq!(workspace.save_target(), Some(source_path.as_path()));
-    assert!(source_path.join("manifest.json").is_file());
+    assert!(source_path.is_file());
     assert_eq!(
         workspace
             .font_info()
@@ -165,7 +165,7 @@ fn save_as_assigns_a_shift_package_save_target() {
         }
     );
     assert_eq!(workspace.save_target(), Some(save_path.as_path()));
-    assert!(save_path.join("manifest.json").is_file());
+    assert!(save_path.is_file());
     workspace.save().unwrap();
 }
 


### PR DESCRIPTION
## Summary

Adds real `.shift` source-package serialization around a deterministic zip-backed file tree. The package now writes and reads the core v0 authoring shape: manifest, font metadata/metrics, axes, sources, glyph geometry, optional feature text, optional stable-ID kerning, guidelines, and a Shift-owned versioned lib-data module.

Also registers `.shift` with `shift-backends` so the format can be loaded and saved through `FontLoader` like the other source backends.

## Notes

- `features.fea` is stored as verbatim text and omitted when empty.
- `kerning.json` stores glyph references by stable glyph IDs with names as label caches, and save rejects unresolved glyph-name references.
- Font guidelines live in `font.json`; layer guidelines live in the owning glyph JSON.
- Current `shift_font::LibData` is preserved via `modules/shift.libData.json`, rather than adding arbitrary `lib` fields to core source documents.
- Bridge save/open work is intentionally not included; it is shelved for the next slice.

## Validation

- `cargo fmt --all --check`
- `cargo test -p shift-source`
- `cargo test -p shift-backends`
- `cargo test -p shift-font`
- `cargo test -p shift-workspace`
- pre-commit hook: `cargo check`, `cargo fmt`, `cargo clippy`, `cargo test`, and configured JS/tooling hooks
