### PR TITLE
[codex] Unify document save ordering

### DIFF
--- a/.agent-skills/writing-tests/SKILL.md
+++ b/.agent-skills/writing-tests/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: writing-tests
+description: Canonical rules for writing tests in the Shift codebase. Use whenever you add, rewrite, or review a `.test.ts` file — or any time you're about to mock, stub, or spy your way around a testing problem. This repo has deliberately swept mock-based testing out, and this skill is what keeps it out.
+---
+
+# /writing-tests — How tests are written in this codebase
+
+The goal is tests that survive a full rewrite of the implementation, as long as the behavior stays the same. If your test breaks when a private method is renamed or a call count changes, you're testing the wrong thing.
+
+## The rule
+
+**Assert on observable state, not on mock calls.**
+
+Drive the code through its user-facing surface (`editor.copy()`, `editor.click()`, `toolManager.handleKeyDown(...)`) and assert on what a user would see — glyph contours, selection, viewport pan, tool state, command history, returned values. Never on "was method X called N times."
+
+Everything else here is a consequence of that rule.
+
+## If you're stuck, research — don't invent a mock
+
+The moment you think "I'll just mock this out" is the moment to stop and look for prior art. Real Electron / font-editor / reactive-signal codebases have solved the same class of problem: VSCode, Obsidian, Signal Desktop, Bitwarden, Fontra, tldraw. Their patterns are on GitHub.
+
+The `SystemClipboard` adapter in this repo came from a short WebSearch pass through VSCode's `IClipboardService` + `TestClipboardService` — not from inventing one locally. Ten minutes of searching usually beats an hour of mock wrangling, and the resulting test survives refactors because it mirrors a pattern that works in production code.
+
+Rule of thumb: if the repo doesn't already show you a clean way to test this, the answer is probably "inject a boundary and test through it." Go find how someone else injected the boundary before reaching for `vi.mock`.
+
+## When to stop and rethink
+
+If you catch yourself doing any of the following, stop. You're about to write a test this codebase has deliberately deleted.
+
+| Reaching for…                                                                                                                                               | What it means                                                                                                                                                   | Do instead                                                                                                                                                                                                                                                                                                                                                               |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Vitest mock primitives** — `vi.fn`, `vi.spyOn`, `toHaveBeenCalled`, `mock.calls.length`, `.mock.calls`, execution-order arrays (`applied.push(...)`)      | Asserting on "was this called" instead of "what did the user see"                                                                                               | Find the user-facing consequence (state change, return value, emitted payload). If there isn't one, the behavior isn't worth a unit test. Exception: when you're testing a primitive whose **contract is the invocation count** (reactive library fire counts, pub/sub dispatch), a plain closure counter (`let n = 0; ...; n++`) is fine — don't reach for vitest mocks |
+| **Hand-built events, states, or snapshots** — constructing `ToolEvent`s, `Coordinates`, `GlyphSnapshot`s inline so you can pass them straight into a method | Recreating the pipeline instead of using it                                                                                                                     | Drive through `TestEditor` — real gestures, real events, real state                                                                                                                                                                                                                                                                                                      |
+| **Global stubs** — `vi.stubGlobal`, monkey-patching `window`, `requestAnimationFrame`, `electronAPI`                                                        | The code has an unmanaged global dependency; stubbing papers over it                                                                                            | Inject the boundary. For rAF: `toolManager.flushPointerMoves()`. For IPC: `SystemClipboard`-style adapter. If the boundary doesn't exist yet, add one                                                                                                                                                                                                                    |
+| **Parallel-world test harnesses** — mock engines, mock renderers, mock command contexts, raw `new Editor(...)` in a `.test.ts`                              | Reimplementing production in TypeScript so the test can "look inside." Drifts from real behavior; the mock/prod divergence is the whole pain the repo swept out | Use `TestEditor`. If you can't, extract the logic into a pure function and test that. `new Editor(...)` in tests is enforced against by `oxlint no-raw-editor-in-tests`                                                                                                                                                                                                  |
+
+## Test categories
+
+| Category             | Use when                                                                   | Template in repo                                                                            |
+| -------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| **Tool test**        | User-triggerable behavior of a tool (pointer, keyboard, selection, cursor) | `lib/tools/pen/Pen.test.ts`, `lib/tools/hand/Hand.test.ts`, `lib/tools/shape/Shape.test.ts` |
+| **Command test**     | A `Command`'s execute/undo/redo round-trip                                 | `lib/commands/primitives/PointCommands.test.ts`                                             |
+| **Pure module test** | Stateless class or function with no `Editor` dependency                    | `lib/tools/text/TextRunController.test.ts`, `lib/editor/hit/boundingBox.test.ts`            |
+| **Bridge test**      | `NativeBridge` against the real Rust engine                                | `bridge/NativeBridge.test.ts`                                                               |
+
+If your target doesn't fit one of these, stop and ask — don't invent a new shape.
+
+### Decision: which one
+
+1. Can a user trigger it with a click, drag, or key? → **Tool test** via `TestEditor`.
+2. Is it a single command's undo/redo contract? → **Command test**.
+3. Is it a pure function or pure class with no `Editor`? → **Pure module test**.
+4. Is it the NAPI boundary? → **Bridge test**.
+
+## Templates
+
+### Tool test
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { TestEditor } from "@/testing/TestEditor";
+
+describe("Hand tool", () => {
+  let editor: TestEditor;
+
+  beforeEach(() => {
+    editor = new TestEditor();
+    editor.startSession();
+    editor.selectTool("hand");
+  });
+
+  it("drag pans the viewport by the screen delta", () => {
+    const startPan = editor.pan;
+
+    editor.pointerDown(0, 0);
+    editor.pointerMove(50, 30); // crosses drag threshold
+    editor.pointerMove(120, 80);
+    editor.pointerUp(120, 80);
+
+    expect(editor.pan.x).toBe(startPan.x + 120);
+    expect(editor.pan.y).toBe(startPan.y + 80);
+  });
+});
+```
+
+### Pure module test
+
+```ts
+import { describe, it, expect } from "vitest";
+import { SnapPipelineRunner } from "./SnapPipelineRunner";
+
+describe("SnapPipelineRunner", () => {
+  const runner = new SnapPipelineRunner();
+
+  it("point-to-point wins over a closer metrics candidate", () => {
+    const result = runner.runPointPipeline(
+      [
+        pointStep("p2p", hit("pointToPoint", { x: 110, y: 110 })),
+        pointStep("metrics", hit("metrics", { x: 101, y: 101 })),
+      ],
+      pointArgs,
+    );
+
+    expect(result.source).toBe("pointToPoint");
+    expect(result.point).toEqual({ x: 110, y: 110 });
+  });
+});
+```
+
+Stub _inputs_ (a `PointSnapStep` here is an interface — build a minimal one). Never stub the class under test.
+
+### Bridge test
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { NativeBridge } from "./NativeBridge";
+import { createBridge } from "@/testing/engine";
+
+describe("NativeBridge session lifecycle", () => {
+  let bridge: NativeBridge;
+
+  beforeEach(() => {
+    bridge = createBridge(); // real Rust engine via shift-node
+  });
+
+  it("startEditSession populates $glyph", () => {
+    bridge.startEditSession("A");
+    expect(bridge.hasSession()).toBe(true);
+    expect(bridge.$glyph.peek()).not.toBe(null);
+  });
+});
+```
+
+## The fake-test checklist
+
+Before committing a test, run through these. Any miss means the test is wrong.
+
+1. **Mental deletion.** Replace the method body under test with `throw new Error("unimplemented")`. Does your test fail? If it still passes, you wrote a tautology — usually because you asserted on a value you constructed rather than on a consequence.
+2. **User-facing surface.** You drove through a method a real user can trigger (pointer, keyboard, command, menu action), not a `#private` field or a tool-internal method.
+3. **Specific assertions.** `expect(editor.pointCount).toBe(4)` — yes. `expect(result).toBeDefined()` or `expect(spy).toHaveBeenCalled()` — no, those survive any implementation.
+4. **Correct code path.** If the real production path goes through command history + bridge + signals, your test goes through those too. You didn't reach behind the facade.
+5. **Under ~15 lines.** If a single `it()` body exceeds ~15 lines, it's testing too much at once, or its setup belongs in `beforeEach`.
+
+## Setup discipline
+
+- `beforeEach` is ≤ 5 lines: `new TestEditor()` + `startSession()` + `selectTool()` + optional fixture.
+- No wrapper factories around `TestEditor`. If you need a reusable helper, it belongs as a method on `TestEditor` itself (see `pointerMove`, `click`, `escape`).
+- If your test needs a pre-drawn shape, draw it with the pen/shape tool in `beforeEach` — don't construct glyph snapshots inline.
+
+## Naming
+
+- `describe()` names should explain the behavior or contract under test, not just repeat a class or file name.
+- Prefer `describe("glyph source geometry follows coordinate patches", ...)` over `describe("GlyphSourceState", ...)`.
+- A class name can appear inside a larger phrase when it adds clarity, but the phrase should still tell the reader what invariant is being protected.
+
+## When testing is genuinely hard
+
+Some code resists clean unit testing — DOM event handlers, focus management, IME composition, React effect lifecycle.
+
+**Default move: extract the non-DOM logic into a pure function and test that.** Example: `HiddenTextInput` keyboard handling → `lib/tools/text/textInput.ts → handleTextKeyDown(event, editor)`. The component becomes a thin adapter; the extracted function is a normal tool test via `TestEditor`. The part that genuinely can't be tested cleanly shrinks to ~20 lines that rely on manual QA.
+
+If after extraction and research you're still reaching for jsdom + `@testing-library/react` + IPC mocks, pause and ask the user before introducing that infrastructure.
+
+## Why these rules exist
+
+The codebase went through a deliberate sweep that deleted thousands of lines of mock-based tests. See commits `5f2f503`, `876e542`, `642ec99`, `bfea0b5`, `3f3a6d6`, `fa8a829`, `bd07e9d`, `3f3a6d6 Delete MockFontEngine`. The motivating pain was real:
+
+- Mocks drifted from the real Rust behavior they pretended to simulate. Tests passed; production broke.
+- Spy-count tests locked in implementation details; every refactor broke tests that weren't guarding any behavior.
+- Global stubs (`vi.stubGlobal("window", ...)`) leaked across test files and hid unmanaged global dependencies.
+- Mock context builders (`services.ts`, 1,795 lines) became their own maintenance burden.
+
+The replacement — real `Editor`, real Rust via NAPI, fake only at the outermost boundary (`SystemClipboard`, `NativeBridge`) — catches regressions mocks silently missed. Don't reintroduce what was deleted.
+
+## Running
+
+```bash
+pnpm test              # full vitest suite, runs against real Rust
+pnpm test:watch        # watch mode
+pnpm typecheck         # tsgo across all packages
+pnpm lint:check        # oxlint, includes no-raw-editor-in-tests and no-mock-call-assertions
+```
+
+All three must pass before committing. If `no-mock-call-assertions` flags your test, it's caught you reaching for the banned pattern — fix the test, don't disable the rule.

