### PR TITLE
[codex] Add source workspace recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -82,7 +82,7 @@ checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -516,7 +516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -574,7 +574,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "libredox",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1621,7 +1621,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1807,6 +1807,7 @@ dependencies = [
  "shift-store",
  "tempfile",
  "thiserror 2.0.18",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1903,7 +1904,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2251,6 +2252,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/apps/desktop/src/utility/workspace/DocumentStorage.ts
+++ b/apps/desktop/src/utility/workspace/DocumentStorage.ts
@@ -34,4 +34,25 @@ export class DocumentStorage {
       storePath: path.join(directoryPath, "document.sqlite"),
     };
   }
+
+  /** Lists retained draft stores that can be inspected for recovery. */
+  listDrafts(): DraftAllocation[] {
+    const draftsRoot = path.join(this.#rootPath, "drafts");
+    if (!fs.existsSync(draftsRoot)) return [];
+
+    const drafts: DraftAllocation[] = [];
+    for (const entry of fs.readdirSync(draftsRoot, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+
+      const storePath = path.join(draftsRoot, entry.name, "document.sqlite");
+      if (!fs.existsSync(storePath)) continue;
+
+      drafts.push({
+        documentId: entry.name,
+        storePath,
+      });
+    }
+
+    return drafts;
+  }
 }

--- a/apps/desktop/src/utility/workspace/WorkspaceHost.test.ts
+++ b/apps/desktop/src/utility/workspace/WorkspaceHost.test.ts
@@ -165,6 +165,45 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     });
   });
 
