### PR TITLE
[codex] Align store with source format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,6 +1780,7 @@ name = "shift-store"
 version = "0.1.0"
 dependencies = [
  "rusqlite",
+ "serde_json",
  "shift-font",
  "tempfile",
  "thiserror 2.0.18",

--- a/crates/shift-source/tests/package_test.rs
+++ b/crates/shift-source/tests/package_test.rs
@@ -51,6 +51,15 @@ fn shift_round_trip_preserves_whole_font() {
 }
 
 #[test]
+fn source_tree_round_trip_preserves_whole_font() {
+    let original = sample_font();
+
+    let loaded = tree_to_font(font_to_tree(&original).unwrap()).unwrap();
+
+    assert_eq!(loaded, original);
+}
+
+#[test]
 fn serializes_same_font_to_byte_identical_tree() {
     let font = sample_font();
 

--- a/crates/shift-store/Cargo.toml
+++ b/crates/shift-store/Cargo.toml
@@ -6,7 +6,9 @@ edition = "2024"
 [dependencies]
 shift-font = { workspace = true }
 rusqlite = { version = "0.37.0", features = ["blob", "backup", "limits"] }
+serde_json = "1.0"
 thiserror = "2"
 
 [dev-dependencies]
+shift-font = { workspace = true, features = ["test-support"] }
 tempfile = "3"

--- a/crates/shift-store/src/change_set.rs
+++ b/crates/shift-store/src/change_set.rs
@@ -18,6 +18,15 @@ impl ShiftStore {
     pub fn replace_font_state(&mut self, font: &font::Font) -> Result<(), StoreError> {
         let tx = self.conn.transaction()?;
 
+        tx.execute("DELETE FROM glyph_layer_lib", [])?;
+        tx.execute("DELETE FROM glyph_lib", [])?;
+        tx.execute("DELETE FROM font_lib", [])?;
+        tx.execute("DELETE FROM kerning_pairs", [])?;
+        tx.execute("DELETE FROM kerning_group_members", [])?;
+        tx.execute("DELETE FROM kerning_groups", [])?;
+        tx.execute("DELETE FROM feature_text", [])?;
+        tx.execute("DELETE FROM glyph_layer_guidelines", [])?;
+        tx.execute("DELETE FROM font_guidelines", [])?;
         tx.execute("DELETE FROM glyph_layer_points", [])?;
         tx.execute("DELETE FROM glyph_layer_contours", [])?;
         tx.execute("DELETE FROM glyph_layer_anchors", [])?;
@@ -29,12 +38,24 @@ impl ShiftStore {
         tx.execute("DELETE FROM sources", [])?;
         tx.execute("DELETE FROM axes", [])?;
 
-        for axis in font.axes() {
-            insert_axis(&tx, &font::AxisCreated::from(axis))?;
+        upsert_font_info(&tx, font)?;
+        replace_feature_text(&tx, font.features().fea_source())?;
+        replace_font_guidelines(&tx, font.guidelines())?;
+        replace_lib_data(&tx, "font_lib", "key", None, font.lib())?;
+        replace_kerning(&tx, font.kerning())?;
+
+        for (order_index, axis) in font.axes().iter().enumerate() {
+            insert_axis_with_order(&tx, &font::AxisCreated::from(axis), order_index as i64)?;
         }
 
-        for source in font.sources() {
-            upsert_source(&tx, &source.id(), Some(source.name()))?;
+        for (order_index, source) in font.sources().iter().enumerate() {
+            upsert_source(
+                &tx,
+                &source.id(),
+                Some(source.name()),
+                source.filename(),
+                order_index as i64,
+            )?;
 
             for (axis_id, value) in source.location().iter() {
                 // Location entries on undefined axes have no row to reference.
@@ -44,9 +65,16 @@ impl ShiftStore {
             }
         }
 
-        for glyph in font.glyphs() {
-            upsert_glyph(&tx, &glyph.id(), glyph.glyph_name())?;
+        for (order_index, glyph) in font.glyphs().enumerate() {
+            upsert_glyph(&tx, &glyph.id(), glyph.glyph_name(), order_index as i64)?;
             replace_glyph_unicodes(&tx, &glyph.id(), glyph.unicodes())?;
+            replace_lib_data(
+                &tx,
+                "glyph_lib",
+                "glyph_id",
+                Some(&glyph.id().to_string()),
+                glyph.lib(),
+            )?;
 
             for layer in glyph.layers().values().map(|layer| layer.as_ref()) {
                 upsert_layer(
@@ -58,7 +86,7 @@ impl ShiftStore {
                     layer.width(),
                     layer.height(),
                 )?;
-                replace_layer_geometry(&tx, &layer.id(), &font::GlyphLayerValue::from(layer))?;
+                replace_full_layer_state(&tx, layer)?;
             }
         }
 
@@ -69,7 +97,7 @@ impl ShiftStore {
 
 fn apply_change(tx: &Transaction<'_>, change: &font::FontChange) -> Result<(), StoreError> {
     match change {
-        font::FontChange::AxisCreated(change) => insert_axis(tx, change),
+        font::FontChange::AxisCreated(change) => insert_axis_with_order(tx, change, 0),
         font::FontChange::AxisDeleted(change) => {
             // source_locations cascade from the axis row.
             let rows_changed = tx.execute(
@@ -80,7 +108,7 @@ fn apply_change(tx: &Transaction<'_>, change: &font::FontChange) -> Result<(), S
             Ok(())
         }
         font::FontChange::SourceCreated(change) => {
-            upsert_source(tx, &change.source_id, Some(&change.name))?;
+            upsert_source(tx, &change.source_id, Some(&change.name), None, 0)?;
 
             for axis_value in &change.location {
                 upsert_source_location(
@@ -103,7 +131,7 @@ fn apply_change(tx: &Transaction<'_>, change: &font::FontChange) -> Result<(), S
             Ok(())
         }
         font::FontChange::GlyphCreated(change) => {
-            upsert_glyph(tx, &change.glyph_id, &change.name)?;
+            upsert_glyph(tx, &change.glyph_id, &change.name, 0)?;
             replace_glyph_unicodes(tx, &change.glyph_id, &change.unicodes)
         }
         font::FontChange::GlyphDeleted(change) => {
@@ -115,7 +143,7 @@ fn apply_change(tx: &Transaction<'_>, change: &font::FontChange) -> Result<(), S
             Ok(())
         }
         font::FontChange::GlyphIdentityChanged(change) => {
-            upsert_glyph(tx, &change.glyph_id, &change.to_name)?;
+            upsert_glyph(tx, &change.glyph_id, &change.to_name, 0)?;
             replace_glyph_unicodes(tx, &change.glyph_id, &change.to_unicodes)
         }
         font::FontChange::GlyphLayerCreated(change) => upsert_layer(
@@ -214,11 +242,15 @@ fn apply_change(tx: &Transaction<'_>, change: &font::FontChange) -> Result<(), S
     }
 }
 
-fn insert_axis(tx: &Transaction<'_>, axis: &font::AxisCreated) -> Result<(), StoreError> {
+fn insert_axis_with_order(
+    tx: &Transaction<'_>,
+    axis: &font::AxisCreated,
+    order_index: i64,
+) -> Result<(), StoreError> {
     tx.execute(
         "
-        INSERT INTO axes (id, tag, name, min_value, default_value, max_value, hidden)
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+        INSERT INTO axes (id, tag, name, min_value, default_value, max_value, hidden, order_index)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
         ",
         params![
             axis.axis_id.to_string(),
@@ -228,6 +260,7 @@ fn insert_axis(tx: &Transaction<'_>, axis: &font::AxisCreated) -> Result<(), Sto
             axis.default,
             axis.maximum,
             axis.hidden,
+            order_index,
         ],
     )?;
     Ok(())
@@ -255,15 +288,19 @@ fn upsert_source(
     tx: &Transaction<'_>,
     source_id: &font::SourceId,
     name: Option<&str>,
+    filename: Option<&str>,
+    order_index: i64,
 ) -> Result<(), StoreError> {
     tx.execute(
         "
-        INSERT INTO sources (id, name, kind)
-        VALUES (?1, ?2, 'master')
+        INSERT INTO sources (id, name, filename, kind, order_index)
+        VALUES (?1, ?2, ?3, 'master', ?4)
         ON CONFLICT(id) DO UPDATE SET
-            name = COALESCE(excluded.name, sources.name)
+            name = COALESCE(excluded.name, sources.name),
+            filename = excluded.filename,
+            order_index = excluded.order_index
         ",
-        params![source_id.to_string(), name],
+        params![source_id.to_string(), name, filename, order_index],
     )?;
     Ok(())
 }
@@ -272,15 +309,17 @@ fn upsert_glyph(
     tx: &Transaction<'_>,
     glyph_id: &font::GlyphId,
     name: &font::GlyphName,
+    order_index: i64,
 ) -> Result<(), StoreError> {
     tx.execute(
         "
-        INSERT INTO glyphs (id, name)
-        VALUES (?1, ?2)
+        INSERT INTO glyphs (id, name, order_index)
+        VALUES (?1, ?2, ?3)
         ON CONFLICT(id) DO UPDATE SET
-            name = excluded.name
+            name = excluded.name,
+            order_index = excluded.order_index
         ",
-        params![glyph_id.to_string(), name.as_str()],
+        params![glyph_id.to_string(), name.as_str(), order_index],
     )?;
     Ok(())
 }
@@ -377,6 +416,421 @@ fn replace_layer_geometry(
     }
 
     Ok(())
+}
+
+fn replace_full_layer_state(
+    tx: &Transaction<'_>,
+    layer: &font::GlyphLayer,
+) -> Result<(), StoreError> {
+    replace_layer_geometry(tx, &layer.id(), &font::GlyphLayerValue::from(layer))?;
+
+    tx.execute(
+        "
+        DELETE FROM glyph_components
+        WHERE layer_id = ?1
+        ",
+        [layer_row_id(&layer.id())],
+    )?;
+
+    for (order_index, component) in layer.components_iter().enumerate() {
+        insert_component(tx, &layer.id(), component, order_index)?;
+    }
+
+    replace_layer_guidelines(tx, &layer.id(), layer.guidelines())?;
+    replace_lib_data(
+        tx,
+        "glyph_layer_lib",
+        "layer_id",
+        Some(&layer.id().to_string()),
+        layer.lib(),
+    )?;
+
+    Ok(())
+}
+
+fn upsert_font_info(tx: &Transaction<'_>, font: &font::Font) -> Result<(), StoreError> {
+    let metadata = font.metadata();
+    let metrics = font.metrics();
+    tx.execute(
+        "
+        INSERT INTO font_info (
+            id,
+            family_name,
+            style_name,
+            copyright,
+            trademark,
+            description,
+            note,
+            sample_text,
+            designer,
+            designer_url,
+            manufacturer,
+            manufacturer_url,
+            license_description,
+            license_info_url,
+            vendor_id,
+            version_major,
+            version_minor,
+            units_per_em,
+            ascender,
+            descender,
+            cap_height,
+            x_height,
+            line_gap,
+            italic_angle,
+            underline_position,
+            underline_thickness,
+            default_source_id
+        )
+        VALUES (
+            1, ?1, ?2, ?3, ?4, ?5, ?6, NULL, ?7, ?8, ?9, ?10, ?11, ?12, NULL,
+            ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24
+        )
+        ON CONFLICT(id) DO UPDATE SET
+            family_name = excluded.family_name,
+            style_name = excluded.style_name,
+            copyright = excluded.copyright,
+            trademark = excluded.trademark,
+            description = excluded.description,
+            note = excluded.note,
+            sample_text = excluded.sample_text,
+            designer = excluded.designer,
+            designer_url = excluded.designer_url,
+            manufacturer = excluded.manufacturer,
+            manufacturer_url = excluded.manufacturer_url,
+            license_description = excluded.license_description,
+            license_info_url = excluded.license_info_url,
+            vendor_id = excluded.vendor_id,
+            version_major = excluded.version_major,
+            version_minor = excluded.version_minor,
+            units_per_em = excluded.units_per_em,
+            ascender = excluded.ascender,
+            descender = excluded.descender,
+            cap_height = excluded.cap_height,
+            x_height = excluded.x_height,
+            line_gap = excluded.line_gap,
+            italic_angle = excluded.italic_angle,
+            underline_position = excluded.underline_position,
+            underline_thickness = excluded.underline_thickness,
+            default_source_id = excluded.default_source_id
+        ",
+        params![
+            metadata.family_name.as_deref(),
+            metadata.style_name.as_deref(),
+            metadata.copyright.as_deref(),
+            metadata.trademark.as_deref(),
+            metadata.description.as_deref(),
+            metadata.note.as_deref(),
+            metadata.designer.as_deref(),
+            metadata.designer_url.as_deref(),
+            metadata.manufacturer.as_deref(),
+            metadata.manufacturer_url.as_deref(),
+            metadata.license.as_deref(),
+            metadata.license_url.as_deref(),
+            metadata.version_major.map(i64::from),
+            metadata.version_minor.map(i64::from),
+            metrics.units_per_em,
+            metrics.ascender,
+            metrics.descender,
+            metrics.cap_height,
+            metrics.x_height,
+            metrics.line_gap,
+            metrics.italic_angle,
+            metrics.underline_position,
+            metrics.underline_thickness,
+            font.default_source_id().map(|id| id.to_string()),
+        ],
+    )?;
+    Ok(())
+}
+
+fn replace_feature_text(tx: &Transaction<'_>, fea_source: Option<&str>) -> Result<(), StoreError> {
+    tx.execute("DELETE FROM feature_text", [])?;
+    tx.execute(
+        "
+        INSERT INTO feature_text (id, fea_source)
+        VALUES (1, ?1)
+        ",
+        [fea_source],
+    )?;
+    Ok(())
+}
+
+fn replace_font_guidelines(
+    tx: &Transaction<'_>,
+    guidelines: &[font::Guideline],
+) -> Result<(), StoreError> {
+    tx.execute("DELETE FROM font_guidelines", [])?;
+    for (order_index, guideline) in guidelines.iter().enumerate() {
+        insert_guideline(tx, "font_guidelines", None, guideline, order_index)?;
+    }
+    Ok(())
+}
+
+fn replace_layer_guidelines(
+    tx: &Transaction<'_>,
+    layer_id: &font::LayerId,
+    guidelines: &[font::Guideline],
+) -> Result<(), StoreError> {
+    tx.execute(
+        "
+        DELETE FROM glyph_layer_guidelines
+        WHERE layer_id = ?1
+        ",
+        [layer_row_id(layer_id)],
+    )?;
+    for (order_index, guideline) in guidelines.iter().enumerate() {
+        insert_guideline(
+            tx,
+            "glyph_layer_guidelines",
+            Some(&layer_row_id(layer_id)),
+            guideline,
+            order_index,
+        )?;
+    }
+    Ok(())
+}
+
+fn insert_guideline(
+    tx: &Transaction<'_>,
+    table: &'static str,
+    layer_id: Option<&str>,
+    guideline: &font::Guideline,
+    order_index: usize,
+) -> Result<(), StoreError> {
+    match layer_id {
+        Some(layer_id) => {
+            debug_assert_eq!(table, "glyph_layer_guidelines");
+            tx.execute(
+                "
+                INSERT INTO glyph_layer_guidelines (
+                    id, layer_id, x, y, angle, name, color, order_index
+                )
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+                ",
+                params![
+                    guideline.id().to_string(),
+                    layer_id,
+                    guideline.x(),
+                    guideline.y(),
+                    guideline.angle(),
+                    guideline.name(),
+                    guideline.color(),
+                    order_index as i64,
+                ],
+            )?;
+        }
+        None => {
+            debug_assert_eq!(table, "font_guidelines");
+            tx.execute(
+                "
+                INSERT INTO font_guidelines (
+                    id, x, y, angle, name, color, order_index
+                )
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                ",
+                params![
+                    guideline.id().to_string(),
+                    guideline.x(),
+                    guideline.y(),
+                    guideline.angle(),
+                    guideline.name(),
+                    guideline.color(),
+                    order_index as i64,
+                ],
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn insert_component(
+    tx: &Transaction<'_>,
+    layer_id: &font::LayerId,
+    component: &font::Component,
+    order_index: usize,
+) -> Result<(), StoreError> {
+    let transform = component.transform();
+    tx.execute(
+        "
+        INSERT INTO glyph_components (
+            id,
+            layer_id,
+            base_glyph_id,
+            base_glyph_name,
+            translate_x,
+            translate_y,
+            rotation,
+            scale_x,
+            scale_y,
+            skew_x,
+            skew_y,
+            t_center_x,
+            t_center_y,
+            order_index
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+        ",
+        params![
+            component.id().to_string(),
+            layer_row_id(layer_id),
+            component.base_glyph_id().to_string(),
+            component.base_glyph_name().as_str(),
+            transform.translate_x,
+            transform.translate_y,
+            transform.rotation,
+            transform.scale_x,
+            transform.scale_y,
+            transform.skew_x,
+            transform.skew_y,
+            transform.t_center_x,
+            transform.t_center_y,
+            order_index as i64,
+        ],
+    )?;
+    Ok(())
+}
+
+fn replace_kerning(tx: &Transaction<'_>, kerning: &font::KerningData) -> Result<(), StoreError> {
+    tx.execute("DELETE FROM kerning_pairs", [])?;
+    tx.execute("DELETE FROM kerning_group_members", [])?;
+    tx.execute("DELETE FROM kerning_groups", [])?;
+
+    for (name, members) in kerning.groups1() {
+        insert_kerning_group(tx, 1, name, members)?;
+    }
+    for (name, members) in kerning.groups2() {
+        insert_kerning_group(tx, 2, name, members)?;
+    }
+    for (order_index, pair) in kerning.pairs().iter().enumerate() {
+        let (first_kind, first_value) = kerning_side_parts(&pair.first);
+        let (second_kind, second_value) = kerning_side_parts(&pair.second);
+        tx.execute(
+            "
+            INSERT INTO kerning_pairs (
+                order_index,
+                first_kind,
+                first_value,
+                second_kind,
+                second_value,
+                value
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+            ",
+            params![
+                order_index as i64,
+                first_kind,
+                first_value,
+                second_kind,
+                second_value,
+                pair.value,
+            ],
+        )?;
+    }
+    Ok(())
+}
+
+fn insert_kerning_group(
+    tx: &Transaction<'_>,
+    side: i64,
+    name: &str,
+    members: &[font::GlyphName],
+) -> Result<(), StoreError> {
+    tx.execute(
+        "
+        INSERT INTO kerning_groups (side, name)
+        VALUES (?1, ?2)
+        ",
+        params![side, name],
+    )?;
+    for (order_index, member) in members.iter().enumerate() {
+        tx.execute(
+            "
+            INSERT INTO kerning_group_members (side, group_name, glyph_name, order_index)
+            VALUES (?1, ?2, ?3, ?4)
+            ",
+            params![side, name, member.as_str(), order_index as i64],
+        )?;
+    }
+    Ok(())
+}
+
+fn kerning_side_parts(side: &font::KerningSide) -> (&'static str, &str) {
+    match side {
+        font::KerningSide::Glyph(name) => ("glyph", name.as_str()),
+        font::KerningSide::Group(group_id) => ("group", group_id.as_str()),
+    }
+}
+
+fn replace_lib_data(
+    tx: &Transaction<'_>,
+    table: &'static str,
+    owner_column: &'static str,
+    owner_id: Option<&str>,
+    lib: &font::LibData,
+) -> Result<(), StoreError> {
+    match owner_id {
+        Some(owner_id) => {
+            let delete_sql = format!("DELETE FROM {table} WHERE {owner_column} = ?1");
+            tx.execute(&delete_sql, [owner_id])?;
+            let insert_sql = format!(
+                "INSERT INTO {table} ({owner_column}, key, value_json) VALUES (?1, ?2, ?3)"
+            );
+            for (key, value) in lib.iter() {
+                tx.execute(&insert_sql, params![owner_id, key, lib_value_json(value)?])?;
+            }
+        }
+        None => {
+            debug_assert_eq!(table, "font_lib");
+            tx.execute("DELETE FROM font_lib", [])?;
+            for (key, value) in lib.iter() {
+                tx.execute(
+                    "
+                    INSERT INTO font_lib (key, value_json)
+                    VALUES (?1, ?2)
+                    ",
+                    params![key, lib_value_json(value)?],
+                )?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn lib_value_json(value: &font::LibValue) -> Result<String, StoreError> {
+    Ok(serde_json::to_string(&lib_value_to_json(value))?)
+}
+
+fn lib_value_to_json(value: &font::LibValue) -> serde_json::Value {
+    match value {
+        font::LibValue::String(value) => {
+            typed_json("string", serde_json::Value::String(value.clone()))
+        }
+        font::LibValue::Integer(value) => typed_json("integer", serde_json::json!(value)),
+        font::LibValue::Float(value) => typed_json("float", serde_json::json!(value)),
+        font::LibValue::Boolean(value) => typed_json("boolean", serde_json::json!(value)),
+        font::LibValue::Array(values) => typed_json(
+            "array",
+            serde_json::Value::Array(values.iter().map(lib_value_to_json).collect()),
+        ),
+        font::LibValue::Dict(values) => typed_json(
+            "dict",
+            serde_json::Value::Object(
+                values
+                    .iter()
+                    .map(|(key, value)| (key.clone(), lib_value_to_json(value)))
+                    .collect(),
+            ),
+        ),
+        font::LibValue::Data(values) => typed_json("data", serde_json::json!(values)),
+    }
+}
+
+fn typed_json(kind: &'static str, value: serde_json::Value) -> serde_json::Value {
+    serde_json::json!({
+        "type": kind,
+        "value": value,
+    })
 }
 
 fn replace_contour(

--- a/crates/shift-store/src/component.rs
+++ b/crates/shift-store/src/component.rs
@@ -4,14 +4,18 @@ pub struct NewGlyphComponent {
     pub id: ComponentId,
     pub layer_id: LayerId,
     pub base_glyph_id: GlyphId,
+    pub base_glyph_name: String,
+    pub transform: shift_font::DecomposedTransform,
     pub order_index: i64,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct GlyphComponentRecord {
     pub id: ComponentId,
     pub layer_id: LayerId,
     pub base_glyph_id: GlyphId,
+    pub base_glyph_name: String,
+    pub transform: shift_font::DecomposedTransform,
     pub order_index: i64,
 }
 
@@ -26,14 +30,34 @@ impl ShiftStore {
                 id,
                 layer_id,
                 base_glyph_id,
+                base_glyph_name,
+                translate_x,
+                translate_y,
+                rotation,
+                scale_x,
+                scale_y,
+                skew_x,
+                skew_y,
+                t_center_x,
+                t_center_y,
                 order_index
             )
-            VALUES (?1, ?2, ?3, ?4)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
             ",
             rusqlite::params![
                 component.id.as_str(),
                 component.layer_id.as_str(),
                 component.base_glyph_id.as_str(),
+                component.base_glyph_name,
+                component.transform.translate_x,
+                component.transform.translate_y,
+                component.transform.rotation,
+                component.transform.scale_x,
+                component.transform.scale_y,
+                component.transform.skew_x,
+                component.transform.skew_y,
+                component.transform.t_center_x,
+                component.transform.t_center_y,
                 component.order_index,
             ],
         )?;
@@ -51,6 +75,16 @@ impl ShiftStore {
                 id,
                 layer_id,
                 base_glyph_id,
+                base_glyph_name,
+                translate_x,
+                translate_y,
+                rotation,
+                scale_x,
+                scale_y,
+                skew_x,
+                skew_y,
+                t_center_x,
+                t_center_y,
                 order_index
             FROM glyph_components
             WHERE id = ?1
@@ -74,6 +108,16 @@ impl ShiftStore {
                 id,
                 layer_id,
                 base_glyph_id,
+                base_glyph_name,
+                translate_x,
+                translate_y,
+                rotation,
+                scale_x,
+                scale_y,
+                skew_x,
+                skew_y,
+                t_center_x,
+                t_center_y,
                 order_index
             FROM glyph_components
             WHERE layer_id = ?1
@@ -92,6 +136,18 @@ fn map_glyph_component_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<GlyphCom
         id: ComponentId::new(row.get::<_, String>(0)?),
         layer_id: LayerId::new(row.get::<_, String>(1)?),
         base_glyph_id: GlyphId::new(row.get::<_, String>(2)?),
-        order_index: row.get(3)?,
+        base_glyph_name: row.get(3)?,
+        transform: shift_font::DecomposedTransform {
+            translate_x: row.get(4)?,
+            translate_y: row.get(5)?,
+            rotation: row.get(6)?,
+            scale_x: row.get(7)?,
+            scale_y: row.get(8)?,
+            skew_x: row.get(9)?,
+            skew_y: row.get(10)?,
+            t_center_x: row.get(11)?,
+            t_center_y: row.get(12)?,
+        },
+        order_index: row.get(13)?,
     })
 }

--- a/crates/shift-store/src/error.rs
+++ b/crates/shift-store/src/error.rs
@@ -3,8 +3,20 @@ pub enum StoreError {
     #[error("sqlite error")]
     Sqlite(#[from] rusqlite::Error),
 
+    #[error("json error")]
+    Json(#[from] serde_json::Error),
+
+    #[error("font error")]
+    Font(#[from] shift_font::error::CoreError),
+
     #[error("unknown source kind: {0}")]
     UnknownSourceKind(String),
+
+    #[error("invalid point type: {0}")]
+    InvalidPointType(String),
+
+    #[error("invalid lib value: {0}")]
+    InvalidLibValue(String),
 
     #[error("missing {kind}: {id}")]
     MissingEntity { kind: &'static str, id: String },

--- a/crates/shift-store/src/font.rs
+++ b/crates/shift-store/src/font.rs
@@ -1,11 +1,13 @@
 use crate::{ShiftStore, StoreError};
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct FontInfo {
     pub family_name: Option<String>,
+    pub style_name: Option<String>,
     pub copyright: Option<String>,
     pub trademark: Option<String>,
     pub description: Option<String>,
+    pub note: Option<String>,
     pub sample_text: Option<String>,
     pub designer: Option<String>,
     pub designer_url: Option<String>,
@@ -16,7 +18,16 @@ pub struct FontInfo {
     pub vendor_id: Option<String>,
     pub version_major: Option<i64>,
     pub version_minor: Option<i64>,
-    pub units_per_em: i64,
+    pub units_per_em: f64,
+    pub ascender: f64,
+    pub descender: f64,
+    pub cap_height: Option<f64>,
+    pub x_height: Option<f64>,
+    pub line_gap: Option<f64>,
+    pub italic_angle: Option<f64>,
+    pub underline_position: Option<f64>,
+    pub underline_thickness: Option<f64>,
+    pub default_source_id: Option<String>,
 }
 
 impl ShiftStore {
@@ -26,9 +37,11 @@ impl ShiftStore {
             INSERT INTO font_info (
                 id,
                 family_name,
+                style_name,
                 copyright,
                 trademark,
                 description,
+                note,
                 sample_text,
                 designer,
                 designer_url,
@@ -39,14 +52,28 @@ impl ShiftStore {
                 vendor_id,
                 version_major,
                 version_minor,
-                units_per_em
+                units_per_em,
+                ascender,
+                descender,
+                cap_height,
+                x_height,
+                line_gap,
+                italic_angle,
+                underline_position,
+                underline_thickness,
+                default_source_id
             )
-            VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+            VALUES (
+                1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15,
+                ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26
+            )
             ON CONFLICT(id) DO UPDATE SET
                 family_name = excluded.family_name,
+                style_name = excluded.style_name,
                 copyright = excluded.copyright,
                 trademark = excluded.trademark,
                 description = excluded.description,
+                note = excluded.note,
                 sample_text = excluded.sample_text,
                 designer = excluded.designer,
                 designer_url = excluded.designer_url,
@@ -57,13 +84,24 @@ impl ShiftStore {
                 vendor_id = excluded.vendor_id,
                 version_major = excluded.version_major,
                 version_minor = excluded.version_minor,
-                units_per_em = excluded.units_per_em
+                units_per_em = excluded.units_per_em,
+                ascender = excluded.ascender,
+                descender = excluded.descender,
+                cap_height = excluded.cap_height,
+                x_height = excluded.x_height,
+                line_gap = excluded.line_gap,
+                italic_angle = excluded.italic_angle,
+                underline_position = excluded.underline_position,
+                underline_thickness = excluded.underline_thickness,
+                default_source_id = excluded.default_source_id
             ",
             rusqlite::params![
                 font_info.family_name,
+                font_info.style_name,
                 font_info.copyright,
                 font_info.trademark,
                 font_info.description,
+                font_info.note,
                 font_info.sample_text,
                 font_info.designer,
                 font_info.designer_url,
@@ -75,6 +113,15 @@ impl ShiftStore {
                 font_info.version_major,
                 font_info.version_minor,
                 font_info.units_per_em,
+                font_info.ascender,
+                font_info.descender,
+                font_info.cap_height,
+                font_info.x_height,
+                font_info.line_gap,
+                font_info.italic_angle,
+                font_info.underline_position,
+                font_info.underline_thickness,
+                font_info.default_source_id,
             ],
         )?;
 
@@ -86,9 +133,11 @@ impl ShiftStore {
             "
             SELECT
                 family_name,
+                style_name,
                 copyright,
                 trademark,
                 description,
+                note,
                 sample_text,
                 designer,
                 designer_url,
@@ -99,7 +148,16 @@ impl ShiftStore {
                 vendor_id,
                 version_major,
                 version_minor,
-                units_per_em
+                units_per_em,
+                ascender,
+                descender,
+                cap_height,
+                x_height,
+                line_gap,
+                italic_angle,
+                underline_position,
+                underline_thickness,
+                default_source_id
             FROM font_info
             WHERE id = 1
             ",
@@ -116,19 +174,30 @@ impl ShiftStore {
 fn map_font_info_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<FontInfo> {
     Ok(FontInfo {
         family_name: row.get(0)?,
-        copyright: row.get(1)?,
-        trademark: row.get(2)?,
-        description: row.get(3)?,
-        sample_text: row.get(4)?,
-        designer: row.get(5)?,
-        designer_url: row.get(6)?,
-        manufacturer: row.get(7)?,
-        manufacturer_url: row.get(8)?,
-        license_description: row.get(9)?,
-        license_info_url: row.get(10)?,
-        vendor_id: row.get(11)?,
-        version_major: row.get(12)?,
-        version_minor: row.get(13)?,
-        units_per_em: row.get(14)?,
+        style_name: row.get(1)?,
+        copyright: row.get(2)?,
+        trademark: row.get(3)?,
+        description: row.get(4)?,
+        note: row.get(5)?,
+        sample_text: row.get(6)?,
+        designer: row.get(7)?,
+        designer_url: row.get(8)?,
+        manufacturer: row.get(9)?,
+        manufacturer_url: row.get(10)?,
+        license_description: row.get(11)?,
+        license_info_url: row.get(12)?,
+        vendor_id: row.get(13)?,
+        version_major: row.get(14)?,
+        version_minor: row.get(15)?,
+        units_per_em: row.get(16)?,
+        ascender: row.get(17)?,
+        descender: row.get(18)?,
+        cap_height: row.get(19)?,
+        x_height: row.get(20)?,
+        line_gap: row.get(21)?,
+        italic_angle: row.get(22)?,
+        underline_position: row.get(23)?,
+        underline_thickness: row.get(24)?,
+        default_source_id: row.get(25)?,
     })
 }

--- a/crates/shift-store/src/font_state.rs
+++ b/crates/shift-store/src/font_state.rs
@@ -1,0 +1,662 @@
+use std::collections::HashMap;
+use std::str::FromStr;
+
+use rusqlite::params;
+use shift_font as font;
+
+use crate::{FontInfo, ShiftStore, StoreError};
+
+impl ShiftStore {
+    pub fn load_font_state(&self) -> Result<font::Font, StoreError> {
+        let mut font = font::Font::empty();
+
+        if let Some(info) = self.get_font_info()? {
+            apply_font_info(&mut font, info);
+        }
+
+        *font.features_mut() = load_feature_data(&self.conn)?;
+        *font.lib_mut() = load_lib_data(&self.conn, "font_lib", None)?;
+
+        for guideline in load_font_guidelines(&self.conn)? {
+            font.add_guideline(guideline);
+        }
+
+        for axis in load_axes(&self.conn)? {
+            font.add_axis(axis);
+        }
+
+        for source in load_sources(&self.conn)? {
+            font.add_source(source);
+        }
+
+        if let Some(default_source_id) = load_default_source_id(&self.conn)? {
+            font.set_default_source_id(default_source_id);
+        }
+
+        for glyph in load_glyphs(&self.conn)? {
+            font.insert_glyph(glyph).map_err(StoreError::from)?;
+        }
+
+        *font.kerning_mut() = load_kerning(&self.conn)?;
+
+        Ok(font)
+    }
+}
+
+fn apply_font_info(font: &mut font::Font, info: FontInfo) {
+    font.metadata_mut().family_name = info.family_name;
+    font.metadata_mut().style_name = info.style_name;
+    font.metadata_mut().copyright = info.copyright;
+    font.metadata_mut().trademark = info.trademark;
+    font.metadata_mut().description = info.description;
+    font.metadata_mut().note = info.note;
+    font.metadata_mut().designer = info.designer;
+    font.metadata_mut().designer_url = info.designer_url;
+    font.metadata_mut().manufacturer = info.manufacturer;
+    font.metadata_mut().manufacturer_url = info.manufacturer_url;
+    font.metadata_mut().license = info.license_description;
+    font.metadata_mut().license_url = info.license_info_url;
+    font.metadata_mut().version_major = info.version_major.map(|value| value as i32);
+    font.metadata_mut().version_minor = info.version_minor.map(|value| value as i32);
+
+    font.metrics_mut().units_per_em = info.units_per_em;
+    font.metrics_mut().ascender = info.ascender;
+    font.metrics_mut().descender = info.descender;
+    font.metrics_mut().cap_height = info.cap_height;
+    font.metrics_mut().x_height = info.x_height;
+    font.metrics_mut().line_gap = info.line_gap;
+    font.metrics_mut().italic_angle = info.italic_angle;
+    font.metrics_mut().underline_position = info.underline_position;
+    font.metrics_mut().underline_thickness = info.underline_thickness;
+}
+
+fn load_default_source_id(
+    conn: &rusqlite::Connection,
+) -> Result<Option<font::SourceId>, StoreError> {
+    let mut stmt = conn.prepare(
+        "
+        SELECT default_source_id
+        FROM font_info
+        WHERE id = 1
+        ",
+    )?;
+
+    match stmt.query_row([], |row| row.get::<_, Option<String>>(0)) {
+        Ok(Some(source_id)) => Ok(Some(font::SourceId::from_raw(source_id))),
+        Ok(None) => Ok(None),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn load_feature_data(conn: &rusqlite::Connection) -> Result<font::FeatureData, StoreError> {
+    let mut stmt = conn.prepare(
+        "
+        SELECT fea_source
+        FROM feature_text
+        WHERE id = 1
+        ",
+    )?;
+
+    let fea_source = match stmt.query_row([], |row| row.get::<_, Option<String>>(0)) {
+        Ok(source) => source,
+        Err(rusqlite::Error::QueryReturnedNoRows) => None,
+        Err(err) => return Err(err.into()),
+    };
+
+    let mut features = font::FeatureData::new();
+    features.set_fea_source(fea_source);
+    Ok(features)
+}
+
+fn load_axes(conn: &rusqlite::Connection) -> Result<Vec<font::Axis>, StoreError> {
+    let mut stmt = conn.prepare(
+        "
+        SELECT id, tag, name, min_value, default_value, max_value, hidden
+        FROM axes
+        ORDER BY order_index, id
+        ",
+    )?;
+
+    let rows = stmt.query_map([], |row| {
+        let mut axis = font::Axis::with_id(
+            font::AxisId::from_raw(row.get::<_, String>(0)?),
+            row.get(1)?,
+            row.get(2)?,
+            row.get(3)?,
+            row.get(4)?,
+            row.get(5)?,
+        );
+        axis.set_hidden(row.get(6)?);
+        Ok(axis)
+    })?;
+
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(StoreError::from)
+}
+
+fn load_sources(conn: &rusqlite::Connection) -> Result<Vec<font::Source>, StoreError> {
+    let mut stmt = conn.prepare(
+        "
+        SELECT id, name, filename
+        FROM sources
+        ORDER BY order_index, id
+        ",
+    )?;
+
+    let rows = stmt.query_map([], |row| {
+        let source_id = font::SourceId::from_raw(row.get::<_, String>(0)?);
+        let location = load_source_location(conn, &source_id)?;
+        Ok(font::Source::with_id(
+            source_id,
+            row.get::<_, Option<String>>(1)?.unwrap_or_default(),
+            location,
+            row.get(2)?,
+        ))
+    })?;
+
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(StoreError::from)
+}
+
+fn load_source_location(
+    conn: &rusqlite::Connection,
+    source_id: &font::SourceId,
+) -> rusqlite::Result<font::Location> {
+    let mut stmt = conn.prepare(
+        "
+        SELECT axis_id, value
+        FROM source_locations
+        WHERE source_id = ?1
+        ORDER BY axis_id
+        ",
+    )?;
+
+    let mut location = font::Location::new();
+    let rows = stmt.query_map([source_id.to_string()], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, f64>(1)?))
+    })?;
+    for row in rows {
+        let (axis_id, value) = row?;
+        location.set(font::AxisId::from_raw(axis_id), value);
+    }
+    Ok(location)
+}
+
+fn load_glyphs(conn: &rusqlite::Connection) -> Result<Vec<font::Glyph>, StoreError> {
+    let mut stmt = conn.prepare(
+        "
+        SELECT id, name
+        FROM glyphs
+        ORDER BY order_index, id
+        ",
+    )?;
+
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            font::GlyphId::from_raw(row.get::<_, String>(0)?),
+            row.get::<_, Option<String>>(1)?.unwrap_or_default(),
+        ))
+    })?;
+
+    let mut glyphs = Vec::new();
+    for row in rows {
+        let (glyph_id, name) = row?;
+        let mut glyph = font::Glyph::with_id(glyph_id.clone(), name);
+        glyph.set_unicodes(load_glyph_unicodes(conn, &glyph_id)?);
+        *glyph.lib_mut() =
+            load_lib_data(conn, "glyph_lib", Some(("glyph_id", &glyph_id.to_string())))?;
+
+        for layer in load_layers_for_glyph(conn, &glyph_id)? {
+            glyph.set_layer(layer);
+        }
+
+        glyphs.push(glyph);
+    }
+
+    Ok(glyphs)
+}
+
+fn load_glyph_unicodes(
+    conn: &rusqlite::Connection,
+    glyph_id: &font::GlyphId,
+) -> Result<Vec<u32>, StoreError> {
+    let mut stmt = conn.prepare(
+        "
+        SELECT unicode
+        FROM glyph_unicodes
+        WHERE glyph_id = ?1
+        ORDER BY order_index
+        ",
+    )?;
+    let rows = stmt.query_map([glyph_id.to_string()], |row| row.get::<_, i64>(0))?;
+    rows.map(|row| row.map(|value| value as u32))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(StoreError::from)
+}
+
+fn load_layers_for_glyph(
+    conn: &rusqlite::Connection,
+    glyph_id: &font::GlyphId,
+) -> Result<Vec<font::GlyphLayer>, StoreError> {
+    let mut stmt = conn.prepare(
+        "
+        SELECT id, source_id, width, height
+        FROM glyph_layers
+        WHERE glyph_id = ?1
+        ORDER BY id
+        ",
+    )?;
+
+    let rows = stmt.query_map([glyph_id.to_string()], |row| {
+        Ok((
+            font::LayerId::from_raw(row.get::<_, String>(0)?),
+            font::SourceId::from_raw(row.get::<_, String>(1)?),
+            row.get::<_, f64>(2)?,
+            row.get::<_, Option<f64>>(3)?,
+        ))
+    })?;
+
+    let mut layers = Vec::new();
+    for row in rows {
+        let (layer_id, source_id, width, height) = row?;
+        let mut layer = font::GlyphLayer::with_width(layer_id.clone(), source_id, width);
+        layer.set_height(height);
+
+        for contour in load_contours_for_layer(conn, &layer_id)? {
+            layer.add_contour(contour);
+        }
+        for component in load_components_for_layer(conn, &layer_id)? {
+            layer.add_component(component);
+        }
+        for anchor in load_anchors_for_layer(conn, &layer_id)? {
+            layer.add_anchor(anchor);
+        }
+        for guideline in load_layer_guidelines(conn, &layer_id)? {
+            layer.add_guideline(guideline);
+        }
+        *layer.lib_mut() = load_lib_data(
+            conn,
+            "glyph_layer_lib",
+            Some(("layer_id", &layer_id.to_string())),
+        )?;
+
+        layers.push(layer);
+    }
+
+    Ok(layers)
+}
+
+fn load_contours_for_layer(
+    conn: &rusqlite::Connection,
+    layer_id: &font::LayerId,
+) -> Result<Vec<font::Contour>, StoreError> {
+    let mut stmt = conn.prepare(
+        "
+        SELECT id, closed
+        FROM glyph_layer_contours
+        WHERE layer_id = ?1
+        ORDER BY order_index
+        ",
+    )?;
+
+    let rows = stmt.query_map([layer_id.to_string()], |row| {
+        Ok((
+            font::ContourId::from_raw(row.get::<_, String>(0)?),
+            row.get::<_, bool>(1)?,
+        ))
+    })?;
+
+    let mut contours = Vec::new();
+    for row in rows {
+        let (contour_id, closed) = row?;
+        let mut contour = font::Contour::with_id(contour_id.clone());
+        for point in load_points_for_contour(conn, &contour_id)? {
+            contour.push_point(point);
+        }
+        if closed {
+            contour.close();
+        }
+        contours.push(contour);
+    }
+
+    Ok(contours)
+}
+
+fn load_points_for_contour(
+    conn: &rusqlite::Connection,
+    contour_id: &font::ContourId,
+) -> Result<Vec<font::Point>, StoreError> {
+    let mut stmt = conn.prepare(
+        "
+        SELECT id, x, y, point_type, smooth
+        FROM glyph_layer_points
+        WHERE contour_id = ?1
+        ORDER BY order_index
+        ",
+    )?;
+
+    let rows = stmt.query_map([contour_id.to_string()], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, f64>(1)?,
+            row.get::<_, f64>(2)?,
+            row.get::<_, String>(3)?,
+            row.get::<_, bool>(4)?,
+        ))
+    })?;
+
+    let mut points = Vec::new();
+    for row in rows {
+        let (id, x, y, point_type, smooth) = row?;
+        let point_type =
+            font::PointType::from_str(&point_type).map_err(StoreError::InvalidPointType)?;
+        points.push(font::Point::new(
+            font::PointId::from_raw(id),
+            x,
+            y,
+            point_type,
+            smooth,
+        ));
+    }
+    Ok(points)
+}
+
+fn load_components_for_layer(
+    conn: &rusqlite::Connection,
+    layer_id: &font::LayerId,
+) -> Result<Vec<font::Component>, StoreError> {
+    let mut stmt = conn.prepare(
+        "
+        SELECT
+            id,
+            base_glyph_id,
+            base_glyph_name,
+            translate_x,
+            translate_y,
+            rotation,
+            scale_x,
+            scale_y,
+            skew_x,
+            skew_y,
+            t_center_x,
+            t_center_y
+        FROM glyph_components
+        WHERE layer_id = ?1
+        ORDER BY order_index, id
+        ",
+    )?;
+
+    let rows = stmt.query_map([layer_id.to_string()], |row| {
+        Ok(font::Component::with_id(
+            font::ComponentId::from_raw(row.get::<_, String>(0)?),
+            font::GlyphId::from_raw(row.get::<_, String>(1)?),
+            row.get::<_, String>(2)?,
+            font::DecomposedTransform {
+                translate_x: row.get(3)?,
+                translate_y: row.get(4)?,
+                rotation: row.get(5)?,
+                scale_x: row.get(6)?,
+                scale_y: row.get(7)?,
+                skew_x: row.get(8)?,
+                skew_y: row.get(9)?,
+                t_center_x: row.get(10)?,
+                t_center_y: row.get(11)?,
+            },
+        ))
+    })?;
+
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(StoreError::from)
+}
+
+fn load_anchors_for_layer(
+    conn: &rusqlite::Connection,
+    layer_id: &font::LayerId,
+) -> Result<Vec<font::Anchor>, StoreError> {
+    let mut stmt = conn.prepare(
+        "
+        SELECT id, name, x, y
+        FROM glyph_layer_anchors
+        WHERE layer_id = ?1
+        ORDER BY order_index
+        ",
+    )?;
+
+    let rows = stmt.query_map([layer_id.to_string()], |row| {
+        Ok(font::Anchor::with_id(
+            font::AnchorId::from_raw(row.get::<_, String>(0)?),
+            row.get::<_, Option<String>>(1)?,
+            row.get(2)?,
+            row.get(3)?,
+        ))
+    })?;
+
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(StoreError::from)
+}
+
+fn load_font_guidelines(conn: &rusqlite::Connection) -> Result<Vec<font::Guideline>, StoreError> {
+    let mut stmt = conn.prepare(
+        "
+        SELECT id, x, y, angle, name, color
+        FROM font_guidelines
+        ORDER BY order_index
+        ",
+    )?;
+    let rows = stmt.query_map([], map_guideline_row)?;
+
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(StoreError::from)
+}
+
+fn load_layer_guidelines(
+    conn: &rusqlite::Connection,
+    layer_id: &font::LayerId,
+) -> Result<Vec<font::Guideline>, StoreError> {
+    let mut stmt = conn.prepare(
+        "
+        SELECT id, x, y, angle, name, color
+        FROM glyph_layer_guidelines
+        WHERE layer_id = ?1
+        ORDER BY order_index
+        ",
+    )?;
+    let rows = stmt.query_map([layer_id.to_string()], map_guideline_row)?;
+
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(StoreError::from)
+}
+
+fn map_guideline_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<font::Guideline> {
+    Ok(font::Guideline::with_id(
+        font::GuidelineId::from_raw(row.get::<_, String>(0)?),
+        row.get(1)?,
+        row.get(2)?,
+        row.get(3)?,
+        row.get(4)?,
+        row.get(5)?,
+    ))
+}
+
+fn load_kerning(conn: &rusqlite::Connection) -> Result<font::KerningData, StoreError> {
+    let mut kerning = font::KerningData::new();
+    for (name, members) in load_kerning_groups(conn, 1)? {
+        kerning.set_group1(name, members);
+    }
+    for (name, members) in load_kerning_groups(conn, 2)? {
+        kerning.set_group2(name, members);
+    }
+
+    let mut stmt = conn.prepare(
+        "
+        SELECT first_kind, first_value, second_kind, second_value, value
+        FROM kerning_pairs
+        ORDER BY order_index
+        ",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, String>(3)?,
+            row.get::<_, f64>(4)?,
+        ))
+    })?;
+    for row in rows {
+        let (first_kind, first_value, second_kind, second_value, value) = row?;
+        kerning.add_pair(font::KerningPair::new(
+            kerning_side(&first_kind, first_value),
+            kerning_side(&second_kind, second_value),
+            value,
+        ));
+    }
+
+    Ok(kerning)
+}
+
+fn load_kerning_groups(
+    conn: &rusqlite::Connection,
+    side: i64,
+) -> Result<Vec<(String, Vec<font::GlyphName>)>, StoreError> {
+    let mut stmt = conn.prepare(
+        "
+        SELECT name
+        FROM kerning_groups
+        WHERE side = ?1
+        ORDER BY name
+        ",
+    )?;
+    let group_names = stmt
+        .query_map([side], |row| row.get::<_, String>(0))?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut groups = Vec::new();
+    for group_name in group_names {
+        let mut member_stmt = conn.prepare(
+            "
+            SELECT glyph_name
+            FROM kerning_group_members
+            WHERE side = ?1 AND group_name = ?2
+            ORDER BY order_index
+            ",
+        )?;
+        let members = member_stmt
+            .query_map(params![side, group_name], |row| {
+                Ok(font::GlyphName::from(row.get::<_, String>(0)?))
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        groups.push((group_name, members));
+    }
+    Ok(groups)
+}
+
+fn kerning_side(kind: &str, value: String) -> font::KerningSide {
+    match kind {
+        "glyph" => font::KerningSide::Glyph(value.into()),
+        "group" => font::KerningSide::Group(value),
+        _ => font::KerningSide::Group(value),
+    }
+}
+
+fn load_lib_data(
+    conn: &rusqlite::Connection,
+    table: &'static str,
+    owner: Option<(&'static str, &str)>,
+) -> Result<font::LibData, StoreError> {
+    let mut values = HashMap::new();
+    match owner {
+        Some((owner_column, owner_id)) => {
+            let sql = format!("SELECT key, value_json FROM {table} WHERE {owner_column} = ?1");
+            let mut stmt = conn.prepare(&sql)?;
+            let rows = stmt.query_map([owner_id], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?;
+            for row in rows {
+                let (key, value_json) = row?;
+                values.insert(key, lib_value_from_json(&value_json)?);
+            }
+        }
+        None => {
+            let sql = format!("SELECT key, value_json FROM {table}");
+            let mut stmt = conn.prepare(&sql)?;
+            let rows = stmt.query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?;
+            for row in rows {
+                let (key, value_json) = row?;
+                values.insert(key, lib_value_from_json(&value_json)?);
+            }
+        }
+    }
+    Ok(font::LibData::from_map(values))
+}
+
+fn lib_value_from_json(value_json: &str) -> Result<font::LibValue, StoreError> {
+    let value: serde_json::Value = serde_json::from_str(value_json)?;
+    lib_value_from_value(value)
+}
+
+fn lib_value_from_value(value: serde_json::Value) -> Result<font::LibValue, StoreError> {
+    let serde_json::Value::Object(mut object) = value else {
+        return Err(StoreError::InvalidLibValue("expected object".to_string()));
+    };
+    let Some(serde_json::Value::String(kind)) = object.remove("type") else {
+        return Err(StoreError::InvalidLibValue("missing type".to_string()));
+    };
+    let value = object
+        .remove("value")
+        .ok_or_else(|| StoreError::InvalidLibValue("missing value".to_string()))?;
+
+    match kind.as_str() {
+        "string" => match value {
+            serde_json::Value::String(value) => Ok(font::LibValue::String(value)),
+            _ => Err(StoreError::InvalidLibValue("expected string".to_string())),
+        },
+        "integer" => value
+            .as_i64()
+            .map(font::LibValue::Integer)
+            .ok_or_else(|| StoreError::InvalidLibValue("expected integer".to_string())),
+        "float" => value
+            .as_f64()
+            .map(font::LibValue::Float)
+            .ok_or_else(|| StoreError::InvalidLibValue("expected float".to_string())),
+        "boolean" => value
+            .as_bool()
+            .map(font::LibValue::Boolean)
+            .ok_or_else(|| StoreError::InvalidLibValue("expected boolean".to_string())),
+        "array" => match value {
+            serde_json::Value::Array(values) => values
+                .into_iter()
+                .map(lib_value_from_value)
+                .collect::<Result<Vec<_>, _>>()
+                .map(font::LibValue::Array),
+            _ => Err(StoreError::InvalidLibValue("expected array".to_string())),
+        },
+        "dict" => match value {
+            serde_json::Value::Object(values) => values
+                .into_iter()
+                .map(|(key, value)| lib_value_from_value(value).map(|value| (key, value)))
+                .collect::<Result<HashMap<_, _>, _>>()
+                .map(font::LibValue::Dict),
+            _ => Err(StoreError::InvalidLibValue("expected dict".to_string())),
+        },
+        "data" => match value {
+            serde_json::Value::Array(values) => values
+                .into_iter()
+                .map(|value| {
+                    let byte = value.as_u64().ok_or_else(|| {
+                        StoreError::InvalidLibValue("expected data byte".to_string())
+                    })?;
+                    u8::try_from(byte).map_err(|_| {
+                        StoreError::InvalidLibValue("data byte out of range".to_string())
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()
+                .map(font::LibValue::Data),
+            _ => Err(StoreError::InvalidLibValue("expected data".to_string())),
+        },
+        _ => Err(StoreError::InvalidLibValue(format!("unknown type {kind}"))),
+    }
+}

--- a/crates/shift-store/src/lib.rs
+++ b/crates/shift-store/src/lib.rs
@@ -3,6 +3,7 @@ mod component;
 mod connection;
 mod error;
 mod font;
+mod font_state;
 mod glyph;
 mod layer;
 mod outline;

--- a/crates/shift-store/src/schema.rs
+++ b/crates/shift-store/src/schema.rs
@@ -4,9 +4,11 @@ pub(crate) const SCHEMA_V1: &str = r#"
 CREATE TABLE IF NOT EXISTS font_info (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     family_name TEXT,
+    style_name TEXT,
     copyright TEXT,
     trademark TEXT,
     description TEXT,
+    note TEXT,
     sample_text TEXT,
     designer TEXT,
     designer_url TEXT,
@@ -17,7 +19,16 @@ CREATE TABLE IF NOT EXISTS font_info (
     vendor_id TEXT,
     version_major INTEGER CHECK (version_major IS NULL OR version_major >= 0),
     version_minor INTEGER CHECK (version_minor IS NULL OR version_minor >= 0),
-    units_per_em INTEGER NOT NULL CHECK (units_per_em > 0)
+    units_per_em REAL NOT NULL CHECK (units_per_em > 0),
+    ascender REAL NOT NULL,
+    descender REAL NOT NULL,
+    cap_height REAL,
+    x_height REAL,
+    line_gap REAL,
+    italic_angle REAL,
+    underline_position REAL,
+    underline_thickness REAL,
+    default_source_id TEXT
 );
 
 CREATE TABLE IF NOT EXISTS axes (
@@ -27,7 +38,8 @@ CREATE TABLE IF NOT EXISTS axes (
     min_value REAL NOT NULL,
     default_value REAL NOT NULL,
     max_value REAL NOT NULL,
-    hidden INTEGER NOT NULL DEFAULT 0 CHECK (hidden IN (0, 1))
+    hidden INTEGER NOT NULL DEFAULT 0 CHECK (hidden IN (0, 1)),
+    order_index INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS axes_tag_unique
@@ -38,12 +50,15 @@ CREATE TABLE IF NOT EXISTS sources (
     name TEXT,
     family_name TEXT,
     style_name TEXT,
-    kind TEXT NOT NULL
+    filename TEXT,
+    kind TEXT NOT NULL,
+    order_index INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS glyphs (
     id TEXT PRIMARY KEY,
-    name TEXT
+    name TEXT,
+    order_index INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE INDEX IF NOT EXISTS glyphs_name_idx
@@ -112,9 +127,18 @@ CREATE TABLE IF NOT EXISTS glyph_components (
     id TEXT PRIMARY KEY,
     layer_id TEXT NOT NULL,
     base_glyph_id TEXT NOT NULL,
+    base_glyph_name TEXT NOT NULL,
+    translate_x REAL NOT NULL DEFAULT 0,
+    translate_y REAL NOT NULL DEFAULT 0,
+    rotation REAL NOT NULL DEFAULT 0,
+    scale_x REAL NOT NULL DEFAULT 1,
+    scale_y REAL NOT NULL DEFAULT 1,
+    skew_x REAL NOT NULL DEFAULT 0,
+    skew_y REAL NOT NULL DEFAULT 0,
+    t_center_x REAL NOT NULL DEFAULT 0,
+    t_center_y REAL NOT NULL DEFAULT 0,
     order_index INTEGER NOT NULL,
-    FOREIGN KEY (layer_id) REFERENCES glyph_layers(id) ON DELETE CASCADE,
-    FOREIGN KEY (base_glyph_id) REFERENCES glyphs(id) ON DELETE CASCADE
+    FOREIGN KEY (layer_id) REFERENCES glyph_layers(id) ON DELETE CASCADE
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS glyph_components_layer_order_unique
@@ -142,6 +166,31 @@ ON glyph_layer_anchors(layer_id, order_index);
 CREATE INDEX IF NOT EXISTS glyph_layer_anchors_layer_id_idx
 ON glyph_layer_anchors(layer_id);
 
+CREATE TABLE IF NOT EXISTS font_guidelines (
+    id TEXT PRIMARY KEY,
+    x REAL,
+    y REAL,
+    angle REAL,
+    name TEXT,
+    color TEXT,
+    order_index INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS glyph_layer_guidelines (
+    id TEXT PRIMARY KEY,
+    layer_id TEXT NOT NULL,
+    x REAL,
+    y REAL,
+    angle REAL,
+    name TEXT,
+    color TEXT,
+    order_index INTEGER NOT NULL,
+    FOREIGN KEY (layer_id) REFERENCES glyph_layers(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS glyph_layer_guidelines_layer_id_idx
+ON glyph_layer_guidelines(layer_id);
+
 CREATE TABLE IF NOT EXISTS source_locations (
     source_id TEXT NOT NULL,
     axis_id TEXT NOT NULL,
@@ -149,6 +198,56 @@ CREATE TABLE IF NOT EXISTS source_locations (
     PRIMARY KEY (source_id, axis_id),
     FOREIGN KEY (source_id) REFERENCES sources(id) ON DELETE CASCADE,
     FOREIGN KEY (axis_id) REFERENCES axes(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS feature_text (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    fea_source TEXT
+);
+
+CREATE TABLE IF NOT EXISTS kerning_groups (
+    side INTEGER NOT NULL CHECK (side IN (1, 2)),
+    name TEXT NOT NULL,
+    PRIMARY KEY (side, name)
+);
+
+CREATE TABLE IF NOT EXISTS kerning_group_members (
+    side INTEGER NOT NULL CHECK (side IN (1, 2)),
+    group_name TEXT NOT NULL,
+    glyph_name TEXT NOT NULL,
+    order_index INTEGER NOT NULL,
+    PRIMARY KEY (side, group_name, order_index),
+    FOREIGN KEY (side, group_name) REFERENCES kerning_groups(side, name) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS kerning_pairs (
+    order_index INTEGER PRIMARY KEY,
+    first_kind TEXT NOT NULL CHECK (first_kind IN ('glyph', 'group')),
+    first_value TEXT NOT NULL,
+    second_kind TEXT NOT NULL CHECK (second_kind IN ('glyph', 'group')),
+    second_value TEXT NOT NULL,
+    value REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS font_lib (
+    key TEXT PRIMARY KEY,
+    value_json TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS glyph_lib (
+    glyph_id TEXT NOT NULL,
+    key TEXT NOT NULL,
+    value_json TEXT NOT NULL,
+    PRIMARY KEY (glyph_id, key),
+    FOREIGN KEY (glyph_id) REFERENCES glyphs(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS glyph_layer_lib (
+    layer_id TEXT NOT NULL,
+    key TEXT NOT NULL,
+    value_json TEXT NOT NULL,
+    PRIMARY KEY (layer_id, key),
+    FOREIGN KEY (layer_id) REFERENCES glyph_layers(id) ON DELETE CASCADE
 );
 "#;
 

--- a/crates/shift-store/src/source.rs
+++ b/crates/shift-store/src/source.rs
@@ -26,6 +26,7 @@ pub struct NewSource {
     pub name: Option<String>,
     pub family_name: Option<String>,
     pub style_name: Option<String>,
+    pub filename: Option<String>,
     pub kind: SourceKind,
 }
 
@@ -35,6 +36,7 @@ pub struct SourceRecord {
     pub name: Option<String>,
     pub family_name: Option<String>,
     pub style_name: Option<String>,
+    pub filename: Option<String>,
     pub kind: SourceKind,
 }
 
@@ -125,15 +127,17 @@ impl ShiftStore {
                 name,
                 family_name,
                 style_name,
+                filename,
                 kind
             )
-            VALUES (?1, ?2, ?3, ?4, ?5)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
             ",
             rusqlite::params![
                 source.id.as_str(),
                 source.name,
                 source.family_name,
                 source.style_name,
+                source.filename,
                 source.kind.as_str(),
             ],
         )?;
@@ -149,6 +153,7 @@ impl ShiftStore {
                 name,
                 family_name,
                 style_name,
+                filename,
                 kind
             FROM sources
             WHERE id = ?1
@@ -170,9 +175,10 @@ impl ShiftStore {
                 name,
                 family_name,
                 style_name,
+                filename,
                 kind
             FROM sources
-            ORDER BY id
+            ORDER BY order_index, id
             ",
         )?;
 
@@ -232,8 +238,8 @@ fn map_axis_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<AxisRecord> {
 }
 
 fn map_source_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SourceRecord> {
-    let kind = SourceKind::parse(row.get(4)?).map_err(|err| {
-        rusqlite::Error::FromSqlConversionFailure(4, rusqlite::types::Type::Text, Box::new(err))
+    let kind = SourceKind::parse(row.get(5)?).map_err(|err| {
+        rusqlite::Error::FromSqlConversionFailure(5, rusqlite::types::Type::Text, Box::new(err))
     })?;
 
     Ok(SourceRecord {
@@ -241,6 +247,7 @@ fn map_source_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SourceRecord> {
         name: row.get(1)?,
         family_name: row.get(2)?,
         style_name: row.get(3)?,
+        filename: row.get(4)?,
         kind,
     })
 }

--- a/crates/shift-store/tests/store_test.rs
+++ b/crates/shift-store/tests/store_test.rs
@@ -1,3 +1,4 @@
+use shift_font::test_support::sample_font;
 use shift_store::{
     AxisId, ComponentId, FontInfo, GlyphId, LayerId, NewAxis, NewGlyph, NewGlyphComponent,
     NewGlyphLayer, NewSource, ShiftStore, SourceId, SourceKind,
@@ -36,7 +37,7 @@ fn overwrites_font_info() {
     store
         .set_font_info(FontInfo {
             family_name: Some("Shift Sans".to_string()),
-            units_per_em: 1000,
+            units_per_em: 1000.0,
             ..empty_font_info()
         })
         .expect("font info should be overwritten");
@@ -47,7 +48,7 @@ fn overwrites_font_info() {
         .expect("font info should exist");
 
     assert_eq!(loaded.family_name.as_deref(), Some("Shift Sans"));
-    assert_eq!(loaded.units_per_em, 1000);
+    assert_eq!(loaded.units_per_em, 1000.0);
     assert_eq!(loaded.copyright, None);
 }
 
@@ -56,7 +57,7 @@ fn font_info_requires_positive_units_per_em() {
     let mut store = ShiftStore::open_memory_for_test().expect("memory store should open");
 
     let result = store.set_font_info(FontInfo {
-        units_per_em: 0,
+        units_per_em: 0.0,
         ..empty_font_info()
     });
 
@@ -231,6 +232,8 @@ fn glyph_component_requires_existing_layer_and_base_glyph() {
         id: ComponentId::new("component-A-B"),
         layer_id: LayerId::new("layer-missing"),
         base_glyph_id: GlyphId::new("glyph-missing"),
+        base_glyph_name: "Missing".to_string(),
+        transform: shift_font::DecomposedTransform::identity(),
         order_index: 0,
     });
 
@@ -591,6 +594,7 @@ fn create_glyph_a(store: &mut ShiftStore) -> GlyphId {
 fn open_sans_font_info() -> FontInfo {
     FontInfo {
         family_name: Some("Open Sans".to_string()),
+        style_name: Some("Regular".to_string()),
         copyright: Some(
             "Copyright 2020 The Open Sans Project Authors (https://github.com/googlefonts/opensans)"
                 .to_string(),
@@ -600,6 +604,7 @@ fn open_sans_font_info() -> FontInfo {
                 .to_string(),
         ),
         description: Some("Designed by Monotype design team.".to_string()),
+        note: Some("source-format fixture".to_string()),
         sample_text: None,
         designer: Some("Monotype Design Team".to_string()),
         designer_url: Some("http://www.monotype.com/studio".to_string()),
@@ -613,16 +618,28 @@ fn open_sans_font_info() -> FontInfo {
         vendor_id: None,
         version_major: Some(3),
         version_minor: Some(3),
-        units_per_em: 2048,
+        units_per_em: 2048.0,
+        ascender: 1500.0,
+        descender: -500.0,
+        cap_height: Some(1456.0),
+        x_height: Some(1012.0),
+        line_gap: Some(42.0),
+        italic_angle: Some(-9.5),
+        underline_position: Some(-175.0),
+        underline_thickness: Some(96.0),
+        default_source_id: Some("source_regular".to_string()),
     }
 }
 
 fn empty_font_info() -> FontInfo {
+    let metrics = shift_font::FontMetrics::default();
     FontInfo {
         family_name: None,
+        style_name: None,
         copyright: None,
         trademark: None,
         description: None,
+        note: None,
         sample_text: None,
         designer: None,
         designer_url: None,
@@ -633,7 +650,16 @@ fn empty_font_info() -> FontInfo {
         vendor_id: None,
         version_major: None,
         version_minor: None,
-        units_per_em: 1000,
+        units_per_em: metrics.units_per_em,
+        ascender: metrics.ascender,
+        descender: metrics.descender,
+        cap_height: metrics.cap_height,
+        x_height: metrics.x_height,
+        line_gap: metrics.line_gap,
+        italic_angle: metrics.italic_angle,
+        underline_position: metrics.underline_position,
+        underline_thickness: metrics.underline_thickness,
+        default_source_id: None,
     }
 }
 
@@ -681,6 +707,8 @@ fn create_default_component(
             id: component_id.clone(),
             layer_id: layer_id.clone(),
             base_glyph_id: base_glyph_id.clone(),
+            base_glyph_name: "B".to_string(),
+            transform: shift_font::DecomposedTransform::identity(),
             order_index: 0,
         })
         .expect("glyph component should be created");
@@ -715,6 +743,7 @@ fn create_regular_source(store: &mut ShiftStore) -> SourceId {
             name: Some("Regular".to_string()),
             family_name: Some("Shift Sans".to_string()),
             style_name: Some("Regular".to_string()),
+            filename: Some("Regular.ufo".to_string()),
             kind: SourceKind::Master,
         })
         .expect("source should be created");
@@ -729,6 +758,7 @@ fn create_regular_source_with_id(store: &mut ShiftStore, source_id: shift_font::
             name: Some("Regular".to_string()),
             family_name: Some("Shift Sans".to_string()),
             style_name: Some("Regular".to_string()),
+            filename: Some("Regular.ufo".to_string()),
             kind: SourceKind::Master,
         })
         .expect("source should be created");
@@ -936,6 +966,19 @@ fn replace_font_state_persists_axes_and_source_locations() {
     assert_eq!(locations.len(), 1);
     assert_eq!(locations[0].axis_id, AxisId::new("axis_weight"));
     assert_eq!(locations[0].value, 700.0);
+}
+
+#[test]
+fn replace_and_load_font_state_preserves_whole_font() {
+    let mut store = ShiftStore::open_memory_for_test().expect("memory store should open");
+    let original = sample_font();
+
+    store
+        .replace_font_state(&original)
+        .expect("replace font state");
+    let loaded = store.load_font_state().expect("load font state");
+
+    assert_eq!(loaded, original);
 }
 
 #[test]

--- a/crates/shift-workspace/src/new_workspace.rs
+++ b/crates/shift-workspace/src/new_workspace.rs
@@ -27,11 +27,17 @@ impl NewWorkspace {
     }
 
     pub(crate) fn font_info(&self) -> shift_store::FontInfo {
+        let metrics = shift_font::FontMetrics {
+            units_per_em: self.units_per_em as f64,
+            ..shift_font::FontMetrics::default()
+        };
         shift_store::FontInfo {
             family_name: Some(self.family_name.clone()),
+            style_name: None,
             copyright: None,
             trademark: None,
             description: None,
+            note: None,
             sample_text: None,
             designer: None,
             designer_url: None,
@@ -42,7 +48,16 @@ impl NewWorkspace {
             vendor_id: None,
             version_major: Some(1),
             version_minor: Some(0),
-            units_per_em: self.units_per_em,
+            units_per_em: metrics.units_per_em,
+            ascender: metrics.ascender,
+            descender: metrics.descender,
+            cap_height: metrics.cap_height,
+            x_height: metrics.x_height,
+            line_gap: metrics.line_gap,
+            italic_angle: metrics.italic_angle,
+            underline_position: metrics.underline_position,
+            underline_thickness: metrics.underline_thickness,
+            default_source_id: None,
         }
     }
 }

--- a/crates/shift-workspace/src/workspace.rs
+++ b/crates/shift-workspace/src/workspace.rs
@@ -543,11 +543,14 @@ fn replay_source(
 
 fn font_info_from_font(font: &shift_font::Font) -> shift_store::FontInfo {
     let metadata = font.metadata();
+    let metrics = font.metrics();
     shift_store::FontInfo {
         family_name: metadata.family_name.clone(),
+        style_name: metadata.style_name.clone(),
         copyright: metadata.copyright.clone(),
         trademark: metadata.trademark.clone(),
         description: metadata.description.clone(),
+        note: metadata.note.clone(),
         sample_text: None,
         designer: metadata.designer.clone(),
         designer_url: metadata.designer_url.clone(),
@@ -558,7 +561,16 @@ fn font_info_from_font(font: &shift_font::Font) -> shift_store::FontInfo {
         vendor_id: None,
         version_major: metadata.version_major.map(i64::from),
         version_minor: metadata.version_minor.map(i64::from),
-        units_per_em: font.metrics().units_per_em as i64,
+        units_per_em: metrics.units_per_em,
+        ascender: metrics.ascender,
+        descender: metrics.descender,
+        cap_height: metrics.cap_height,
+        x_height: metrics.x_height,
+        line_gap: metrics.line_gap,
+        italic_angle: metrics.italic_angle,
+        underline_position: metrics.underline_position,
+        underline_thickness: metrics.underline_thickness,
+        default_source_id: font.default_source_id().map(|id| id.to_string()),
     }
 }
 


### PR DESCRIPTION
## Summary
- Expand `shift-store` schema to mirror stable `.shift` source data for metrics, default source, source filenames, component transforms, guidelines, features, kerning, and lib data.
- Add `ShiftStore::load_font_state()` plus full-font equality round-trip coverage for the store.
- Add direct `shift-source` tree round-trip coverage using whole-`Font` equality.
- Keep the component owner FK while treating `base_glyph_id` as a semantic reference validated at the source/package boundary.

## Validation
- `cargo test -p shift-source -p shift-store -p shift-workspace -p shift-bridge`
- `pnpm typecheck`
- `git diff --check`
- pre-commit on commit: `cargo check`, `cargo fmt`, `cargo clippy`, `cargo test`