--- a/.codex/skills/writing-tests/SKILL.md
+++ b/.codex/skills/writing-tests/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: writing-tests
+description: Canonical rules for writing tests in the Shift codebase. Use whenever you add, rewrite, or review a `.test.ts` file — or any time you're about to mock, stub, or spy your way around a testing problem. This repo has deliberately swept mock-based testing out, and this skill is what keeps it out.
+---
+
+# /writing-tests — How tests are written in this codebase
+
+The goal is tests that survive a full rewrite of the implementation, as long as the behavior stays the same. If your test breaks when a private method is renamed or a call count changes, you're testing the wrong thing.
+
+## The rule
+
+**Assert on observable state, not on mock calls.**
+
+Drive the code through its user-facing surface (`editor.copy()`, `editor.click()`, `toolManager.handleKeyDown(...)`) and assert on what a user would see — glyph contours, selection, viewport pan, tool state, command history, returned values. Never on "was method X called N times."
+
+Everything else here is a consequence of that rule.
+
+## If you're stuck, research — don't invent a mock
+
+The moment you think "I'll just mock this out" is the moment to stop and look for prior art. Real Electron / font-editor / reactive-signal codebases have solved the same class of problem: VSCode, Obsidian, Signal Desktop, Bitwarden, Fontra, tldraw. Their patterns are on GitHub.
+
+The `SystemClipboard` adapter in this repo came from a short WebSearch pass through VSCode's `IClipboardService` + `TestClipboardService` — not from inventing one locally. Ten minutes of searching usually beats an hour of mock wrangling, and the resulting test survives refactors because it mirrors a pattern that works in production code.
+
+Rule of thumb: if the repo doesn't already show you a clean way to test this, the answer is probably "inject a boundary and test through it." Go find how someone else injected the boundary before reaching for `vi.mock`.
+
+## When to stop and rethink
+
+If you catch yourself doing any of the following, stop. You're about to write a test this codebase has deliberately deleted.
+
+| Reaching for…                                                                                                                                               | What it means                                                                                                                                                   | Do instead                                                                                                                                                                                                                                                                                                                                                               |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Vitest mock primitives** — `vi.fn`, `vi.spyOn`, `toHaveBeenCalled`, `mock.calls.length`, `.mock.calls`, execution-order arrays (`applied.push(...)`)      | Asserting on "was this called" instead of "what did the user see"                                                                                               | Find the user-facing consequence (state change, return value, emitted payload). If there isn't one, the behavior isn't worth a unit test. Exception: when you're testing a primitive whose **contract is the invocation count** (reactive library fire counts, pub/sub dispatch), a plain closure counter (`let n = 0; ...; n++`) is fine — don't reach for vitest mocks |
+| **Hand-built events, states, or snapshots** — constructing `ToolEvent`s, `Coordinates`, `GlyphSnapshot`s inline so you can pass them straight into a method | Recreating the pipeline instead of using it                                                                                                                     | Drive through `TestEditor` — real gestures, real events, real state                                                                                                                                                                                                                                                                                                      |
+| **Global stubs** — `vi.stubGlobal`, monkey-patching `window`, `requestAnimationFrame`, `electronAPI`                                                        | The code has an unmanaged global dependency; stubbing papers over it                                                                                            | Inject the boundary. For rAF: `toolManager.flushPointerMoves()`. For IPC: `SystemClipboard`-style adapter. If the boundary doesn't exist yet, add one                                                                                                                                                                                                                    |
+| **Parallel-world test harnesses** — mock engines, mock renderers, mock command contexts, raw `new Editor(...)` in a `.test.ts`                              | Reimplementing production in TypeScript so the test can "look inside." Drifts from real behavior; the mock/prod divergence is the whole pain the repo swept out | Use `TestEditor`. If you can't, extract the logic into a pure function and test that. `new Editor(...)` in tests is enforced against by `oxlint no-raw-editor-in-tests`                                                                                                                                                                                                  |
+
+## Test categories
+
+| Category             | Use when                                                                   | Template in repo                                                                            |
+| -------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| **Tool test**        | User-triggerable behavior of a tool (pointer, keyboard, selection, cursor) | `lib/tools/pen/Pen.test.ts`, `lib/tools/hand/Hand.test.ts`, `lib/tools/shape/Shape.test.ts` |
+| **Command test**     | A `Command`'s execute/undo/redo round-trip                                 | `lib/commands/primitives/PointCommands.test.ts`                                             |
+| **Pure module test** | Stateless class or function with no `Editor` dependency                    | `lib/tools/text/TextRunController.test.ts`, `lib/editor/hit/boundingBox.test.ts`            |
+| **Bridge test**      | `NativeBridge` against the real Rust engine                                | `bridge/NativeBridge.test.ts`                                                               |
+
+If your target doesn't fit one of these, stop and ask — don't invent a new shape.
+
+### Decision: which one
+
+1. Can a user trigger it with a click, drag, or key? → **Tool test** via `TestEditor`.
+2. Is it a single command's undo/redo contract? → **Command test**.
+3. Is it a pure function or pure class with no `Editor`? → **Pure module test**.
+4. Is it the NAPI boundary? → **Bridge test**.
+
+## Templates
+
+### Tool test
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { TestEditor } from "@/testing/TestEditor";
+
+describe("Hand tool", () => {
+  let editor: TestEditor;
+
+  beforeEach(() => {
+    editor = new TestEditor();
+    editor.startSession();
+    editor.selectTool("hand");
+  });
+
+  it("drag pans the viewport by the screen delta", () => {
+    const startPan = editor.pan;
+
+    editor.pointerDown(0, 0);
+    editor.pointerMove(50, 30); // crosses drag threshold
+    editor.pointerMove(120, 80);
+    editor.pointerUp(120, 80);
+
+    expect(editor.pan.x).toBe(startPan.x + 120);
+    expect(editor.pan.y).toBe(startPan.y + 80);
+  });
+});
+```
+
+### Pure module test
+
+```ts
+import { describe, it, expect } from "vitest";
+import { SnapPipelineRunner } from "./SnapPipelineRunner";
+
+describe("SnapPipelineRunner", () => {
+  const runner = new SnapPipelineRunner();
+
+  it("point-to-point wins over a closer metrics candidate", () => {
+    const result = runner.runPointPipeline(
+      [
+        pointStep("p2p", hit("pointToPoint", { x: 110, y: 110 })),
+        pointStep("metrics", hit("metrics", { x: 101, y: 101 })),
+      ],
+      pointArgs,
+    );
+
+    expect(result.source).toBe("pointToPoint");
+    expect(result.point).toEqual({ x: 110, y: 110 });
+  });
+});
+```
+
+Stub _inputs_ (a `PointSnapStep` here is an interface — build a minimal one). Never stub the class under test.
+
+### Bridge test
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { NativeBridge } from "./NativeBridge";
+import { createBridge } from "@/testing/engine";
+
+describe("NativeBridge session lifecycle", () => {
+  let bridge: NativeBridge;
+
+  beforeEach(() => {
+    bridge = createBridge(); // real Rust engine via shift-node
+  });
+
+  it("startEditSession populates $glyph", () => {
+    bridge.startEditSession("A");
+    expect(bridge.hasSession()).toBe(true);
+    expect(bridge.$glyph.peek()).not.toBe(null);
+  });
+});
+```
+
+## The fake-test checklist
+
+Before committing a test, run through these. Any miss means the test is wrong.
+
+1. **Mental deletion.** Replace the method body under test with `throw new Error("unimplemented")`. Does your test fail? If it still passes, you wrote a tautology — usually because you asserted on a value you constructed rather than on a consequence.
+2. **User-facing surface.** You drove through a method a real user can trigger (pointer, keyboard, command, menu action), not a `#private` field or a tool-internal method.
+3. **Specific assertions.** `expect(editor.pointCount).toBe(4)` — yes. `expect(result).toBeDefined()` or `expect(spy).toHaveBeenCalled()` — no, those survive any implementation.
+4. **Correct code path.** If the real production path goes through command history + bridge + signals, your test goes through those too. You didn't reach behind the facade.
+5. **Under ~15 lines.** If a single `it()` body exceeds ~15 lines, it's testing too much at once, or its setup belongs in `beforeEach`.
+
+## Setup discipline
+
+- `beforeEach` is ≤ 5 lines: `new TestEditor()` + `startSession()` + `selectTool()` + optional fixture.
+- No wrapper factories around `TestEditor`. If you need a reusable helper, it belongs as a method on `TestEditor` itself (see `pointerMove`, `click`, `escape`).
+- If your test needs a pre-drawn shape, draw it with the pen/shape tool in `beforeEach` — don't construct glyph snapshots inline.
+
+## Naming
+
+- `describe()` names should explain the behavior or contract under test, not just repeat a class or file name.
+- Prefer `describe("glyph source geometry follows coordinate patches", ...)` over `describe("GlyphSourceState", ...)`.
+- A class name can appear inside a larger phrase when it adds clarity, but the phrase should still tell the reader what invariant is being protected.
+
+## When testing is genuinely hard
+
+Some code resists clean unit testing — DOM event handlers, focus management, IME composition, React effect lifecycle.
+
+**Default move: extract the non-DOM logic into a pure function and test that.** Example: `HiddenTextInput` keyboard handling → `lib/tools/text/textInput.ts → handleTextKeyDown(event, editor)`. The component becomes a thin adapter; the extracted function is a normal tool test via `TestEditor`. The part that genuinely can't be tested cleanly shrinks to ~20 lines that rely on manual QA.
+
+If after extraction and research you're still reaching for jsdom + `@testing-library/react` + IPC mocks, pause and ask the user before introducing that infrastructure.
+
+## Why these rules exist
+
+The codebase went through a deliberate sweep that deleted thousands of lines of mock-based tests. See commits `5f2f503`, `876e542`, `642ec99`, `bfea0b5`, `3f3a6d6`, `fa8a829`, `bd07e9d`, `3f3a6d6 Delete MockFontEngine`. The motivating pain was real:
+
+- Mocks drifted from the real Rust behavior they pretended to simulate. Tests passed; production broke.
+- Spy-count tests locked in implementation details; every refactor broke tests that weren't guarding any behavior.
+- Global stubs (`vi.stubGlobal("window", ...)`) leaked across test files and hid unmanaged global dependencies.
+- Mock context builders (`services.ts`, 1,795 lines) became their own maintenance burden.
+
+The replacement — real `Editor`, real Rust via NAPI, fake only at the outermost boundary (`SystemClipboard`, `NativeBridge`) — catches regressions mocks silently missed. Don't reintroduce what was deleted.
+
+## Running
+
+```bash
+pnpm test              # full vitest suite, runs against real Rust
+pnpm test:watch        # watch mode
+pnpm typecheck         # tsgo across all packages
+pnpm lint:check        # oxlint, includes no-raw-editor-in-tests and no-mock-call-assertions
+```
+
+All three must pass before committing. If `no-mock-call-assertions` flags your test, it's caught you reaching for the banned pattern — fix the test, don't disable the rule.

--- a/apps/desktop/src/main/app/App.ts
+++ b/apps/desktop/src/main/app/App.ts
@@ -30,7 +30,11 @@ export class App {
 
   #appIcon = new AppIcon();
   #applicationMenu = new ApplicationMenu(this.#appIcon.path(), (id) => {
-    void this.#commands.run(id, this.#commandContext());
+    // Menu/accelerator commands run detached, so a failure (e.g. a save that
+    // throws) has nowhere to propagate — catch and surface it here.
+    void this.#commands.run(id, this.#commandContext()).catch((error) => {
+      this.#log.error("menu command failed", id, error);
+    });
   });
 
   #workspace = new WorkspaceProcess();
