### PR TITLE
[codex] Add Font semantic equality + round-trip corpus

### DIFF
--- a/crates/shift-font/Cargo.toml
+++ b/crates/shift-font/Cargo.toml
@@ -8,6 +8,9 @@ license = "MIT OR Apache-2.0"
 [lib]
 crate-type = ["rlib"]
 
+[features]
+test-support = []
+
 [dependencies]
 fontdrasil = "0.4.0"
 indexmap = { version = "2", features = ["serde"] }

--- a/crates/shift-font/src/ir/anchor.rs
+++ b/crates/shift-font/src/ir/anchor.rs
@@ -1,7 +1,7 @@
 use crate::entity::AnchorId;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Anchor {
     id: AnchorId,
     name: Option<String>,

--- a/crates/shift-font/src/ir/axis.rs
+++ b/crates/shift-font/src/ir/axis.rs
@@ -2,7 +2,7 @@ use crate::entity::AxisId;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Axis {
     id: AxisId,
@@ -113,7 +113,7 @@ impl Axis {
     }
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct Location {
     values: HashMap<AxisId, f64>,
 }

--- a/crates/shift-font/src/ir/component.rs
+++ b/crates/shift-font/src/ir/component.rs
@@ -2,7 +2,7 @@ use crate::entity::{ComponentId, GlyphId};
 use crate::GlyphName;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Component {
     id: ComponentId,
     base_glyph_id: GlyphId,
@@ -18,7 +18,7 @@ pub struct Component {
 /// | xy  yy  dy |
 /// | 0   0   1  | (implicit)
 /// ```
-#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct Transform {
     pub xx: f64,
     pub xy: f64,
@@ -30,7 +30,7 @@ pub struct Transform {
 
 /// Decomposed 2D transformation with explicit scale, rotation, skew, and translation.
 /// Composition order: translate to center → rotate → scale → skew → translate back
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DecomposedTransform {
     pub translate_x: f64,

--- a/crates/shift-font/src/ir/contour.rs
+++ b/crates/shift-font/src/ir/contour.rs
@@ -4,7 +4,7 @@ use crate::segment::CurveSegmentIter;
 use kurbo::{BezPath, PathEl};
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Contour {
     id: ContourId,
     points: Vec<Point>,

--- a/crates/shift-font/src/ir/features.rs
+++ b/crates/shift-font/src/ir/features.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct FeatureData {
     fea_source: Option<String>,
 }

--- a/crates/shift-font/src/ir/font.rs
+++ b/crates/shift-font/src/ir/font.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FontMetadata {
     pub family_name: Option<String>,
@@ -88,7 +88,7 @@ struct FontState {
     index: FontIndex,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 struct FontData {
     metadata: FontMetadata,
     metrics: FontMetrics,
@@ -244,6 +244,12 @@ impl FontState {
     fn rebuild_index(&mut self) -> CoreResult<()> {
         self.index = FontIndex::from_glyphs(&self.data.glyphs)?;
         Ok(())
+    }
+}
+
+impl PartialEq for Font {
+    fn eq(&self, other: &Self) -> bool {
+        self.state.data == other.state.data
     }
 }
 
@@ -641,7 +647,9 @@ impl Font {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Contour, GlyphLayer, LayerId, PointType};
+    use crate::{
+        test_support::sample_font, Contour, ContourId, GlyphLayer, LayerId, PointId, PointType,
+    };
     use std::sync::Arc;
     use std::time::{Duration, Instant};
 
@@ -835,6 +843,36 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![glyph_id.clone()]
         );
+    }
+
+    #[test]
+    fn font_equality_detects_field_divergence() {
+        let original = sample_font();
+        let mut changed = original.clone();
+
+        let point = changed
+            .layer_mut(LayerId::from_raw("A_regular"))
+            .unwrap()
+            .contour_mut(ContourId::from_raw("A_outer"))
+            .unwrap()
+            .get_point_mut(PointId::from_raw("A_1"))
+            .unwrap();
+        point.set_position(point.x(), point.y() + 1.0);
+
+        assert_ne!(changed, original);
+    }
+
+    #[test]
+    fn font_equality_ignores_index() {
+        let original = sample_font();
+        let mut reindexed = original.clone();
+        Arc::make_mut(&mut reindexed.state).index = FontIndex::default();
+
+        assert_ne!(
+            reindexed.glyph_id_by_name("A"),
+            original.glyph_id_by_name("A")
+        );
+        assert_eq!(reindexed, original);
     }
 
     #[test]

--- a/crates/shift-font/src/ir/glyph.rs
+++ b/crates/shift-font/src/ir/glyph.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Glyph {
     id: GlyphId,
     name: GlyphName,
@@ -19,7 +19,7 @@ pub struct Glyph {
     lib: LibData,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GlyphLayer {
     id: LayerId,
     source_id: SourceId,

--- a/crates/shift-font/src/ir/guideline.rs
+++ b/crates/shift-font/src/ir/guideline.rs
@@ -8,7 +8,7 @@ pub enum GuidelineOrientation {
     Angle,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Guideline {
     id: GuidelineId,
     x: Option<f64>,

--- a/crates/shift-font/src/ir/kerning.rs
+++ b/crates/shift-font/src/ir/kerning.rs
@@ -37,7 +37,7 @@ impl KerningPair {
     }
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct KerningData {
     pairs: Vec<KerningPair>,
     groups1: HashMap<String, Vec<GlyphName>>,

--- a/crates/shift-font/src/ir/lib_data.rs
+++ b/crates/shift-font/src/ir/lib_data.rs
@@ -1,12 +1,12 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct LibData {
     data: HashMap<String, LibValue>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum LibValue {
     String(String),

--- a/crates/shift-font/src/ir/metrics.rs
+++ b/crates/shift-font/src/ir/metrics.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FontMetrics {
     pub units_per_em: f64,

--- a/crates/shift-font/src/ir/point.rs
+++ b/crates/shift-font/src/ir/point.rs
@@ -23,7 +23,7 @@ impl std::str::FromStr for PointType {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Point {
     id: PointId,
     x: f64,

--- a/crates/shift-font/src/ir/source.rs
+++ b/crates/shift-font/src/ir/source.rs
@@ -2,7 +2,7 @@ use crate::axis::Location;
 use crate::entity::SourceId;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Source {
     id: SourceId,

--- a/crates/shift-font/src/lib.rs
+++ b/crates/shift-font/src/lib.rs
@@ -36,6 +36,8 @@ pub mod error;
 pub mod intents;
 pub mod ir;
 pub mod layer_edit;
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support;
 
 pub use changes::*;
 pub use error::{CoreError, CoreResult};

--- a/crates/shift-font/src/test_support.rs
+++ b/crates/shift-font/src/test_support.rs
@@ -1,0 +1,230 @@
+//! Shared test corpora for round-trip and persistence tests.
+
+use crate::{
+    Anchor, AnchorId, Axis, AxisId, Component, ComponentId, Contour, ContourId,
+    DecomposedTransform, Font, Glyph, GlyphId, GlyphLayer, Guideline, GuidelineId, KerningPair,
+    KerningSide, LayerId, LibValue, Location, Point, PointId, PointType, Source, SourceId,
+};
+use std::collections::HashMap;
+
+/// Builds a kitchen-sink font corpus for semantic round-trip tests.
+///
+/// Checklist when adding a new `FontData` field: populate it here with a
+/// non-default, distinguishable value before relying on equality round-trips.
+pub fn sample_font() -> Font {
+    let mut font = Font::empty();
+    font.metadata_mut().family_name = Some("Dogfood Sans".to_string());
+    font.metadata_mut().style_name = Some("Regular".to_string());
+    font.metadata_mut().version_major = Some(2);
+    font.metadata_mut().version_minor = Some(7);
+    font.metadata_mut().copyright = Some("Copyright 2026 Shift".to_string());
+    font.metadata_mut().trademark = Some("Dogfood Sans is a Shift mark".to_string());
+    font.metadata_mut().designer = Some("Shift Test Lab".to_string());
+    font.metadata_mut().designer_url = Some("https://shift.example/designer".to_string());
+    font.metadata_mut().manufacturer = Some("Shift Foundry".to_string());
+    font.metadata_mut().manufacturer_url = Some("https://shift.example/foundry".to_string());
+    font.metadata_mut().license = Some("OFL-1.1".to_string());
+    font.metadata_mut().license_url = Some("https://shift.example/license".to_string());
+    font.metadata_mut().description = Some("Round-trip coverage corpus".to_string());
+    font.metadata_mut().note = Some("Every persisted field should be represented.".to_string());
+
+    font.metrics_mut().units_per_em = 2048.0;
+    font.metrics_mut().ascender = 1500.0;
+    font.metrics_mut().descender = -500.0;
+    font.metrics_mut().cap_height = Some(1456.0);
+    font.metrics_mut().x_height = Some(1012.0);
+    font.metrics_mut().line_gap = Some(42.0);
+    font.metrics_mut().italic_angle = Some(-9.5);
+    font.metrics_mut().underline_position = Some(-175.0);
+    font.metrics_mut().underline_thickness = Some(96.0);
+
+    font.features_mut()
+        .set_fea_source(Some("feature kern { pos A A -80; } kern;\n".to_string()));
+    font.kerning_mut()
+        .set_group1("public.kern1.A".to_string(), vec!["A".into()]);
+    font.kerning_mut()
+        .set_group2("public.kern2.A".to_string(), vec!["A".into()]);
+    font.kerning_mut().add_pair(KerningPair::new(
+        KerningSide::Group("public.kern1.A".to_string()),
+        KerningSide::Group("public.kern2.A".to_string()),
+        -80.0,
+    ));
+
+    let mut font_guideline = Guideline::with_id(
+        GuidelineId::from_raw("cap_height"),
+        Some(12.0),
+        Some(700.0),
+        Some(0.0),
+        Some("Cap Height".to_string()),
+        Some("blue".to_string()),
+    );
+    font_guideline.set_color(Some("green".to_string()));
+    font.add_guideline(font_guideline);
+
+    let mut nested = HashMap::new();
+    nested.insert(
+        "nestedString".to_string(),
+        LibValue::String("value".to_string()),
+    );
+    nested.insert("nestedFloat".to_string(), LibValue::Float(3.25));
+    font.lib_mut().set(
+        "com.shift.note".to_string(),
+        LibValue::String("font note".to_string()),
+    );
+    font.lib_mut().set(
+        "com.shift.allLibVariants".to_string(),
+        LibValue::Array(vec![
+            LibValue::String("array string".to_string()),
+            LibValue::Integer(12),
+            LibValue::Float(1.5),
+            LibValue::Boolean(false),
+            LibValue::Dict(nested),
+            LibValue::Data(vec![0, 1, 2, 255]),
+        ]),
+    );
+
+    let weight_id = AxisId::from_raw("weight");
+    let mut weight = Axis::with_id(
+        weight_id.clone(),
+        "wght".to_string(),
+        "Weight".to_string(),
+        100.0,
+        400.0,
+        900.0,
+    );
+    weight.set_hidden(true);
+    font.add_axis(weight);
+
+    let width_id = AxisId::from_raw("width");
+    font.add_axis(Axis::with_id(
+        width_id.clone(),
+        "wdth".to_string(),
+        "Width".to_string(),
+        75.0,
+        100.0,
+        125.0,
+    ));
+
+    let regular_id = SourceId::from_raw("regular");
+    let bold_id = SourceId::from_raw("bold");
+    let mut regular_location = Location::new();
+    regular_location.set(weight_id.clone(), 400.0);
+    regular_location.set(width_id.clone(), 100.0);
+    let mut bold_location = Location::new();
+    bold_location.set(weight_id, 900.0);
+    bold_location.set(width_id, 112.5);
+    font.add_source(Source::with_id(
+        regular_id.clone(),
+        "Regular".to_string(),
+        regular_location,
+        Some("Regular.ufo".to_string()),
+    ));
+    font.add_source(Source::with_id(
+        bold_id.clone(),
+        "Bold".to_string(),
+        bold_location,
+        Some("Bold.ufo".to_string()),
+    ));
+    font.set_default_source_id(regular_id.clone());
+
+    let acute_id = GlyphId::from_raw("acute");
+    let mut acute = Glyph::with_id(acute_id.clone(), "acute");
+    acute.set_layer(GlyphLayer::with_width(
+        LayerId::from_raw("acute_regular"),
+        regular_id.clone(),
+        200.0,
+    ));
+    font.insert_glyph(acute).unwrap();
+
+    let glyph_id = GlyphId::from_raw("A");
+    let mut glyph = Glyph::with_id(glyph_id, "A");
+    glyph.set_unicodes(vec![0x0041, 0x00C1]);
+
+    let mut regular_layer =
+        GlyphLayer::with_width(LayerId::from_raw("A_regular"), regular_id, 600.0);
+    regular_layer.set_height(Some(700.0));
+    let mut contour = Contour::with_id(ContourId::from_raw("A_outer"));
+    contour.push_point(Point::new(
+        PointId::from_raw("A_0"),
+        100.0,
+        0.0,
+        PointType::OnCurve,
+        false,
+    ));
+    contour.push_point(Point::new(
+        PointId::from_raw("A_1"),
+        300.0,
+        700.0,
+        PointType::OffCurve,
+        true,
+    ));
+    contour.push_point(Point::new(
+        PointId::from_raw("A_2"),
+        500.0,
+        0.0,
+        PointType::QCurve,
+        false,
+    ));
+    contour.close();
+    regular_layer.add_contour(contour);
+    regular_layer.add_anchor(Anchor::with_id(
+        AnchorId::from_raw("A_top"),
+        Some("top".to_string()),
+        300.0,
+        700.0,
+    ));
+    regular_layer.add_component(Component::with_id(
+        ComponentId::from_raw("acute_component"),
+        acute_id,
+        "acute",
+        DecomposedTransform {
+            translate_x: 10.0,
+            translate_y: 20.0,
+            rotation: 5.0,
+            scale_x: 1.1,
+            scale_y: 0.9,
+            skew_x: 2.0,
+            skew_y: -1.5,
+            t_center_x: 50.0,
+            t_center_y: 75.0,
+        },
+    ));
+    regular_layer.add_guideline(Guideline::with_id(
+        GuidelineId::from_raw("baseline"),
+        None,
+        Some(0.0),
+        None,
+        Some("Baseline".to_string()),
+        Some("baseline-blue".to_string()),
+    ));
+    regular_layer
+        .lib_mut()
+        .set("com.shift.layer".to_string(), LibValue::Integer(42));
+    glyph.set_layer(regular_layer);
+
+    let mut bold_layer = GlyphLayer::with_width(LayerId::from_raw("A_bold"), bold_id, 650.0);
+    bold_layer.set_height(Some(720.0));
+    let mut bold_contour = Contour::with_id(ContourId::from_raw("A_bold_outer"));
+    bold_contour.push_point(Point::new(
+        PointId::from_raw("A_bold_0"),
+        90.0,
+        0.0,
+        PointType::OnCurve,
+        false,
+    ));
+    bold_contour.push_point(Point::new(
+        PointId::from_raw("A_bold_1"),
+        310.0,
+        720.0,
+        PointType::OnCurve,
+        false,
+    ));
+    bold_layer.add_contour(bold_contour);
+    glyph.set_layer(bold_layer);
+    glyph
+        .lib_mut()
+        .set("com.shift.glyph".to_string(), LibValue::Boolean(true));
+
+    font.insert_glyph(glyph).unwrap();
+    font
+}

--- a/crates/shift-source/Cargo.toml
+++ b/crates/shift-source/Cargo.toml
@@ -11,4 +11,5 @@ thiserror = "2"
 zip = { version = "2", default-features = false }
 
 [dev-dependencies]
+shift-font = { workspace = true, features = ["test-support"] }
 tempfile = "3"

--- a/crates/shift-source/tests/package_test.rs
+++ b/crates/shift-source/tests/package_test.rs
@@ -1,9 +1,7 @@
 use std::fs::File;
 
 use shift_font::{
-    Anchor, AnchorId, Axis, AxisId, Component, ComponentId, Contour, ContourId,
-    DecomposedTransform, Font, Glyph, GlyphId, GlyphLayer, Guideline, GuidelineId, KerningPair,
-    KerningSide, LayerId, LibValue, Location, Point, PointId, PointType, Source, SourceId,
+    Axis, AxisId, Font, KerningPair, Location, Source, SourceId, test_support::sample_font,
 };
 use shift_source::{
     AXES_FILE, FEATURES_FILE, FONT_FILE, GLYPHS_DIR, KERNING_FILE, LIB_MODULE_FILE, MANIFEST_FILE,
@@ -11,167 +9,6 @@ use shift_source::{
     write_tree_atomic,
 };
 use zip::{CompressionMethod, ZipArchive};
-
-fn sample_font() -> Font {
-    let mut font = Font::empty();
-    font.metadata_mut().family_name = Some("Dogfood Sans".to_string());
-    font.metadata_mut().style_name = Some("Regular".to_string());
-    font.metrics_mut().units_per_em = 2048.0;
-    font.metrics_mut().ascender = 1500.0;
-    font.metrics_mut().descender = -500.0;
-    font.features_mut()
-        .set_fea_source(Some("feature kern { pos A A -80; } kern;".to_string()));
-    font.kerning_mut()
-        .set_group1("public.kern1.A".to_string(), vec!["A".into()]);
-    font.kerning_mut()
-        .set_group2("public.kern2.A".to_string(), vec!["A".into()]);
-    font.kerning_mut().add_pair(KerningPair::new(
-        KerningSide::Group("public.kern1.A".to_string()),
-        KerningSide::Group("public.kern2.A".to_string()),
-        -80.0,
-    ));
-    let mut font_guideline = Guideline::with_id(
-        GuidelineId::from_raw("cap_height"),
-        None,
-        Some(700.0),
-        None,
-        Some("Cap Height".to_string()),
-        Some("blue".to_string()),
-    );
-    font_guideline.set_color(Some("green".to_string()));
-    font.add_guideline(font_guideline);
-    font.lib_mut().set(
-        "com.shift.note".to_string(),
-        LibValue::String("font note".to_string()),
-    );
-
-    let weight_id = AxisId::from_raw("weight");
-    let mut weight = Axis::with_id(
-        weight_id.clone(),
-        "wght".to_string(),
-        "Weight".to_string(),
-        100.0,
-        400.0,
-        900.0,
-    );
-    weight.set_hidden(true);
-    font.add_axis(weight);
-
-    let regular_id = SourceId::from_raw("regular");
-    let bold_id = SourceId::from_raw("bold");
-    let mut bold_location = Location::new();
-    bold_location.set(weight_id, 900.0);
-    font.add_source(Source::with_id(
-        regular_id.clone(),
-        "Regular".to_string(),
-        Location::new(),
-        Some("Regular.ufo".to_string()),
-    ));
-    font.add_source(Source::with_id(
-        bold_id.clone(),
-        "Bold".to_string(),
-        bold_location,
-        None,
-    ));
-    font.set_default_source_id(regular_id.clone());
-
-    let acute_id = GlyphId::from_raw("acute");
-    let mut acute = Glyph::with_id(acute_id.clone(), "acute");
-    acute.set_layer(GlyphLayer::with_width(
-        LayerId::from_raw("acute_regular"),
-        regular_id.clone(),
-        200.0,
-    ));
-    font.insert_glyph(acute).unwrap();
-
-    let glyph_id = GlyphId::from_raw("A");
-    let mut glyph = Glyph::with_id(glyph_id, "A");
-    glyph.set_unicodes(vec![0x0041, 0x00C1]);
-
-    let mut regular_layer =
-        GlyphLayer::with_width(LayerId::from_raw("A_regular"), regular_id, 600.0);
-    regular_layer.set_height(Some(700.0));
-    let mut contour = Contour::with_id(ContourId::from_raw("A_outer"));
-    contour.push_point(Point::new(
-        PointId::from_raw("A_0"),
-        100.0,
-        0.0,
-        PointType::OnCurve,
-        false,
-    ));
-    contour.push_point(Point::new(
-        PointId::from_raw("A_1"),
-        300.0,
-        700.0,
-        PointType::OffCurve,
-        true,
-    ));
-    contour.push_point(Point::new(
-        PointId::from_raw("A_2"),
-        500.0,
-        0.0,
-        PointType::OnCurve,
-        false,
-    ));
-    contour.close();
-    regular_layer.add_contour(contour);
-    regular_layer.add_anchor(Anchor::with_id(
-        AnchorId::from_raw("A_top"),
-        Some("top".to_string()),
-        300.0,
-        700.0,
-    ));
-    regular_layer.add_component(Component::with_id(
-        ComponentId::from_raw("acute_component"),
-        acute_id,
-        "acute",
-        DecomposedTransform {
-            translate_x: 10.0,
-            translate_y: 20.0,
-            rotation: 5.0,
-            scale_x: 1.1,
-            scale_y: 0.9,
-            ..Default::default()
-        },
-    ));
-    regular_layer.add_guideline(Guideline::with_id(
-        GuidelineId::from_raw("baseline"),
-        None,
-        Some(0.0),
-        None,
-        Some("Baseline".to_string()),
-        None,
-    ));
-    regular_layer
-        .lib_mut()
-        .set("com.shift.layer".to_string(), LibValue::Integer(42));
-    glyph.set_layer(regular_layer);
-
-    let mut bold_layer = GlyphLayer::with_width(LayerId::from_raw("A_bold"), bold_id, 650.0);
-    let mut bold_contour = Contour::with_id(ContourId::from_raw("A_bold_outer"));
-    bold_contour.push_point(Point::new(
-        PointId::from_raw("A_bold_0"),
-        90.0,
-        0.0,
-        PointType::OnCurve,
-        false,
-    ));
-    bold_contour.push_point(Point::new(
-        PointId::from_raw("A_bold_1"),
-        310.0,
-        720.0,
-        PointType::OnCurve,
-        false,
-    ));
-    bold_layer.add_contour(bold_contour);
-    glyph.set_layer(bold_layer);
-    glyph
-        .lib_mut()
-        .set("com.shift.glyph".to_string(), LibValue::Boolean(true));
-
-    font.insert_glyph(glyph).unwrap();
-    font
-}
 
 fn replace_tree_entry(tree: &mut PackageTree, path: &str, from: &str, to: &str) {
     let entry = tree
@@ -202,7 +39,7 @@ fn creates_zip_package_with_manifest_first_and_stored() {
 }
 
 #[test]
-fn roundtrips_geometry_font_through_zip_package() {
+fn shift_round_trip_preserves_whole_font() {
     let temp = tempfile::tempdir().unwrap();
     let package_path = temp.path().join("Dogfood.shift");
     let original = sample_font();
@@ -210,81 +47,7 @@ fn roundtrips_geometry_font_through_zip_package() {
     ShiftSourcePackage::save_font(&package_path, &original).unwrap();
     let loaded = ShiftSourcePackage::load_font(&package_path).unwrap();
 
-    assert_eq!(
-        loaded.metadata().family_name.as_deref(),
-        Some("Dogfood Sans")
-    );
-    assert_eq!(loaded.metrics().units_per_em, 2048.0);
-    assert_eq!(loaded.axes().len(), 1);
-    assert_eq!(loaded.axes()[0].tag(), "wght");
-    assert!(loaded.axes()[0].is_hidden());
-    assert_eq!(loaded.kerning().get_kerning("A", "A"), Some(-80.0));
-    assert!(
-        loaded
-            .features()
-            .fea_source()
-            .is_some_and(|source| source.contains("feature kern"))
-    );
-    assert_eq!(loaded.guidelines().len(), 1);
-    assert_eq!(
-        loaded.guidelines()[0].id(),
-        GuidelineId::from_raw("cap_height")
-    );
-    assert_eq!(loaded.guidelines()[0].name(), Some("Cap Height"));
-    assert_eq!(loaded.guidelines()[0].color(), Some("green"));
-    assert!(matches!(
-        loaded.lib().get("com.shift.note"),
-        Some(LibValue::String(value)) if value == "font note"
-    ));
-    assert_eq!(loaded.sources().len(), 2);
-    assert_eq!(
-        loaded.default_source_id(),
-        Some(SourceId::from_raw("regular"))
-    );
-
-    let glyph = loaded.glyph(GlyphId::from_raw("A")).unwrap();
-    assert_eq!(glyph.name(), "A");
-    assert_eq!(glyph.unicodes(), &[0x0041, 0x00C1]);
-    assert!(matches!(
-        glyph.lib().get("com.shift.glyph"),
-        Some(LibValue::Boolean(true))
-    ));
-
-    let regular_layer = glyph.layer(LayerId::from_raw("A_regular")).unwrap();
-    assert_eq!(regular_layer.source_id(), SourceId::from_raw("regular"));
-    assert_eq!(regular_layer.width(), 600.0);
-    assert_eq!(regular_layer.height(), Some(700.0));
-    assert_eq!(regular_layer.contours().len(), 1);
-    assert_eq!(regular_layer.components().len(), 1);
-    assert_eq!(regular_layer.anchors().len(), 1);
-    assert_eq!(regular_layer.guidelines().len(), 1);
-    assert_eq!(
-        regular_layer.guidelines()[0].id(),
-        GuidelineId::from_raw("baseline")
-    );
-    assert!(matches!(
-        regular_layer.lib().get("com.shift.layer"),
-        Some(LibValue::Integer(42))
-    ));
-
-    let contour = regular_layer
-        .contour(ContourId::from_raw("A_outer"))
-        .unwrap();
-    assert!(contour.is_closed());
-    assert_eq!(contour.points().len(), 3);
-    assert_eq!(contour.points()[1].point_type(), PointType::OffCurve);
-    assert!(contour.points()[1].is_smooth());
-
-    let component = regular_layer
-        .component(ComponentId::from_raw("acute_component"))
-        .unwrap();
-    assert_eq!(component.base_glyph_id(), GlyphId::from_raw("acute"));
-    assert_eq!(component.base_glyph_name().as_str(), "acute");
-    assert_eq!(component.transform().translate_x, 10.0);
-
-    let bold_layer = glyph.layer(LayerId::from_raw("A_bold")).unwrap();
-    assert_eq!(bold_layer.source_id(), SourceId::from_raw("bold"));
-    assert_eq!(bold_layer.width(), 650.0);
+    assert_eq!(loaded, original);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #82.

- Adds PartialEq through the serializable shift-font IR tree and hand-writes Font equality to compare only FontData, not the derived FontIndex.
- Moves the .shift round-trip corpus into shift-font behind a test-support feature so other crates can reuse it.
- Expands the corpus to cover previously unpopulated round-tripped fields, including metadata optionals, metric optionals, source locations/filenames, component skew/transform center, QCurve, layer/font guidelines, and all LibValue variants.
- Replaces the old spot-checking .shift package test with assert_eq!(loaded, original) while keeping package-structure tests intact.

## Notes

I found two inconsistencies while implementing this:

- The issue described the existing corpus as near-complete, but several saved fields were left default or absent. The shared corpus now fills those gaps and includes a checklist comment for future FontData fields.
- The acceptance text mentions different insertion call order, while the design says equality is on FontData and order-normalized semantic_eq is a non-goal. I tested the actual invariant directly by corrupting the private derived index and verifying Font equality ignores it.

## Validation

- cargo test -p shift-font -p shift-source
- cargo clippy
- Pre-commit hook suite during commit: cargo check, cargo fmt, cargo clippy, cargo test
- Negative check: temporarily dropped component.transform.tCenterY from .shift save output and confirmed shift_round_trip_preserves_whole_font failed, then restored it before commit.