+  it("opening a package resumes a retained dirty working store", async () => {
+    const source = await connectSyncLane();
+    const created = await source.call("workspace.create", undefined);
+    await source.call("workspace.apply", { intents: [createGlyphA()], label: "Add Glyph" });
+    const savePath = path.join(tmpRoot, "RecoverMe.shift");
+    await source.call("workspace.saveAs", { path: savePath });
+    await source.call("workspace.apply", {
+      intents: [
+        {
+          kind: "createGlyph",
+          createGlyph: {
+            glyphId: mintGlyphId(),
+            name: "B" as GlyphName,
+            unicodes: [66 as Unicode],
+          },
+        },
+      ],
+      label: "Add Glyph",
+    });
+
+    const lane = new MessageChannel();
+    const restartedShell: ShellChannel = new Channel(nodePortTransport(lane.port1));
+    channels.push(restartedShell);
+    startHost(nodePortTransport(lane.port2));
+    const restarted = await connectSyncLane(restartedShell);
+
+    const opened = await restarted.call("workspace.open", { path: savePath });
+
+    expect(opened.documentId).toBe(created.documentId);
+    expect(opened.glyphs.map((glyph) => glyph.name)).toEqual(["A", "B"]);
+    await expect(restartedShell.call("document.state", undefined)).resolves.toMatchObject({
+      documentId: created.documentId,
+      sourceKind: "package",
+      saveTarget: savePath,
+      dirty: true,
+      needsSaveAs: false,
+    });
+  });
+
   it("emits utility-owned document state after create and apply", async () => {
     let latestState: WorkspaceDocumentState | null = null;
     const unlisten = shell.listen("document.changed", (state) => {

--- a/apps/desktop/src/utility/workspace/WorkspaceHost.ts
+++ b/apps/desktop/src/utility/workspace/WorkspaceHost.ts
@@ -109,6 +109,7 @@ export class WorkspaceHost {
     const draft = this.#documents.createDraft();
 
     this.#bridge.createUntitledWorkspace(draft.storePath);
+    this.#bridge.setDocumentId(draft.documentId);
     this.#documentId = draft.documentId;
 
     const snapshot = this.#snapshot(draft.documentId);
@@ -128,10 +129,18 @@ export class WorkspaceHost {
   }
 
   #open(path: string): WorkspaceSnapshot {
-    const draft = this.#documents.createDraft(); // fresh working store, same as create/open model
-    this.#bridge.openWorkspace(path, draft.storePath);
-    this.#documentId = draft.documentId;
-    const snapshot = this.#snapshot(draft.documentId);
+    const recovery = this.#bridge.findRecoverableWorkspace(path, this.#documents.listDrafts());
+    const document = recovery ?? this.#documents.createDraft();
+
+    if (recovery) {
+      this.#bridge.resumeWorkspaceForSource(recovery.storePath, path);
+    } else {
+      this.#bridge.openWorkspace(path, document.storePath);
+    }
+
+    this.#bridge.setDocumentId(document.documentId);
+    this.#documentId = document.documentId;
+    const snapshot = this.#snapshot(document.documentId);
     this.#emitDocumentChanged();
 
     return snapshot;

--- a/crates/shift-bridge/index.d.ts
+++ b/crates/shift-bridge/index.d.ts
@@ -17,6 +17,9 @@ export declare class Bridge {
   exportWorkspace(request: NapiFontExportRequest): Promise<NapiFontExportResult>
   documentState(): NapiDocumentState
   openWorkspace(path: string, storePath: string): void
+  resumeWorkspaceForSource(storePath: string, sourcePath: string): void
+  setDocumentId(documentId: string): NapiDocumentState
+  findRecoverableWorkspace(sourcePath: string, candidates: Array<NapiWorkspaceRecoveryCandidate>): NapiWorkspaceRecoveryMatch | null
   saveWorkspace(): NapiDocumentState
   saveWorkspaceAs(path: string): NapiDocumentState
   getMetadata(): NapiFontMetadata
@@ -66,6 +69,18 @@ export interface NapiFontExportResult {
 export interface NapiNewWorkspace {
   familyName?: string
   unitsPerEm?: number
+}
+
+export interface NapiWorkspaceRecoveryCandidate {
+  documentId: string
+  storePath: string
+}
+
+export interface NapiWorkspaceRecoveryMatch {
+  documentId: string
+  storePath: string
+  matchKind: string
+  dirty: boolean
 }
 export interface NapiAddAnchorsIntent {
   layerId: LayerId

--- a/crates/shift-bridge/src/bridge.rs
+++ b/crates/shift-bridge/src/bridge.rs
@@ -19,7 +19,8 @@ use shift_wire::{
   Source,
 };
 use shift_workspace::{
-  FontWorkspace, NewWorkspace, WorkspaceError, WorkspaceRecoveryCandidate, WorkspaceSource,
+  FontWorkspace, NewWorkspace, RecoverySelection, WorkspaceError, WorkspaceRecoveryCandidate,
+  WorkspaceSource,
 };
 use std::{path::Path, sync::Arc};
 
@@ -304,11 +305,14 @@ impl Bridge {
         store_path: candidate.store_path.into(),
       })
       .collect::<Vec<_>>();
-    let Some(recovery_match) =
-      FontWorkspace::find_recoverable_package_workspace(source_path, &candidates)?
-    else {
-      return Ok(None);
-    };
+    let recovery_match =
+      match FontWorkspace::find_recoverable_package_workspace(source_path, &candidates)? {
+        RecoverySelection::None => return Ok(None),
+        RecoverySelection::One(recovery_match) => recovery_match,
+        RecoverySelection::Ambiguous(matches) => {
+          return Err(WorkspaceError::AmbiguousRecoveryCandidates(matches.len()).into());
+        }
+      };
 
     Ok(Some(NapiWorkspaceRecoveryMatch {
       document_id: recovery_match.document_id,

--- a/crates/shift-bridge/src/bridge.rs
+++ b/crates/shift-bridge/src/bridge.rs
@@ -18,7 +18,9 @@ use shift_wire::{
   Axis, FontMetadata, FontMetrics, GlyphChangedEntities, GlyphRecord, GlyphState, GlyphStructure,
   Source,
 };
-use shift_workspace::{FontWorkspace, NewWorkspace, WorkspaceError, WorkspaceSource};
+use shift_workspace::{
+  FontWorkspace, NewWorkspace, WorkspaceError, WorkspaceRecoveryCandidate, WorkspaceSource,
+};
 use std::{path::Path, sync::Arc};
 
 #[napi(object)]
@@ -47,6 +49,20 @@ pub struct NapiDocumentState {
   pub save_target: Option<String>,
   pub dirty: bool,
   pub needs_save_as: bool,
+}
+
+#[napi(object)]
+pub struct NapiWorkspaceRecoveryCandidate {
+  pub document_id: String,
+  pub store_path: String,
+}
+
+#[napi(object)]
+pub struct NapiWorkspaceRecoveryMatch {
+  pub document_id: String,
+  pub store_path: String,
+  pub match_kind: String,
+  pub dirty: bool,
 }
 
 fn new_workspace_from_options(options: Option<NapiNewWorkspace>) -> NewWorkspace {
@@ -256,6 +272,50 @@ impl Bridge {
     self.workspace = Some(FontWorkspace::open(path, store_path)?);
     self.reset_versions();
     Ok(())
+  }
+
+  #[napi]
+  pub fn resume_workspace_for_source(
+    &mut self,
+    store_path: String,
+    source_path: String,
+  ) -> errors::Result<()> {
+    self.workspace = Some(FontWorkspace::resume_for_source(store_path, source_path)?);
+    self.reset_versions();
+    Ok(())
+  }
+
+  #[napi]
+  pub fn set_document_id(&mut self, document_id: String) -> errors::Result<NapiDocumentState> {
+    self.workspace_mut()?.set_document_id(document_id)?;
+    self.document_state_snapshot()
+  }
+
+  #[napi]
+  pub fn find_recoverable_workspace(
+    &self,
+    source_path: String,
+    candidates: Vec<NapiWorkspaceRecoveryCandidate>,
+  ) -> errors::Result<Option<NapiWorkspaceRecoveryMatch>> {
+    let candidates = candidates
+      .into_iter()
+      .map(|candidate| WorkspaceRecoveryCandidate {
+        document_id: candidate.document_id,
+        store_path: candidate.store_path.into(),
+      })
+      .collect::<Vec<_>>();
+    let Some(recovery_match) =
+      FontWorkspace::find_recoverable_package_workspace(source_path, &candidates)?
+    else {
+      return Ok(None);
+    };
+
+    Ok(Some(NapiWorkspaceRecoveryMatch {
+      document_id: recovery_match.document_id,
+      store_path: path_to_string(&recovery_match.store_path)?,
+      match_kind: recovery_match.match_kind.as_str().to_string(),
+      dirty: recovery_match.dirty,
+    }))
   }
 
   #[napi]
@@ -516,10 +576,7 @@ impl Bridge {
     Ok(NapiDocumentState {
       source_kind: source_kind.to_string(),
       save_target,
-      // `live_version`/`saved_version` stay internal: `dirty` is the only
-      // answer callers need, and shipping the raw counters next to it only
-      // invites three fields that must agree.
-      dirty: self.live_version != self.saved_version,
+      dirty: workspace.is_dirty()?,
       needs_save_as,
     })
   }
@@ -1557,6 +1614,44 @@ mod tests {
     let state = bridge.document_state().unwrap();
     assert!(state.dirty);
     assert!(state.needs_save_as);
+  }
+
+  #[test]
+  fn resume_workspace_restores_persisted_dirty_state() {
+    let (save_path, store_path) = test_paths("resume");
+    {
+      let mut bridge = Bridge::new();
+      bridge
+        .create_untitled_workspace(store_path.clone(), None)
+        .unwrap();
+      bridge
+        .apply(vec![create_glyph_napi("A", vec![65])], None)
+        .unwrap();
+      bridge.save_workspace_as(save_path.clone()).unwrap();
+      bridge
+        .apply(vec![create_glyph_napi("B", vec![66])], None)
+        .unwrap();
+      assert!(bridge.document_state().unwrap().dirty);
+    }
+
+    let mut bridge = Bridge::new();
+    bridge
+      .resume_workspace_for_source(store_path, save_path.clone())
+      .unwrap();
+
+    let state = bridge.document_state().unwrap();
+    assert_eq!(state.source_kind, "package");
+    assert_eq!(state.save_target.as_deref(), Some(save_path.as_str()));
+    assert!(state.dirty);
+    assert_eq!(
+      bridge
+        .get_glyphs()
+        .unwrap()
+        .into_iter()
+        .map(|glyph| glyph.name)
+        .collect::<Vec<_>>(),
+      vec!["A".to_string(), "B".to_string()]
+    );
   }
 
   fn default_source_id(bridge: &Bridge) -> String {

--- a/crates/shift-store/src/change_set.rs
+++ b/crates/shift-store/src/change_set.rs
@@ -1,7 +1,7 @@
 use rusqlite::{Transaction, params};
 use shift_font as font;
 
-use crate::{ShiftStore, StoreError};
+use crate::{ShiftStore, StoreError, workspace_state::mark_workspace_dirty_in_tx};
 
 impl ShiftStore {
     pub fn apply_change_set(&mut self, change_set: &font::FontChangeSet) -> Result<(), StoreError> {
@@ -10,6 +10,7 @@ impl ShiftStore {
         for change in &change_set.changes {
             apply_change(&tx, change)?;
         }
+        mark_workspace_dirty_in_tx(&tx)?;
 
         tx.commit()?;
         Ok(())

--- a/crates/shift-store/src/error.rs
+++ b/crates/shift-store/src/error.rs
@@ -18,6 +18,9 @@ pub enum StoreError {
     #[error("invalid lib value: {0}")]
     InvalidLibValue(String),
 
+    #[error("invalid workspace state: {0}")]
+    InvalidWorkspaceState(String),
+
     #[error("missing {kind}: {id}")]
     MissingEntity { kind: &'static str, id: String },
 

--- a/crates/shift-store/src/lib.rs
+++ b/crates/shift-store/src/lib.rs
@@ -23,5 +23,5 @@ pub use source::{AxisRecord, NewAxis, NewSource, SourceAxisLocation, SourceKind,
 pub use store::ShiftStore;
 pub use types::{AxisId, ComponentId, GlyphId, LayerId, RevisionId, SourceId};
 pub use workspace_state::{
-    FileIdentity, SourceIdentitySnapshot, WorkspaceSourceKind, WorkspaceState,
+    Evidence, FileIdentity, SourceIdentitySnapshot, WorkspaceSourceKind, WorkspaceState,
 };

--- a/crates/shift-store/src/lib.rs
+++ b/crates/shift-store/src/lib.rs
@@ -11,6 +11,7 @@ mod schema;
 mod source;
 mod store;
 mod types;
+mod workspace_state;
 
 pub use component::{GlyphComponentRecord, NewGlyphComponent};
 pub use error::StoreError;
@@ -21,3 +22,6 @@ pub use outline::{AnchorRecord, ContourRecord, PointRecord};
 pub use source::{AxisRecord, NewAxis, NewSource, SourceAxisLocation, SourceKind, SourceRecord};
 pub use store::ShiftStore;
 pub use types::{AxisId, ComponentId, GlyphId, LayerId, RevisionId, SourceId};
+pub use workspace_state::{
+    FileIdentity, SourceIdentitySnapshot, WorkspaceSourceKind, WorkspaceState,
+};

--- a/crates/shift-store/src/schema.rs
+++ b/crates/shift-store/src/schema.rs
@@ -249,6 +249,25 @@ CREATE TABLE IF NOT EXISTS glyph_layer_lib (
     PRIMARY KEY (layer_id, key),
     FOREIGN KEY (layer_id) REFERENCES glyph_layers(id) ON DELETE CASCADE
 );
+
+CREATE TABLE IF NOT EXISTS workspace_state (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    document_id TEXT,
+    source_kind TEXT NOT NULL CHECK (source_kind IN ('untitled', 'package', 'imported')),
+    source_path TEXT,
+    canonical_source_path TEXT,
+    original_import_path TEXT,
+    source_package_id TEXT,
+    source_file_identity_kind TEXT,
+    source_file_identity_value TEXT,
+    source_size INTEGER,
+    source_mtime_ms INTEGER,
+    source_fingerprint TEXT,
+    dirty INTEGER NOT NULL DEFAULT 0 CHECK (dirty IN (0, 1)),
+    revision INTEGER NOT NULL DEFAULT 0,
+    saved_revision INTEGER NOT NULL DEFAULT 0,
+    updated_at_ms INTEGER NOT NULL
+);
 "#;
 
 pub(crate) const SCHEMA_VERSION: i64 = 1;

--- a/crates/shift-store/src/workspace_state.rs
+++ b/crates/shift-store/src/workspace_state.rs
@@ -1,0 +1,409 @@
+use std::{
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use rusqlite::{Transaction, params};
+
+use crate::{ShiftStore, StoreError};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FileIdentity {
+    pub kind: String,
+    pub value: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SourceIdentitySnapshot {
+    pub source_path: Option<PathBuf>,
+    pub canonical_source_path: Option<PathBuf>,
+    pub source_package_id: Option<String>,
+    pub source_file_identity: Option<FileIdentity>,
+    pub source_size: Option<u64>,
+    pub source_mtime_ms: Option<i64>,
+    pub source_fingerprint: Option<String>,
+    pub observed_at_ms: i64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WorkspaceSourceKind {
+    Untitled,
+    Package,
+    Imported,
+}
+
+impl WorkspaceSourceKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Untitled => "untitled",
+            Self::Package => "package",
+            Self::Imported => "imported",
+        }
+    }
+}
+
+impl TryFrom<&str> for WorkspaceSourceKind {
+    type Error = StoreError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "untitled" => Ok(Self::Untitled),
+            "package" => Ok(Self::Package),
+            "imported" => Ok(Self::Imported),
+            other => Err(StoreError::InvalidWorkspaceState(format!(
+                "unknown source kind {other:?}"
+            ))),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WorkspaceState {
+    pub document_id: Option<String>,
+    pub source_kind: WorkspaceSourceKind,
+    pub source_path: Option<PathBuf>,
+    pub canonical_source_path: Option<PathBuf>,
+    pub original_import_path: Option<PathBuf>,
+    pub source_package_id: Option<String>,
+    pub source_file_identity: Option<FileIdentity>,
+    pub source_size: Option<u64>,
+    pub source_mtime_ms: Option<i64>,
+    pub source_fingerprint: Option<String>,
+    pub dirty: bool,
+    pub revision: i64,
+    pub saved_revision: i64,
+    pub updated_at_ms: i64,
+}
+
+impl WorkspaceState {
+    pub fn untitled(document_id: Option<String>) -> Self {
+        Self {
+            document_id,
+            source_kind: WorkspaceSourceKind::Untitled,
+            source_path: None,
+            canonical_source_path: None,
+            original_import_path: None,
+            source_package_id: None,
+            source_file_identity: None,
+            source_size: None,
+            source_mtime_ms: None,
+            source_fingerprint: None,
+            dirty: false,
+            revision: 0,
+            saved_revision: 0,
+            updated_at_ms: now_ms(),
+        }
+    }
+
+    pub fn imported(original_path: impl AsRef<Path>, document_id: Option<String>) -> Self {
+        Self {
+            document_id,
+            source_kind: WorkspaceSourceKind::Imported,
+            source_path: None,
+            canonical_source_path: None,
+            original_import_path: Some(original_path.as_ref().to_path_buf()),
+            source_package_id: None,
+            source_file_identity: None,
+            source_size: None,
+            source_mtime_ms: None,
+            source_fingerprint: None,
+            dirty: false,
+            revision: 0,
+            saved_revision: 0,
+            updated_at_ms: now_ms(),
+        }
+    }
+
+    pub fn package(identity: SourceIdentitySnapshot, document_id: Option<String>) -> Self {
+        Self {
+            document_id,
+            source_kind: WorkspaceSourceKind::Package,
+            source_path: identity.source_path,
+            canonical_source_path: identity.canonical_source_path,
+            original_import_path: None,
+            source_package_id: identity.source_package_id,
+            source_file_identity: identity.source_file_identity,
+            source_size: identity.source_size,
+            source_mtime_ms: identity.source_mtime_ms,
+            source_fingerprint: identity.source_fingerprint,
+            dirty: false,
+            revision: 0,
+            saved_revision: 0,
+            updated_at_ms: identity.observed_at_ms,
+        }
+    }
+
+    pub fn source_identity(&self) -> SourceIdentitySnapshot {
+        SourceIdentitySnapshot {
+            source_path: self.source_path.clone(),
+            canonical_source_path: self.canonical_source_path.clone(),
+            source_package_id: self.source_package_id.clone(),
+            source_file_identity: self.source_file_identity.clone(),
+            source_size: self.source_size,
+            source_mtime_ms: self.source_mtime_ms,
+            source_fingerprint: self.source_fingerprint.clone(),
+            observed_at_ms: self.updated_at_ms,
+        }
+    }
+}
+
+impl ShiftStore {
+    pub fn set_workspace_state(&mut self, state: WorkspaceState) -> Result<(), StoreError> {
+        let file_identity_kind = state
+            .source_file_identity
+            .as_ref()
+            .map(|identity| identity.kind.as_str());
+        let file_identity_value = state
+            .source_file_identity
+            .as_ref()
+            .map(|identity| identity.value.as_str());
+        let source_path = state.source_path.as_deref().map(path_to_db);
+        let canonical_source_path = state.canonical_source_path.as_deref().map(path_to_db);
+        let original_import_path = state.original_import_path.as_deref().map(path_to_db);
+        let source_size = state
+            .source_size
+            .map(i64::try_from)
+            .transpose()
+            .map_err(|_| {
+                StoreError::InvalidWorkspaceState("source size does not fit i64".into())
+            })?;
+
+        self.conn.execute(
+            "
+            INSERT INTO workspace_state (
+                id,
+                document_id,
+                source_kind,
+                source_path,
+                canonical_source_path,
+                original_import_path,
+                source_package_id,
+                source_file_identity_kind,
+                source_file_identity_value,
+                source_size,
+                source_mtime_ms,
+                source_fingerprint,
+                dirty,
+                revision,
+                saved_revision,
+                updated_at_ms
+            )
+            VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+            ON CONFLICT(id) DO UPDATE SET
+                document_id = excluded.document_id,
+                source_kind = excluded.source_kind,
+                source_path = excluded.source_path,
+                canonical_source_path = excluded.canonical_source_path,
+                original_import_path = excluded.original_import_path,
+                source_package_id = excluded.source_package_id,
+                source_file_identity_kind = excluded.source_file_identity_kind,
+                source_file_identity_value = excluded.source_file_identity_value,
+                source_size = excluded.source_size,
+                source_mtime_ms = excluded.source_mtime_ms,
+                source_fingerprint = excluded.source_fingerprint,
+                dirty = excluded.dirty,
+                revision = excluded.revision,
+                saved_revision = excluded.saved_revision,
+                updated_at_ms = excluded.updated_at_ms
+            ",
+            params![
+                state.document_id.as_deref(),
+                state.source_kind.as_str(),
+                source_path,
+                canonical_source_path,
+                original_import_path,
+                state.source_package_id.as_deref(),
+                file_identity_kind,
+                file_identity_value,
+                source_size,
+                state.source_mtime_ms,
+                state.source_fingerprint.as_deref(),
+                state.dirty,
+                state.revision,
+                state.saved_revision,
+                state.updated_at_ms,
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn workspace_state(&self) -> Result<Option<WorkspaceState>, StoreError> {
+        let mut stmt = self.conn.prepare(
+            "
+            SELECT
+                document_id,
+                source_kind,
+                source_path,
+                canonical_source_path,
+                original_import_path,
+                source_package_id,
+                source_file_identity_kind,
+                source_file_identity_value,
+                source_size,
+                source_mtime_ms,
+                source_fingerprint,
+                dirty,
+                revision,
+                saved_revision,
+                updated_at_ms
+            FROM workspace_state
+            WHERE id = 1
+            ",
+        )?;
+
+        match stmt.query_row([], map_workspace_state_row) {
+            Ok(state) => Ok(Some(state)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    pub fn set_workspace_document_id(&mut self, document_id: String) -> Result<(), StoreError> {
+        self.conn.execute(
+            "
+            UPDATE workspace_state
+            SET document_id = ?1, updated_at_ms = ?2
+            WHERE id = 1
+            ",
+            params![document_id, now_ms()],
+        )?;
+        Ok(())
+    }
+
+    pub fn mark_workspace_clean(
+        &mut self,
+        identity: Option<&SourceIdentitySnapshot>,
+    ) -> Result<(), StoreError> {
+        let Some(identity) = identity else {
+            self.conn.execute(
+                "
+                UPDATE workspace_state
+                SET
+                    dirty = 0,
+                    saved_revision = revision,
+                    updated_at_ms = ?1
+                WHERE id = 1
+                ",
+                params![now_ms()],
+            )?;
+            return Ok(());
+        };
+
+        let file_identity_kind = identity
+            .source_file_identity
+            .as_ref()
+            .map(|file_identity| file_identity.kind.as_str());
+        let file_identity_value = identity
+            .source_file_identity
+            .as_ref()
+            .map(|file_identity| file_identity.value.as_str());
+
+        self.conn.execute(
+            "
+            UPDATE workspace_state
+            SET
+                source_path = ?1,
+                canonical_source_path = ?2,
+                source_package_id = ?3,
+                source_file_identity_kind = ?4,
+                source_file_identity_value = ?5,
+                source_size = ?6,
+                source_mtime_ms = ?7,
+                source_fingerprint = ?8,
+                dirty = 0,
+                saved_revision = revision,
+                updated_at_ms = ?9
+            WHERE id = 1
+            ",
+            params![
+                identity.source_path.as_deref().map(path_to_db),
+                identity.canonical_source_path.as_deref().map(path_to_db),
+                identity.source_package_id.as_deref(),
+                file_identity_kind,
+                file_identity_value,
+                identity
+                    .source_size
+                    .map(i64::try_from)
+                    .transpose()
+                    .map_err(|_| StoreError::InvalidWorkspaceState(
+                        "source size does not fit i64".into()
+                    ))?,
+                identity.source_mtime_ms,
+                identity.source_fingerprint.as_deref(),
+                identity.observed_at_ms,
+            ],
+        )?;
+        Ok(())
+    }
+}
+
+pub(crate) fn mark_workspace_dirty_in_tx(tx: &Transaction<'_>) -> Result<(), StoreError> {
+    tx.execute(
+        "
+        UPDATE workspace_state
+        SET
+            dirty = 1,
+            revision = revision + 1,
+            updated_at_ms = ?1
+        WHERE id = 1
+        ",
+        params![now_ms()],
+    )?;
+    Ok(())
+}
+
+fn map_workspace_state_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<WorkspaceState> {
+    let source_kind = row.get::<_, String>(1)?;
+    let source_file_identity = match (
+        row.get::<_, Option<String>>(6)?,
+        row.get::<_, Option<String>>(7)?,
+    ) {
+        (Some(kind), Some(value)) => Some(FileIdentity { kind, value }),
+        _ => None,
+    };
+
+    let source_size = row
+        .get::<_, Option<i64>>(8)?
+        .map(|size| {
+            u64::try_from(size).map_err(|err| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    8,
+                    rusqlite::types::Type::Integer,
+                    Box::new(err),
+                )
+            })
+        })
+        .transpose()?;
+
+    let source_kind = WorkspaceSourceKind::try_from(source_kind.as_str()).map_err(|err| {
+        rusqlite::Error::FromSqlConversionFailure(1, rusqlite::types::Type::Text, Box::new(err))
+    })?;
+
+    Ok(WorkspaceState {
+        document_id: row.get(0)?,
+        source_kind,
+        source_path: row.get::<_, Option<String>>(2)?.map(PathBuf::from),
+        canonical_source_path: row.get::<_, Option<String>>(3)?.map(PathBuf::from),
+        original_import_path: row.get::<_, Option<String>>(4)?.map(PathBuf::from),
+        source_package_id: row.get(5)?,
+        source_file_identity,
+        source_size,
+        source_mtime_ms: row.get(9)?,
+        source_fingerprint: row.get(10)?,
+        dirty: row.get(11)?,
+        revision: row.get(12)?,
+        saved_revision: row.get(13)?,
+        updated_at_ms: row.get(14)?,
+    })
+}
+
+fn path_to_db(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+fn now_ms() -> i64 {
+    match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => i64::try_from(duration.as_millis()).unwrap_or(i64::MAX),
+        Err(_) => 0,
+    }
+}

--- a/crates/shift-store/src/workspace_state.rs
+++ b/crates/shift-store/src/workspace_state.rs
@@ -22,7 +22,77 @@ pub struct SourceIdentitySnapshot {
     pub source_size: Option<u64>,
     pub source_mtime_ms: Option<i64>,
     pub source_fingerprint: Option<String>,
-    pub observed_at_ms: i64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Evidence {
+    Same,
+    Different,
+    Unknown,
+}
+
+impl Evidence {
+    pub fn is_same(self) -> bool {
+        self == Self::Same
+    }
+
+    pub fn is_different(self) -> bool {
+        self == Self::Different
+    }
+}
+
+impl SourceIdentitySnapshot {
+    pub fn source_path_match(&self, other: &Self) -> Evidence {
+        compare_optional(self.source_path.as_ref(), other.source_path.as_ref())
+    }
+
+    pub fn canonical_path_match(&self, other: &Self) -> Evidence {
+        compare_optional(
+            self.canonical_source_path.as_ref(),
+            other.canonical_source_path.as_ref(),
+        )
+    }
+
+    pub fn package_id_match(&self, other: &Self) -> Evidence {
+        compare_optional(
+            self.source_package_id.as_ref(),
+            other.source_package_id.as_ref(),
+        )
+    }
+
+    pub fn file_identity_match(&self, other: &Self) -> Evidence {
+        compare_optional(
+            self.source_file_identity.as_ref(),
+            other.source_file_identity.as_ref(),
+        )
+    }
+
+    pub fn fingerprint_match(&self, other: &Self) -> Evidence {
+        compare_optional(
+            self.source_fingerprint.as_ref(),
+            other.source_fingerprint.as_ref(),
+        )
+    }
+
+    pub fn same_path_as(&self, other: &Self) -> bool {
+        self.canonical_path_match(other).is_same() || self.source_path_match(other).is_same()
+    }
+
+    pub fn fingerprint_changed_from(&self, other: &Self) -> bool {
+        self.fingerprint_match(other).is_different()
+    }
+
+    pub fn source_path_missing(&self) -> bool {
+        self.source_path.as_ref().is_none_or(|path| !path.exists())
+    }
+}
+
+fn compare_optional<T: PartialEq>(left: Option<&T>, right: Option<&T>) -> Evidence {
+    match (left, right) {
+        (Some(left), Some(right)) if left == right => Evidence::Same,
+        (Some(_), Some(_)) => Evidence::Different,
+        _ => Evidence::Unknown,
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -129,7 +199,7 @@ impl WorkspaceState {
             dirty: false,
             revision: 0,
             saved_revision: 0,
-            updated_at_ms: identity.observed_at_ms,
+            updated_at_ms: now_ms(),
         }
     }
 
@@ -142,8 +212,20 @@ impl WorkspaceState {
             source_size: self.source_size,
             source_mtime_ms: self.source_mtime_ms,
             source_fingerprint: self.source_fingerprint.clone(),
-            observed_at_ms: self.updated_at_ms,
         }
+    }
+
+    pub fn set_package_identity(&mut self, identity: SourceIdentitySnapshot) {
+        self.source_kind = WorkspaceSourceKind::Package;
+        self.source_path = identity.source_path;
+        self.canonical_source_path = identity.canonical_source_path;
+        self.original_import_path = None;
+        self.source_package_id = identity.source_package_id;
+        self.source_file_identity = identity.source_file_identity;
+        self.source_size = identity.source_size;
+        self.source_mtime_ms = identity.source_mtime_ms;
+        self.source_fingerprint = identity.source_fingerprint;
+        self.updated_at_ms = now_ms();
     }
 }
 
@@ -330,7 +412,7 @@ impl ShiftStore {
                     ))?,
                 identity.source_mtime_ms,
                 identity.source_fingerprint.as_deref(),
-                identity.observed_at_ms,
+                now_ms(),
             ],
         )?;
         Ok(())

--- a/crates/shift-store/tests/store_test.rs
+++ b/crates/shift-store/tests/store_test.rs
@@ -1,7 +1,7 @@
 use shift_font::test_support::sample_font;
 use shift_store::{
     AxisId, ComponentId, FontInfo, GlyphId, LayerId, NewAxis, NewGlyph, NewGlyphComponent,
-    NewGlyphLayer, NewSource, ShiftStore, SourceId, SourceKind,
+    NewGlyphLayer, NewSource, ShiftStore, SourceId, SourceKind, WorkspaceState,
 };
 
 #[test]
@@ -24,6 +24,47 @@ fn writes_and_reads_font_info() {
         .expect("font info should exist");
 
     assert_eq!(loaded, font_info);
+}
+
+#[test]
+fn writes_and_reads_workspace_state() {
+    let mut store = ShiftStore::open_memory_for_test().expect("memory store should open");
+    let state = WorkspaceState::untitled(Some("doc-1".to_string()));
+
+    store
+        .set_workspace_state(state.clone())
+        .expect("workspace state should be written");
+
+    let loaded = store
+        .workspace_state()
+        .expect("workspace state query should succeed")
+        .expect("workspace state should exist");
+
+    assert_eq!(loaded, state);
+}
+
+#[test]
+fn applying_change_set_marks_workspace_state_dirty() {
+    let mut store = ShiftStore::open_memory_for_test().expect("memory store should open");
+    let glyph = shift_font::Glyph::with_unicode("A", 65);
+    store
+        .set_workspace_state(WorkspaceState::untitled(Some("doc-1".to_string())))
+        .expect("workspace state should be written");
+
+    store
+        .apply_change_set(&shift_font::FontChangeSet::new(vec![
+            shift_font::FontChange::glyph_created(&glyph),
+        ]))
+        .expect("change set should apply");
+
+    let loaded = store
+        .workspace_state()
+        .expect("workspace state query should succeed")
+        .expect("workspace state should exist");
+
+    assert!(loaded.dirty);
+    assert_eq!(loaded.revision, 1);
+    assert_eq!(loaded.saved_revision, 0);
 }
 
 #[test]

--- a/crates/shift-store/tests/store_test.rs
+++ b/crates/shift-store/tests/store_test.rs
@@ -1,7 +1,8 @@
 use shift_font::test_support::sample_font;
 use shift_store::{
-    AxisId, ComponentId, FontInfo, GlyphId, LayerId, NewAxis, NewGlyph, NewGlyphComponent,
-    NewGlyphLayer, NewSource, ShiftStore, SourceId, SourceKind, WorkspaceState,
+    AxisId, ComponentId, Evidence, FileIdentity, FontInfo, GlyphId, LayerId, NewAxis, NewGlyph,
+    NewGlyphComponent, NewGlyphLayer, NewSource, ShiftStore, SourceId, SourceIdentitySnapshot,
+    SourceKind, WorkspaceState,
 };
 
 #[test]
@@ -65,6 +66,37 @@ fn applying_change_set_marks_workspace_state_dirty() {
     assert!(loaded.dirty);
     assert_eq!(loaded.revision, 1);
     assert_eq!(loaded.saved_revision, 0);
+}
+
+#[test]
+fn source_identity_snapshot_separates_exact_equality_from_match_evidence() {
+    let left = SourceIdentitySnapshot {
+        source_path: Some("Family.shift".into()),
+        canonical_source_path: Some("/fonts/Family.shift".into()),
+        source_package_id: None,
+        source_file_identity: Some(FileIdentity {
+            kind: "unix-dev-inode".to_string(),
+            value: "1:2".to_string(),
+        }),
+        source_size: Some(128),
+        source_mtime_ms: Some(1_000),
+        source_fingerprint: Some("fnv1a64:abc".to_string()),
+    };
+    let moved = SourceIdentitySnapshot {
+        source_path: Some("Renamed.shift".into()),
+        canonical_source_path: Some("/fonts/Renamed.shift".into()),
+        ..left.clone()
+    };
+    let unknown = SourceIdentitySnapshot {
+        source_file_identity: None,
+        source_fingerprint: None,
+        ..left.clone()
+    };
+
+    assert_ne!(left, moved);
+    assert_eq!(left.file_identity_match(&moved), Evidence::Same);
+    assert_eq!(left.canonical_path_match(&moved), Evidence::Different);
+    assert_eq!(left.fingerprint_match(&unknown), Evidence::Unknown);
 }
 
 #[test]

--- a/crates/shift-workspace/Cargo.toml
+++ b/crates/shift-workspace/Cargo.toml
@@ -10,5 +10,8 @@ shift-source = { workspace = true }
 shift-store = { workspace = true }
 thiserror = "2"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem"] }
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/shift-workspace/src/lib.rs
+++ b/crates/shift-workspace/src/lib.rs
@@ -4,4 +4,7 @@ mod workspace;
 
 pub use ledger::{LayerPair, Ledger, LedgerEntry, LedgerStep};
 pub use new_workspace::NewWorkspace;
-pub use workspace::{FontWorkspace, WorkspaceError, WorkspaceSource};
+pub use workspace::{
+    FontWorkspace, SourceMatchKind, WorkspaceError, WorkspaceRecoveryCandidate,
+    WorkspaceRecoveryMatch, WorkspaceSource,
+};

--- a/crates/shift-workspace/src/lib.rs
+++ b/crates/shift-workspace/src/lib.rs
@@ -1,10 +1,11 @@
 mod ledger;
 mod new_workspace;
+mod source_identity;
 mod workspace;
 
 pub use ledger::{LayerPair, Ledger, LedgerEntry, LedgerStep};
 pub use new_workspace::NewWorkspace;
-pub use workspace::{
-    FontWorkspace, SourceMatchKind, WorkspaceError, WorkspaceRecoveryCandidate,
-    WorkspaceRecoveryMatch, WorkspaceSource,
+pub use source_identity::{
+    RecoverySelection, SourceMatchKind, WorkspaceRecoveryCandidate, WorkspaceRecoveryMatch,
 };
+pub use workspace::{FontWorkspace, WorkspaceError, WorkspaceSource};

--- a/crates/shift-workspace/src/source_identity.rs
+++ b/crates/shift-workspace/src/source_identity.rs
@@ -1,0 +1,308 @@
+use std::{
+    fs::{self, File},
+    io::{self, Read},
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use shift_store::{
+    Evidence, FileIdentity, ShiftStore, SourceIdentitySnapshot, WorkspaceSourceKind,
+};
+
+use crate::WorkspaceError;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub enum SourceMatchKind {
+    PossiblePackageMove,
+    SamePath,
+    SamePathAndFingerprint,
+    SameFileMoved,
+    SamePathAndFile,
+}
+
+impl SourceMatchKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SamePathAndFile => "samePathAndFile",
+            Self::SamePathAndFingerprint => "samePathAndFingerprint",
+            Self::SameFileMoved => "sameFileMoved",
+            Self::SamePath => "samePath",
+            Self::PossiblePackageMove => "possiblePackageMove",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WorkspaceRecoveryCandidate {
+    pub document_id: String,
+    pub store_path: PathBuf,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WorkspaceRecoveryMatch {
+    pub document_id: String,
+    pub store_path: PathBuf,
+    pub match_kind: SourceMatchKind,
+    pub dirty: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RecoverySelection {
+    None,
+    One(WorkspaceRecoveryMatch),
+    Ambiguous(Vec<WorkspaceRecoveryMatch>),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+struct RecoveryRank {
+    dirty: bool,
+    match_kind: SourceMatchKind,
+}
+
+impl RecoveryRank {
+    fn new(recovery_match: &WorkspaceRecoveryMatch) -> Self {
+        Self {
+            dirty: recovery_match.dirty,
+            match_kind: recovery_match.match_kind,
+        }
+    }
+}
+
+pub(crate) fn source_identity_snapshot(
+    path: impl AsRef<Path>,
+) -> Result<SourceIdentitySnapshot, WorkspaceError> {
+    let path = path.as_ref();
+    let metadata = fs::metadata(path).map_err(|err| {
+        if err.kind() == io::ErrorKind::NotFound {
+            WorkspaceError::SourceMissing(path.to_path_buf())
+        } else {
+            WorkspaceError::Io(err)
+        }
+    })?;
+    let canonical_source_path = fs::canonicalize(path).ok();
+    let source_file_identity = file_identity(path, &metadata)?;
+    let source_size = Some(metadata.len());
+    let source_mtime_ms = metadata.modified().ok().map(system_time_ms);
+    let source_fingerprint = Some(file_fingerprint(path)?);
+
+    Ok(SourceIdentitySnapshot {
+        source_path: Some(path.to_path_buf()),
+        canonical_source_path,
+        source_package_id: None,
+        source_file_identity,
+        source_size,
+        source_mtime_ms,
+        source_fingerprint,
+    })
+}
+
+pub(crate) fn validate_source_identity_for_save(
+    expected: &SourceIdentitySnapshot,
+    current: &SourceIdentitySnapshot,
+    path: &Path,
+) -> Result<(), WorkspaceError> {
+    if expected.file_identity_match(current).is_different()
+        || expected.canonical_path_match(current).is_different()
+    {
+        return Err(WorkspaceError::SourceIdentityConflict(path.to_path_buf()));
+    }
+
+    if expected.fingerprint_changed_from(current) {
+        return Err(WorkspaceError::SourceExternallyModified(path.to_path_buf()));
+    }
+
+    Ok(())
+}
+
+pub(crate) fn select_recoverable_package_workspace(
+    source_path: impl AsRef<Path>,
+    candidates: &[WorkspaceRecoveryCandidate],
+) -> Result<RecoverySelection, WorkspaceError> {
+    let requested = source_identity_snapshot(source_path)?;
+    let mut best_rank: Option<RecoveryRank> = None;
+    let mut best_matches: Vec<WorkspaceRecoveryMatch> = Vec::new();
+
+    for candidate in candidates {
+        let Ok(store) = ShiftStore::open(&candidate.store_path) else {
+            // Retained draft directories are a recovery cache. A corrupt or
+            // temporarily locked DB must not block opening the requested source.
+            continue;
+        };
+        let Ok(Some(state)) = store.workspace_state() else {
+            // Older or broken draft DBs may not carry workspace metadata yet.
+            // Ignore them here; explicit recovery UI can surface them later.
+            continue;
+        };
+        if state.source_kind != WorkspaceSourceKind::Package {
+            // Untitled/imported drafts are recoverable, but not by opening a
+            // package source path. Keep this selector package-only.
+            continue;
+        }
+        if !state.dirty && state.source_identity().fingerprint_changed_from(&requested) {
+            // A clean DB is just a cache of the source package. If the package
+            // changed on disk, hydrate fresh from the package instead.
+            continue;
+        }
+        let Some(match_kind) = classify_source_match(&state.source_identity(), &requested) else {
+            continue;
+        };
+
+        let candidate_match = WorkspaceRecoveryMatch {
+            document_id: candidate.document_id.clone(),
+            store_path: candidate.store_path.clone(),
+            match_kind,
+            dirty: state.dirty,
+        };
+        keep_best_recovery_match(candidate_match, &mut best_rank, &mut best_matches);
+    }
+
+    Ok(match best_matches.len() {
+        0 => RecoverySelection::None,
+        1 => RecoverySelection::One(best_matches.remove(0)),
+        _ => RecoverySelection::Ambiguous(best_matches),
+    })
+}
+
+fn keep_best_recovery_match(
+    candidate: WorkspaceRecoveryMatch,
+    best_rank: &mut Option<RecoveryRank>,
+    best_matches: &mut Vec<WorkspaceRecoveryMatch>,
+) {
+    let candidate_rank = RecoveryRank::new(&candidate);
+    match best_rank {
+        None => {
+            *best_rank = Some(candidate_rank);
+            best_matches.push(candidate);
+        }
+        Some(current_rank) if candidate_rank > *current_rank => {
+            *best_rank = Some(candidate_rank);
+            best_matches.clear();
+            best_matches.push(candidate);
+        }
+        Some(current_rank) if candidate_rank == *current_rank => {
+            best_matches.push(candidate);
+        }
+        Some(_) => {}
+    }
+}
+
+fn classify_source_match(
+    stored: &SourceIdentitySnapshot,
+    requested: &SourceIdentitySnapshot,
+) -> Option<SourceMatchKind> {
+    let same_path = stored.same_path_as(requested);
+    let file_identity = stored.file_identity_match(requested);
+    let fingerprint = stored.fingerprint_match(requested);
+    let package_id = stored.package_id_match(requested);
+
+    match (same_path, file_identity, fingerprint, package_id) {
+        (true, Evidence::Same, _, _) => Some(SourceMatchKind::SamePathAndFile),
+        (_, Evidence::Same, _, _) => Some(SourceMatchKind::SameFileMoved),
+        (true, _, Evidence::Same, _) => Some(SourceMatchKind::SamePathAndFingerprint),
+        (true, Evidence::Unknown, Evidence::Unknown, _) => Some(SourceMatchKind::SamePath),
+        (_, _, Evidence::Same, _) | (_, _, _, Evidence::Same) if stored.source_path_missing() => {
+            Some(SourceMatchKind::PossiblePackageMove)
+        }
+        _ => None,
+    }
+}
+
+fn file_fingerprint(path: &Path) -> Result<String, WorkspaceError> {
+    let mut file = File::open(path)?;
+    let mut buffer = [0u8; 8192];
+    let mut hash = 0xcbf29ce484222325u64;
+
+    loop {
+        let bytes_read = file.read(&mut buffer)?;
+        if bytes_read == 0 {
+            break;
+        }
+        for byte in &buffer[..bytes_read] {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+    }
+
+    Ok(format!("fnv1a64:{hash:016x}"))
+}
+
+#[cfg(unix)]
+fn file_identity(
+    _path: &Path,
+    metadata: &fs::Metadata,
+) -> Result<Option<FileIdentity>, WorkspaceError> {
+    use std::os::unix::fs::MetadataExt;
+
+    Ok(Some(FileIdentity {
+        kind: "unix-dev-inode".to_string(),
+        value: format!("{}:{}", metadata.dev(), metadata.ino()),
+    }))
+}
+
+#[cfg(windows)]
+fn file_identity(
+    path: &Path,
+    _metadata: &fs::Metadata,
+) -> Result<Option<FileIdentity>, WorkspaceError> {
+    use std::{os::windows::ffi::OsStrExt, ptr};
+    use windows_sys::Win32::{
+        Foundation::{CloseHandle, INVALID_HANDLE_VALUE},
+        Storage::FileSystem::{
+            BY_HANDLE_FILE_INFORMATION, CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_DELETE,
+            FILE_SHARE_READ, FILE_SHARE_WRITE, GetFileInformationByHandle, OPEN_EXISTING,
+        },
+    };
+
+    let wide_path = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+
+    let handle = unsafe {
+        CreateFileW(
+            wide_path.as_ptr(),
+            0,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            ptr::null(),
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL,
+            ptr::null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        return Err(WorkspaceError::Io(io::Error::last_os_error()));
+    }
+
+    let mut info = std::mem::MaybeUninit::<BY_HANDLE_FILE_INFORMATION>::zeroed();
+    let succeeded = unsafe { GetFileInformationByHandle(handle, info.as_mut_ptr()) };
+    let close_result = unsafe { CloseHandle(handle) };
+    if succeeded == 0 {
+        return Err(WorkspaceError::Io(io::Error::last_os_error()));
+    }
+    if close_result == 0 {
+        return Err(WorkspaceError::Io(io::Error::last_os_error()));
+    }
+
+    let info = unsafe { info.assume_init() };
+    let file_index = (u64::from(info.nFileIndexHigh) << 32) | u64::from(info.nFileIndexLow);
+    Ok(Some(FileIdentity {
+        kind: "windows-volume-file-index".to_string(),
+        value: format!("{}:{file_index}", info.dwVolumeSerialNumber),
+    }))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn file_identity(
+    _path: &Path,
+    _metadata: &fs::Metadata,
+) -> Result<Option<FileIdentity>, WorkspaceError> {
+    Ok(None)
+}
+
+fn system_time_ms(time: SystemTime) -> i64 {
+    match time.duration_since(UNIX_EPOCH) {
+        Ok(duration) => i64::try_from(duration.as_millis()).unwrap_or(i64::MAX),
+        Err(_) => 0,
+    }
+}

--- a/crates/shift-workspace/src/workspace.rs
+++ b/crates/shift-workspace/src/workspace.rs
@@ -1,4 +1,9 @@
-use std::path::{Path, PathBuf};
+use std::{
+    fs::{self, File},
+    io::{self, Read},
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use shift_backends::{FontExportRequest, FontExportResult, FontExporter, font_loader::FontLoader};
 use shift_font::{
@@ -6,7 +11,9 @@ use shift_font::{
     Source, TouchedLayer, error::CoreError,
 };
 use shift_source::ShiftSourcePackage;
-use shift_store::ShiftStore;
+use shift_store::{
+    FileIdentity, ShiftStore, SourceIdentitySnapshot, WorkspaceSourceKind, WorkspaceState,
+};
 
 use crate::NewWorkspace;
 use crate::ledger::{LayerPair, Ledger, LedgerEntry, LedgerStep};
@@ -31,8 +38,23 @@ pub enum WorkspaceError {
     #[error("workspace needs a save path")]
     NeedsSaveAs,
 
+    #[error("source package is missing: {0}")]
+    SourceMissing(PathBuf),
+
+    #[error("source package identity no longer matches: {0}")]
+    SourceIdentityConflict(PathBuf),
+
+    #[error("source package was modified outside Shift: {0}")]
+    SourceExternallyModified(PathBuf),
+
+    #[error("corrupt working store: {0}")]
+    CorruptWorkingStore(String),
+
     #[error("invalid UTF-8 in workspace path: {0}")]
     InvalidPathUtf8(PathBuf),
+
+    #[error("workspace file-system error")]
+    Io(#[from] io::Error),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -40,6 +62,51 @@ pub enum WorkspaceSource {
     Untitled,
     Package { path: PathBuf },
     Imported { original_path: PathBuf },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SourceMatchKind {
+    SamePathAndFile,
+    SamePathAndFingerprint,
+    SameFileMoved,
+    SamePath,
+    PossiblePackageMove,
+}
+
+impl SourceMatchKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SamePathAndFile => "samePathAndFile",
+            Self::SamePathAndFingerprint => "samePathAndFingerprint",
+            Self::SameFileMoved => "sameFileMoved",
+            Self::SamePath => "samePath",
+            Self::PossiblePackageMove => "possiblePackageMove",
+        }
+    }
+
+    fn score(self) -> i64 {
+        match self {
+            Self::SamePathAndFile => 50,
+            Self::SameFileMoved => 45,
+            Self::SamePathAndFingerprint => 40,
+            Self::SamePath => 20,
+            Self::PossiblePackageMove => 10,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WorkspaceRecoveryCandidate {
+    pub document_id: String,
+    pub store_path: PathBuf,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WorkspaceRecoveryMatch {
+    pub document_id: String,
+    pub store_path: PathBuf,
+    pub match_kind: SourceMatchKind,
+    pub dirty: bool,
 }
 
 pub struct FontWorkspace {
@@ -59,6 +126,7 @@ impl FontWorkspace {
 
         let font = new_font(new_workspace);
         store.replace_font_state(&font)?;
+        store.set_workspace_state(WorkspaceState::untitled(None))?;
 
         Ok(Self {
             font,
@@ -73,13 +141,8 @@ impl FontWorkspace {
         store_path: impl AsRef<Path>,
         new_workspace: NewWorkspace,
     ) -> Result<Self, WorkspaceError> {
-        let source_package = ShiftSourcePackage::create_empty(source_path)?;
         let mut workspace = Self::create_untitled(store_path, new_workspace)?;
-
-        workspace.source = WorkspaceSource::Package {
-            path: source_package.path().to_path_buf(),
-        };
-
+        workspace.save_as(source_path)?;
         Ok(workspace)
     }
 
@@ -96,9 +159,12 @@ impl FontWorkspace {
     }
 
     pub fn save(&mut self) -> Result<(), WorkspaceError> {
-        match &self.source {
+        match self.source.clone() {
             WorkspaceSource::Package { path } => {
-                ShiftSourcePackage::save_font(path, &self.font)?;
+                self.validate_save_target(&path)?;
+                ShiftSourcePackage::save_font(&path, &self.font)?;
+                let identity = source_identity_snapshot(&path)?;
+                self.mark_saved_package(identity)?;
                 Ok(())
             }
             WorkspaceSource::Untitled | WorkspaceSource::Imported { .. } => {
@@ -109,11 +175,82 @@ impl FontWorkspace {
 
     pub fn save_as(&mut self, source_path: impl AsRef<Path>) -> Result<(), WorkspaceError> {
         let source_package = ShiftSourcePackage::save_font(source_path, &self.font)?;
+        let identity = source_identity_snapshot(source_package.path())?;
         self.source = WorkspaceSource::Package {
             path: source_package.path().to_path_buf(),
         };
+        self.mark_saved_package(identity)?;
 
         Ok(())
+    }
+
+    pub fn resume(store_path: impl AsRef<Path>) -> Result<Self, WorkspaceError> {
+        let store = ShiftStore::open(store_path)?;
+        let state = store
+            .workspace_state()?
+            .ok_or_else(|| WorkspaceError::CorruptWorkingStore("missing workspace_state".into()))?;
+        let font = store.load_font_state()?;
+        let source = source_from_workspace_state(&state)?;
+
+        Ok(Self {
+            font,
+            source,
+            store,
+            ledger: Ledger::default(),
+        })
+    }
+
+    pub fn resume_for_source(
+        store_path: impl AsRef<Path>,
+        source_path: impl AsRef<Path>,
+    ) -> Result<Self, WorkspaceError> {
+        let mut workspace = Self::resume(store_path)?;
+        let identity = source_identity_snapshot(source_path)?;
+        workspace.relink_package_source(identity)?;
+        Ok(workspace)
+    }
+
+    pub fn find_recoverable_package_workspace(
+        source_path: impl AsRef<Path>,
+        candidates: &[WorkspaceRecoveryCandidate],
+    ) -> Result<Option<WorkspaceRecoveryMatch>, WorkspaceError> {
+        let requested = source_identity_snapshot(source_path)?;
+        let mut best: Option<(WorkspaceRecoveryMatch, i64)> = None;
+
+        for candidate in candidates {
+            let Ok(store) = ShiftStore::open(&candidate.store_path) else {
+                continue;
+            };
+            let Ok(Some(state)) = store.workspace_state() else {
+                continue;
+            };
+            if state.source_kind != WorkspaceSourceKind::Package {
+                continue;
+            }
+            if !state.dirty && source_fingerprint_changed(&state.source_identity(), &requested) {
+                continue;
+            }
+            let Some(match_kind) = classify_source_match(&state, &requested) else {
+                continue;
+            };
+
+            let score = recovery_score(match_kind, &state);
+            let candidate_match = WorkspaceRecoveryMatch {
+                document_id: candidate.document_id.clone(),
+                store_path: candidate.store_path.clone(),
+                match_kind,
+                dirty: state.dirty,
+            };
+
+            if best
+                .as_ref()
+                .is_none_or(|(_, best_score)| score > *best_score)
+            {
+                best = Some((candidate_match, score));
+            }
+        }
+
+        Ok(best.map(|(candidate, _)| candidate))
     }
 
     pub fn export(&self, request: FontExportRequest) -> Result<FontExportResult, WorkspaceError> {
@@ -322,6 +459,72 @@ impl FontWorkspace {
         Ok(result)
     }
 
+    fn validate_save_target(&self, path: &Path) -> Result<(), WorkspaceError> {
+        if !path.exists() {
+            return Err(WorkspaceError::SourceMissing(path.to_path_buf()));
+        }
+
+        let current = source_identity_snapshot(path)?;
+        let Some(state) = self.store.workspace_state()? else {
+            return Ok(());
+        };
+        if state.source_kind != WorkspaceSourceKind::Package {
+            return Ok(());
+        }
+
+        validate_source_identity_for_save(&state.source_identity(), &current, path)
+    }
+
+    fn mark_saved_package(
+        &mut self,
+        identity: SourceIdentitySnapshot,
+    ) -> Result<(), WorkspaceError> {
+        let mut state = self
+            .store
+            .workspace_state()?
+            .unwrap_or_else(|| WorkspaceState::package(identity.clone(), None));
+        state.source_kind = WorkspaceSourceKind::Package;
+        state.source_path = identity.source_path.clone();
+        state.canonical_source_path = identity.canonical_source_path.clone();
+        state.original_import_path = None;
+        state.source_package_id = identity.source_package_id.clone();
+        state.source_file_identity = identity.source_file_identity.clone();
+        state.source_size = identity.source_size;
+        state.source_mtime_ms = identity.source_mtime_ms;
+        state.source_fingerprint = identity.source_fingerprint.clone();
+        state.dirty = false;
+        state.saved_revision = state.revision;
+        state.updated_at_ms = identity.observed_at_ms;
+        self.store.set_workspace_state(state)?;
+        Ok(())
+    }
+
+    fn relink_package_source(
+        &mut self,
+        identity: SourceIdentitySnapshot,
+    ) -> Result<(), WorkspaceError> {
+        let path = identity.source_path.clone().ok_or_else(|| {
+            WorkspaceError::CorruptWorkingStore("package identity missing source path".into())
+        })?;
+        let mut state = self
+            .store
+            .workspace_state()?
+            .ok_or_else(|| WorkspaceError::CorruptWorkingStore("missing workspace_state".into()))?;
+        state.source_kind = WorkspaceSourceKind::Package;
+        state.source_path = identity.source_path;
+        state.canonical_source_path = identity.canonical_source_path;
+        state.original_import_path = None;
+        state.source_package_id = identity.source_package_id;
+        state.source_file_identity = identity.source_file_identity;
+        state.source_size = identity.source_size;
+        state.source_mtime_ms = identity.source_mtime_ms;
+        state.source_fingerprint = identity.source_fingerprint;
+        state.updated_at_ms = identity.observed_at_ms;
+        self.store.set_workspace_state(state)?;
+        self.source = WorkspaceSource::Package { path };
+        Ok(())
+    }
+
     fn open_package(
         source_path: impl AsRef<Path>,
         store_path: impl AsRef<Path>,
@@ -331,6 +534,8 @@ impl FontWorkspace {
         let font = ShiftSourcePackage::load_font(source_package.path())?;
         store.set_font_info(font_info_from_font(&font))?;
         store.replace_font_state(&font)?;
+        let identity = source_identity_snapshot(source_package.path())?;
+        store.set_workspace_state(WorkspaceState::package(identity, None))?;
 
         Ok(Self {
             font,
@@ -354,6 +559,7 @@ impl FontWorkspace {
         let mut store = ShiftStore::open(store_path)?;
         store.set_font_info(font_info_from_font(&font))?;
         store.replace_font_state(&font)?;
+        store.set_workspace_state(WorkspaceState::imported(import_path, None))?;
 
         Ok(Self {
             font,
@@ -391,6 +597,18 @@ impl FontWorkspace {
 
     pub fn font_info(&self) -> Result<Option<shift_store::FontInfo>, WorkspaceError> {
         self.store.get_font_info().map_err(WorkspaceError::from)
+    }
+
+    pub fn is_dirty(&self) -> Result<bool, WorkspaceError> {
+        Ok(self
+            .store
+            .workspace_state()?
+            .is_some_and(|state| state.dirty))
+    }
+
+    pub fn set_document_id(&mut self, document_id: String) -> Result<(), WorkspaceError> {
+        self.store.set_workspace_document_id(document_id)?;
+        Ok(())
     }
 }
 
@@ -579,4 +797,200 @@ fn new_font(new_workspace: NewWorkspace) -> shift_font::Font {
     font.metadata_mut().family_name = Some(new_workspace.family_name);
     font.metrics_mut().units_per_em = new_workspace.units_per_em as f64;
     font
+}
+
+fn source_from_workspace_state(state: &WorkspaceState) -> Result<WorkspaceSource, WorkspaceError> {
+    match state.source_kind {
+        WorkspaceSourceKind::Untitled => Ok(WorkspaceSource::Untitled),
+        WorkspaceSourceKind::Package => {
+            let path = state.source_path.clone().ok_or_else(|| {
+                WorkspaceError::CorruptWorkingStore("package workspace missing source_path".into())
+            })?;
+            Ok(WorkspaceSource::Package { path })
+        }
+        WorkspaceSourceKind::Imported => {
+            let original_path = state.original_import_path.clone().ok_or_else(|| {
+                WorkspaceError::CorruptWorkingStore(
+                    "imported workspace missing original_import_path".into(),
+                )
+            })?;
+            Ok(WorkspaceSource::Imported { original_path })
+        }
+    }
+}
+
+fn source_identity_snapshot(
+    path: impl AsRef<Path>,
+) -> Result<SourceIdentitySnapshot, WorkspaceError> {
+    let path = path.as_ref();
+    let metadata = fs::metadata(path).map_err(|err| {
+        if err.kind() == io::ErrorKind::NotFound {
+            WorkspaceError::SourceMissing(path.to_path_buf())
+        } else {
+            WorkspaceError::Io(err)
+        }
+    })?;
+    let canonical_source_path = fs::canonicalize(path).ok();
+    let source_file_identity = file_identity(&metadata);
+    let source_size = Some(metadata.len());
+    let source_mtime_ms = metadata.modified().ok().map(system_time_ms);
+    let source_fingerprint = Some(file_fingerprint(path)?);
+
+    Ok(SourceIdentitySnapshot {
+        source_path: Some(path.to_path_buf()),
+        canonical_source_path,
+        source_package_id: None,
+        source_file_identity,
+        source_size,
+        source_mtime_ms,
+        source_fingerprint,
+        observed_at_ms: now_ms(),
+    })
+}
+
+fn validate_source_identity_for_save(
+    expected: &SourceIdentitySnapshot,
+    current: &SourceIdentitySnapshot,
+    path: &Path,
+) -> Result<(), WorkspaceError> {
+    if let (Some(expected), Some(current)) = (
+        &expected.source_file_identity,
+        &current.source_file_identity,
+    ) && expected != current
+    {
+        return Err(WorkspaceError::SourceIdentityConflict(path.to_path_buf()));
+    }
+
+    if let (Some(expected), Some(current)) = (
+        &expected.canonical_source_path,
+        &current.canonical_source_path,
+    ) && expected != current
+    {
+        return Err(WorkspaceError::SourceIdentityConflict(path.to_path_buf()));
+    }
+
+    if let (Some(expected), Some(current)) =
+        (&expected.source_fingerprint, &current.source_fingerprint)
+        && expected != current
+    {
+        return Err(WorkspaceError::SourceExternallyModified(path.to_path_buf()));
+    }
+
+    Ok(())
+}
+
+fn classify_source_match(
+    state: &WorkspaceState,
+    requested: &SourceIdentitySnapshot,
+) -> Option<SourceMatchKind> {
+    let stored = state.source_identity();
+    let same_path = paths_match(
+        &stored.canonical_source_path,
+        &requested.canonical_source_path,
+    ) || paths_match(&stored.source_path, &requested.source_path);
+    let same_file = identities_match(
+        &stored.source_file_identity,
+        &requested.source_file_identity,
+    );
+    let same_fingerprint = stored.source_fingerprint.is_some()
+        && requested.source_fingerprint.is_some()
+        && stored.source_fingerprint == requested.source_fingerprint;
+    let same_package_id = stored.source_package_id.is_some()
+        && requested.source_package_id.is_some()
+        && stored.source_package_id == requested.source_package_id;
+
+    if same_path && same_file {
+        Some(SourceMatchKind::SamePathAndFile)
+    } else if same_file {
+        Some(SourceMatchKind::SameFileMoved)
+    } else if same_path && same_fingerprint {
+        Some(SourceMatchKind::SamePathAndFingerprint)
+    } else if same_path
+        && stored.source_file_identity.is_none()
+        && stored.source_fingerprint.is_none()
+    {
+        Some(SourceMatchKind::SamePath)
+    } else if (same_package_id || same_fingerprint) && old_source_path_missing(&stored) {
+        Some(SourceMatchKind::PossiblePackageMove)
+    } else {
+        None
+    }
+}
+
+fn recovery_score(match_kind: SourceMatchKind, state: &WorkspaceState) -> i64 {
+    let dirty_bonus = if state.dirty { 1_000 } else { 0 };
+    dirty_bonus + match_kind.score() + state.revision + state.updated_at_ms / 1_000_000_000
+}
+
+fn paths_match(left: &Option<PathBuf>, right: &Option<PathBuf>) -> bool {
+    left.as_ref()
+        .zip(right.as_ref())
+        .is_some_and(|(left, right)| left == right)
+}
+
+fn identities_match(left: &Option<FileIdentity>, right: &Option<FileIdentity>) -> bool {
+    left.as_ref()
+        .zip(right.as_ref())
+        .is_some_and(|(left, right)| left == right)
+}
+
+fn old_source_path_missing(identity: &SourceIdentitySnapshot) -> bool {
+    identity
+        .source_path
+        .as_ref()
+        .is_none_or(|path| !path.exists())
+}
+
+fn source_fingerprint_changed(
+    stored: &SourceIdentitySnapshot,
+    requested: &SourceIdentitySnapshot,
+) -> bool {
+    stored.source_fingerprint.is_some()
+        && requested.source_fingerprint.is_some()
+        && stored.source_fingerprint != requested.source_fingerprint
+}
+
+fn file_fingerprint(path: &Path) -> Result<String, WorkspaceError> {
+    let mut file = File::open(path)?;
+    let mut buffer = [0u8; 8192];
+    let mut hash = 0xcbf29ce484222325u64;
+
+    loop {
+        let bytes_read = file.read(&mut buffer)?;
+        if bytes_read == 0 {
+            break;
+        }
+        for byte in &buffer[..bytes_read] {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+    }
+
+    Ok(format!("fnv1a64:{hash:016x}"))
+}
+
+#[cfg(unix)]
+fn file_identity(metadata: &fs::Metadata) -> Option<FileIdentity> {
+    use std::os::unix::fs::MetadataExt;
+
+    Some(FileIdentity {
+        kind: "unix-dev-inode".to_string(),
+        value: format!("{}:{}", metadata.dev(), metadata.ino()),
+    })
+}
+
+#[cfg(not(unix))]
+fn file_identity(_metadata: &fs::Metadata) -> Option<FileIdentity> {
+    None
+}
+
+fn system_time_ms(time: SystemTime) -> i64 {
+    match time.duration_since(UNIX_EPOCH) {
+        Ok(duration) => i64::try_from(duration.as_millis()).unwrap_or(i64::MAX),
+        Err(_) => 0,
+    }
+}
+
+fn now_ms() -> i64 {
+    system_time_ms(SystemTime::now())
 }

--- a/crates/shift-workspace/src/workspace.rs
+++ b/crates/shift-workspace/src/workspace.rs
@@ -1,8 +1,6 @@
 use std::{
-    fs::{self, File},
-    io::{self, Read},
+    io,
     path::{Path, PathBuf},
-    time::{SystemTime, UNIX_EPOCH},
 };
 
 use shift_backends::{FontExportRequest, FontExportResult, FontExporter, font_loader::FontLoader};
@@ -11,12 +9,14 @@ use shift_font::{
     Source, TouchedLayer, error::CoreError,
 };
 use shift_source::ShiftSourcePackage;
-use shift_store::{
-    FileIdentity, ShiftStore, SourceIdentitySnapshot, WorkspaceSourceKind, WorkspaceState,
-};
+use shift_store::{ShiftStore, SourceIdentitySnapshot, WorkspaceSourceKind, WorkspaceState};
 
 use crate::NewWorkspace;
 use crate::ledger::{LayerPair, Ledger, LedgerEntry, LedgerStep};
+use crate::source_identity::{
+    RecoverySelection, WorkspaceRecoveryCandidate, select_recoverable_package_workspace,
+    source_identity_snapshot, validate_source_identity_for_save,
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum WorkspaceError {
@@ -47,6 +47,9 @@ pub enum WorkspaceError {
     #[error("source package was modified outside Shift: {0}")]
     SourceExternallyModified(PathBuf),
 
+    #[error("ambiguous recoverable workspaces for source: {0} candidates")]
+    AmbiguousRecoveryCandidates(usize),
+
     #[error("corrupt working store: {0}")]
     CorruptWorkingStore(String),
 
@@ -62,51 +65,6 @@ pub enum WorkspaceSource {
     Untitled,
     Package { path: PathBuf },
     Imported { original_path: PathBuf },
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum SourceMatchKind {
-    SamePathAndFile,
-    SamePathAndFingerprint,
-    SameFileMoved,
-    SamePath,
-    PossiblePackageMove,
-}
-
-impl SourceMatchKind {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::SamePathAndFile => "samePathAndFile",
-            Self::SamePathAndFingerprint => "samePathAndFingerprint",
-            Self::SameFileMoved => "sameFileMoved",
-            Self::SamePath => "samePath",
-            Self::PossiblePackageMove => "possiblePackageMove",
-        }
-    }
-
-    fn score(self) -> i64 {
-        match self {
-            Self::SamePathAndFile => 50,
-            Self::SameFileMoved => 45,
-            Self::SamePathAndFingerprint => 40,
-            Self::SamePath => 20,
-            Self::PossiblePackageMove => 10,
-        }
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct WorkspaceRecoveryCandidate {
-    pub document_id: String,
-    pub store_path: PathBuf,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct WorkspaceRecoveryMatch {
-    pub document_id: String,
-    pub store_path: PathBuf,
-    pub match_kind: SourceMatchKind,
-    pub dirty: bool,
 }
 
 pub struct FontWorkspace {
@@ -213,44 +171,8 @@ impl FontWorkspace {
     pub fn find_recoverable_package_workspace(
         source_path: impl AsRef<Path>,
         candidates: &[WorkspaceRecoveryCandidate],
-    ) -> Result<Option<WorkspaceRecoveryMatch>, WorkspaceError> {
-        let requested = source_identity_snapshot(source_path)?;
-        let mut best: Option<(WorkspaceRecoveryMatch, i64)> = None;
-
-        for candidate in candidates {
-            let Ok(store) = ShiftStore::open(&candidate.store_path) else {
-                continue;
-            };
-            let Ok(Some(state)) = store.workspace_state() else {
-                continue;
-            };
-            if state.source_kind != WorkspaceSourceKind::Package {
-                continue;
-            }
-            if !state.dirty && source_fingerprint_changed(&state.source_identity(), &requested) {
-                continue;
-            }
-            let Some(match_kind) = classify_source_match(&state, &requested) else {
-                continue;
-            };
-
-            let score = recovery_score(match_kind, &state);
-            let candidate_match = WorkspaceRecoveryMatch {
-                document_id: candidate.document_id.clone(),
-                store_path: candidate.store_path.clone(),
-                match_kind,
-                dirty: state.dirty,
-            };
-
-            if best
-                .as_ref()
-                .is_none_or(|(_, best_score)| score > *best_score)
-            {
-                best = Some((candidate_match, score));
-            }
-        }
-
-        Ok(best.map(|(candidate, _)| candidate))
+    ) -> Result<RecoverySelection, WorkspaceError> {
+        select_recoverable_package_workspace(source_path, candidates)
     }
 
     pub fn export(&self, request: FontExportRequest) -> Result<FontExportResult, WorkspaceError> {
@@ -483,18 +405,9 @@ impl FontWorkspace {
             .store
             .workspace_state()?
             .unwrap_or_else(|| WorkspaceState::package(identity.clone(), None));
-        state.source_kind = WorkspaceSourceKind::Package;
-        state.source_path = identity.source_path.clone();
-        state.canonical_source_path = identity.canonical_source_path.clone();
-        state.original_import_path = None;
-        state.source_package_id = identity.source_package_id.clone();
-        state.source_file_identity = identity.source_file_identity.clone();
-        state.source_size = identity.source_size;
-        state.source_mtime_ms = identity.source_mtime_ms;
-        state.source_fingerprint = identity.source_fingerprint.clone();
+        state.set_package_identity(identity);
         state.dirty = false;
         state.saved_revision = state.revision;
-        state.updated_at_ms = identity.observed_at_ms;
         self.store.set_workspace_state(state)?;
         Ok(())
     }
@@ -510,16 +423,7 @@ impl FontWorkspace {
             .store
             .workspace_state()?
             .ok_or_else(|| WorkspaceError::CorruptWorkingStore("missing workspace_state".into()))?;
-        state.source_kind = WorkspaceSourceKind::Package;
-        state.source_path = identity.source_path;
-        state.canonical_source_path = identity.canonical_source_path;
-        state.original_import_path = None;
-        state.source_package_id = identity.source_package_id;
-        state.source_file_identity = identity.source_file_identity;
-        state.source_size = identity.source_size;
-        state.source_mtime_ms = identity.source_mtime_ms;
-        state.source_fingerprint = identity.source_fingerprint;
-        state.updated_at_ms = identity.observed_at_ms;
+        state.set_package_identity(identity);
         self.store.set_workspace_state(state)?;
         self.source = WorkspaceSource::Package { path };
         Ok(())
@@ -817,180 +721,4 @@ fn source_from_workspace_state(state: &WorkspaceState) -> Result<WorkspaceSource
             Ok(WorkspaceSource::Imported { original_path })
         }
     }
-}
-
-fn source_identity_snapshot(
-    path: impl AsRef<Path>,
-) -> Result<SourceIdentitySnapshot, WorkspaceError> {
-    let path = path.as_ref();
-    let metadata = fs::metadata(path).map_err(|err| {
-        if err.kind() == io::ErrorKind::NotFound {
-            WorkspaceError::SourceMissing(path.to_path_buf())
-        } else {
-            WorkspaceError::Io(err)
-        }
-    })?;
-    let canonical_source_path = fs::canonicalize(path).ok();
-    let source_file_identity = file_identity(&metadata);
-    let source_size = Some(metadata.len());
-    let source_mtime_ms = metadata.modified().ok().map(system_time_ms);
-    let source_fingerprint = Some(file_fingerprint(path)?);
-
-    Ok(SourceIdentitySnapshot {
-        source_path: Some(path.to_path_buf()),
-        canonical_source_path,
-        source_package_id: None,
-        source_file_identity,
-        source_size,
-        source_mtime_ms,
-        source_fingerprint,
-        observed_at_ms: now_ms(),
-    })
-}
-
-fn validate_source_identity_for_save(
-    expected: &SourceIdentitySnapshot,
-    current: &SourceIdentitySnapshot,
-    path: &Path,
-) -> Result<(), WorkspaceError> {
-    if let (Some(expected), Some(current)) = (
-        &expected.source_file_identity,
-        &current.source_file_identity,
-    ) && expected != current
-    {
-        return Err(WorkspaceError::SourceIdentityConflict(path.to_path_buf()));
-    }
-
-    if let (Some(expected), Some(current)) = (
-        &expected.canonical_source_path,
-        &current.canonical_source_path,
-    ) && expected != current
-    {
-        return Err(WorkspaceError::SourceIdentityConflict(path.to_path_buf()));
-    }
-
-    if let (Some(expected), Some(current)) =
-        (&expected.source_fingerprint, &current.source_fingerprint)
-        && expected != current
-    {
-        return Err(WorkspaceError::SourceExternallyModified(path.to_path_buf()));
-    }
-
-    Ok(())
-}
-
-fn classify_source_match(
-    state: &WorkspaceState,
-    requested: &SourceIdentitySnapshot,
-) -> Option<SourceMatchKind> {
-    let stored = state.source_identity();
-    let same_path = paths_match(
-        &stored.canonical_source_path,
-        &requested.canonical_source_path,
-    ) || paths_match(&stored.source_path, &requested.source_path);
-    let same_file = identities_match(
-        &stored.source_file_identity,
-        &requested.source_file_identity,
-    );
-    let same_fingerprint = stored.source_fingerprint.is_some()
-        && requested.source_fingerprint.is_some()
-        && stored.source_fingerprint == requested.source_fingerprint;
-    let same_package_id = stored.source_package_id.is_some()
-        && requested.source_package_id.is_some()
-        && stored.source_package_id == requested.source_package_id;
-
-    if same_path && same_file {
-        Some(SourceMatchKind::SamePathAndFile)
-    } else if same_file {
-        Some(SourceMatchKind::SameFileMoved)
-    } else if same_path && same_fingerprint {
-        Some(SourceMatchKind::SamePathAndFingerprint)
-    } else if same_path
-        && stored.source_file_identity.is_none()
-        && stored.source_fingerprint.is_none()
-    {
-        Some(SourceMatchKind::SamePath)
-    } else if (same_package_id || same_fingerprint) && old_source_path_missing(&stored) {
-        Some(SourceMatchKind::PossiblePackageMove)
-    } else {
-        None
-    }
-}
-
-fn recovery_score(match_kind: SourceMatchKind, state: &WorkspaceState) -> i64 {
-    let dirty_bonus = if state.dirty { 1_000 } else { 0 };
-    dirty_bonus + match_kind.score() + state.revision + state.updated_at_ms / 1_000_000_000
-}
-
-fn paths_match(left: &Option<PathBuf>, right: &Option<PathBuf>) -> bool {
-    left.as_ref()
-        .zip(right.as_ref())
-        .is_some_and(|(left, right)| left == right)
-}
-
-fn identities_match(left: &Option<FileIdentity>, right: &Option<FileIdentity>) -> bool {
-    left.as_ref()
-        .zip(right.as_ref())
-        .is_some_and(|(left, right)| left == right)
-}
-
-fn old_source_path_missing(identity: &SourceIdentitySnapshot) -> bool {
-    identity
-        .source_path
-        .as_ref()
-        .is_none_or(|path| !path.exists())
-}
-
-fn source_fingerprint_changed(
-    stored: &SourceIdentitySnapshot,
-    requested: &SourceIdentitySnapshot,
-) -> bool {
-    stored.source_fingerprint.is_some()
-        && requested.source_fingerprint.is_some()
-        && stored.source_fingerprint != requested.source_fingerprint
-}
-
-fn file_fingerprint(path: &Path) -> Result<String, WorkspaceError> {
-    let mut file = File::open(path)?;
-    let mut buffer = [0u8; 8192];
-    let mut hash = 0xcbf29ce484222325u64;
-
-    loop {
-        let bytes_read = file.read(&mut buffer)?;
-        if bytes_read == 0 {
-            break;
-        }
-        for byte in &buffer[..bytes_read] {
-            hash ^= u64::from(*byte);
-            hash = hash.wrapping_mul(0x100000001b3);
-        }
-    }
-
-    Ok(format!("fnv1a64:{hash:016x}"))
-}
-
-#[cfg(unix)]
-fn file_identity(metadata: &fs::Metadata) -> Option<FileIdentity> {
-    use std::os::unix::fs::MetadataExt;
-
-    Some(FileIdentity {
-        kind: "unix-dev-inode".to_string(),
-        value: format!("{}:{}", metadata.dev(), metadata.ino()),
-    })
-}
-
-#[cfg(not(unix))]
-fn file_identity(_metadata: &fs::Metadata) -> Option<FileIdentity> {
-    None
-}
-
-fn system_time_ms(time: SystemTime) -> i64 {
-    match time.duration_since(UNIX_EPOCH) {
-        Ok(duration) => i64::try_from(duration.as_millis()).unwrap_or(i64::MAX),
-        Err(_) => 0,
-    }
-}
-
-fn now_ms() -> i64 {
-    system_time_ms(SystemTime::now())
 }

--- a/crates/shift-workspace/tests/workspace_test.rs
+++ b/crates/shift-workspace/tests/workspace_test.rs
@@ -6,8 +6,8 @@ use shift_font::{
 };
 use shift_source::ShiftSourcePackage;
 use shift_workspace::{
-    FontWorkspace, NewWorkspace, SourceMatchKind, WorkspaceError, WorkspaceRecoveryCandidate,
-    WorkspaceSource,
+    FontWorkspace, NewWorkspace, RecoverySelection, SourceMatchKind, WorkspaceError,
+    WorkspaceRecoveryCandidate, WorkspaceSource,
 };
 
 fn create_glyph_intent(name: &str, unicodes: Vec<u32>) -> FontIntent {
@@ -291,15 +291,16 @@ fn moved_package_open_can_recover_dirty_workspace_by_file_identity() {
     }
     fs::rename(&save_path, &moved_path).unwrap();
 
-    let recovery = FontWorkspace::find_recoverable_package_workspace(
+    let RecoverySelection::One(recovery) = FontWorkspace::find_recoverable_package_workspace(
         &moved_path,
         &[WorkspaceRecoveryCandidate {
             document_id: "doc-1".to_string(),
             store_path: store_path.clone(),
         }],
     )
-    .unwrap()
-    .expect("renamed source should match retained dirty store");
+    .unwrap() else {
+        panic!("renamed source should match retained dirty store");
+    };
 
     assert_eq!(recovery.document_id, "doc-1");
     assert_eq!(recovery.match_kind, SourceMatchKind::SameFileMoved);
@@ -330,15 +331,16 @@ fn copied_then_deleted_package_can_recover_dirty_workspace_by_fingerprint() {
     fs::copy(&save_path, &moved_path).unwrap();
     fs::remove_file(&save_path).unwrap();
 
-    let recovery = FontWorkspace::find_recoverable_package_workspace(
+    let RecoverySelection::One(recovery) = FontWorkspace::find_recoverable_package_workspace(
         &moved_path,
         &[WorkspaceRecoveryCandidate {
             document_id: "doc-1".to_string(),
             store_path,
         }],
     )
-    .unwrap()
-    .expect("moved source with new file identity should match by fingerprint");
+    .unwrap() else {
+        panic!("moved source with new file identity should match by fingerprint");
+    };
 
     assert_eq!(recovery.document_id, "doc-1");
     assert_eq!(recovery.match_kind, SourceMatchKind::PossiblePackageMove);
@@ -368,7 +370,7 @@ fn copied_package_does_not_recover_original_dirty_workspace_while_original_exist
     )
     .unwrap();
 
-    assert_eq!(recovery, None);
+    assert_eq!(recovery, RecoverySelection::None);
 }
 
 #[test]
@@ -398,7 +400,7 @@ fn clean_package_workspace_is_not_recovered_after_source_file_changes() {
     )
     .unwrap();
 
-    assert_eq!(recovery, None);
+    assert_eq!(recovery, RecoverySelection::None);
 }
 
 fn set_x_advance_intents(layer_id: LayerId, width: f64) -> FontIntentSet {

--- a/crates/shift-workspace/tests/workspace_test.rs
+++ b/crates/shift-workspace/tests/workspace_test.rs
@@ -1,11 +1,14 @@
-use std::path::PathBuf;
+use std::{fs, path::PathBuf};
 
 use shift_font::{
     Axis, AxisId, FontChange, FontIntent, FontIntentSet, GlyphId, LayerId, Location,
     error::CoreError,
 };
 use shift_source::ShiftSourcePackage;
-use shift_workspace::{FontWorkspace, NewWorkspace, WorkspaceError, WorkspaceSource};
+use shift_workspace::{
+    FontWorkspace, NewWorkspace, SourceMatchKind, WorkspaceError, WorkspaceRecoveryCandidate,
+    WorkspaceSource,
+};
 
 fn create_glyph_intent(name: &str, unicodes: Vec<u32>) -> FontIntent {
     FontIntent::CreateGlyph {
@@ -194,6 +197,208 @@ fn save_and_save_as_write_the_live_font_to_the_source_package() {
     let saved = ShiftSourcePackage::load_font(&save_path).unwrap();
     assert!(saved.glyph_id_by_name("A").is_some());
     assert!(saved.glyph_id_by_name("B").is_some());
+}
+
+#[test]
+fn resume_rebuilds_dirty_untitled_workspace_from_store() {
+    let temp = tempfile::tempdir().unwrap();
+    let store_path = temp.path().join("working.sqlite");
+
+    {
+        let mut workspace =
+            FontWorkspace::create_untitled(&store_path, NewWorkspace::new()).unwrap();
+        create_glyph(&mut workspace, "A", vec![65]);
+        assert!(workspace.is_dirty().unwrap());
+    }
+
+    let workspace = FontWorkspace::resume(&store_path).unwrap();
+
+    assert_eq!(workspace.source(), &WorkspaceSource::Untitled);
+    assert!(workspace.is_dirty().unwrap());
+    assert!(workspace.font().glyph_id_by_name("A").is_some());
+}
+
+#[test]
+fn resume_package_workspace_can_save_unsaved_store_state() {
+    let temp = tempfile::tempdir().unwrap();
+    let store_path = temp.path().join("working.sqlite");
+    let save_path = temp.path().join("SavedFont.shift");
+
+    {
+        let mut workspace =
+            FontWorkspace::create_untitled(&store_path, NewWorkspace::new()).unwrap();
+        create_glyph(&mut workspace, "A", vec![65]);
+        workspace.save_as(&save_path).unwrap();
+        create_glyph(&mut workspace, "B", vec![66]);
+        assert!(workspace.is_dirty().unwrap());
+    }
+
+    let mut workspace = FontWorkspace::resume(&store_path).unwrap();
+    assert_eq!(workspace.save_target(), Some(save_path.as_path()));
+    assert!(workspace.font().glyph_id_by_name("B").is_some());
+
+    workspace.save().unwrap();
+
+    let saved = ShiftSourcePackage::load_font(&save_path).unwrap();
+    assert!(saved.glyph_id_by_name("A").is_some());
+    assert!(saved.glyph_id_by_name("B").is_some());
+    assert!(!workspace.is_dirty().unwrap());
+}
+
+#[test]
+fn save_rejects_missing_package_target_without_recreating_it() {
+    let temp = tempfile::tempdir().unwrap();
+    let store_path = temp.path().join("working.sqlite");
+    let save_path = temp.path().join("SavedFont.shift");
+
+    let mut workspace = FontWorkspace::create_untitled(&store_path, NewWorkspace::new()).unwrap();
+    workspace.save_as(&save_path).unwrap();
+    fs::remove_file(&save_path).unwrap();
+
+    let error = workspace.save().unwrap_err();
+
+    assert!(matches!(error, WorkspaceError::SourceMissing(path) if path == save_path));
+    assert!(!save_path.exists());
+}
+
+#[test]
+fn save_rejects_package_target_replaced_by_another_file() {
+    let temp = tempfile::tempdir().unwrap();
+    let store_path = temp.path().join("working.sqlite");
+    let save_path = temp.path().join("SavedFont.shift");
+
+    let mut workspace = FontWorkspace::create_untitled(&store_path, NewWorkspace::new()).unwrap();
+    workspace.save_as(&save_path).unwrap();
+    ShiftSourcePackage::save_font(&save_path, &shift_font::Font::new()).unwrap();
+
+    let error = workspace.save().unwrap_err();
+
+    assert!(matches!(error, WorkspaceError::SourceIdentityConflict(path) if path == save_path));
+}
+
+#[test]
+fn moved_package_open_can_recover_dirty_workspace_by_file_identity() {
+    let temp = tempfile::tempdir().unwrap();
+    let store_path = temp.path().join("working.sqlite");
+    let save_path = temp.path().join("SavedFont.shift");
+    let moved_path = temp.path().join("MovedFont.shift");
+
+    {
+        let mut workspace =
+            FontWorkspace::create_untitled(&store_path, NewWorkspace::new()).unwrap();
+        workspace.save_as(&save_path).unwrap();
+        create_glyph(&mut workspace, "B", vec![66]);
+    }
+    fs::rename(&save_path, &moved_path).unwrap();
+
+    let recovery = FontWorkspace::find_recoverable_package_workspace(
+        &moved_path,
+        &[WorkspaceRecoveryCandidate {
+            document_id: "doc-1".to_string(),
+            store_path: store_path.clone(),
+        }],
+    )
+    .unwrap()
+    .expect("renamed source should match retained dirty store");
+
+    assert_eq!(recovery.document_id, "doc-1");
+    assert_eq!(recovery.match_kind, SourceMatchKind::SameFileMoved);
+
+    let mut workspace = FontWorkspace::resume_for_source(&store_path, &moved_path).unwrap();
+    assert_eq!(workspace.save_target(), Some(moved_path.as_path()));
+    assert!(workspace.font().glyph_id_by_name("B").is_some());
+
+    workspace.save().unwrap();
+
+    let saved = ShiftSourcePackage::load_font(&moved_path).unwrap();
+    assert!(saved.glyph_id_by_name("B").is_some());
+}
+
+#[test]
+fn copied_then_deleted_package_can_recover_dirty_workspace_by_fingerprint() {
+    let temp = tempfile::tempdir().unwrap();
+    let store_path = temp.path().join("working.sqlite");
+    let save_path = temp.path().join("SavedFont.shift");
+    let moved_path = temp.path().join("MovedFont.shift");
+
+    {
+        let mut workspace =
+            FontWorkspace::create_untitled(&store_path, NewWorkspace::new()).unwrap();
+        workspace.save_as(&save_path).unwrap();
+        create_glyph(&mut workspace, "B", vec![66]);
+    }
+    fs::copy(&save_path, &moved_path).unwrap();
+    fs::remove_file(&save_path).unwrap();
+
+    let recovery = FontWorkspace::find_recoverable_package_workspace(
+        &moved_path,
+        &[WorkspaceRecoveryCandidate {
+            document_id: "doc-1".to_string(),
+            store_path,
+        }],
+    )
+    .unwrap()
+    .expect("moved source with new file identity should match by fingerprint");
+
+    assert_eq!(recovery.document_id, "doc-1");
+    assert_eq!(recovery.match_kind, SourceMatchKind::PossiblePackageMove);
+}
+
+#[test]
+fn copied_package_does_not_recover_original_dirty_workspace_while_original_exists() {
+    let temp = tempfile::tempdir().unwrap();
+    let store_path = temp.path().join("working.sqlite");
+    let save_path = temp.path().join("SavedFont.shift");
+    let copy_path = temp.path().join("CopyFont.shift");
+
+    {
+        let mut workspace =
+            FontWorkspace::create_untitled(&store_path, NewWorkspace::new()).unwrap();
+        workspace.save_as(&save_path).unwrap();
+        create_glyph(&mut workspace, "B", vec![66]);
+    }
+    fs::copy(&save_path, &copy_path).unwrap();
+
+    let recovery = FontWorkspace::find_recoverable_package_workspace(
+        &copy_path,
+        &[WorkspaceRecoveryCandidate {
+            document_id: "doc-1".to_string(),
+            store_path,
+        }],
+    )
+    .unwrap();
+
+    assert_eq!(recovery, None);
+}
+
+#[test]
+fn clean_package_workspace_is_not_recovered_after_source_file_changes() {
+    let temp = tempfile::tempdir().unwrap();
+    let store_path = temp.path().join("working.sqlite");
+    let save_path = temp.path().join("SavedFont.shift");
+    let replacement_path = temp.path().join("Replacement.shift");
+
+    {
+        let mut workspace =
+            FontWorkspace::create_untitled(&store_path, NewWorkspace::new()).unwrap();
+        workspace.save_as(&save_path).unwrap();
+        assert!(!workspace.is_dirty().unwrap());
+    }
+    let mut replacement = shift_font::Font::new();
+    replacement.metadata_mut().family_name = Some("Replacement".to_string());
+    ShiftSourcePackage::save_font(&replacement_path, &replacement).unwrap();
+    fs::copy(&replacement_path, &save_path).unwrap();
+
+    let recovery = FontWorkspace::find_recoverable_package_workspace(
+        &save_path,
+        &[WorkspaceRecoveryCandidate {
+            document_id: "doc-1".to_string(),
+            store_path,
+        }],
+    )
+    .unwrap();
+
+    assert_eq!(recovery, None);
 }
 
 fn set_x_advance_intents(layer_id: LayerId, width: f64) -> FontIntentSet {

--- a/packages/types/src/bridge/generated.ts
+++ b/packages/types/src/bridge/generated.ts
@@ -22,6 +22,9 @@ export interface BridgeApi {
   exportWorkspace(request: FontExportRequest): Promise<FontExportResult>
   documentState(): DocumentState
   openWorkspace(path: string, storePath: string): void
+  resumeWorkspaceForSource(storePath: string, sourcePath: string): void
+  setDocumentId(documentId: string): DocumentState
+  findRecoverableWorkspace(sourcePath: string, candidates: Array<WorkspaceRecoveryCandidate>): WorkspaceRecoveryMatch | null
   saveWorkspace(): DocumentState
   saveWorkspaceAs(path: string): DocumentState
   getMetadata(): FontMetadata
@@ -71,6 +74,18 @@ export interface FontExportResult {
 export interface NewWorkspace {
   familyName?: string
   unitsPerEm?: number
+}
+
+export interface WorkspaceRecoveryCandidate {
+  documentId: string
+  storePath: string
+}
+
+export interface WorkspaceRecoveryMatch {
+  documentId: string
+  storePath: string
+  matchKind: string
+  dirty: boolean
 }
 export interface AddAnchorsIntent {
   layerId: LayerId


### PR DESCRIPTION
## Summary

Implements the first-class persistence slice for issue #80: retained SQLite working stores now carry durable source/workspace metadata, can be resumed after process death, and package opens can recover a matching dirty working DB before hydrating from the saved `.shift` package.

## What changed

- Added a single-row `workspace_state` table to `shift-store` with source kind/path metadata, file identity, fingerprint, dirty state, revision counters, and document id.
- Added `WorkspaceState`, `SourceIdentitySnapshot`, and `FileIdentity` store types with structural equality for round-trip tests.
- Marked successful font change-set commits dirty/revisioned in the same SQLite transaction as the font data.
- Added `FontWorkspace::resume`, source relinking, recovery candidate matching, and conservative package save validation.
- Added bridge APIs for source-aware resume/recovery and wired desktop `WorkspaceHost.open` to scan retained draft DBs before allocating a fresh store.
- Added coverage for dirty resume, moved/renamed package recovery, copy ambiguity, clean stale DB handling, and unsafe save refusal.

## Notes

`source_package_id` is represented in the store schema but is not populated yet because the current `.shift` manifest does not expose a stable package UUID. The initial matching policy uses path, OS file identity where available, and content fingerprint. Package copies while the original still exists do not auto-adopt the original dirty DB.

## Validation

- `cargo test -p shift-source -p shift-store -p shift-workspace -p shift-bridge`
- `pnpm --filter @shift/desktop exec vitest run src/utility/workspace/WorkspaceHost.test.ts`
- `pnpm typecheck`
- `git diff --check`
- Commit hooks: cargo check/fmt/clippy/test, oxlint, tsgo typecheck, deadcode strict, vitest