@@ -120,9 +124,6 @@ export class App {
   #registerIpcHandlers(): void {
     ipc.handle(ipcMain, "commands.run", (_event, id) => {
       return this.#commands.run(id, this.#commandContext());
-    });
-    ipc.handle(ipcMain, "document.flushCompleted", (_event, completion) => {
-      this.#document.completeFlush(completion);
     });
     ipc.handle(ipcMain, "workspace.connect", async (event) => {
       const { port1, port2 } = new MessageChannelMain();

--- a/apps/desktop/src/main/app/App.ts
+++ b/apps/desktop/src/main/app/App.ts
@@ -10,6 +10,7 @@ import { registerCommands } from "../commands/Commands";
 import { ApplicationMenu } from "../menu/ApplicationMenu";
 import { createShiftLogger, type ShiftLogger } from "../logging";
 import { WorkspaceProcess } from "../workspace/WorkspaceProcess";
+import { DocumentSession } from "../document/DocumentSession";
 
 const APP_NAME = "Shift";
 
@@ -33,6 +34,11 @@ export class App {
   });
 
   #workspace = new WorkspaceProcess();
+  #document = new DocumentSession({
+    workspace: this.#workspace,
+    activeWindow: () => this.#workingWindow,
+    applicationName: () => this.applicationName,
+  });
 
   constructor(log: ShiftLogger = createShiftLogger("app")) {
     this.#log = log;
@@ -72,6 +78,7 @@ export class App {
 
       const documentsRoot = path.join(app.getPath("userData"), "working-documents");
       this.#workspace.start(documentsRoot);
+      this.#workspace.onDocumentChanged((state) => this.#document.acceptState(state));
 
       this.#appIcon.install();
       this.#applicationMenu.install();
@@ -114,6 +121,9 @@ export class App {
     ipc.handle(ipcMain, "commands.run", (_event, id) => {
       return this.#commands.run(id, this.#commandContext());
     });
+    ipc.handle(ipcMain, "document.flushCompleted", (_event, completion) => {
+      this.#document.completeFlush(completion);
+    });
     ipc.handle(ipcMain, "workspace.connect", async (event) => {
       const { port1, port2 } = new MessageChannelMain();
 
@@ -132,6 +142,10 @@ export class App {
 
   #commandContext(): CommandContext {
     return {
+      document: {
+        save: () => this.#document.save(),
+        saveAs: () => this.#document.saveAs(),
+      },
       windows: {
         active: () => this.#workingWindow,
       },

--- a/apps/desktop/src/main/commands/Command.ts
+++ b/apps/desktop/src/main/commands/Command.ts
@@ -87,6 +87,12 @@ export class CommandRegistry {
  * objects from this context after they finish running.
  */
 export type CommandContext = {
+  document: {
+    /** Saves through main's native document workflow. */
+    save: () => Promise<void>;
+    /** Runs main's native Save As workflow. */
+    saveAs: () => Promise<void>;
+  };
   windows: {
     /**
      * Returns the current working window.

--- a/apps/desktop/src/main/commands/Commands.ts
+++ b/apps/desktop/src/main/commands/Commands.ts
@@ -60,7 +60,22 @@ const viewCommands: Command[] = [
   },
 ];
 
-const fileCommands: Command[] = [];
+const fileCommands: Command[] = [
+  {
+    id: "file.save",
+    label: "Save",
+    accelerator: "CmdOrCtrl+S",
+    enabled: (ctx) => ctx.windows.active() !== null,
+    run: (ctx) => ctx.document.save(),
+  },
+  {
+    id: "file.saveAs",
+    label: "Save As...",
+    accelerator: "CmdOrCtrl+Shift+S",
+    enabled: (ctx) => ctx.windows.active() !== null,
+    run: (ctx) => ctx.document.saveAs(),
+  },
+];
 const editCommands: Command[] = [];
 
 /**

--- a/apps/desktop/src/main/document/DocumentSession.test.ts
+++ b/apps/desktop/src/main/document/DocumentSession.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import type { DocumentFlushRequest } from "../../shared/ipc/contract";
+import type { WorkspaceDocumentState } from "../../shared/workspace/protocol";
+import type { Window } from "../windows/Window";
+import type { WorkspaceProcess } from "../workspace/WorkspaceProcess";
+import { DocumentSession } from "./DocumentSession";
+
+class TestWorkspace {
+  savedPath: string | null = null;
+
+  constructor(public state: WorkspaceDocumentState) {}
+
+  async documentState(): Promise<WorkspaceDocumentState> {
+    return this.state;
+  }
+
+  async saveDocumentAs(path: string): Promise<WorkspaceDocumentState> {
+    this.savedPath = path;
+    this.state = {
+      ...this.state,
+      sourceKind: "package",
+      saveTarget: path,
+      savedRevision: this.state.revision,
+      dirty: false,
+      needsSaveAs: false,
+    };
+    return this.state;
+  }
+}
+
+class TestWindow {
+  title = "";
+  flushRequest: DocumentFlushRequest | null = null;
+
+  readonly window = {
+    webContents: {
+      isDestroyed: () => false,
+    },
+  };
+
+  setTitle(title: string): void {
+    this.title = title;
+  }
+}
+
+describe("main document save workflow", () => {
+  it("keeps Save As behind the renderer flush barrier", async () => {
+    const savePath = "/tmp/SavedFont.shift";
+    const workspace = new TestWorkspace({
+      documentId: "doc-1",
+      sourceKind: "untitled",
+      saveTarget: null,
+      revision: 1,
+      savedRevision: 0,
+      dirty: true,
+      needsSaveAs: true,
+    });
+    const window = new TestWindow();
+    const session = new DocumentSession({
+      workspace: workspace as unknown as WorkspaceProcess,
+      activeWindow: () => window as unknown as Window,
+      applicationName: () => "Shift Test",
+      saveDialog: async () => savePath,
+      sendFlushRequest: (_window, request) => {
+        window.flushRequest = request;
+      },
+    });
+
+    const save = session.saveAs();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(window.flushRequest).toEqual({ requestId: "1" });
+    expect(workspace.savedPath).toBeNull();
+
+    session.completeFlush(window.flushRequest!);
+    await save;
+
+    expect(workspace.savedPath).toBe(savePath);
+    expect(workspace.state.dirty).toBe(false);
+    expect(workspace.state.savedRevision).toBe(1);
+    expect(window.title).toBe("SavedFont.shift - Shift Test");
+  });
+});

--- a/apps/desktop/src/main/document/DocumentSession.test.ts
+++ b/apps/desktop/src/main/document/DocumentSession.test.ts
@@ -1,36 +1,21 @@
 import { describe, expect, it } from "vitest";
-import type { DocumentFlushRequest } from "../../shared/ipc/contract";
+import type { DocumentSaveRequest } from "../../shared/ipc/contract";
 import type { WorkspaceDocumentState } from "../../shared/workspace/protocol";
 import type { Window } from "../windows/Window";
 import type { WorkspaceProcess } from "../workspace/WorkspaceProcess";
 import { DocumentSession } from "./DocumentSession";
 
 class TestWorkspace {
-  savedPath: string | null = null;
+  constructor(public state: WorkspaceDocumentState | null) {}
 
-  constructor(public state: WorkspaceDocumentState) {}
-
-  async documentState(): Promise<WorkspaceDocumentState> {
-    return this.state;
-  }
-
-  async saveDocumentAs(path: string): Promise<WorkspaceDocumentState> {
-    this.savedPath = path;
-    this.state = {
-      ...this.state,
-      sourceKind: "package",
-      saveTarget: path,
-      savedRevision: this.state.revision,
-      dirty: false,
-      needsSaveAs: false,
-    };
+  async documentState(): Promise<WorkspaceDocumentState | null> {
     return this.state;
   }
 }
 
 class TestWindow {
   title = "";
-  flushRequest: DocumentFlushRequest | null = null;
+  saveRequest: DocumentSaveRequest | null = null;
 
   readonly window = {
     webContents: {
@@ -43,42 +28,106 @@ class TestWindow {
   }
 }
 
+const openState = (overrides: Partial<WorkspaceDocumentState> = {}): WorkspaceDocumentState => ({
+  documentId: "doc-1",
+  sourceKind: "package",
+  saveTarget: "/tmp/Existing.shift",
+  dirty: true,
+  needsSaveAs: false,
+  ...overrides,
+});
+
 describe("main document save workflow", () => {
-  it("keeps Save As behind the renderer flush barrier", async () => {
+  it("escalates an untitled document to Save As and issues the chosen path", async () => {
     const savePath = "/tmp/SavedFont.shift";
-    const workspace = new TestWorkspace({
-      documentId: "doc-1",
-      sourceKind: "untitled",
-      saveTarget: null,
-      revision: 1,
-      savedRevision: 0,
-      dirty: true,
-      needsSaveAs: true,
-    });
+    const workspace = new TestWorkspace(
+      openState({ sourceKind: "untitled", saveTarget: null, needsSaveAs: true }),
+    );
     const window = new TestWindow();
     const session = new DocumentSession({
       workspace: workspace as unknown as WorkspaceProcess,
       activeWindow: () => window as unknown as Window,
       applicationName: () => "Shift Test",
       saveDialog: async () => savePath,
-      sendFlushRequest: (_window, request) => {
-        window.flushRequest = request;
+      sendSave: (_window, request) => {
+        window.saveRequest = request;
       },
     });
 
-    const save = session.saveAs();
-    await Promise.resolve();
-    await Promise.resolve();
+    await session.save();
 
-    expect(window.flushRequest).toEqual({ requestId: "1" });
-    expect(workspace.savedPath).toBeNull();
+    expect(window.saveRequest).toEqual({ path: savePath });
+  });
 
-    session.completeFlush(window.flushRequest!);
-    await save;
+  it("issues a current-target save when the document already has a path", async () => {
+    const workspace = new TestWorkspace(openState());
+    const window = new TestWindow();
+    const session = new DocumentSession({
+      workspace: workspace as unknown as WorkspaceProcess,
+      activeWindow: () => window as unknown as Window,
+      applicationName: () => "Shift Test",
+      sendSave: (_window, request) => {
+        window.saveRequest = request;
+      },
+    });
 
-    expect(workspace.savedPath).toBe(savePath);
-    expect(workspace.state.dirty).toBe(false);
-    expect(workspace.state.savedRevision).toBe(1);
-    expect(window.title).toBe("SavedFont.shift - Shift Test");
+    await session.save();
+
+    expect(window.saveRequest).toEqual({ path: null });
+    expect(window.title).toBe("Existing.shift * - Shift Test");
+  });
+
+  it("Save As always issues the path the dialog returns", async () => {
+    const savePath = "/tmp/Renamed.shift";
+    const workspace = new TestWorkspace(openState());
+    const window = new TestWindow();
+    const session = new DocumentSession({
+      workspace: workspace as unknown as WorkspaceProcess,
+      activeWindow: () => window as unknown as Window,
+      applicationName: () => "Shift Test",
+      saveDialog: async () => savePath,
+      sendSave: (_window, request) => {
+        window.saveRequest = request;
+      },
+    });
+
+    await session.saveAs();
+
+    expect(window.saveRequest).toEqual({ path: savePath });
+  });
+
+  it("issues nothing when the Save As dialog is cancelled", async () => {
+    const workspace = new TestWorkspace(openState({ needsSaveAs: true }));
+    const window = new TestWindow();
+    const session = new DocumentSession({
+      workspace: workspace as unknown as WorkspaceProcess,
+      activeWindow: () => window as unknown as Window,
+      applicationName: () => "Shift Test",
+      saveDialog: async () => null,
+      sendSave: (_window, request) => {
+        window.saveRequest = request;
+      },
+    });
+
+    await session.save();
+
+    expect(window.saveRequest).toBeNull();
+  });
+
+  it("issues nothing when no document is open", async () => {
+    const workspace = new TestWorkspace(null);
+    const window = new TestWindow();
+    const session = new DocumentSession({
+      workspace: workspace as unknown as WorkspaceProcess,
+      activeWindow: () => window as unknown as Window,
+      applicationName: () => "Shift Test",
+      sendSave: (_window, request) => {
+        window.saveRequest = request;
+      },
+    });
+
+    await session.save();
+
+    expect(window.saveRequest).toBeNull();
   });
 });

--- a/apps/desktop/src/main/document/DocumentSession.ts
+++ b/apps/desktop/src/main/document/DocumentSession.ts
@@ -1,0 +1,205 @@
+import { dialog, type SaveDialogOptions } from "electron";
+import path from "node:path";
+import * as ipc from "../../shared/ipc/main";
+import type { DocumentFlushCompletion, DocumentFlushRequest } from "../../shared/ipc/contract";
+import type { WorkspaceDocumentState } from "../../shared/workspace/protocol";
+import type { Window } from "../windows/Window";
+import type { WorkspaceProcess } from "../workspace/WorkspaceProcess";
+
+const DEFAULT_FLUSH_TIMEOUT_MS = 5_000;
+
+export type DocumentSessionOptions = {
+  workspace: WorkspaceProcess;
+  activeWindow: () => Window | null;
+  applicationName: () => string;
+  saveDialog?: DocumentSaveDialog;
+  sendFlushRequest?: DocumentFlushRequestSender;
+  flushTimeoutMs?: number;
+};
+
+export type DocumentSaveDialog = (
+  window: Window | null,
+  state: WorkspaceDocumentState,
+) => Promise<string | null>;
+
+export type DocumentFlushRequestSender = (window: Window, request: DocumentFlushRequest) => void;
+
+type PendingFlush = {
+  resolve: () => void;
+  reject: (error: Error) => void;
+  timeout: NodeJS.Timeout;
+};
+
+/**
+ * Main-process owner of native document lifecycle workflow.
+ *
+ * @remarks
+ * The session coordinates renderer quiescence, utility save ordering, native
+ * dialogs, and window title state. It never forwards generic commands to the
+ * renderer; the renderer can only answer the narrow flush request.
+ */
+export class DocumentSession {
+  readonly #workspace: WorkspaceProcess;
+  readonly #activeWindow: () => Window | null;
+  readonly #applicationName: () => string;
+  readonly #saveDialog: DocumentSaveDialog;
+  readonly #sendFlushRequest: DocumentFlushRequestSender;
+  readonly #flushTimeoutMs: number;
+  readonly #pendingFlushes = new Map<string, PendingFlush>();
+
+  #nextFlushId = 0;
+  #state: WorkspaceDocumentState | null = null;
+
+  constructor(options: DocumentSessionOptions) {
+    this.#workspace = options.workspace;
+    this.#activeWindow = options.activeWindow;
+    this.#applicationName = options.applicationName;
+    this.#saveDialog = options.saveDialog ?? defaultSaveDialog;
+    this.#sendFlushRequest = options.sendFlushRequest ?? defaultSendFlushRequest;
+    this.#flushTimeoutMs = options.flushTimeoutMs ?? DEFAULT_FLUSH_TIMEOUT_MS;
+  }
+
+  /**
+   * Runs Save from main, escalating to Save As when the utility has no target.
+   *
+   * @throws {Error} when renderer flushing, utility state, or filesystem save fails.
+   */
+  async save(): Promise<void> {
+    await this.#flushRenderer();
+
+    const state = await this.#workspace.documentState();
+    this.acceptState(state);
+    if (!state) return;
+
+    if (state.needsSaveAs) {
+      await this.#saveAsAfterFlush(state);
+      return;
+    }
+
+    try {
+      this.acceptState(await this.#workspace.saveDocument());
+    } catch (error) {
+      if (isNeedsSaveAs(error)) {
+        await this.#saveAsAfterFlush(state);
+        return;
+      }
+
+      throw error;
+    }
+  }
+
+  /**
+   * Runs Save As from main with a native save dialog.
+   *
+   * @throws {Error} when renderer flushing, utility state, or filesystem save fails.
+   */
+  async saveAs(): Promise<void> {
+    await this.#flushRenderer();
+
+    const state = await this.#workspace.documentState();
+    this.acceptState(state);
+    if (!state) return;
+
+    await this.#saveAsAfterFlush(state);
+  }
+
+  /**
+   * Applies a utility-owned document state snapshot to main-owned UI.
+   *
+   * @param state - latest utility state, or null when no document is open.
+   */
+  acceptState(state: WorkspaceDocumentState | null): void {
+    this.#state = state;
+    this.#updateWindowTitle();
+  }
+
+  /**
+   * Resolves a pending renderer flush request.
+   *
+   * @param completion - request id plus an optional renderer failure message.
+   */
+  completeFlush(completion: DocumentFlushCompletion): void {
+    const pending = this.#pendingFlushes.get(completion.requestId);
+    if (!pending) return;
+
+    clearTimeout(pending.timeout);
+    this.#pendingFlushes.delete(completion.requestId);
+
+    if (completion.error) {
+      pending.reject(new Error(completion.error));
+      return;
+    }
+
+    pending.resolve();
+  }
+
+  async #saveAsAfterFlush(state: WorkspaceDocumentState): Promise<void> {
+    const savePath = await this.#showSaveDialog(state);
+    if (!savePath) return;
+
+    this.acceptState(await this.#workspace.saveDocumentAs(savePath));
+  }
+
+  async #flushRenderer(): Promise<void> {
+    const window = this.#activeWindow();
+    if (!window || window.window.webContents.isDestroyed()) return;
+
+    this.#nextFlushId += 1;
+    const requestId = String(this.#nextFlushId);
+
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.#pendingFlushes.delete(requestId);
+        reject(new Error("renderer did not settle document edits before save"));
+      }, this.#flushTimeoutMs);
+
+      this.#pendingFlushes.set(requestId, { resolve, reject, timeout });
+      this.#sendFlushRequest(window, { requestId });
+    });
+  }
+
+  async #showSaveDialog(state: WorkspaceDocumentState): Promise<string | null> {
+    return this.#saveDialog(this.#activeWindow(), state);
+  }
+
+  #updateWindowTitle(): void {
+    const window = this.#activeWindow();
+    if (!window) return;
+
+    const state = this.#state;
+    if (!state) {
+      window.setTitle(this.#applicationName());
+      return;
+    }
+
+    const name = state.saveTarget ? path.basename(state.saveTarget) : "Untitled";
+    const dirty = state.dirty ? " *" : "";
+    window.setTitle(`${name}${dirty} - ${this.#applicationName()}`);
+  }
+}
+
+function isNeedsSaveAs(error: unknown): boolean {
+  return error instanceof Error && error.message.includes("workspace needs a save path");
+}
+
+async function defaultSaveDialog(
+  window: Window | null,
+  state: WorkspaceDocumentState,
+): Promise<string | null> {
+  const options: SaveDialogOptions = {
+    title: "Save Shift Document",
+    defaultPath: state.saveTarget ?? undefined,
+    filters: [{ name: "Shift Source Package", extensions: ["shift"] }],
+    properties: ["createDirectory", "showOverwriteConfirmation"],
+  };
+
+  const result = window
+    ? await dialog.showSaveDialog(window.window, options)
+    : await dialog.showSaveDialog(options);
+
+  return result.canceled ? null : (result.filePath ?? null);
+}
+
+function defaultSendFlushRequest(window: Window, request: DocumentFlushRequest): void {
+  ipc.send(window.window.webContents, "document.flushRequested", request);
+}

--- a/apps/desktop/src/main/document/DocumentSession.ts
+++ b/apps/desktop/src/main/document/DocumentSession.ts
@@ -1,20 +1,17 @@
 import { dialog, type SaveDialogOptions } from "electron";
 import path from "node:path";
 import * as ipc from "../../shared/ipc/main";
-import type { DocumentFlushCompletion, DocumentFlushRequest } from "../../shared/ipc/contract";
+import type { DocumentSaveRequest } from "../../shared/ipc/contract";
 import type { WorkspaceDocumentState } from "../../shared/workspace/protocol";
 import type { Window } from "../windows/Window";
 import type { WorkspaceProcess } from "../workspace/WorkspaceProcess";
-
-const DEFAULT_FLUSH_TIMEOUT_MS = 5_000;
 
 export type DocumentSessionOptions = {
   workspace: WorkspaceProcess;
   activeWindow: () => Window | null;
   applicationName: () => string;
   saveDialog?: DocumentSaveDialog;
-  sendFlushRequest?: DocumentFlushRequestSender;
-  flushTimeoutMs?: number;
+  sendSave?: DocumentSaveSender;
 };
 
 export type DocumentSaveDialog = (
@@ -22,32 +19,27 @@ export type DocumentSaveDialog = (
   state: WorkspaceDocumentState,
 ) => Promise<string | null>;
 
-export type DocumentFlushRequestSender = (window: Window, request: DocumentFlushRequest) => void;
-
-type PendingFlush = {
-  resolve: () => void;
-  reject: (error: Error) => void;
-  timeout: NodeJS.Timeout;
-};
+export type DocumentSaveSender = (window: Window, request: DocumentSaveRequest) => void;
 
 /**
- * Main-process owner of native document lifecycle workflow.
+ * Main-process owner of the native document save workflow.
  *
  * @remarks
- * The session coordinates renderer quiescence, utility save ordering, native
- * dialogs, and window title state. It never forwards generic commands to the
- * renderer; the renderer can only answer the narrow flush request.
+ * Main owns the shell chrome: the menu/accelerator, the Save vs Save As
+ * decision (read from the utility's `document.state`), and the native Save As
+ * dialog. The *write* belongs to the renderer's committed-op lane — main
+ * resolves the path, then asks the renderer to issue the save (one-way), so the
+ * utility serializes it behind pending edits with no cross-lane watermark. Main
+ * never waits on the renderer; it reflects the result when the utility emits
+ * `document.changed`.
  */
 export class DocumentSession {
   readonly #workspace: WorkspaceProcess;
   readonly #activeWindow: () => Window | null;
   readonly #applicationName: () => string;
   readonly #saveDialog: DocumentSaveDialog;
-  readonly #sendFlushRequest: DocumentFlushRequestSender;
-  readonly #flushTimeoutMs: number;
-  readonly #pendingFlushes = new Map<string, PendingFlush>();
+  readonly #sendSave: DocumentSaveSender;
 
-  #nextFlushId = 0;
   #state: WorkspaceDocumentState | null = null;
 
   constructor(options: DocumentSessionOptions) {
@@ -55,52 +47,38 @@ export class DocumentSession {
     this.#activeWindow = options.activeWindow;
     this.#applicationName = options.applicationName;
     this.#saveDialog = options.saveDialog ?? defaultSaveDialog;
-    this.#sendFlushRequest = options.sendFlushRequest ?? defaultSendFlushRequest;
-    this.#flushTimeoutMs = options.flushTimeoutMs ?? DEFAULT_FLUSH_TIMEOUT_MS;
+    this.#sendSave = options.sendSave ?? defaultSendSave;
   }
 
   /**
-   * Runs Save from main, escalating to Save As when the utility has no target.
+   * Runs Save, escalating to Save As when the document has no target yet.
    *
-   * @throws {Error} when renderer flushing, utility state, or filesystem save fails.
+   * @throws {Error} when reading utility state fails.
    */
   async save(): Promise<void> {
-    await this.#flushRenderer();
-
     const state = await this.#workspace.documentState();
     this.acceptState(state);
     if (!state) return;
 
     if (state.needsSaveAs) {
-      await this.#saveAsAfterFlush(state);
+      await this.#saveToNewPath(state);
       return;
     }
 
-    try {
-      this.acceptState(await this.#workspace.saveDocument());
-    } catch (error) {
-      if (isNeedsSaveAs(error)) {
-        await this.#saveAsAfterFlush(state);
-        return;
-      }
-
-      throw error;
-    }
+    this.#requestSave({ path: null });
   }
 
   /**
    * Runs Save As from main with a native save dialog.
    *
-   * @throws {Error} when renderer flushing, utility state, or filesystem save fails.
+   * @throws {Error} when reading utility state fails.
    */
   async saveAs(): Promise<void> {
-    await this.#flushRenderer();
-
     const state = await this.#workspace.documentState();
     this.acceptState(state);
     if (!state) return;
 
-    await this.#saveAsAfterFlush(state);
+    await this.#saveToNewPath(state);
   }
 
   /**
@@ -113,49 +91,19 @@ export class DocumentSession {
     this.#updateWindowTitle();
   }
 
-  /**
-   * Resolves a pending renderer flush request.
-   *
-   * @param completion - request id plus an optional renderer failure message.
-   */
-  completeFlush(completion: DocumentFlushCompletion): void {
-    const pending = this.#pendingFlushes.get(completion.requestId);
-    if (!pending) return;
-
-    clearTimeout(pending.timeout);
-    this.#pendingFlushes.delete(completion.requestId);
-
-    if (completion.error) {
-      pending.reject(new Error(completion.error));
-      return;
-    }
-
-    pending.resolve();
-  }
-
-  async #saveAsAfterFlush(state: WorkspaceDocumentState): Promise<void> {
+  async #saveToNewPath(state: WorkspaceDocumentState): Promise<void> {
     const savePath = await this.#showSaveDialog(state);
     if (!savePath) return;
 
-    this.acceptState(await this.#workspace.saveDocumentAs(savePath));
+    this.#requestSave({ path: savePath });
   }
 
-  async #flushRenderer(): Promise<void> {
+  /** Asks the active renderer to issue the save on its committed-op lane. */
+  #requestSave(request: DocumentSaveRequest): void {
     const window = this.#activeWindow();
     if (!window || window.window.webContents.isDestroyed()) return;
 
-    this.#nextFlushId += 1;
-    const requestId = String(this.#nextFlushId);
-
-    await new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        this.#pendingFlushes.delete(requestId);
-        reject(new Error("renderer did not settle document edits before save"));
-      }, this.#flushTimeoutMs);
-
-      this.#pendingFlushes.set(requestId, { resolve, reject, timeout });
-      this.#sendFlushRequest(window, { requestId });
-    });
+    this.#sendSave(window, request);
   }
 
   async #showSaveDialog(state: WorkspaceDocumentState): Promise<string | null> {
@@ -178,10 +126,6 @@ export class DocumentSession {
   }
 }
 
-function isNeedsSaveAs(error: unknown): boolean {
-  return error instanceof Error && error.message.includes("workspace needs a save path");
-}
-
 async function defaultSaveDialog(
   window: Window | null,
   state: WorkspaceDocumentState,
@@ -200,6 +144,6 @@ async function defaultSaveDialog(
   return result.canceled ? null : (result.filePath ?? null);
 }
 
-function defaultSendFlushRequest(window: Window, request: DocumentFlushRequest): void {
-  ipc.send(window.window.webContents, "document.flushRequested", request);
+function defaultSendSave(window: Window, request: DocumentSaveRequest): void {
+  ipc.send(window.window.webContents, "document.save", request);
 }

--- a/apps/desktop/src/main/menu/ApplicationMenu.ts
+++ b/apps/desktop/src/main/menu/ApplicationMenu.ts
@@ -61,6 +61,10 @@ export class ApplicationMenu {
         submenu: [{ role: "about" }, { type: "separator" }, { role: "quit" }],
       },
       {
+        label: "File",
+        submenu: this.#fileItems(),
+      },
+      {
         label: "View",
         submenu: [
           ...this.#viewZoomItems(),
@@ -74,6 +78,10 @@ export class ApplicationMenu {
   /** Builds the Windows/Linux app menu. */
   buildWindowsMenu(): MenuItemConstructorOptions[] {
     return [
+      {
+        label: "File",
+        submenu: this.#fileItems(),
+      },
       {
         label: "View",
         submenu: this.#viewZoomItems(),
@@ -91,6 +99,10 @@ export class ApplicationMenu {
       this.#commandItem("ui.zoomOut"),
       this.#commandItem("ui.zoomReset"),
     ];
+  }
+
+  #fileItems(): MenuItemConstructorOptions[] {
+    return [this.#commandItem("file.save"), this.#commandItem("file.saveAs")];
   }
 
   /** Builds a menu item from the command registry's metadata. */

--- a/apps/desktop/src/main/windows/Window.ts
+++ b/apps/desktop/src/main/windows/Window.ts
@@ -83,6 +83,11 @@ export class Window {
     this.#window.close();
   }
 
+  /** Updates the native window title shown by the operating system. */
+  setTitle(title: string): void {
+    this.#window.setTitle(title);
+  }
+
   minimize(): void {
     this.#window.minimize();
   }

--- a/apps/desktop/src/main/workspace/WorkspaceProcess.ts
+++ b/apps/desktop/src/main/workspace/WorkspaceProcess.ts
@@ -1,7 +1,11 @@
 import { utilityProcess, type MessagePortMain, type UtilityProcess } from "electron";
 import path from "node:path";
 import { Channel, utilityProcessTransport } from "../../shared/workspace/channel";
-import type { ShellCallMap, ShellEventMap } from "../../shared/workspace/protocol";
+import type {
+  ShellCallMap,
+  ShellEventMap,
+  WorkspaceDocumentState,
+} from "../../shared/workspace/protocol";
 import { createShiftLogger, type ShiftLogger } from "../logging";
 
 /**
@@ -17,6 +21,8 @@ export class WorkspaceProcess {
   #process: UtilityProcess | null = null;
   #channel: Channel<ShellCallMap, ShellEventMap> | null = null;
   #ready: Promise<void> | null = null;
+  #unlistenDocumentChanged: (() => void) | null = null;
+  #documentListeners = new Set<(state: WorkspaceDocumentState | null) => void>();
 
   constructor(log: ShiftLogger = createShiftLogger("workspace.process")) {
     this.#log = log;
@@ -41,15 +47,20 @@ export class WorkspaceProcess {
     this.#process = proc;
     this.#channel = channel;
     this.#ready = this.#trackReady(proc, channel);
+    this.#unlistenDocumentChanged = channel.listen("document.changed", (state) => {
+      for (const listener of this.#documentListeners) listener(state);
+    });
     this.#wire(proc, channel);
   }
 
   /** Stops the utility process; in-flight shell-lane calls reject. */
   stop(): void {
-    this.#channel?.dispose();
+    if (this.#unlistenDocumentChanged) this.#unlistenDocumentChanged();
+    if (this.#channel) this.#channel.dispose();
     this.#process = null;
     this.#channel = null;
     this.#ready = null;
+    this.#unlistenDocumentChanged = null;
   }
 
   /**
@@ -69,6 +80,51 @@ export class WorkspaceProcess {
     }
 
     return this.#channel.call("workspace.connect", undefined, [port]);
+  }
+
+  /**
+   * Subscribes to document lifecycle snapshots emitted by the utility process.
+   *
+   * @param listener - called for every utility-owned document state change.
+   * @returns a function that removes this listener.
+   */
+  onDocumentChanged(listener: (state: WorkspaceDocumentState | null) => void): () => void {
+    this.#documentListeners.add(listener);
+
+    return () => {
+      this.#documentListeners.delete(listener);
+    };
+  }
+
+  /**
+   * Reads the current utility-owned document lifecycle state.
+   *
+   * @returns null when no workspace is open in the utility process.
+   * @throws {Error} when the utility process is not running or rejects the call.
+   */
+  documentState(): Promise<WorkspaceDocumentState | null> {
+    return this.#requireChannel().call("document.state", undefined);
+  }
+
+  /**
+   * Saves the open workspace to its current package target.
+   *
+   * @returns the post-save document state snapshot.
+   * @throws {Error} when no workspace is open, no save target exists, or writing fails.
+   */
+  saveDocument(): Promise<WorkspaceDocumentState> {
+    return this.#requireChannel().call("document.save", undefined);
+  }
+
+  /**
+   * Saves the open workspace to a Shift package and makes that path the target.
+   *
+   * @param path - filesystem path selected by main's native Save As dialog.
+   * @returns the post-save document state snapshot.
+   * @throws {Error} when no workspace is open or writing fails.
+   */
+  saveDocumentAs(path: string): Promise<WorkspaceDocumentState> {
+    return this.#requireChannel().call("document.saveAs", { path });
   }
 
   #trackReady(proc: UtilityProcess, channel: Channel<ShellCallMap, ShellEventMap>): Promise<void> {
@@ -103,6 +159,7 @@ export class WorkspaceProcess {
         this.#process = null;
         this.#channel = null;
         this.#ready = null;
+        this.#unlistenDocumentChanged = null;
       }
     });
 
@@ -119,5 +176,13 @@ export class WorkspaceProcess {
       const text = String(chunk).trimEnd();
       if (text) this.#log.error(text);
     });
+  }
+
+  #requireChannel(): Channel<ShellCallMap, ShellEventMap> {
+    if (!this.#channel) {
+      throw new Error("workspace process is not running");
+    }
+
+    return this.#channel;
   }
 }

--- a/apps/desktop/src/main/workspace/WorkspaceProcess.ts
+++ b/apps/desktop/src/main/workspace/WorkspaceProcess.ts
@@ -99,32 +99,15 @@ export class WorkspaceProcess {
   /**
    * Reads the current utility-owned document lifecycle state.
    *
+   * @remarks
+   * Save itself rides the renderer's sync lane (see {@link WorkspaceHost}); main
+   * only reads state here to decide Save vs Save As and to update the title.
+   *
    * @returns null when no workspace is open in the utility process.
    * @throws {Error} when the utility process is not running or rejects the call.
    */
   documentState(): Promise<WorkspaceDocumentState | null> {
     return this.#requireChannel().call("document.state", undefined);
-  }
-
-  /**
-   * Saves the open workspace to its current package target.
-   *
-   * @returns the post-save document state snapshot.
-   * @throws {Error} when no workspace is open, no save target exists, or writing fails.
-   */
-  saveDocument(): Promise<WorkspaceDocumentState> {
-    return this.#requireChannel().call("document.save", undefined);
-  }
-
-  /**
-   * Saves the open workspace to a Shift package and makes that path the target.
-   *
-   * @param path - filesystem path selected by main's native Save As dialog.
-   * @returns the post-save document state snapshot.
-   * @throws {Error} when no workspace is open or writing fails.
-   */
-  saveDocumentAs(path: string): Promise<WorkspaceDocumentState> {
-    return this.#requireChannel().call("document.saveAs", { path });
   }
 
   #trackReady(proc: UtilityProcess, channel: Channel<ShellCallMap, ShellEventMap>): Promise<void> {

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -11,8 +11,7 @@ const shiftHost: ShiftHost = {
     run: invoke(ipcRenderer, "commands.run"),
   },
   document: {
-    onFlushRequested: listen(ipcRenderer, "document.flushRequested"),
-    flushCompleted: invoke(ipcRenderer, "document.flushCompleted"),
+    onSave: listen(ipcRenderer, "document.save"),
   },
   workspace: {
     connect: invoke(ipcRenderer, "workspace.connect"),

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -10,6 +10,10 @@ const shiftHost: ShiftHost = {
   commands: {
     run: invoke(ipcRenderer, "commands.run"),
   },
+  document: {
+    onFlushRequested: listen(ipcRenderer, "document.flushRequested"),
+    flushCompleted: invoke(ipcRenderer, "document.flushCompleted"),
+  },
   workspace: {
     connect: invoke(ipcRenderer, "workspace.connect"),
   },

--- a/apps/desktop/src/renderer/src/lib/editor/Editor.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/Editor.ts
@@ -820,11 +820,11 @@ export class Editor {
 
   public undo() {
     // One undo authority: the workspace ledger (state-pair replay).
-    void this.font.writer.undo();
+    void this.font.editQueue.undo();
   }
 
   public redo() {
-    void this.font.writer.redo();
+    void this.font.editQueue.redo();
   }
 
   public setCameraRect(rect: Rect2D) {

--- a/apps/desktop/src/renderer/src/lib/model/Font.ts
+++ b/apps/desktop/src/renderer/src/lib/model/Font.ts
@@ -12,7 +12,7 @@ import type {
 } from "@shift/types";
 import { mintGlyphId } from "@shift/types";
 import { computed, type Signal } from "@/lib/signals/signal";
-import type { ChangeWriter } from "@/lib/workspace/ChangeWriter";
+import type { WorkspaceEditQueue } from "@/lib/workspace/WorkspaceEditQueue";
 import type { WorkspaceSnapshot } from "@shared/workspace/protocol";
 import { Glyph, type GlyphSource } from "./Glyph";
 import { GlyphOutline } from "./GlyphOutline";
@@ -267,7 +267,7 @@ export class Font {
   /** Open glyph models keyed by stable id; survives directory re-keys. */
   readonly #glyphsById = new Map<GlyphId, Glyph>();
   readonly #glyphSources = new Map<GlyphSourceKey, GlyphSource>();
-  readonly #writer: ChangeWriter | null;
+  readonly #editQueue: WorkspaceEditQueue | null;
   #cachesKeyedTo: GlyphDirectory | null = null;
 
   /**
@@ -276,9 +276,11 @@ export class Font {
    * @param $workspace - Single source of workspace truth owned by
    *   `WorkspaceClient`. There is no load: every derived value follows this
    *   signal, and `null` means no font is open.
+   * @param editQueue - Optional queue used by editable projections to submit
+   *   committed edits to the utility workspace.
    */
-  constructor($workspace: Signal<WorkspaceSnapshot | null>, writer?: ChangeWriter) {
-    this.#writer = writer ?? null;
+  constructor($workspace: Signal<WorkspaceSnapshot | null>, editQueue?: WorkspaceEditQueue) {
+    this.#editQueue = editQueue ?? null;
     this.#$loaded = computed(() => $workspace.value !== null);
     this.#$metrics = computed(() => $workspace.value?.metrics ?? DEFAULT_FONT_METRICS);
     this.#$metadata = computed(() => $workspace.value?.metadata ?? {});
@@ -463,7 +465,7 @@ export class Font {
     const unicodes = handle.unicode === undefined ? [] : [handle.unicode];
     const glyphId = mintGlyphId();
 
-    this.writer.push({
+    this.editQueue.push({
       kind: "createGlyph",
       createGlyph: { glyphId, name: finalName, unicodes },
     });
@@ -704,18 +706,21 @@ export class Font {
   }
 
   /**
-   * The renderer's single durable-write path; editing verbs push intents
-   * through it.
+   * Returns the renderer queue for committed edits awaiting utility echoes.
+   *
+   * @remarks
+   * Save and dirty semantics live in the utility workspace; this queue only
+   * tracks renderer-submitted edits and serializes reads behind them.
    *
    * @throws {Error} when constructed without a workspace (pure projection
    *   tests) — same not-wired contract as the legacy bridge getter.
    */
-  get writer(): ChangeWriter {
-    if (!this.#writer) {
+  get editQueue(): WorkspaceEditQueue {
+    if (!this.#editQueue) {
       throw new Error("editing is not wired to the workspace yet");
     }
 
-    return this.#writer;
+    return this.#editQueue;
   }
 
   /**
@@ -733,7 +738,7 @@ export class Font {
     const record = this.#directory.peek().records.find((entry) => entry.id === glyphId);
     if (!record) return null;
 
-    const state = await this.writer.glyph(glyphId, source.id);
+    const state = await this.editQueue.glyph(glyphId, source.id);
     if (!state) return null;
 
     const handle = this.#directory.peek().glyphHandleForName(record.name);
@@ -761,7 +766,7 @@ export class Font {
     const cached = this.glyphSource(glyph.handle, source);
     if (cached) return cached;
 
-    const state = await this.writer.glyph(glyphId, source.id);
+    const state = await this.editQueue.glyph(glyphId, source.id);
     if (!state) return null;
 
     const glyphSource = glyph.createGlyphSource(source, state);

--- a/apps/desktop/src/renderer/src/lib/model/Glyph.ts
+++ b/apps/desktop/src/renderer/src/lib/model/Glyph.ts
@@ -104,7 +104,7 @@ class GlyphEditSession {
   readonly #state: GlyphEditState;
 
   constructor(font: Font, layerId: LayerId, state: GlyphEditState) {
-    this.#intents = new LayerIntents(font.writer, layerId);
+    this.#intents = new LayerIntents(font.editQueue, layerId);
     this.#state = state;
   }
 
@@ -145,7 +145,7 @@ class GlyphEditSession {
       }
     }
 
-    // Mixed patches push two intents in the same tick; the writer coalesces
+    // Mixed patches push two intents in the same tick; the editQueue coalesces
     // them into one apply and therefore one undo step.
     if (pointIds.length > 0) {
       this.#intents.movePoints({ pointIds, coords: pointCoords });
@@ -1360,7 +1360,7 @@ export class Glyph {
 
     if (glyphId) {
       // Echoes (apply/undo/redo) fold into this session's state by layerId.
-      font.writer.register(state.layerId, {
+      font.editQueue.register(state.layerId, {
         state: this.#sourceState,
         glyphId,
         sourceId: source.id,
@@ -1532,7 +1532,7 @@ export class Glyph {
 
     if (this.#glyphId) {
       // Echoes for this source's layer fold here, same as the primary.
-      this.#font.writer.register(state.layerId, {
+      this.#font.editQueue.register(state.layerId, {
         state: sourceState,
         glyphId: this.#glyphId,
         sourceId: source.id,

--- a/apps/desktop/src/renderer/src/lib/model/variation.test.ts
+++ b/apps/desktop/src/renderer/src/lib/model/variation.test.ts
@@ -126,11 +126,11 @@ describe("variable editing across sources", () => {
     const point = boldSource.allPoints[1]!;
 
     boldSource.commitPositionPatch([{ kind: "point", id: point.id, x: 250, y: 0 }]);
-    await stack.writer.settled();
+    await stack.editQueue.settled();
 
     expect(boldSource.point(point.id)).toMatchObject({ x: 250, y: 0 });
 
-    const undone = await stack.writer.undo();
+    const undone = await stack.editQueue.undo();
     expect(undone).not.toBeNull();
     expect(boldSource.point(point.id)).toMatchObject({ x: 200, y: 0 });
   });

--- a/apps/desktop/src/renderer/src/lib/text/layout/testUtils.ts
+++ b/apps/desktop/src/renderer/src/lib/text/layout/testUtils.ts
@@ -48,7 +48,7 @@ export async function layoutTestFont(): Promise<Font> {
   a.addOnCurvePoint(contourId, { x: 100, y: 0 });
   a.addOnCurvePoint(contourId, { x: 50, y: 100 });
   a.closeContour(contourId);
-  await stack.writer.settled();
+  await stack.editQueue.settled();
 
   return stack.font;
 }

--- a/apps/desktop/src/renderer/src/lib/workspace/LayerIntents.ts
+++ b/apps/desktop/src/renderer/src/lib/workspace/LayerIntents.ts
@@ -14,7 +14,7 @@ import type {
   SetXAdvanceIntent,
   TranslatePointsIntent,
 } from "@shift/types";
-import type { ChangeWriter } from "./ChangeWriter";
+import type { WorkspaceEditQueue } from "./WorkspaceEditQueue";
 
 /** An intent payload minus the layer id this channel already carries. */
 type Payload<TIntent> = Omit<TIntent, "layerId">;
@@ -24,88 +24,103 @@ type Payload<TIntent> = Omit<TIntent, "layerId">;
  *
  * @remarks
  * This is the ONLY place wire envelopes (`{ kind, <payload> }`) are built;
- * everything above it speaks typed calls. Each call queues on the writer's
+ * everything above it speaks typed calls. Each call enters the edit queue's
  * coalescing window, so calls in the same tick become one apply and one
  * undo step. No display strings ride the calls; undo labels are a concern
  * for the ledger, not the renderer.
  */
 export class LayerIntents {
-  readonly #writer: ChangeWriter;
+  readonly #editQueue: WorkspaceEditQueue;
   readonly #layerId: LayerId;
 
-  constructor(writer: ChangeWriter, layerId: LayerId) {
-    this.#writer = writer;
+  constructor(editQueue: WorkspaceEditQueue, layerId: LayerId) {
+    this.#editQueue = editQueue;
     this.#layerId = layerId;
   }
 
   addPoints(payload: Payload<AddPointsIntent>): void {
-    this.#writer.push({ kind: "addPoints", addPoints: { layerId: this.#layerId, ...payload } });
+    this.#editQueue.push({ kind: "addPoints", addPoints: { layerId: this.#layerId, ...payload } });
   }
 
   addContour(payload: Payload<AddContourIntent>): void {
-    this.#writer.push({ kind: "addContour", addContour: { layerId: this.#layerId, ...payload } });
+    this.#editQueue.push({
+      kind: "addContour",
+      addContour: { layerId: this.#layerId, ...payload },
+    });
   }
 
   setContourClosed(payload: Payload<SetContourClosedIntent>): void {
-    this.#writer.push({
+    this.#editQueue.push({
       kind: "setContourClosed",
       setContourClosed: { layerId: this.#layerId, ...payload },
     });
   }
 
   movePoints(payload: Payload<MovePointsIntent>): void {
-    this.#writer.push({ kind: "movePoints", movePoints: { layerId: this.#layerId, ...payload } });
+    this.#editQueue.push({
+      kind: "movePoints",
+      movePoints: { layerId: this.#layerId, ...payload },
+    });
   }
 
   setPointSmooth(payload: Payload<SetPointSmoothIntent>): void {
-    this.#writer.push({
+    this.#editQueue.push({
       kind: "setPointSmooth",
       setPointSmooth: { layerId: this.#layerId, ...payload },
     });
   }
 
   removePoints(payload: Payload<RemovePointsIntent>): void {
-    this.#writer.push({
+    this.#editQueue.push({
       kind: "removePoints",
       removePoints: { layerId: this.#layerId, ...payload },
     });
   }
 
   reverseContour(payload: Payload<ReverseContourIntent>): void {
-    this.#writer.push({
+    this.#editQueue.push({
       kind: "reverseContour",
       reverseContour: { layerId: this.#layerId, ...payload },
     });
   }
 
   translatePoints(payload: Payload<TranslatePointsIntent>): void {
-    this.#writer.push({
+    this.#editQueue.push({
       kind: "translatePoints",
       translatePoints: { layerId: this.#layerId, ...payload },
     });
   }
 
   setXAdvance(payload: Payload<SetXAdvanceIntent>): void {
-    this.#writer.push({ kind: "setXAdvance", setXAdvance: { layerId: this.#layerId, ...payload } });
+    this.#editQueue.push({
+      kind: "setXAdvance",
+      setXAdvance: { layerId: this.#layerId, ...payload },
+    });
   }
 
   applyBooleanOp(payload: Payload<BooleanOpIntent>): void {
-    this.#writer.push({
+    this.#editQueue.push({
       kind: "applyBooleanOp",
       applyBooleanOp: { layerId: this.#layerId, ...payload },
     });
   }
 
   addAnchors(payload: Payload<AddAnchorsIntent>): void {
-    this.#writer.push({ kind: "addAnchors", addAnchors: { layerId: this.#layerId, ...payload } });
+    this.#editQueue.push({
+      kind: "addAnchors",
+      addAnchors: { layerId: this.#layerId, ...payload },
+    });
   }
 
   moveAnchors(payload: Payload<MoveAnchorsIntent>): void {
-    this.#writer.push({ kind: "moveAnchors", moveAnchors: { layerId: this.#layerId, ...payload } });
+    this.#editQueue.push({
+      kind: "moveAnchors",
+      moveAnchors: { layerId: this.#layerId, ...payload },
+    });
   }
 
   removeAnchors(payload: Payload<RemoveAnchorsIntent>): void {
-    this.#writer.push({
+    this.#editQueue.push({
       kind: "removeAnchors",
       removeAnchors: { layerId: this.#layerId, ...payload },
     });

--- a/apps/desktop/src/renderer/src/lib/workspace/WorkspaceClient.ts
+++ b/apps/desktop/src/renderer/src/lib/workspace/WorkspaceClient.ts
@@ -65,7 +65,7 @@ export class WorkspaceClient {
    *
    * @remarks
    * The record fold happens here (directory follows `$workspace`); layer
-   * folds belong to the glyph model and land with the CS3 ChangeWriter —
+   * folds belong to the glyph model and land with the CS3 WorkspaceEditQueue —
    * callers receive the AppliedChange to fold geometry themselves until then.
    */
   async apply(intents: FontIntent[]): Promise<AppliedChange> {

--- a/apps/desktop/src/renderer/src/lib/workspace/WorkspaceClient.ts
+++ b/apps/desktop/src/renderer/src/lib/workspace/WorkspaceClient.ts
@@ -1,5 +1,10 @@
 import { Channel, domPortTransport, type Transport } from "@shared/workspace/channel";
-import type { SyncCallMap, SyncEventMap, WorkspaceSnapshot } from "@shared/workspace/protocol";
+import type {
+  SyncCallMap,
+  SyncEventMap,
+  WorkspaceDocumentState,
+  WorkspaceSnapshot,
+} from "@shared/workspace/protocol";
 import type { ShiftHost } from "@shared/host/ShiftHost";
 import type { AppliedChange, FontIntent, GlyphId, GlyphState, SourceId } from "@shift/types";
 import { signal } from "@/lib/signals/signal";
@@ -88,6 +93,20 @@ export class WorkspaceClient {
 
     const applied = await this.#require().call("workspace.redo", undefined);
     return applied === null ? null : this.#fold(applied);
+  }
+
+  /** Saves to the current target; rejects when the document still needs a path. */
+  async save(): Promise<WorkspaceDocumentState> {
+    await this.connected();
+
+    return this.#require().call("workspace.save", undefined);
+  }
+
+  /** Saves to `path` and adopts it as the document's target. */
+  async saveAs(path: string): Promise<WorkspaceDocumentState> {
+    await this.connected();
+
+    return this.#require().call("workspace.saveAs", { path });
   }
 
   /** Pulls replace-grade glyph state (resync + editor open); id-addressed. */

--- a/apps/desktop/src/renderer/src/lib/workspace/WorkspaceEditQueue.test.ts
+++ b/apps/desktop/src/renderer/src/lib/workspace/WorkspaceEditQueue.test.ts
@@ -1,0 +1,43 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+import { type FontIntent, type GlyphName, type Unicode, mintGlyphId } from "@shift/types";
+import { createWorkspaceStack, type WorkspaceStack } from "@/testing/workspaceStack";
+
+const createGlyph = (name: string, unicode: number): FontIntent => ({
+  kind: "createGlyph",
+  createGlyph: { glyphId: mintGlyphId(), name: name as GlyphName, unicodes: [unicode as Unicode] },
+});
+
+const savePath = (): string => join(mkdtempSync(join(tmpdir(), "shift-save-")), "Saved.shift");
+
+describe("WorkspaceEditQueue issues save on the committed-op lane", () => {
+  let stack: WorkspaceStack;
+
+  beforeEach(async () => {
+    stack = createWorkspaceStack();
+    await stack.client.create();
+  });
+
+  it("flushes queued edits before the save so the write includes them", async () => {
+    const { client, editQueue } = stack;
+
+    editQueue.push(createGlyph("A", 65)); // queued, not yet applied
+    const saved = await editQueue.save(savePath()); // flushes the push, then saves behind it
+
+    expect(client.$workspace.peek()?.glyphs).toHaveLength(1); // the apply was folded
+    expect(saved).toMatchObject({ dirty: false, needsSaveAs: false });
+  });
+
+  it("a current-target save serializes behind a later edit", async () => {
+    const { client, editQueue } = stack;
+    await editQueue.save(savePath()); // adopt a package target
+
+    editQueue.push(createGlyph("B", 66));
+    const saved = await editQueue.save(null); // null = save to current target
+
+    expect(client.$workspace.peek()?.glyphs).toHaveLength(1);
+    expect(saved).toMatchObject({ dirty: false });
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/workspace/WorkspaceEditQueue.ts
+++ b/apps/desktop/src/renderer/src/lib/workspace/WorkspaceEditQueue.ts
@@ -6,6 +6,7 @@ import type {
   LayerId,
   SourceId,
 } from "@shift/types";
+import type { WorkspaceDocumentState } from "@shared/workspace/protocol";
 import { signal, type Signal } from "@/lib/signals/signal";
 import type { GlyphSourceState } from "@/lib/model/GlyphSourceState";
 import type { WorkspaceClient } from "./WorkspaceClient";
@@ -25,9 +26,14 @@ type FoldTarget = {
  * coalesce into ONE `workspace.apply` — one SQLite transaction, one undo
  * step. Echoes fold by substitution only (replace structure, replace
  * values); the queue contains zero change-application or save semantics.
- * Undo and redo are serialized through the same queue so they can never
+ * Undo, redo, and save are serialized through the same queue so none can
  * overtake a pending flush. Tools never hold the queue — they speak domain
  * verbs on `GlyphSource`.
+ *
+ * Save ownership lives in the utility. The renderer issues save as one more op
+ * on this queue (see {@link save}); because it shares the FIFO edit lane, the
+ * utility serializes the write behind every committed edit with no cross-lane
+ * watermark.
  */
 export class WorkspaceEditQueue {
   readonly #workspace: WorkspaceClient;
@@ -99,6 +105,18 @@ export class WorkspaceEditQueue {
       if (applied) this.#fold(applied);
       return applied;
     });
+  }
+
+  /**
+   * Issues a save behind every queued and in-flight committed op.
+   *
+   * @param path - target path for Save As, or null to save the current target.
+   */
+  save(path: string | null): Promise<WorkspaceDocumentState> {
+    this.#enqueueFlush();
+    return this.#serialize(() =>
+      path === null ? this.#workspace.save() : this.#workspace.saveAs(path),
+    );
   }
 
   #enqueueFlush(): void {

--- a/apps/desktop/src/renderer/src/lib/workspace/WorkspaceEditQueue.ts
+++ b/apps/desktop/src/renderer/src/lib/workspace/WorkspaceEditQueue.ts
@@ -18,18 +18,18 @@ type FoldTarget = {
 };
 
 /**
- * The renderer's single durable-write path.
+ * Tracks optimistic renderer edits until the utility workspace echoes them.
  *
  * @remarks
  * Every editing verb pushes one intent; all intents in the same microtask
  * coalesce into ONE `workspace.apply` — one SQLite transaction, one undo
  * step. Echoes fold by substitution only (replace structure, replace
- * values); the writer contains zero change-application semantics. Undo and
- * redo are serialized through the same queue so they can never overtake a
- * pending flush. Tools never hold the writer — they speak domain verbs on
- * `GlyphSource`.
+ * values); the queue contains zero change-application or save semantics.
+ * Undo and redo are serialized through the same queue so they can never
+ * overtake a pending flush. Tools never hold the queue — they speak domain
+ * verbs on `GlyphSource`.
  */
-export class ChangeWriter {
+export class WorkspaceEditQueue {
   readonly #workspace: WorkspaceClient;
   readonly #targets = new Map<LayerId, FoldTarget>();
   readonly #$settled = signal(true);

--- a/apps/desktop/src/renderer/src/store/appStore.ts
+++ b/apps/desktop/src/renderer/src/store/appStore.ts
@@ -4,7 +4,7 @@ import { registerBuiltInTools } from "@/lib/tools/tools";
 import { defaultResources, GlyphInfo } from "@shift/glyph-info";
 import { Font } from "@/lib/model/Font";
 import { WorkspaceClient } from "@/lib/workspace/WorkspaceClient";
-import { ChangeWriter } from "@/lib/workspace/ChangeWriter";
+import { WorkspaceEditQueue } from "@/lib/workspace/WorkspaceEditQueue";
 import { getShiftHost } from "@/host/shiftHost";
 
 let instance: GlyphInfo | null = null;
@@ -14,8 +14,8 @@ export function getGlyphInfo(): GlyphInfo {
 }
 
 const workspace = new WorkspaceClient(getShiftHost());
-const writer = new ChangeWriter(workspace);
-const font = new Font(workspace.$workspace, writer);
+const editQueue = new WorkspaceEditQueue(workspace);
+const font = new Font(workspace.$workspace, editQueue);
 const editor = new Editor({ font, clipboard: electronSystemClipboard });
 registerBuiltInTools(editor);
 
@@ -23,6 +23,21 @@ registerBuiltInTools(editor);
 editor.setActiveTool("select");
 
 void workspace.connected();
+
+getShiftHost().document.onFlushRequested(({ requestId }) => {
+  void editQueue
+    .settled()
+    .then(() => getShiftHost().document.flushCompleted({ requestId }))
+    .catch((error) =>
+      getShiftHost().document.flushCompleted({
+        requestId,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    )
+    .catch((error) => {
+      console.error("document flush completion failed", error);
+    });
+});
 
 export const getWorkspace = () => workspace;
 export const getEditor = () => editor;

--- a/apps/desktop/src/renderer/src/store/appStore.ts
+++ b/apps/desktop/src/renderer/src/store/appStore.ts
@@ -24,19 +24,13 @@ editor.setActiveTool("select");
 
 void workspace.connected();
 
-getShiftHost().document.onFlushRequested(({ requestId }) => {
-  void editQueue
-    .settled()
-    .then(() => getShiftHost().document.flushCompleted({ requestId }))
-    .catch((error) =>
-      getShiftHost().document.flushCompleted({
-        requestId,
-        error: error instanceof Error ? error.message : String(error),
-      }),
-    )
-    .catch((error) => {
-      console.error("document flush completion failed", error);
-    });
+// Main resolves the save path, then asks us to issue the save on the edit
+// lane. The queue serializes it behind pending edits; the utility owns the
+// write and reports the result to main via document.changed.
+getShiftHost().document.onSave(({ path }) => {
+  void editQueue.save(path).catch((error) => {
+    console.error("document save failed", error);
+  });
 });
 
 export const getWorkspace = () => workspace;

--- a/apps/desktop/src/renderer/src/testing/TestEditor.ts
+++ b/apps/desktop/src/renderer/src/testing/TestEditor.ts
@@ -91,19 +91,19 @@ export class TestEditor extends Editor {
 
   /** Awaits every queued and in-flight apply; geometry reads confirmed truth after. */
   async settle(): Promise<this> {
-    await this.font.writer.settled();
+    await this.font.editQueue.settled();
     return this;
   }
 
   /** Undo through the one authority (workspace ledger), settled. */
   async undoAndSettle(): Promise<this> {
-    await this.font.writer.undo();
+    await this.font.editQueue.undo();
     return this;
   }
 
   /** Redo through the workspace ledger, settled. */
   async redoAndSettle(): Promise<this> {
-    await this.font.writer.redo();
+    await this.font.editQueue.redo();
     return this;
   }
 

--- a/apps/desktop/src/renderer/src/testing/workspaceStack.ts
+++ b/apps/desktop/src/renderer/src/testing/workspaceStack.ts
@@ -6,19 +6,19 @@ import { Channel, nodePortTransport } from "@shared/workspace/channel";
 import type { ShellCallMap, ShellEventMap } from "@shared/workspace/protocol";
 import { WorkspaceHost } from "../../../utility/workspace/WorkspaceHost";
 import { WorkspaceClient } from "@/lib/workspace/WorkspaceClient";
-import { ChangeWriter } from "@/lib/workspace/ChangeWriter";
+import { WorkspaceEditQueue } from "@/lib/workspace/WorkspaceEditQueue";
 import { Font } from "@/lib/model/Font";
 
 export type WorkspaceStack = {
   client: WorkspaceClient;
-  writer: ChangeWriter;
+  editQueue: WorkspaceEditQueue;
   font: Font;
 };
 
 /**
  * The full production editing stack, in-process: real WorkspaceHost (real
  * NAPI, real SQLite in a temp dir) served over real node MessagePorts, with
- * the real client/writer/font wiring. No Electron, no mocks — the same
+ * the real client/editQueue/font wiring. No Electron, no mocks — the same
  * pattern as WorkspaceHost.test.ts, extended to the renderer side.
  */
 export function createWorkspaceStack(): WorkspaceStack {
@@ -39,8 +39,8 @@ export function createWorkspaceStack(): WorkspaceStack {
       return nodePortTransport(lane.port2);
     },
   });
-  const writer = new ChangeWriter(client);
-  const font = new Font(client.$workspace, writer);
+  const editQueue = new WorkspaceEditQueue(client);
+  const font = new Font(client.$workspace, editQueue);
 
-  return { client, writer, font };
+  return { client, editQueue, font };
 }

--- a/apps/desktop/src/shared/commands.ts
+++ b/apps/desktop/src/shared/commands.ts
@@ -6,6 +6,8 @@
  * behavior for each command.
  */
 export type CommandId =
+  | "file.save"
+  | "file.saveAs"
   | "window.close"
   | "window.minimise"
   | "window.maximise"

--- a/apps/desktop/src/shared/host/ShiftHost.ts
+++ b/apps/desktop/src/shared/host/ShiftHost.ts
@@ -1,4 +1,5 @@
 import type { CommandId } from "../commands";
+import type { DocumentFlushCompletion, DocumentFlushRequest } from "../ipc/contract";
 
 /**
  * Renderer-facing API for Electron app-shell behavior.
@@ -18,6 +19,22 @@ export interface ShiftHost {
      * @throws {Error} when the preload bridge is unavailable or main rejects the command.
      */
     run: (id: CommandId) => Promise<void>;
+  };
+  /** Narrow document lifecycle hooks owned by main. */
+  document: {
+    /**
+     * Subscribes to main's request for renderer-only state to settle.
+     *
+     * @returns an unsubscribe function.
+     */
+    onFlushRequested: (callback: (request: DocumentFlushRequest) => void) => () => void;
+    /**
+     * Reports that the renderer has settled or failed a requested flush.
+     *
+     * @param completion - request id plus an optional failure message.
+     * @throws {Error} when main rejects the completion IPC.
+     */
+    flushCompleted: (completion: DocumentFlushCompletion) => Promise<void>;
   };
   /** Connects the renderer to the workspace utility process. */
   workspace: {

--- a/apps/desktop/src/shared/host/ShiftHost.ts
+++ b/apps/desktop/src/shared/host/ShiftHost.ts
@@ -1,5 +1,5 @@
 import type { CommandId } from "../commands";
-import type { DocumentFlushCompletion, DocumentFlushRequest } from "../ipc/contract";
+import type { DocumentSaveRequest } from "../ipc/contract";
 
 /**
  * Renderer-facing API for Electron app-shell behavior.
@@ -23,18 +23,12 @@ export interface ShiftHost {
   /** Narrow document lifecycle hooks owned by main. */
   document: {
     /**
-     * Subscribes to main's request for renderer-only state to settle.
+     * Subscribes to main's request to save; the renderer issues the save on its
+     * committed-op lane so it lands behind pending edits.
      *
      * @returns an unsubscribe function.
      */
-    onFlushRequested: (callback: (request: DocumentFlushRequest) => void) => () => void;
-    /**
-     * Reports that the renderer has settled or failed a requested flush.
-     *
-     * @param completion - request id plus an optional failure message.
-     * @throws {Error} when main rejects the completion IPC.
-     */
-    flushCompleted: (completion: DocumentFlushCompletion) => Promise<void>;
+    onSave: (callback: (request: DocumentSaveRequest) => void) => () => void;
   };
   /** Connects the renderer to the workspace utility process. */
   workspace: {

--- a/apps/desktop/src/shared/ipc/contract.ts
+++ b/apps/desktop/src/shared/ipc/contract.ts
@@ -1,5 +1,14 @@
 import type { CommandId } from "../commands";
 
+export type DocumentFlushRequest = {
+  requestId: string;
+};
+
+export type DocumentFlushCompletion = {
+  requestId: string;
+  error?: string;
+};
+
 /**
  * Defines request/response channels that the renderer may invoke on main.
  *
@@ -9,6 +18,7 @@ import type { CommandId } from "../commands";
  */
 export type RendererToMain = {
   "commands.run": (id: CommandId) => void;
+  "document.flushCompleted": (completion: DocumentFlushCompletion) => void;
   /**
    * Asks main to wire a sync lane to the workspace process. The port itself
    * arrives separately on the `workspace.port` postMessage channel because
@@ -25,6 +35,8 @@ export type RendererToMain = {
  * merely reflects it.
  */
 export type MainToRenderer = {
+  /** Main is about to run a document lifecycle operation and needs renderer edits settled. */
+  "document.flushRequested": (request: DocumentFlushRequest) => void;
   /** UI (chrome) zoom changed via the View menu or its accelerators. */
   "ui.zoomChanged": (percent: number) => void;
 };

--- a/apps/desktop/src/shared/ipc/contract.ts
+++ b/apps/desktop/src/shared/ipc/contract.ts
@@ -1,12 +1,16 @@
 import type { CommandId } from "../commands";
 
-export type DocumentFlushRequest = {
-  requestId: string;
-};
-
-export type DocumentFlushCompletion = {
-  requestId: string;
-  error?: string;
+/**
+ * Tells the renderer to issue a save on its committed-op lane.
+ *
+ * @remarks
+ * `path` is null for Save (current target) and a filesystem path for Save As —
+ * main owns the dialog and resolves the path before sending. The renderer
+ * enqueues the save behind its edits; main learns the outcome from the
+ * utility's `document.changed` event, so this is one-way (no reply channel).
+ */
+export type DocumentSaveRequest = {
+  path: string | null;
 };
 
 /**
@@ -18,7 +22,6 @@ export type DocumentFlushCompletion = {
  */
 export type RendererToMain = {
   "commands.run": (id: CommandId) => void;
-  "document.flushCompleted": (completion: DocumentFlushCompletion) => void;
   /**
    * Asks main to wire a sync lane to the workspace process. The port itself
    * arrives separately on the `workspace.port` postMessage channel because
@@ -35,8 +38,8 @@ export type RendererToMain = {
  * merely reflects it.
  */
 export type MainToRenderer = {
-  /** Main is about to run a document lifecycle operation and needs renderer edits settled. */
-  "document.flushRequested": (request: DocumentFlushRequest) => void;
+  /** Main resolved the save path; the renderer issues the save on its edit lane. */
+  "document.save": (request: DocumentSaveRequest) => void;
   /** UI (chrome) zoom changed via the View menu or its accelerators. */
   "ui.zoomChanged": (percent: number) => void;
 };

--- a/apps/desktop/src/shared/workspace/protocol.ts
+++ b/apps/desktop/src/shared/workspace/protocol.ts
@@ -29,15 +29,15 @@ export type WorkspaceDocumentSourceKind = "untitled" | "package" | "imported";
  * Main-visible document lifecycle state owned by the utility workspace.
  *
  * @remarks
- * Revisions are utility-assigned and monotonic for the open document. Main
- * treats `dirty` and `needsSaveAs` as derived state, not renderer queue state.
+ * `dirty` is the single semantic answer to "are there unsaved changes"; the
+ * utility owns the version arithmetic that derives it and never ships the raw
+ * counters. `needsSaveAs` is likewise derived from the source kind. Main
+ * treats both as utility-owned state, not renderer queue state.
  */
 export type WorkspaceDocumentState = {
   documentId: string;
   sourceKind: WorkspaceDocumentSourceKind;
   saveTarget: string | null;
-  revision: number;
-  savedRevision: number;
   dirty: boolean;
   needsSaveAs: boolean;
 };
@@ -47,13 +47,14 @@ export type WorkspaceDocumentState = {
  *
  * @remarks
  * `workspace.connect` carries the renderer's sync-lane port as a transferred
- * port, not as payload.
+ * port, not as payload. Save is NOT here: it rides the sync lane as a committed
+ * operation so FIFO orders it behind edits (see `workspace.save`). Main reads
+ * `document.state` to decide Save vs Save As and learns save outcomes from the
+ * `document.changed` event.
  */
 export type ShellCallMap = {
   "workspace.connect": { request: void; response: void };
   "document.state": { request: void; response: WorkspaceDocumentState | null };
-  "document.save": { request: void; response: WorkspaceDocumentState };
-  "document.saveAs": { request: { path: string }; response: WorkspaceDocumentState };
 };
 
 export type ShellEventMap = {
@@ -85,6 +86,14 @@ export type SyncCallMap = {
   /** Replays the most recent ledger entry; null when the stack is empty. */
   "workspace.undo": { request: void; response: AppliedChange | null };
   "workspace.redo": { request: void; response: AppliedChange | null };
+  /**
+   * Saves to the current package target, or rejects when the document still
+   * needs a path. Rides the edit lane so the utility serializes it behind every
+   * committed edit — no cross-lane watermark required.
+   */
+  "workspace.save": { request: void; response: WorkspaceDocumentState };
+  /** Saves to `path` (main's Save As dialog choice) and adopts it as target. */
+  "workspace.saveAs": { request: { path: string }; response: WorkspaceDocumentState };
   /**
    * Pulls replace-grade glyph state for one source (resync + editor open).
    * Addressed by stable GlyphId — references survive renames.

--- a/apps/desktop/src/shared/workspace/protocol.ts
+++ b/apps/desktop/src/shared/workspace/protocol.ts
@@ -23,6 +23,25 @@ export type WorkspaceSnapshot = {
   axes: Axis[];
 };
 
+export type WorkspaceDocumentSourceKind = "untitled" | "package" | "imported";
+
+/**
+ * Main-visible document lifecycle state owned by the utility workspace.
+ *
+ * @remarks
+ * Revisions are utility-assigned and monotonic for the open document. Main
+ * treats `dirty` and `needsSaveAs` as derived state, not renderer queue state.
+ */
+export type WorkspaceDocumentState = {
+  documentId: string;
+  sourceKind: WorkspaceDocumentSourceKind;
+  saveTarget: string | null;
+  revision: number;
+  savedRevision: number;
+  dirty: boolean;
+  needsSaveAs: boolean;
+};
+
 /**
  * Shell lane: main ↔ utility. Plumbing only; never font data.
  *
@@ -32,9 +51,15 @@ export type WorkspaceSnapshot = {
  */
 export type ShellCallMap = {
   "workspace.connect": { request: void; response: void };
+  "document.state": { request: void; response: WorkspaceDocumentState | null };
+  "document.save": { request: void; response: WorkspaceDocumentState };
+  "document.saveAs": { request: { path: string }; response: WorkspaceDocumentState };
 };
 
-export type ShellEventMap = { ready: void };
+export type ShellEventMap = {
+  ready: void;
+  "document.changed": WorkspaceDocumentState | null;
+};
 
 /**
  * Sync lane: renderer ↔ utility.

--- a/apps/desktop/src/utility/workspace/WorkspaceHost.test.ts
+++ b/apps/desktop/src/utility/workspace/WorkspaceHost.test.ts
@@ -18,6 +18,7 @@ import type {
   ShellEventMap,
   SyncCallMap,
   SyncEventMap,
+  WorkspaceDocumentState,
 } from "../../shared/workspace/protocol";
 import { WorkspaceHost } from "./WorkspaceHost";
 
@@ -106,6 +107,10 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     await expect(sync.call("workspace.snapshot", undefined)).resolves.toBeNull();
   });
 
+  it("returns null document state before any workspace exists", async () => {
+    await expect(shell.call("document.state", undefined)).resolves.toBeNull();
+  });
+
   it("creates an untitled workspace and returns it as the next state", async () => {
     const sync = await connectSyncLane();
 
@@ -134,6 +139,40 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     await expect(sync.call("workspace.snapshot", undefined)).resolves.toEqual(created);
   });
 
+  it("emits utility-owned document state after create and apply", async () => {
+    let latestState: WorkspaceDocumentState | null = null;
+    const unlisten = shell.listen("document.changed", (state) => {
+      latestState = state;
+    });
+    const sync = await connectSyncLane();
+
+    const created = await sync.call("workspace.create", undefined);
+    await shell.call("document.state", undefined);
+    expect(latestState).toMatchObject({
+      documentId: created.documentId,
+      sourceKind: "untitled",
+      saveTarget: null,
+      revision: 0,
+      savedRevision: 0,
+      dirty: false,
+      needsSaveAs: true,
+    });
+
+    await sync.call("workspace.apply", {
+      intents: [createGlyphA()],
+      label: "Add Glyph",
+    });
+    await shell.call("document.state", undefined);
+    expect(latestState).toMatchObject({
+      revision: 1,
+      savedRevision: 0,
+      dirty: true,
+      needsSaveAs: true,
+    });
+
+    unlisten();
+  });
+
   it("a reconnected sync lane still serves the open workspace", async () => {
     const first = await connectSyncLane();
     const created = await first.call("workspace.create", undefined);
@@ -158,6 +197,92 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
 
     const snapshot = await sync.call("workspace.snapshot", undefined);
     expect(snapshot?.glyphs.map((glyph) => glyph.name)).toEqual(["A"]);
+  });
+
+  it("document.save reports NeedsSaveAs for untitled workspaces", async () => {
+    const sync = await connectSyncLane();
+    await sync.call("workspace.create", undefined);
+    await sync.call("workspace.apply", {
+      intents: [createGlyphA()],
+      label: "Add Glyph",
+    });
+
+    await expect(shell.call("document.save", undefined)).rejects.toThrow(
+      "workspace needs a save path",
+    );
+
+    await expect(shell.call("document.state", undefined)).resolves.toMatchObject({
+      revision: 1,
+      savedRevision: 0,
+      dirty: true,
+      needsSaveAs: true,
+    });
+  });
+
+  it("document.saveAs updates saved revision and source state", async () => {
+    const sync = await connectSyncLane();
+    await sync.call("workspace.create", undefined);
+    await sync.call("workspace.apply", {
+      intents: [createGlyphA()],
+      label: "Add Glyph",
+    });
+
+    const savePath = path.join(tmpRoot, "SavedFont.shift");
+    const saved = await shell.call("document.saveAs", { path: savePath });
+
+    expect(saved).toMatchObject({
+      sourceKind: "package",
+      saveTarget: savePath,
+      revision: 1,
+      savedRevision: 1,
+      dirty: false,
+      needsSaveAs: false,
+    });
+    expect(fs.existsSync(savePath)).toBe(true);
+
+    await sync.call("workspace.apply", {
+      intents: [
+        {
+          kind: "createGlyph",
+          createGlyph: {
+            glyphId: mintGlyphId(),
+            name: "B" as GlyphName,
+            unicodes: [66 as Unicode],
+          },
+        },
+      ],
+      label: "Add Glyph",
+    });
+    await expect(shell.call("document.state", undefined)).resolves.toMatchObject({
+      revision: 2,
+      savedRevision: 1,
+      dirty: true,
+    });
+
+    await expect(shell.call("document.save", undefined)).resolves.toMatchObject({
+      revision: 2,
+      savedRevision: 2,
+      dirty: false,
+      needsSaveAs: false,
+    });
+  });
+
+  it("document.saveAs after an applied edit marks that revision saved", async () => {
+    const sync = await connectSyncLane();
+    await sync.call("workspace.create", undefined);
+
+    await sync.call("workspace.apply", {
+      intents: [createGlyphA()],
+      label: "Add Glyph",
+    });
+    const savePath = path.join(tmpRoot, "OrderedSave.shift");
+
+    await expect(shell.call("document.saveAs", { path: savePath })).resolves.toMatchObject({
+      revision: 1,
+      savedRevision: 1,
+      dirty: false,
+      needsSaveAs: false,
+    });
   });
 
   it("undo and redo createGlyph update glyph records", async () => {

--- a/apps/desktop/src/utility/workspace/WorkspaceHost.test.ts
+++ b/apps/desktop/src/utility/workspace/WorkspaceHost.test.ts
@@ -152,8 +152,6 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
       documentId: created.documentId,
       sourceKind: "untitled",
       saveTarget: null,
-      revision: 0,
-      savedRevision: 0,
       dirty: false,
       needsSaveAs: true,
     });
@@ -164,8 +162,6 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     });
     await shell.call("document.state", undefined);
     expect(latestState).toMatchObject({
-      revision: 1,
-      savedRevision: 0,
       dirty: true,
       needsSaveAs: true,
     });
@@ -199,7 +195,7 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     expect(snapshot?.glyphs.map((glyph) => glyph.name)).toEqual(["A"]);
   });
 
-  it("document.save reports NeedsSaveAs for untitled workspaces", async () => {
+  it("workspace.save reports NeedsSaveAs for untitled workspaces", async () => {
     const sync = await connectSyncLane();
     await sync.call("workspace.create", undefined);
     await sync.call("workspace.apply", {
@@ -207,19 +203,17 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
       label: "Add Glyph",
     });
 
-    await expect(shell.call("document.save", undefined)).rejects.toThrow(
+    await expect(sync.call("workspace.save", undefined)).rejects.toThrow(
       "workspace needs a save path",
     );
 
     await expect(shell.call("document.state", undefined)).resolves.toMatchObject({
-      revision: 1,
-      savedRevision: 0,
       dirty: true,
       needsSaveAs: true,
     });
   });
 
-  it("document.saveAs updates saved revision and source state", async () => {
+  it("workspace.saveAs writes the package and clears dirty for later saves", async () => {
     const sync = await connectSyncLane();
     await sync.call("workspace.create", undefined);
     await sync.call("workspace.apply", {
@@ -228,13 +222,11 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     });
 
     const savePath = path.join(tmpRoot, "SavedFont.shift");
-    const saved = await shell.call("document.saveAs", { path: savePath });
+    const saved = await sync.call("workspace.saveAs", { path: savePath });
 
     expect(saved).toMatchObject({
       sourceKind: "package",
       saveTarget: savePath,
-      revision: 1,
-      savedRevision: 1,
       dirty: false,
       needsSaveAs: false,
     });
@@ -254,34 +246,30 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
       label: "Add Glyph",
     });
     await expect(shell.call("document.state", undefined)).resolves.toMatchObject({
-      revision: 2,
-      savedRevision: 1,
       dirty: true,
     });
 
-    await expect(shell.call("document.save", undefined)).resolves.toMatchObject({
-      revision: 2,
-      savedRevision: 2,
+    await expect(sync.call("workspace.save", undefined)).resolves.toMatchObject({
       dirty: false,
       needsSaveAs: false,
     });
   });
 
-  it("document.saveAs after an applied edit marks that revision saved", async () => {
+  it("serializes a save behind an un-awaited apply on the same lane", async () => {
     const sync = await connectSyncLane();
     await sync.call("workspace.create", undefined);
+    const savePath = path.join(tmpRoot, "Ordered.shift");
 
-    await sync.call("workspace.apply", {
-      intents: [createGlyphA()],
-      label: "Add Glyph",
-    });
-    const savePath = path.join(tmpRoot, "OrderedSave.shift");
+    // Issue the apply and the save back-to-back without awaiting the apply. The
+    // host serializes both on one queue, so the save observes the glyph — if it
+    // had raced ahead, the doc would read dirty once the apply landed.
+    const apply = sync.call("workspace.apply", { intents: [createGlyphA()], label: "Add Glyph" });
+    const saved = await sync.call("workspace.saveAs", { path: savePath });
+    await apply;
 
-    await expect(shell.call("document.saveAs", { path: savePath })).resolves.toMatchObject({
-      revision: 1,
-      savedRevision: 1,
+    expect(saved).toMatchObject({ dirty: false, needsSaveAs: false });
+    await expect(shell.call("document.state", undefined)).resolves.toMatchObject({
       dirty: false,
-      needsSaveAs: false,
     });
   });
 

--- a/apps/desktop/src/utility/workspace/WorkspaceHost.ts
+++ b/apps/desktop/src/utility/workspace/WorkspaceHost.ts
@@ -59,8 +59,6 @@ export class WorkspaceHost {
         this.#connectSyncLane(context.ports);
       },
       "document.state": () => this.#serialize(() => this.#documentState()),
-      "document.save": () => this.#serialize(() => this.#save()),
-      "document.saveAs": ({ path }) => this.#serialize(() => this.#saveAs(path)),
     });
 
     this.#shell.emit("ready", undefined);
@@ -97,6 +95,10 @@ export class WorkspaceHost {
           if (applied) this.#emitDocumentChanged();
           return applied;
         }),
+      // Save rides the edit lane: the same #serialize queue orders it behind
+      // every committed apply/undo/redo, so it never writes stale state.
+      "workspace.save": () => this.#serialize(() => this.#save()),
+      "workspace.saveAs": ({ path }) => this.#serialize(() => this.#saveAs(path)),
       "workspace.glyph": ({ glyphId, sourceId }) =>
         this.#serialize(() => this.#bridge.getGlyph(glyphId, sourceId)),
     });
@@ -142,8 +144,6 @@ export class WorkspaceHost {
       documentId: this.#documentId,
       sourceKind: parseDocumentSourceKind(state.sourceKind),
       saveTarget: state.saveTarget ?? null,
-      revision: state.revision,
-      savedRevision: state.savedRevision,
       dirty: state.dirty,
       needsSaveAs: state.needsSaveAs,
     };

--- a/apps/desktop/src/utility/workspace/WorkspaceHost.ts
+++ b/apps/desktop/src/utility/workspace/WorkspaceHost.ts
@@ -5,6 +5,8 @@ import type {
   ShellEventMap,
   SyncCallMap,
   SyncEventMap,
+  WorkspaceDocumentSourceKind,
+  WorkspaceDocumentState,
   WorkspaceSnapshot,
 } from "../../shared/workspace/protocol";
 import { DocumentStorage } from "./DocumentStorage";
@@ -36,27 +38,32 @@ export type WorkspaceHostOptions = {
 export class WorkspaceHost {
   readonly #bridge: ShiftBridge;
   readonly #documents: DocumentStorage;
-  readonly #shell: Transport;
+  readonly #shellTransport: Transport;
   readonly #syncTransport: (port: unknown) => Transport;
+  #shell: ChannelServer<ShellEventMap> | null = null;
   #sync: ChannelServer<SyncEventMap> | null = null;
   #documentId: string | null = null;
+  #operations: Promise<void> = Promise.resolve();
 
   constructor(options: WorkspaceHostOptions) {
     this.#bridge = createBridge();
     this.#documents = new DocumentStorage(options.documentsRoot);
-    this.#shell = options.shell;
+    this.#shellTransport = options.shell;
     this.#syncTransport = options.syncTransport;
   }
 
   /** Serves the shell lane and announces readiness. Drafts are retained. */
   start(): void {
-    const shell = serveChannel<ShellCallMap, ShellEventMap>(this.#shell, {
+    this.#shell = serveChannel<ShellCallMap, ShellEventMap>(this.#shellTransport, {
       "workspace.connect": (_payload, context) => {
         this.#connectSyncLane(context.ports);
       },
+      "document.state": () => this.#serialize(() => this.#documentState()),
+      "document.save": () => this.#serialize(() => this.#save()),
+      "document.saveAs": ({ path }) => this.#serialize(() => this.#saveAs(path)),
     });
 
-    shell.emit("ready", undefined);
+    this.#shell.emit("ready", undefined);
   }
 
   #connectSyncLane(ports: readonly unknown[]): void {
@@ -67,13 +74,31 @@ export class WorkspaceHost {
 
     this.#sync?.dispose();
     this.#sync = serveChannel<SyncCallMap, SyncEventMap>(this.#syncTransport(port), {
-      "workspace.create": () => this.#create(),
+      "workspace.create": () => this.#serialize(() => this.#create()),
       "workspace.snapshot": () =>
-        this.#documentId === null ? null : this.#snapshot(this.#documentId),
-      "workspace.apply": ({ intents, label }) => this.#bridge.apply(intents, label),
-      "workspace.undo": () => this.#bridge.undo(),
-      "workspace.redo": () => this.#bridge.redo(),
-      "workspace.glyph": ({ glyphId, sourceId }) => this.#bridge.getGlyph(glyphId, sourceId),
+        this.#serialize(() =>
+          this.#documentId === null ? null : this.#snapshot(this.#documentId),
+        ),
+      "workspace.apply": ({ intents, label }) =>
+        this.#serialize(() => {
+          const applied = this.#bridge.apply(intents, label);
+          this.#emitDocumentChanged();
+          return applied;
+        }),
+      "workspace.undo": () =>
+        this.#serialize(() => {
+          const applied = this.#bridge.undo();
+          if (applied) this.#emitDocumentChanged();
+          return applied;
+        }),
+      "workspace.redo": () =>
+        this.#serialize(() => {
+          const applied = this.#bridge.redo();
+          if (applied) this.#emitDocumentChanged();
+          return applied;
+        }),
+      "workspace.glyph": ({ glyphId, sourceId }) =>
+        this.#serialize(() => this.#bridge.getGlyph(glyphId, sourceId)),
     });
   }
 
@@ -83,7 +108,9 @@ export class WorkspaceHost {
     this.#bridge.createUntitledWorkspace(draft.storePath);
     this.#documentId = draft.documentId;
 
-    return this.#snapshot(draft.documentId);
+    const snapshot = this.#snapshot(draft.documentId);
+    this.#emitDocumentChanged();
+    return snapshot;
   }
 
   #snapshot(documentId: string): WorkspaceSnapshot {
@@ -96,4 +123,56 @@ export class WorkspaceHost {
       axes: this.#bridge.getAxes(),
     };
   }
+
+  #save(): WorkspaceDocumentState {
+    this.#bridge.saveWorkspace();
+    return this.#emitDocumentChanged();
+  }
+
+  #saveAs(path: string): WorkspaceDocumentState {
+    this.#bridge.saveWorkspaceAs(path);
+    return this.#emitDocumentChanged();
+  }
+
+  #documentState(): WorkspaceDocumentState | null {
+    if (this.#documentId === null) return null;
+    const state = this.#bridge.documentState();
+
+    return {
+      documentId: this.#documentId,
+      sourceKind: parseDocumentSourceKind(state.sourceKind),
+      saveTarget: state.saveTarget ?? null,
+      revision: state.revision,
+      savedRevision: state.savedRevision,
+      dirty: state.dirty,
+      needsSaveAs: state.needsSaveAs,
+    };
+  }
+
+  #emitDocumentChanged(): WorkspaceDocumentState {
+    const state = this.#documentState();
+    if (!state) {
+      throw new Error("no workspace is open");
+    }
+
+    this.#shell?.emit("document.changed", state);
+    return state;
+  }
+
+  #serialize<T>(operation: () => T | Promise<T>): Promise<T> {
+    const run = this.#operations.then(operation);
+    this.#operations = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+}
+
+function parseDocumentSourceKind(sourceKind: string): WorkspaceDocumentSourceKind {
+  if (sourceKind === "untitled" || sourceKind === "package" || sourceKind === "imported") {
+    return sourceKind;
+  }
+
+  throw new Error(`unknown document source kind: ${sourceKind}`);
 }

--- a/crates/shift-bridge/index.d.ts
+++ b/crates/shift-bridge/index.d.ts
@@ -48,8 +48,6 @@ export declare class Bridge {
 export interface NapiDocumentState {
   sourceKind: string
   saveTarget?: string
-  revision: number
-  savedRevision: number
   dirty: boolean
   needsSaveAs: boolean
 }

--- a/crates/shift-bridge/index.d.ts
+++ b/crates/shift-bridge/index.d.ts
@@ -15,6 +15,9 @@ export declare class Bridge {
   constructor()
   createUntitledWorkspace(storePath: string, options?: NapiNewWorkspace | undefined | null): void
   exportWorkspace(request: NapiFontExportRequest): Promise<NapiFontExportResult>
+  documentState(): NapiDocumentState
+  saveWorkspace(): NapiDocumentState
+  saveWorkspaceAs(path: string): NapiDocumentState
   getMetadata(): NapiFontMetadata
   getMetrics(): NapiFontMetrics
   getGlyphs(): Array<NapiGlyphRecord>
@@ -40,6 +43,15 @@ export declare class Bridge {
   isVariable(): boolean
   getAxes(): Array<NapiAxis>
   getSources(): Array<NapiSource>
+}
+
+export interface NapiDocumentState {
+  sourceKind: string
+  saveTarget?: string
+  revision: number
+  savedRevision: number
+  dirty: boolean
+  needsSaveAs: boolean
 }
 
 export interface NapiFontExportRequest {

--- a/crates/shift-bridge/src/bridge.rs
+++ b/crates/shift-bridge/src/bridge.rs
@@ -18,8 +18,8 @@ use shift_wire::{
   Axis, FontMetadata, FontMetrics, GlyphChangedEntities, GlyphRecord, GlyphState, GlyphStructure,
   Source,
 };
-use shift_workspace::{FontWorkspace, NewWorkspace};
-use std::sync::Arc;
+use shift_workspace::{FontWorkspace, NewWorkspace, WorkspaceError, WorkspaceSource};
+use std::{path::Path, sync::Arc};
 
 #[napi(object)]
 #[derive(Clone, Debug)]
@@ -38,6 +38,17 @@ pub struct NapiFontExportResult {
 pub struct NapiNewWorkspace {
   pub family_name: Option<String>,
   pub units_per_em: Option<i64>,
+}
+
+#[napi(object)]
+#[derive(Debug)]
+pub struct NapiDocumentState {
+  pub source_kind: String,
+  pub save_target: Option<String>,
+  pub revision: i64,
+  pub saved_revision: i64,
+  pub dirty: bool,
+  pub needs_save_as: bool,
 }
 
 fn new_workspace_from_options(options: Option<NapiNewWorkspace>) -> NewWorkspace {
@@ -85,6 +96,10 @@ pub struct DocumentVersion(u64);
 impl DocumentVersion {
   fn next(self) -> Self {
     Self(self.0 + 1)
+  }
+
+  fn as_i64(self) -> i64 {
+    self.0 as i64
   }
 }
 
@@ -196,6 +211,7 @@ impl Task for ExportFontTask {
 pub struct Bridge {
   workspace: Option<FontWorkspace>,
   live_version: DocumentVersion,
+  saved_version: DocumentVersion,
 }
 
 #[napi]
@@ -205,6 +221,7 @@ impl Bridge {
     Self {
       workspace: None,
       live_version: DocumentVersion::default(),
+      saved_version: DocumentVersion::default(),
     }
   }
 
@@ -233,6 +250,25 @@ impl Bridge {
         .map_err(|e| Error::new(Status::GenericFailure, e.to_string()))?,
       request: request.try_into()?,
     }))
+  }
+
+  #[napi]
+  pub fn document_state(&self) -> errors::Result<NapiDocumentState> {
+    self.document_state_snapshot()
+  }
+
+  #[napi]
+  pub fn save_workspace(&mut self) -> errors::Result<NapiDocumentState> {
+    self.workspace_mut()?.save()?;
+    self.mark_saved();
+    self.document_state_snapshot()
+  }
+
+  #[napi]
+  pub fn save_workspace_as(&mut self, path: String) -> errors::Result<NapiDocumentState> {
+    self.workspace_mut()?.save_as(path)?;
+    self.mark_saved();
+    self.document_state_snapshot()
   }
 
   #[napi]
@@ -466,8 +502,32 @@ impl Bridge {
     Ok(self.workspace()?.font())
   }
 
+  fn document_state_snapshot(&self) -> BridgeResult<NapiDocumentState> {
+    let workspace = self.workspace()?;
+    let source_kind = match workspace.source() {
+      WorkspaceSource::Untitled => "untitled",
+      WorkspaceSource::Package { .. } => "package",
+      WorkspaceSource::Imported { .. } => "imported",
+    };
+    let save_target = workspace.save_target().map(path_to_string).transpose()?;
+    let needs_save_as = !matches!(workspace.source(), WorkspaceSource::Package { .. });
+
+    Ok(NapiDocumentState {
+      source_kind: source_kind.to_string(),
+      save_target,
+      revision: self.live_version.as_i64(),
+      saved_revision: self.saved_version.as_i64(),
+      dirty: self.live_version != self.saved_version,
+      needs_save_as,
+    })
+  }
+
   fn mark_font_changed(&mut self) {
     self.bump_live_version();
+  }
+
+  fn mark_saved(&mut self) {
+    self.saved_version = self.live_version;
   }
 
   fn bump_live_version(&mut self) {
@@ -476,7 +536,15 @@ impl Bridge {
 
   fn reset_versions(&mut self) {
     self.live_version = DocumentVersion::default();
+    self.saved_version = DocumentVersion::default();
   }
+}
+
+fn path_to_string(path: &Path) -> BridgeResult<String> {
+  path
+    .to_str()
+    .map(str::to_string)
+    .ok_or_else(|| WorkspaceError::InvalidPathUtf8(path.to_path_buf()).into())
 }
 
 fn parse_id_list<T: BridgeParse>(ids: &[String]) -> BridgeResult<Vec<T>> {
@@ -1439,6 +1507,68 @@ mod tests {
     let (_, store_path) = test_paths("workspace");
     bridge.create_untitled_workspace(store_path, None).unwrap();
     bridge
+  }
+
+  #[test]
+  fn document_state_tracks_dirty_and_saved_revisions() {
+    let mut bridge = bridge_with_workspace();
+
+    let state = bridge.document_state().unwrap();
+    assert_eq!(state.source_kind, "untitled");
+    assert_eq!(state.save_target, None);
+    assert_eq!(state.revision, 0);
+    assert_eq!(state.saved_revision, 0);
+    assert!(!state.dirty);
+    assert!(state.needs_save_as);
+
+    bridge
+      .apply(vec![create_glyph_napi("A", vec![65])], None)
+      .unwrap();
+
+    let state = bridge.document_state().unwrap();
+    assert_eq!(state.revision, 1);
+    assert_eq!(state.saved_revision, 0);
+    assert!(state.dirty);
+
+    let (save_path, _) = test_paths("save-as");
+    let state = bridge.save_workspace_as(save_path.clone()).unwrap();
+    assert_eq!(state.source_kind, "package");
+    assert_eq!(state.save_target.as_deref(), Some(save_path.as_str()));
+    assert_eq!(state.revision, 1);
+    assert_eq!(state.saved_revision, 1);
+    assert!(!state.dirty);
+    assert!(!state.needs_save_as);
+
+    bridge
+      .apply(vec![create_glyph_napi("B", vec![66])], None)
+      .unwrap();
+
+    let state = bridge.document_state().unwrap();
+    assert_eq!(state.revision, 2);
+    assert_eq!(state.saved_revision, 1);
+    assert!(state.dirty);
+
+    let state = bridge.save_workspace().unwrap();
+    assert_eq!(state.revision, 2);
+    assert_eq!(state.saved_revision, 2);
+    assert!(!state.dirty);
+  }
+
+  #[test]
+  fn save_workspace_reports_needs_save_as_for_untitled_documents() {
+    let mut bridge = bridge_with_workspace();
+    bridge
+      .apply(vec![create_glyph_napi("A", vec![65])], None)
+      .unwrap();
+
+    let error = bridge.save_workspace().unwrap_err();
+
+    assert!(error.to_string().contains("workspace needs a save path"));
+    let state = bridge.document_state().unwrap();
+    assert_eq!(state.revision, 1);
+    assert_eq!(state.saved_revision, 0);
+    assert!(state.dirty);
+    assert!(state.needs_save_as);
   }
 
   fn default_source_id(bridge: &Bridge) -> String {

--- a/crates/shift-bridge/src/bridge.rs
+++ b/crates/shift-bridge/src/bridge.rs
@@ -45,8 +45,6 @@ pub struct NapiNewWorkspace {
 pub struct NapiDocumentState {
   pub source_kind: String,
   pub save_target: Option<String>,
-  pub revision: i64,
-  pub saved_revision: i64,
   pub dirty: bool,
   pub needs_save_as: bool,
 }
@@ -96,10 +94,6 @@ pub struct DocumentVersion(u64);
 impl DocumentVersion {
   fn next(self) -> Self {
     Self(self.0 + 1)
-  }
-
-  fn as_i64(self) -> i64 {
-    self.0 as i64
   }
 }
 
@@ -515,8 +509,9 @@ impl Bridge {
     Ok(NapiDocumentState {
       source_kind: source_kind.to_string(),
       save_target,
-      revision: self.live_version.as_i64(),
-      saved_revision: self.saved_version.as_i64(),
+      // `live_version`/`saved_version` stay internal: `dirty` is the only
+      // answer callers need, and shipping the raw counters next to it only
+      // invites three fields that must agree.
       dirty: self.live_version != self.saved_version,
       needs_save_as,
     })
@@ -1510,14 +1505,12 @@ mod tests {
   }
 
   #[test]
-  fn document_state_tracks_dirty_and_saved_revisions() {
+  fn document_state_tracks_dirty_across_edits_and_saves() {
     let mut bridge = bridge_with_workspace();
 
     let state = bridge.document_state().unwrap();
     assert_eq!(state.source_kind, "untitled");
     assert_eq!(state.save_target, None);
-    assert_eq!(state.revision, 0);
-    assert_eq!(state.saved_revision, 0);
     assert!(!state.dirty);
     assert!(state.needs_save_as);
 
@@ -1525,17 +1518,12 @@ mod tests {
       .apply(vec![create_glyph_napi("A", vec![65])], None)
       .unwrap();
 
-    let state = bridge.document_state().unwrap();
-    assert_eq!(state.revision, 1);
-    assert_eq!(state.saved_revision, 0);
-    assert!(state.dirty);
+    assert!(bridge.document_state().unwrap().dirty);
 
     let (save_path, _) = test_paths("save-as");
     let state = bridge.save_workspace_as(save_path.clone()).unwrap();
     assert_eq!(state.source_kind, "package");
     assert_eq!(state.save_target.as_deref(), Some(save_path.as_str()));
-    assert_eq!(state.revision, 1);
-    assert_eq!(state.saved_revision, 1);
     assert!(!state.dirty);
     assert!(!state.needs_save_as);
 
@@ -1543,14 +1531,9 @@ mod tests {
       .apply(vec![create_glyph_napi("B", vec![66])], None)
       .unwrap();
 
-    let state = bridge.document_state().unwrap();
-    assert_eq!(state.revision, 2);
-    assert_eq!(state.saved_revision, 1);
-    assert!(state.dirty);
+    assert!(bridge.document_state().unwrap().dirty);
 
     let state = bridge.save_workspace().unwrap();
-    assert_eq!(state.revision, 2);
-    assert_eq!(state.saved_revision, 2);
     assert!(!state.dirty);
   }
 
@@ -1565,8 +1548,6 @@ mod tests {
 
     assert!(error.to_string().contains("workspace needs a save path"));
     let state = bridge.document_state().unwrap();
-    assert_eq!(state.revision, 1);
-    assert_eq!(state.saved_revision, 0);
     assert!(state.dirty);
     assert!(state.needs_save_as);
   }

--- a/crates/shift-workspace/src/workspace.rs
+++ b/crates/shift-workspace/src/workspace.rs
@@ -98,7 +98,7 @@ impl FontWorkspace {
     pub fn save(&mut self) -> Result<(), WorkspaceError> {
         match &self.source {
             WorkspaceSource::Package { path } => {
-                ShiftSourcePackage::open(path)?;
+                ShiftSourcePackage::save_font(path, &self.font)?;
                 Ok(())
             }
             WorkspaceSource::Untitled | WorkspaceSource::Imported { .. } => {
@@ -108,7 +108,7 @@ impl FontWorkspace {
     }
 
     pub fn save_as(&mut self, source_path: impl AsRef<Path>) -> Result<(), WorkspaceError> {
-        let source_package = ShiftSourcePackage::create_empty(source_path)?;
+        let source_package = ShiftSourcePackage::save_font(source_path, &self.font)?;
         self.source = WorkspaceSource::Package {
             path: source_package.path().to_path_buf(),
         };

--- a/crates/shift-workspace/tests/workspace_test.rs
+++ b/crates/shift-workspace/tests/workspace_test.rs
@@ -4,6 +4,7 @@ use shift_font::{
     Axis, AxisId, FontChange, FontIntent, FontIntentSet, GlyphId, LayerId, Location,
     error::CoreError,
 };
+use shift_source::ShiftSourcePackage;
 use shift_workspace::{FontWorkspace, NewWorkspace, WorkspaceError, WorkspaceSource};
 
 fn create_glyph_intent(name: &str, unicodes: Vec<u32>) -> FontIntent {
@@ -168,6 +169,31 @@ fn save_as_assigns_a_shift_package_save_target() {
     assert_eq!(workspace.save_target(), Some(save_path.as_path()));
     assert!(save_path.is_file());
     workspace.save().unwrap();
+}
+
+#[test]
+fn save_and_save_as_write_the_live_font_to_the_source_package() {
+    let temp = tempfile::tempdir().unwrap();
+    let store_path = temp.path().join("working.sqlite");
+    let save_path = temp.path().join("SavedFont.shift");
+
+    let mut workspace =
+        FontWorkspace::create_untitled(&store_path, NewWorkspace::with_family_name("Saved Font"))
+            .unwrap();
+    create_glyph(&mut workspace, "A", vec![65]);
+
+    workspace.save_as(&save_path).unwrap();
+
+    let saved = ShiftSourcePackage::load_font(&save_path).unwrap();
+    assert_eq!(saved.metadata().family_name.as_deref(), Some("Saved Font"));
+    assert!(saved.glyph_id_by_name("A").is_some());
+
+    create_glyph(&mut workspace, "B", vec![66]);
+    workspace.save().unwrap();
+
+    let saved = ShiftSourcePackage::load_font(&save_path).unwrap();
+    assert!(saved.glyph_id_by_name("A").is_some());
+    assert!(saved.glyph_id_by_name("B").is_some());
 }
 
 fn set_x_advance_intents(layer_id: LayerId, width: f64) -> FontIntentSet {

--- a/packages/types/src/bridge/generated.ts
+++ b/packages/types/src/bridge/generated.ts
@@ -20,6 +20,9 @@ export type Unicode = number;
 export interface BridgeApi {
   createUntitledWorkspace(storePath: string, options?: NewWorkspace | undefined | null): void
   exportWorkspace(request: FontExportRequest): Promise<FontExportResult>
+  documentState(): DocumentState
+  saveWorkspace(): DocumentState
+  saveWorkspaceAs(path: string): DocumentState
   getMetadata(): FontMetadata
   getMetrics(): FontMetrics
   getGlyphs(): Array<GlyphRecord>
@@ -45,6 +48,15 @@ export interface BridgeApi {
   isVariable(): boolean
   getAxes(): Array<Axis>
   getSources(): Array<Source>
+}
+
+export interface DocumentState {
+  sourceKind: string
+  saveTarget?: string
+  revision: number
+  savedRevision: number
+  dirty: boolean
+  needsSaveAs: boolean
 }
 
 export interface FontExportRequest {

--- a/packages/types/src/bridge/generated.ts
+++ b/packages/types/src/bridge/generated.ts
@@ -53,8 +53,6 @@ export interface BridgeApi {
 export interface DocumentState {
   sourceKind: string
   saveTarget?: string
-  revision: number
-  savedRevision: number
   dirty: boolean
   needsSaveAs: boolean
 }


### PR DESCRIPTION
## Summary

This PR moves document save operations behind a main-owned renderer flush barrier and utility workspace save path. It adds the IPC contract for renderer flush completion, main-process save/session coordination, and tests covering save ordering across renderer, main, utility, and Rust workspace boundaries.

## Why

Save needed one ordering authority so pending renderer edits settle before utility state is written. The changes make save and save-as flow through DocumentSession, preserving dirty/path state and giving the main process a narrow way to wait for renderer edit quiescence before persisting.

## Impact

- File save commands now run through the main document session.
- Renderer edits are flushed before save and save-as continue.
- Utility and Rust workspace save APIs update source-package state and saved revisions.
- Tests cover save-as ordering, workspace save behavior, and Shift package save semantics.

## Validation

- `pnpm --filter @shift/desktop test -- DocumentSession WorkspaceHost variation`
- `cargo test -p shift-workspace`
- `pnpm typecheck`