### PR TITLE
[codex] Add dirty document close guard and chrome state

### DIFF
--- a/apps/desktop/src/main/app/App.ts
+++ b/apps/desktop/src/main/app/App.ts
@@ -11,6 +11,8 @@ import { ApplicationMenu } from "../menu/ApplicationMenu";
 import { createShiftLogger, type ShiftLogger } from "../logging";
 import { WorkspaceProcess } from "../workspace/WorkspaceProcess";
 import { DocumentSession } from "../document/DocumentSession";
+import { DocumentClient } from "../document/DocumentClient";
+import { AppLifecycle } from "./AppLifecycle";
 
 const APP_NAME = "Shift";
 
@@ -24,6 +26,7 @@ const APP_NAME = "Shift";
  */
 export class App {
   readonly #log: ShiftLogger;
+  readonly #lifecycle: AppLifecycle;
 
   #workingWindow: Window | null = null;
   #commands = new CommandRegistry();
@@ -38,14 +41,19 @@ export class App {
   });
 
   #workspace = new WorkspaceProcess();
+  #documentClient = new DocumentClient();
   #document = new DocumentSession({
-    workspace: this.#workspace,
+    document: this.#documentClient,
     activeWindow: () => this.#workingWindow,
     applicationName: () => this.applicationName,
   });
 
   constructor(log: ShiftLogger = createShiftLogger("app")) {
     this.#log = log;
+    this.#lifecycle = new AppLifecycle({
+      document: this.#document,
+      log: this.#log,
+    });
   }
 
   get applicationName(): string {
@@ -71,6 +79,7 @@ export class App {
 
     this.#registerCommands();
     this.#registerIpcHandlers();
+    this.#lifecycle.start();
     app.setName(this.applicationName);
 
     if (!app.isPackaged) {
@@ -90,13 +99,19 @@ export class App {
       this.#workingWindow = new Window({
         preloadPath: path.join(__dirname, "preload.js"),
       });
+      this.#lifecycle.registerWindow(this.#workingWindow, {
+        onClosed: () => {
+          this.#workingWindow = null;
+          this.#documentClient.dispose();
+        },
+      });
 
       this.#loadRenderer();
 
       this.#log.info("finished when ready callback");
     });
-
     app.on("will-quit", () => {
+      this.#documentClient.dispose();
       this.#workspace.stop();
     });
   }
@@ -125,6 +140,12 @@ export class App {
     ipc.handle(ipcMain, "commands.run", (_event, id) => {
       return this.#commands.run(id, this.#commandContext());
     });
+    ipc.handle(ipcMain, "document.connect", (event) => {
+      const { port1, port2 } = new MessageChannelMain();
+
+      this.#documentClient.connect(port1);
+      event.sender.postMessage("document.port", null, [port2]);
+    });
     ipc.handle(ipcMain, "workspace.connect", async (event) => {
       const { port1, port2 } = new MessageChannelMain();
 
@@ -144,6 +165,7 @@ export class App {
   #commandContext(): CommandContext {
     return {
       document: {
+        create: () => this.#document.create(),
         open: () => this.#document.open(),
         save: () => this.#document.save(),
         saveAs: () => this.#document.saveAs(),

--- a/apps/desktop/src/main/app/App.ts
+++ b/apps/desktop/src/main/app/App.ts
@@ -101,6 +101,7 @@ export class App {
       });
       this.#lifecycle.registerWindow(this.#workingWindow, {
         onClosed: () => {
+          this.#log.info("working window closed");
           this.#workingWindow = null;
           this.#documentClient.dispose();
         },
@@ -111,6 +112,7 @@ export class App {
       this.#log.info("finished when ready callback");
     });
     app.on("will-quit", () => {
+      this.#log.info("will quit: disposing app services");
       this.#documentClient.dispose();
       this.#workspace.stop();
     });
@@ -141,24 +143,29 @@ export class App {
       return this.#commands.run(id, this.#commandContext());
     });
     ipc.handle(ipcMain, "document.connect", (event) => {
+      this.#log.info("document connect requested");
       const { port1, port2 } = new MessageChannelMain();
 
       this.#documentClient.connect(port1);
       event.sender.postMessage("document.port", null, [port2]);
+      this.#log.info("document port sent to renderer");
     });
     ipc.handle(ipcMain, "workspace.connect", async (event) => {
+      this.#log.info("workspace connect requested");
       const { port1, port2 } = new MessageChannelMain();
 
       try {
         await this.#workspace.whenReady();
         await this.#workspace.connectSyncLane(port1);
       } catch (error) {
+        this.#log.error("workspace connect failed", error);
         port1.close();
         port2.close();
         throw error;
       }
 
       event.sender.postMessage("workspace.port", null, [port2]);
+      this.#log.info("workspace port sent to renderer");
     });
   }
 

--- a/apps/desktop/src/main/app/AppLifecycle.ts
+++ b/apps/desktop/src/main/app/AppLifecycle.ts
@@ -1,0 +1,109 @@
+import { app, type Event } from "electron";
+import type { ShiftLogger } from "../logging";
+import type { Window } from "../windows/Window";
+import type { CloseReason } from "../document/DocumentSession";
+
+export type CloseConfirmation = {
+  shouldConfirmClose(): boolean;
+  confirmClose(reason: CloseReason): Promise<boolean>;
+};
+
+export type AppLifecycleOptions = {
+  document: CloseConfirmation;
+  log: ShiftLogger;
+};
+
+export type WindowLifecycleOptions = {
+  onClosed: () => void;
+};
+
+type QuitState = "idle" | "confirming" | "confirmed";
+
+/**
+ * Coordinates Electron close and quit events around document vetoes.
+ *
+ * @remarks
+ * Electron exposes window close and app quit as separate event paths. This
+ * coordinator keeps their re-entrant state in one place and exposes a narrow
+ * `registerWindow` surface to the app bootstrap.
+ */
+export class AppLifecycle {
+  readonly #document: CloseConfirmation;
+  readonly #log: ShiftLogger;
+
+  #quitState: QuitState = "idle";
+  #confirmedWindowCloses = new Set<number>();
+  #pendingWindowCloses = new Set<number>();
+
+  constructor(options: AppLifecycleOptions) {
+    this.#document = options.document;
+    this.#log = options.log;
+  }
+
+  /** Installs app-wide lifecycle handlers. */
+  start(): void {
+    app.on("before-quit", (event) => this.#handleBeforeQuit(event));
+  }
+
+  /** Registers close handling for one BrowserWindow wrapper. */
+  registerWindow(window: Window, options: WindowLifecycleOptions): void {
+    const windowId = window.window.id;
+
+    window.window.on("close", (event) => this.#handleWindowClose(window, event));
+    window.window.on("closed", () => {
+      this.#confirmedWindowCloses.delete(windowId);
+      this.#pendingWindowCloses.delete(windowId);
+      options.onClosed();
+    });
+  }
+
+  #handleWindowClose(window: Window, event: Event): void {
+    const windowId = window.window.id;
+    if (this.#quitState === "confirmed" || this.#confirmedWindowCloses.has(windowId)) return;
+    if (!this.#document.shouldConfirmClose()) return;
+
+    event.preventDefault();
+    if (this.#pendingWindowCloses.has(windowId)) return;
+
+    this.#pendingWindowCloses.add(windowId);
+    void this.#document
+      .confirmClose("window")
+      .then((confirmed) => {
+        if (!confirmed) return;
+
+        this.#confirmedWindowCloses.add(windowId);
+        window.close();
+      })
+      .catch((error) => {
+        this.#log.error("window close guard failed", error);
+      })
+      .finally(() => {
+        this.#pendingWindowCloses.delete(windowId);
+      });
+  }
+
+  #handleBeforeQuit(event: Event): void {
+    if (this.#quitState === "confirmed") return;
+    if (!this.#document.shouldConfirmClose()) return;
+
+    event.preventDefault();
+    if (this.#quitState === "confirming") return;
+
+    this.#quitState = "confirming";
+    void this.#document
+      .confirmClose("quit")
+      .then((confirmed) => {
+        if (!confirmed) {
+          this.#quitState = "idle";
+          return;
+        }
+
+        this.#quitState = "confirmed";
+        app.quit();
+      })
+      .catch((error) => {
+        this.#quitState = "idle";
+        this.#log.error("quit guard failed", error);
+      });
+  }
+}

--- a/apps/desktop/src/main/app/AppLifecycle.ts
+++ b/apps/desktop/src/main/app/AppLifecycle.ts
@@ -42,15 +42,18 @@ export class AppLifecycle {
 
   /** Installs app-wide lifecycle handlers. */
   start(): void {
+    this.#log.info("starting app lifecycle");
     app.on("before-quit", (event) => this.#handleBeforeQuit(event));
   }
 
   /** Registers close handling for one BrowserWindow wrapper. */
   registerWindow(window: Window, options: WindowLifecycleOptions): void {
     const windowId = window.window.id;
+    this.#log.info("registering window lifecycle", { windowId });
 
     window.window.on("close", (event) => this.#handleWindowClose(window, event));
     window.window.on("closed", () => {
+      this.#log.info("window closed", { windowId });
       this.#confirmedWindowCloses.delete(windowId);
       this.#pendingWindowCloses.delete(windowId);
       options.onClosed();
@@ -59,18 +62,37 @@ export class AppLifecycle {
 
   #handleWindowClose(window: Window, event: Event): void {
     const windowId = window.window.id;
-    if (this.#quitState === "confirmed" || this.#confirmedWindowCloses.has(windowId)) return;
-    if (!this.#document.shouldConfirmClose()) return;
+    this.#log.debug("window close requested", { windowId, quitState: this.#quitState });
+    if (this.#quitState === "confirmed" || this.#confirmedWindowCloses.has(windowId)) {
+      this.#log.debug("window close allowed without guard", {
+        windowId,
+        quitState: this.#quitState,
+      });
+      return;
+    }
+
+    if (!this.#document.shouldConfirmClose()) {
+      this.#log.debug("window close guard skipped", { windowId });
+      return;
+    }
 
     event.preventDefault();
-    if (this.#pendingWindowCloses.has(windowId)) return;
+    if (this.#pendingWindowCloses.has(windowId)) {
+      this.#log.debug("window close guard already pending", { windowId });
+      return;
+    }
 
     this.#pendingWindowCloses.add(windowId);
+    this.#log.info("window close guard started", { windowId });
     void this.#document
       .confirmClose("window")
       .then((confirmed) => {
-        if (!confirmed) return;
+        if (!confirmed) {
+          this.#log.info("window close canceled by document guard", { windowId });
+          return;
+        }
 
+        this.#log.info("window close confirmed by document guard", { windowId });
         this.#confirmedWindowCloses.add(windowId);
         window.close();
       })
@@ -83,22 +105,36 @@ export class AppLifecycle {
   }
 
   #handleBeforeQuit(event: Event): void {
-    if (this.#quitState === "confirmed") return;
-    if (!this.#document.shouldConfirmClose()) return;
+    this.#log.debug("before quit received", { quitState: this.#quitState });
+    if (this.#quitState === "confirmed") {
+      this.#log.debug("quit allowed after confirmation");
+      return;
+    }
+
+    if (!this.#document.shouldConfirmClose()) {
+      this.#log.info("quit guard skipped");
+      return;
+    }
 
     event.preventDefault();
-    if (this.#quitState === "confirming") return;
+    if (this.#quitState === "confirming") {
+      this.#log.debug("quit guard already running");
+      return;
+    }
 
     this.#quitState = "confirming";
+    this.#log.info("quit guard started");
     void this.#document
       .confirmClose("quit")
       .then((confirmed) => {
         if (!confirmed) {
           this.#quitState = "idle";
+          this.#log.info("quit canceled by document guard");
           return;
         }
 
         this.#quitState = "confirmed";
+        this.#log.info("quit confirmed by document guard");
         app.quit();
       })
       .catch((error) => {

--- a/apps/desktop/src/main/commands/Command.ts
+++ b/apps/desktop/src/main/commands/Command.ts
@@ -88,6 +88,8 @@ export class CommandRegistry {
  */
 export type CommandContext = {
   document: {
+    /** Creates a new untitled workspace through main's document workflow. */
+    create: () => Promise<void>;
     open: () => Promise<void>;
     /** Saves through main's native document workflow. */
     save: () => Promise<void>;

--- a/apps/desktop/src/main/commands/Commands.ts
+++ b/apps/desktop/src/main/commands/Commands.ts
@@ -62,6 +62,13 @@ const viewCommands: Command[] = [
 
 const fileCommands: Command[] = [
   {
+    id: "file.new",
+    label: "New Font",
+    accelerator: "CmdOrCtrl+N",
+    enabled: (ctx) => ctx.windows.active() !== null,
+    run: (ctx) => ctx.document.create(),
+  },
+  {
     id: "file.open",
     label: "Open…",
     accelerator: "CmdOrCtrl+O",

--- a/apps/desktop/src/main/document/DocumentClient.ts
+++ b/apps/desktop/src/main/document/DocumentClient.ts
@@ -2,6 +2,7 @@ import type { MessagePortMain } from "electron";
 import type { WorkspaceDocumentState } from "../../shared/workspace/protocol";
 import type { DocumentCallMap, DocumentEventMap } from "../../shared/ipc/contract";
 import { Channel, electronPortTransport } from "../../shared/workspace/channel";
+import { createShiftLogger, type ShiftLogger } from "../logging";
 
 export interface Document {
   readonly connected: boolean;
@@ -20,7 +21,13 @@ export interface Document {
  * mutating the utility process directly.
  */
 export class DocumentClient implements Document {
+  readonly #log: ShiftLogger;
+
   #channel: Channel<DocumentCallMap, DocumentEventMap> | null = null;
+
+  constructor(log: ShiftLogger = createShiftLogger("document.client")) {
+    this.#log = log;
+  }
 
   get connected(): boolean {
     return this.#channel !== null;
@@ -28,6 +35,12 @@ export class DocumentClient implements Document {
 
   /** Replaces the active renderer document lane. */
   connect(port: MessagePortMain): void {
+    if (this.#channel) {
+      this.#log.info("replacing document renderer connection");
+    } else {
+      this.#log.info("document renderer connected");
+    }
+
     this.#channel?.dispose();
     this.#channel = new Channel<DocumentCallMap, DocumentEventMap>(electronPortTransport(port));
   }
@@ -50,6 +63,12 @@ export class DocumentClient implements Document {
 
   /** Disconnects the active renderer document lane. */
   dispose(): void {
+    if (!this.#channel) {
+      this.#log.debug("document renderer already disconnected");
+      return;
+    }
+
+    this.#log.info("document renderer disconnected");
     this.#channel?.dispose();
     this.#channel = null;
   }
@@ -59,6 +78,7 @@ export class DocumentClient implements Document {
     payload: DocumentCallMap[K]["request"],
   ): Promise<DocumentCallMap[K]["response"]> {
     if (!this.#channel) {
+      this.#log.warn("document request failed: renderer is not connected", { type });
       return Promise.reject(new Error("document renderer is not connected"));
     }
 

--- a/apps/desktop/src/main/document/DocumentClient.ts
+++ b/apps/desktop/src/main/document/DocumentClient.ts
@@ -1,0 +1,67 @@
+import type { MessagePortMain } from "electron";
+import type { WorkspaceDocumentState } from "../../shared/workspace/protocol";
+import type { DocumentCallMap, DocumentEventMap } from "../../shared/ipc/contract";
+import { Channel, electronPortTransport } from "../../shared/workspace/channel";
+
+export interface Document {
+  readonly connected: boolean;
+  state(): Promise<WorkspaceDocumentState | null>;
+  create(): Promise<void>;
+  save(path: string | null): Promise<WorkspaceDocumentState>;
+  open(path: string): Promise<void>;
+}
+
+/**
+ * Main-process client for document operations served by the renderer.
+ *
+ * @remarks
+ * The renderer owns the committed edit lane, so main routes document state,
+ * create, save, and open requests through this client instead of reading or
+ * mutating the utility process directly.
+ */
+export class DocumentClient implements Document {
+  #channel: Channel<DocumentCallMap, DocumentEventMap> | null = null;
+
+  get connected(): boolean {
+    return this.#channel !== null;
+  }
+
+  /** Replaces the active renderer document lane. */
+  connect(port: MessagePortMain): void {
+    this.#channel?.dispose();
+    this.#channel = new Channel<DocumentCallMap, DocumentEventMap>(electronPortTransport(port));
+  }
+
+  state(): Promise<WorkspaceDocumentState | null> {
+    return this.#call("document.state", undefined);
+  }
+
+  create(): Promise<void> {
+    return this.#call("document.create", undefined);
+  }
+
+  save(path: string | null): Promise<WorkspaceDocumentState> {
+    return this.#call("document.save", { path });
+  }
+
+  open(path: string): Promise<void> {
+    return this.#call("document.open", { path });
+  }
+
+  /** Disconnects the active renderer document lane. */
+  dispose(): void {
+    this.#channel?.dispose();
+    this.#channel = null;
+  }
+
+  #call<K extends keyof DocumentCallMap & string>(
+    type: K,
+    payload: DocumentCallMap[K]["request"],
+  ): Promise<DocumentCallMap[K]["response"]> {
+    if (!this.#channel) {
+      return Promise.reject(new Error("document renderer is not connected"));
+    }
+
+    return this.#channel.call(type, payload);
+  }
+}

--- a/apps/desktop/src/main/document/DocumentSession.ts
+++ b/apps/desktop/src/main/document/DocumentSession.ts
@@ -9,6 +9,7 @@ import { errorToMessage } from "../../shared/errors";
 import type { WorkspaceDocumentState } from "../../shared/workspace/protocol";
 import type { Window } from "../windows/Window";
 import type { Document } from "./DocumentClient";
+import { createShiftLogger, type ShiftLogger } from "../logging";
 
 const OPEN_FONT_EXTENSIONS = [
   "shift",
@@ -24,6 +25,7 @@ export type DocumentSessionOptions = {
   document: Document;
   activeWindow: () => Window | null;
   applicationName: () => string;
+  log?: ShiftLogger;
 };
 
 export type CloseReason = "window" | "quit" | "replace-document";
@@ -42,6 +44,7 @@ export class DocumentSession {
   readonly #document: Document;
   readonly #activeWindow: () => Window | null;
   readonly #applicationName: () => string;
+  readonly #log: ShiftLogger;
 
   #state: WorkspaceDocumentState | null = null;
 
@@ -49,28 +52,48 @@ export class DocumentSession {
     this.#document = options.document;
     this.#activeWindow = options.activeWindow;
     this.#applicationName = options.applicationName;
+    this.#log = options.log ?? createShiftLogger("document.session");
   }
 
   /** Creates an untitled workspace through the renderer edit lane. */
   async create(): Promise<void> {
-    if (!(await this.confirmClose("replace-document"))) return;
+    this.#log.info("new document requested");
+    if (!(await this.confirmClose("replace-document"))) {
+      this.#log.info("new document canceled by close guard");
+      return;
+    }
 
     await this.#document.create();
+    this.#log.info("new document created");
   }
 
   /** Runs Open from main with a native open dialog. */
   async open(): Promise<void> {
+    this.#log.info("open document requested");
     const openPath = await this.#showOpenDialog();
-    if (!openPath) return;
+    if (!openPath) {
+      this.#log.info("open document canceled before file selection");
+      return;
+    }
 
-    if (!(await this.confirmClose("replace-document"))) return;
+    if (!(await this.confirmClose("replace-document"))) {
+      this.#log.info("open document canceled by close guard", { path: openPath });
+      return;
+    }
 
     await this.#requestOpen(openPath);
+    this.#log.info("open document completed", { path: openPath });
   }
 
   /** Returns whether a close transition needs document confirmation. */
   shouldConfirmClose(): boolean {
-    return this.#document.connected || this.#state?.dirty === true;
+    const shouldConfirm = this.#document.connected || this.#state?.dirty === true;
+    this.#log.debug("close guard availability checked", {
+      connected: this.#document.connected,
+      cachedDirty: this.#state?.dirty ?? null,
+      shouldConfirm,
+    });
+    return shouldConfirm;
   }
 
   /**
@@ -81,14 +104,49 @@ export class DocumentSession {
    * @throws {Error} when the renderer cannot provide a settled document state.
    */
   async confirmClose(reason: CloseReason): Promise<boolean> {
+    this.#log.info("close guard started", {
+      reason,
+      connected: this.#document.connected,
+      cachedDirty: this.#state?.dirty ?? null,
+    });
+
     const state = await this.#closeState();
-    if (!state || !state.dirty) return true;
+    if (!state) {
+      this.#log.info("close guard allowed: no document state", { reason });
+      return true;
+    }
+
+    if (!state.dirty) {
+      this.#log.info("close guard allowed: document is clean", { reason });
+      return true;
+    }
 
     const choice = await this.#showDirtyDocumentDialog(state, reason);
-    if (choice === "cancel") return false;
-    if (choice === "discard") return true;
+    this.#log.info("dirty document dialog completed", {
+      reason,
+      choice,
+      saveTarget: state.saveTarget,
+      needsSaveAs: state.needsSaveAs,
+    });
 
-    return this.#saveDirtyDocument(state);
+    if (choice === "cancel") {
+      this.#log.info("close guard canceled by user", { reason });
+      return false;
+    }
+
+    if (choice === "discard") {
+      this.#log.info("close guard allowed: changes discarded", { reason });
+      return true;
+    }
+
+    const saved = await this.#saveDirtyDocument(state);
+    this.#log.info(
+      saved ? "close guard allowed: document saved" : "close guard blocked: save failed",
+      {
+        reason,
+      },
+    );
+    return saved;
   }
 
   /**
@@ -97,9 +155,13 @@ export class DocumentSession {
    * @throws {Error} when the renderer cannot read state or save.
    */
   async save(): Promise<void> {
+    this.#log.info("save document requested");
     const state = await this.#requestState();
     this.acceptState(state);
-    if (!state) return;
+    if (!state) {
+      this.#log.info("save document skipped: no document state");
+      return;
+    }
 
     if (state.needsSaveAs) {
       await this.#saveToNewPath(state);
@@ -107,6 +169,7 @@ export class DocumentSession {
     }
 
     await this.#requestSave(null);
+    this.#log.info("save document completed", { saveTarget: state.saveTarget });
   }
 
   /**
@@ -115,9 +178,13 @@ export class DocumentSession {
    * @throws {Error} when the renderer cannot read state or save.
    */
   async saveAs(): Promise<void> {
+    this.#log.info("save as requested");
     const state = await this.#requestState();
     this.acceptState(state);
-    if (!state) return;
+    if (!state) {
+      this.#log.info("save as skipped: no document state");
+      return;
+    }
 
     await this.#saveToNewPath(state);
   }
@@ -134,8 +201,12 @@ export class DocumentSession {
 
   async #saveToNewPath(state: WorkspaceDocumentState): Promise<WorkspaceDocumentState | null> {
     const savePath = await this.#showSaveDialog(state);
-    if (!savePath) return null;
+    if (!savePath) {
+      this.#log.info("save as canceled", { saveTarget: state.saveTarget });
+      return null;
+    }
 
+    this.#log.info("save as path selected", { path: savePath });
     return this.#requestSave(savePath);
   }
 
@@ -146,6 +217,7 @@ export class DocumentSession {
         : await this.#requestSave(null);
       return saved !== null;
     } catch (error) {
+      this.#log.warn("dirty document save failed", error);
       await this.#showSaveFailedDialog(error);
       return false;
     }
@@ -156,9 +228,14 @@ export class DocumentSession {
       return await this.#requestState();
     } catch (error) {
       if (!this.#document.connected && (!this.#state || !this.#state.dirty)) {
+        this.#log.warn(
+          "close guard ignored disconnected renderer with no cached dirty document",
+          error,
+        );
         return null;
       }
 
+      this.#log.warn("close guard could not read document state", error);
       await this.#showSaveFailedDialog(error);
       return this.#state;
     }
@@ -171,12 +248,14 @@ export class DocumentSession {
   }
 
   async #requestSave(savePath: string | null): Promise<WorkspaceDocumentState> {
+    this.#log.info("document save sent to renderer", { path: savePath });
     const state = await this.#document.save(savePath);
     this.acceptState(state);
     return state;
   }
 
   async #requestOpen(openPath: string): Promise<void> {
+    this.#log.info("document open sent to renderer", { path: openPath });
     await this.#document.open(openPath);
   }
 

--- a/apps/desktop/src/main/document/DocumentSession.ts
+++ b/apps/desktop/src/main/document/DocumentSession.ts
@@ -1,10 +1,14 @@
-import { dialog, type OpenDialogOptions, type SaveDialogOptions } from "electron";
+import {
+  dialog,
+  type MessageBoxOptions,
+  type OpenDialogOptions,
+  type SaveDialogOptions,
+} from "electron";
 import path from "node:path";
-import * as ipc from "../../shared/ipc/main";
-import type { DocumentOpenRequest, DocumentSaveRequest } from "../../shared/ipc/contract";
+import { errorToMessage } from "../../shared/errors";
 import type { WorkspaceDocumentState } from "../../shared/workspace/protocol";
 import type { Window } from "../windows/Window";
-import type { WorkspaceProcess } from "../workspace/WorkspaceProcess";
+import type { Document } from "./DocumentClient";
 
 const OPEN_FONT_EXTENSIONS = [
   "shift",
@@ -17,31 +21,41 @@ const OPEN_FONT_EXTENSIONS = [
 ];
 
 export type DocumentSessionOptions = {
-  workspace: WorkspaceProcess;
+  document: Document;
   activeWindow: () => Window | null;
   applicationName: () => string;
 };
+
+export type CloseReason = "window" | "quit" | "replace-document";
+type DirtyDocumentChoice = "save" | "discard" | "cancel";
 
 /**
  * Main-process owner of the native document workflow.
  *
  * @remarks
- * Main owns the shell chrome, native dialogs, and the Save vs Save As decision
- * read from the utility's `document.state`. Document reads and writes belong to
- * the renderer's committed-op lane; main resolves dialog paths, then asks the
- * renderer to issue the open/save request one-way.
+ * Main owns the shell chrome and native dialogs. Document state reads and
+ * writes that affect replacement or save decisions go through the renderer's
+ * committed-op lane so pending edits cannot be bypassed by main-process state
+ * reads.
  */
 export class DocumentSession {
-  readonly #workspace: WorkspaceProcess;
+  readonly #document: Document;
   readonly #activeWindow: () => Window | null;
   readonly #applicationName: () => string;
 
   #state: WorkspaceDocumentState | null = null;
 
   constructor(options: DocumentSessionOptions) {
-    this.#workspace = options.workspace;
+    this.#document = options.document;
     this.#activeWindow = options.activeWindow;
     this.#applicationName = options.applicationName;
+  }
+
+  /** Creates an untitled workspace through the renderer edit lane. */
+  async create(): Promise<void> {
+    if (!(await this.confirmClose("replace-document"))) return;
+
+    await this.#document.create();
   }
 
   /** Runs Open from main with a native open dialog. */
@@ -49,16 +63,41 @@ export class DocumentSession {
     const openPath = await this.#showOpenDialog();
     if (!openPath) return;
 
-    this.#requestOpen({ path: openPath });
+    if (!(await this.confirmClose("replace-document"))) return;
+
+    await this.#requestOpen(openPath);
+  }
+
+  /** Returns whether a close transition needs document confirmation. */
+  shouldConfirmClose(): boolean {
+    return this.#document.connected || this.#state?.dirty === true;
+  }
+
+  /**
+   * Confirms whether the current document may be closed or replaced.
+   *
+   * @param reason - Native transition that would discard or replace the document.
+   * @returns `true` when the transition may continue.
+   * @throws {Error} when the renderer cannot provide a settled document state.
+   */
+  async confirmClose(reason: CloseReason): Promise<boolean> {
+    const state = await this.#closeState();
+    if (!state || !state.dirty) return true;
+
+    const choice = await this.#showDirtyDocumentDialog(state, reason);
+    if (choice === "cancel") return false;
+    if (choice === "discard") return true;
+
+    return this.#saveDirtyDocument(state);
   }
 
   /**
    * Runs Save, escalating to Save As when the document has no target yet.
    *
-   * @throws {Error} when reading utility state fails.
+   * @throws {Error} when the renderer cannot read state or save.
    */
   async save(): Promise<void> {
-    const state = await this.#workspace.documentState();
+    const state = await this.#requestState();
     this.acceptState(state);
     if (!state) return;
 
@@ -67,16 +106,16 @@ export class DocumentSession {
       return;
     }
 
-    this.#requestSave({ path: null });
+    await this.#requestSave(null);
   }
 
   /**
    * Runs Save As from main with a native save dialog.
    *
-   * @throws {Error} when reading utility state fails.
+   * @throws {Error} when the renderer cannot read state or save.
    */
   async saveAs(): Promise<void> {
-    const state = await this.#workspace.documentState();
+    const state = await this.#requestState();
     this.acceptState(state);
     if (!state) return;
 
@@ -93,27 +132,52 @@ export class DocumentSession {
     this.#updateWindowTitle();
   }
 
-  async #saveToNewPath(state: WorkspaceDocumentState): Promise<void> {
+  async #saveToNewPath(state: WorkspaceDocumentState): Promise<WorkspaceDocumentState | null> {
     const savePath = await this.#showSaveDialog(state);
-    if (!savePath) return;
+    if (!savePath) return null;
 
-    this.#requestSave({ path: savePath });
+    return this.#requestSave(savePath);
   }
 
-  /** Asks the active renderer to issue the save on its committed-op lane. */
-  #requestSave(request: DocumentSaveRequest): void {
-    const window = this.#activeWindow();
-    if (!window || window.window.webContents.isDestroyed()) return;
-
-    ipc.send(window.window.webContents, "document.save", request);
+  async #saveDirtyDocument(state: WorkspaceDocumentState): Promise<boolean> {
+    try {
+      const saved = state.needsSaveAs
+        ? await this.#saveToNewPath(state)
+        : await this.#requestSave(null);
+      return saved !== null;
+    } catch (error) {
+      await this.#showSaveFailedDialog(error);
+      return false;
+    }
   }
 
-  /** Asks the active renderer to open the selected document. */
-  #requestOpen(request: DocumentOpenRequest): void {
-    const window = this.#activeWindow();
-    if (!window || window.window.webContents.isDestroyed()) return;
+  async #closeState(): Promise<WorkspaceDocumentState | null> {
+    try {
+      return await this.#requestState();
+    } catch (error) {
+      if (!this.#document.connected && (!this.#state || !this.#state.dirty)) {
+        return null;
+      }
 
-    ipc.send(window.window.webContents, "document.open", request);
+      await this.#showSaveFailedDialog(error);
+      return this.#state;
+    }
+  }
+
+  async #requestState(): Promise<WorkspaceDocumentState | null> {
+    const state = await this.#document.state();
+    this.acceptState(state);
+    return state;
+  }
+
+  async #requestSave(savePath: string | null): Promise<WorkspaceDocumentState> {
+    const state = await this.#document.save(savePath);
+    this.acceptState(state);
+    return state;
+  }
+
+  async #requestOpen(openPath: string): Promise<void> {
+    await this.#document.open(openPath);
   }
 
   async #showSaveDialog(state: WorkspaceDocumentState): Promise<string | null> {
@@ -130,6 +194,59 @@ export class DocumentSession {
       : await dialog.showSaveDialog(options);
 
     return result.canceled ? null : (result.filePath ?? null);
+  }
+
+  async #showDirtyDocumentDialog(
+    state: WorkspaceDocumentState,
+    reason: CloseReason,
+  ): Promise<DirtyDocumentChoice> {
+    const name = state.saveTarget ? path.basename(state.saveTarget) : "Untitled";
+    const options: MessageBoxOptions = {
+      type: "warning",
+      buttons: ["Save", "Don't Save", "Cancel"],
+      defaultId: 0,
+      cancelId: 2,
+      noLink: true,
+      title: this.#applicationName(),
+      message: this.#dirtyDocumentMessage(reason, name),
+      detail: "Your changes will be lost if you don't save them.",
+    };
+
+    const window = this.#activeWindow();
+    const result = window
+      ? await dialog.showMessageBox(window.window, options)
+      : await dialog.showMessageBox(options);
+
+    if (result.response === 0) return "save";
+    if (result.response === 1) return "discard";
+    return "cancel";
+  }
+
+  async #showSaveFailedDialog(error: unknown): Promise<void> {
+    const options: MessageBoxOptions = {
+      type: "error",
+      buttons: ["OK"],
+      defaultId: 0,
+      title: this.#applicationName(),
+      message: "The document could not be saved.",
+      detail: errorToMessage(error),
+    };
+
+    const window = this.#activeWindow();
+    if (window) {
+      await dialog.showMessageBox(window.window, options);
+      return;
+    }
+
+    await dialog.showMessageBox(options);
+  }
+
+  #dirtyDocumentMessage(reason: CloseReason, name: string): string {
+    if (reason === "replace-document") {
+      return `Save changes to ${name} before replacing it?`;
+    }
+
+    return `Save changes to ${name} before closing?`;
   }
 
   async #showOpenDialog(): Promise<string | null> {

--- a/apps/desktop/src/main/menu/ApplicationMenu.ts
+++ b/apps/desktop/src/main/menu/ApplicationMenu.ts
@@ -103,6 +103,7 @@ export class ApplicationMenu {
 
   #fileItems(): MenuItemConstructorOptions[] {
     return [
+      this.#commandItem("file.new"),
       this.#commandItem("file.open"),
       { type: "separator" },
       this.#commandItem("file.save"),

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -11,8 +11,7 @@ const shiftHost: ShiftHost = {
     run: invoke(ipcRenderer, "commands.run"),
   },
   document: {
-    onSave: listen(ipcRenderer, "document.save"),
-    onOpen: listen(ipcRenderer, "document.open"),
+    connect: invoke(ipcRenderer, "document.connect"),
   },
   workspace: {
     connect: invoke(ipcRenderer, "workspace.connect"),
@@ -31,4 +30,8 @@ contextBridge.exposeInMainWorld("shiftHost", shiftHost);
 // MessagePorts cannot cross the context bridge; relay them into the page.
 ipcRenderer.on("workspace.port", (event: IpcRendererEvent) => {
   window.postMessage({ type: "workspace.port" }, window.location.origin, event.ports);
+});
+
+ipcRenderer.on("document.port", (event: IpcRendererEvent) => {
+  window.postMessage({ type: "document.port" }, window.location.origin, event.ports);
 });

--- a/apps/desktop/src/renderer/src/components/chrome/Titlebar.tsx
+++ b/apps/desktop/src/renderer/src/components/chrome/Titlebar.tsx
@@ -82,7 +82,7 @@ export const Titlebar = () => {
 
   return (
     <div
-      className="titlebar flex items-center gap-2 px-3 py-2"
+      className="titlebar-drag flex items-center gap-2 px-3 py-2"
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >

--- a/apps/desktop/src/renderer/src/components/chrome/Toolbar.tsx
+++ b/apps/desktop/src/renderer/src/components/chrome/Toolbar.tsx
@@ -1,14 +1,32 @@
 import { NavigationPane } from "./NavigationPane";
 import { Titlebar } from "./Titlebar";
 import { ToolsPane } from "@/components/editor/ToolsPane";
+import { useDocumentChromeState } from "@/hooks/useDocumentChromeState";
+import { getFont } from "@/store/appStore";
 
 export const Toolbar = () => {
+  const { filename, dirty } = useDocumentChromeState();
+  const familyName = getFont().metadata.familyName;
+  const editedFilename = `${filename} — Edited`;
+
   return (
-    <header className="titlebar-drag flex min-h-12 w-screen items-center bg-toolbar py-1">
+    <header className="titlebar-drag flex min-h-12 w-screen items-center bg-toolbar py-1 pr-6">
       <Titlebar />
-      <NavigationPane />
-      <ToolsPane />
-      <div className="flex-1" />
+      <div className="flex justify-center items-center gap-6">
+        <NavigationPane />
+        <div className="flex flex-row justify-center items-center">
+          <div>
+            <p className="grid whitespace-nowrap text-ui">
+              <span className="invisible col-start-1 row-start-1">{editedFilename}</span>
+              <span className="col-start-1 row-start-1">{dirty ? editedFilename : filename}</span>
+            </p>
+            <p className="text-ui font-medium">{familyName}</p>
+          </div>
+        </div>
+      </div>
+      <div className="flex-1">
+        <ToolsPane />
+      </div>
     </header>
   );
 };

--- a/apps/desktop/src/renderer/src/hooks/useDocumentChromeState.ts
+++ b/apps/desktop/src/renderer/src/hooks/useDocumentChromeState.ts
@@ -1,0 +1,51 @@
+import { useMemo } from "react";
+
+import { useSignalState } from "@/lib/signals";
+import { getEditQueue, getEditor, getWorkspace } from "@/store/appStore";
+
+import type { WorkspaceDocumentState } from "@shared/workspace/protocol";
+import type { WorkspaceCommitState } from "@/lib/workspace/WorkspaceEditQueue";
+
+export type DocumentActivity = "clean" | "editing" | "committing" | "dirty";
+
+type DocumentChromeState = {
+  readonly documentState: WorkspaceDocumentState | null;
+  readonly filename: string;
+  readonly activity: DocumentActivity;
+  readonly dirty: boolean;
+};
+
+export function useDocumentChromeState(): DocumentChromeState {
+  const documentState = useSignalState(getWorkspace().documentStateCell);
+  const isEditing = useSignalState(getEditor().isEditingCell);
+  const commitState = useSignalState(getEditQueue().commitStateCell);
+
+  return useMemo(() => {
+    const activity = activityForDocument(documentState, isEditing, commitState);
+
+    return {
+      documentState,
+      filename: filenameForDocument(documentState),
+      activity,
+      dirty: activity !== "clean",
+    };
+  }, [documentState, isEditing, commitState]);
+}
+
+function activityForDocument(
+  documentState: WorkspaceDocumentState | null,
+  isEditing: boolean,
+  commitState: WorkspaceCommitState,
+): DocumentActivity {
+  if (documentState?.dirty) return "dirty";
+  if (isEditing) return "editing";
+  if (commitState !== "idle") return "committing";
+  return "clean";
+}
+
+function filenameForDocument(state: WorkspaceDocumentState | null): string {
+  const saveTarget = state?.saveTarget;
+  if (!saveTarget) return "Untitled";
+
+  return saveTarget.split(/[\\/]/).filter(Boolean).at(-1) ?? "Untitled";
+}

--- a/apps/desktop/src/renderer/src/lib/editor/Editor.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/Editor.ts
@@ -36,6 +36,7 @@ import {
 } from "../transform";
 import {
   batch,
+  computed,
   effect,
   signal,
   type Effect,
@@ -154,6 +155,7 @@ export class Editor {
   >;
   #activeTool: WritableSignal<ToolName>;
   #activeToolState: WritableSignal<ActiveToolState>;
+  #isEditing: Signal<boolean>;
 
   /**
    * Runtime services with lifecycle or side effects.
@@ -242,9 +244,12 @@ export class Editor {
         name: "editor.tool.state",
       },
     );
-
     this.#events = new EventEmitter();
     this.#toolManager = new ToolManager(this);
+    this.#isEditing = computed(
+      () => this.#toolManager.activeToolCell.value?.isEditingCell.value ?? false,
+      { name: "editor.isEditing" },
+    );
 
     this.#clipboard = new Clipboard(options.clipboard);
 
@@ -327,6 +332,14 @@ export class Editor {
 
   public get activeToolStateCell(): Signal<ActiveToolState> {
     return this.#activeToolState;
+  }
+
+  public get isEditing(): boolean {
+    return this.#isEditing.peek();
+  }
+
+  public get isEditingCell(): Signal<boolean> {
+    return this.#isEditing;
   }
 
   // oxlint-disable-next-line shift/no-get-signal-value-method -- retained for upcoming tool refactor

--- a/apps/desktop/src/renderer/src/lib/model/Font.ts
+++ b/apps/desktop/src/renderer/src/lib/model/Font.ts
@@ -274,7 +274,7 @@ export class Font {
    * Projects the renderer's workspace snapshot into the font domain model.
    *
    * @param $workspace - Single source of workspace truth owned by
-   *   `WorkspaceClient`. There is no load: every derived value follows this
+   *   `WorkspaceSession`. There is no load: every derived value follows this
    *   signal, and `null` means no font is open.
    * @param editQueue - Optional queue used by editable projections to submit
    *   committed edits to the utility workspace.

--- a/apps/desktop/src/renderer/src/lib/tools/core/BaseTool.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/core/BaseTool.ts
@@ -40,6 +40,7 @@ export abstract class BaseTool<S extends ToolState, TTool = unknown, Settings = 
   /** Ordered behavior list -- first match wins on each event. */
   abstract readonly behaviors: Behavior<S, TTool>[];
   readonly cursorCell: ComputedSignal<CursorType>;
+  readonly isEditingCell: ComputedSignal<boolean>;
   readonly stateCell: Signal<S>;
   readonly #stateCell: WritableSignal<S>;
   state: S;
@@ -58,6 +59,9 @@ export abstract class BaseTool<S extends ToolState, TTool = unknown, Settings = 
     this.cursorCell = computed(() => this.getCursor(this.stateCell.value), {
       name: `tool.${this.constructor.name}.cursor`,
     });
+    this.isEditingCell = computed(() => this.isEditing(this.stateCell.value), {
+      name: `tool.${this.constructor.name}.isEditing`,
+    });
   }
 
   getCursor(state: S): CursorType {
@@ -74,6 +78,11 @@ export abstract class BaseTool<S extends ToolState, TTool = unknown, Settings = 
 
   defaultSettings(): Settings {
     return {} as Settings;
+  }
+
+  protected isEditing(state: S): boolean {
+    void state;
+    return false;
   }
 
   /** Return a state to short-circuit the behavior loop, or null to continue. */

--- a/apps/desktop/src/renderer/src/lib/tools/pen/Pen.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/pen/Pen.ts
@@ -45,6 +45,10 @@ export class Pen extends BaseTool<PenState> {
     return { type: "pen" };
   }
 
+  protected override isEditing(state: PenState): boolean {
+    return state.type === "dragging";
+  }
+
   initialState(): PenState {
     return { type: "idle" };
   }

--- a/apps/desktop/src/renderer/src/lib/tools/select/Select.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/Select.ts
@@ -70,6 +70,15 @@ export class Select extends BaseTool<SelectState, Select> {
     return { type: "default" };
   }
 
+  protected override isEditing(state: SelectState): boolean {
+    return (
+      state.type === "translating" ||
+      state.type === "resizing" ||
+      state.type === "rotating" ||
+      state.type === "bending"
+    );
+  }
+
   initialState(): SelectState {
     return { type: "idle" };
   }

--- a/apps/desktop/src/renderer/src/lib/tools/shape/Shape.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/shape/Shape.ts
@@ -39,6 +39,10 @@ export class Shape extends BaseTool<ShapeState> {
     return { type: "crosshair" };
   }
 
+  protected override isEditing(state: ShapeState): boolean {
+    return state.type === "dragging";
+  }
+
   override activate(): void {
     this.state = { type: "ready" };
   }

--- a/apps/desktop/src/renderer/src/lib/workspace/WorkspaceClient.ts
+++ b/apps/desktop/src/renderer/src/lib/workspace/WorkspaceClient.ts
@@ -103,6 +103,13 @@ export class WorkspaceClient {
     return snapshot;
   }
 
+  /** Reads utility-owned document state through the renderer sync lane. */
+  async documentState(): Promise<WorkspaceDocumentState | null> {
+    await this.connected();
+
+    return this.#require().call("document.state", undefined);
+  }
+
   /** Saves to the current target; rejects when the document still needs a path. */
   async save(): Promise<WorkspaceDocumentState> {
     await this.connected();

--- a/apps/desktop/src/renderer/src/lib/workspace/WorkspaceEditQueue.test.ts
+++ b/apps/desktop/src/renderer/src/lib/workspace/WorkspaceEditQueue.test.ts
@@ -26,7 +26,7 @@ describe("WorkspaceEditQueue issues save on the committed-op lane", () => {
     editQueue.push(createGlyph("A", 65)); // queued, not yet applied
     const saved = await editQueue.save(savePath()); // flushes the push, then saves behind it
 
-    expect(client.$workspace.peek()?.glyphs).toHaveLength(1); // the apply was folded
+    expect(client.workspaceCell.peek()?.glyphs).toHaveLength(1); // the apply was folded
     expect(saved).toMatchObject({ dirty: false, needsSaveAs: false });
   });
 
@@ -37,7 +37,19 @@ describe("WorkspaceEditQueue issues save on the committed-op lane", () => {
     editQueue.push(createGlyph("B", 66));
     const saved = await editQueue.save(null); // null = save to current target
 
-    expect(client.$workspace.peek()?.glyphs).toHaveLength(1);
+    expect(client.workspaceCell.peek()?.glyphs).toHaveLength(1);
     expect(saved).toMatchObject({ dirty: false });
+  });
+
+  it("marks locally committed edits as queued until the utility echo settles", async () => {
+    const { client, editQueue } = stack;
+    await editQueue.save(savePath());
+
+    editQueue.push(createGlyph("C", 67));
+
+    expect(editQueue.commitStateCell.peek()).toBe("queued");
+    await editQueue.settled();
+    expect(editQueue.commitStateCell.peek()).toBe("idle");
+    expect(client.documentStateCell.peek()).toMatchObject({ dirty: true });
   });
 });

--- a/apps/desktop/src/renderer/src/lib/workspace/WorkspaceEditQueue.ts
+++ b/apps/desktop/src/renderer/src/lib/workspace/WorkspaceEditQueue.ts
@@ -83,8 +83,7 @@ export class WorkspaceEditQueue {
 
   /** Replays the latest undo entry after pending pushes flush. */
   undo(): Promise<AppliedChange | null> {
-    this.#enqueueFlush();
-    return this.#serialize(async () => {
+    return this.#withFlush(async () => {
       const applied = await this.#workspace.undo();
       if (applied) this.#fold(applied);
       return applied;
@@ -93,18 +92,33 @@ export class WorkspaceEditQueue {
 
   /** Pulls replace-grade glyph state, serialized behind pending writes. */
   glyph(glyphId: GlyphId, sourceId: SourceId): Promise<GlyphState | null> {
-    this.#enqueueFlush();
-    return this.#serialize(() => this.#workspace.glyph(glyphId, sourceId));
+    return this.#withFlush(() => this.#workspace.glyph(glyphId, sourceId));
   }
 
   /** Replays the latest redo entry after pending pushes flush. */
   redo(): Promise<AppliedChange | null> {
-    this.#enqueueFlush();
-    return this.#serialize(async () => {
+    return this.#withFlush(async () => {
       const applied = await this.#workspace.redo();
       if (applied) this.#fold(applied);
       return applied;
     });
+  }
+
+  /** Creates an untitled workspace behind every queued and in-flight edit. */
+  create(): Promise<void> {
+    return this.#withFlush(() => this.#workspace.create());
+  }
+
+  /** Opens a workspace behind every queued and in-flight edit. */
+  open(path: string): Promise<void> {
+    return this.#withFlush(async () => {
+      await this.#workspace.open(path);
+    });
+  }
+
+  /** Reads document state behind every queued and in-flight edit. */
+  state(): Promise<WorkspaceDocumentState | null> {
+    return this.#withFlush(() => this.#workspace.documentState());
   }
 
   /**
@@ -113,10 +127,14 @@ export class WorkspaceEditQueue {
    * @param path - target path for Save As, or null to save the current target.
    */
   save(path: string | null): Promise<WorkspaceDocumentState> {
-    this.#enqueueFlush();
-    return this.#serialize(() =>
+    return this.#withFlush(() =>
       path === null ? this.#workspace.save() : this.#workspace.saveAs(path),
     );
+  }
+
+  #withFlush<T>(job: () => Promise<T>): Promise<T> {
+    this.#enqueueFlush();
+    return this.#serialize(job);
   }
 
   #enqueueFlush(): void {

--- a/apps/desktop/src/renderer/src/lib/workspace/WorkspaceEditQueue.ts
+++ b/apps/desktop/src/renderer/src/lib/workspace/WorkspaceEditQueue.ts
@@ -9,7 +9,9 @@ import type {
 import type { WorkspaceDocumentState } from "@shared/workspace/protocol";
 import { signal, type Signal } from "@/lib/signals/signal";
 import type { GlyphSourceState } from "@/lib/model/GlyphSourceState";
-import type { WorkspaceClient } from "./WorkspaceClient";
+import type { WorkspaceSession } from "./WorkspaceSession";
+
+export type WorkspaceCommitState = "idle" | "queued" | "applying";
 
 /** Where one layer's replace-grade echoes fold; registered per open session. */
 type FoldTarget = {
@@ -36,16 +38,19 @@ type FoldTarget = {
  * watermark.
  */
 export class WorkspaceEditQueue {
-  readonly #workspace: WorkspaceClient;
+  readonly #workspace: WorkspaceSession;
   readonly #targets = new Map<LayerId, FoldTarget>();
   readonly #$settled = signal(true);
+  readonly #commitState = signal<WorkspaceCommitState>("idle", {
+    name: "workspace.commitState",
+  });
 
   #queue: FontIntent[] = [];
   #flushQueued = false;
   #chain: Promise<unknown> = Promise.resolve();
   #busy = 0;
 
-  constructor(workspace: WorkspaceClient) {
+  constructor(workspace: WorkspaceSession) {
     this.#workspace = workspace;
   }
 
@@ -57,6 +62,18 @@ export class WorkspaceEditQueue {
     return this.#$settled;
   }
 
+  /**
+   * Returns the renderer commit lifecycle for locally-authored edits.
+   *
+   * @remarks
+   * This is intentionally separate from utility-owned `documentState.dirty`.
+   * It covers the short window after a tool commits an edit locally but before
+   * the utility process has echoed the new dirty state.
+   */
+  get commitStateCell(): Signal<WorkspaceCommitState> {
+    return this.#commitState;
+  }
+
   /** Routes one layer's echoes to its session state. */
   register(layerId: LayerId, target: FoldTarget): void {
     this.#targets.set(layerId, target);
@@ -66,6 +83,9 @@ export class WorkspaceEditQueue {
   push(intent: FontIntent): void {
     this.#queue.push(intent);
     this.#$settled.set(false);
+    if (this.#commitState.peek() === "idle") {
+      this.#commitState.set("queued");
+    }
 
     if (!this.#flushQueued) {
       this.#flushQueued = true;
@@ -146,7 +166,9 @@ export class WorkspaceEditQueue {
 
     void this.#serialize(async () => {
       try {
-        this.#fold(await this.#workspace.apply(intents));
+        this.#commitState.set("applying");
+        const applied = await this.#workspace.apply(intents);
+        this.#fold(applied);
       } catch (error) {
         console.error("workspace apply failed; resyncing from truth", error);
         await this.#resync();
@@ -170,6 +192,7 @@ export class WorkspaceEditQueue {
     this.#busy -= 1;
     if (this.#busy === 0 && this.#queue.length === 0) {
       this.#$settled.set(true);
+      this.#commitState.set("idle");
     }
   }
 

--- a/apps/desktop/src/renderer/src/lib/workspace/WorkspaceSession.ts
+++ b/apps/desktop/src/renderer/src/lib/workspace/WorkspaceSession.ts
@@ -13,12 +13,12 @@ import { signal } from "@/lib/signals/signal";
  * Renderer side of the workspace sync lane.
  *
  * @remarks
- * `$workspace` is the renderer's single source of workspace truth; every
+ * `workspaceCell` is the renderer's single source of workspace truth; every
  * sync-lane response is the next state. `null` currently conflates
  * disconnected/empty/crashed — it becomes a tagged union when recovery lands,
  * so do not derive connectedness from it.
  */
-export type WorkspaceClientOptions = {
+export type WorkspaceSessionOptions = {
   /**
    * Test seam: supplies the sync-lane transport directly (in-process
    * WorkspaceHost over node ports). Production uses the preload port relay.
@@ -26,15 +26,16 @@ export type WorkspaceClientOptions = {
   transport?: () => Promise<Transport>;
 };
 
-export class WorkspaceClient {
-  readonly $workspace = signal<WorkspaceSnapshot | null>(null);
+export class WorkspaceSession {
+  readonly workspaceCell = signal<WorkspaceSnapshot | null>(null);
+  readonly documentStateCell = signal<WorkspaceDocumentState | null>(null);
 
   readonly #host: ShiftHost | null;
   readonly #transport: (() => Promise<Transport>) | null;
   #channel: Channel<SyncCallMap, SyncEventMap> | null = null;
   #connected: Promise<void> | null = null;
 
-  constructor(host: ShiftHost | null, options: WorkspaceClientOptions = {}) {
+  constructor(host: ShiftHost | null, options: WorkspaceSessionOptions = {}) {
     this.#host = host;
     this.#transport = options.transport ?? null;
   }
@@ -58,11 +59,11 @@ export class WorkspaceClient {
     return this.#connected;
   }
 
-  /** Creates an untitled workspace; `$workspace` becomes the returned state. */
+  /** Creates an untitled workspace; `workspaceCell` becomes the returned state. */
   async create(): Promise<void> {
     await this.connected();
 
-    this.$workspace.set(await this.#require().call("workspace.create", undefined));
+    this.workspaceCell.set(await this.#require().call("workspace.create", undefined));
   }
 
   /**
@@ -76,14 +77,17 @@ export class WorkspaceClient {
   async apply(intents: FontIntent[]): Promise<AppliedChange> {
     await this.connected();
 
-    return this.#fold(await this.#require().call("workspace.apply", { intents }));
+    const { applied, documentState } = await this.#require().call("workspace.apply", { intents });
+    this.#setDocumentState(documentState);
+    return this.#fold(applied);
   }
 
   /** Replays the latest ledger entry; null when nothing is undoable. */
   async undo(): Promise<AppliedChange | null> {
     await this.connected();
 
-    const applied = await this.#require().call("workspace.undo", undefined);
+    const { applied, documentState } = await this.#require().call("workspace.undo", undefined);
+    this.documentStateCell.set(documentState);
     return applied === null ? null : this.#fold(applied);
   }
 
@@ -91,7 +95,8 @@ export class WorkspaceClient {
   async redo(): Promise<AppliedChange | null> {
     await this.connected();
 
-    const applied = await this.#require().call("workspace.redo", undefined);
+    const { applied, documentState } = await this.#require().call("workspace.redo", undefined);
+    this.documentStateCell.set(documentState);
     return applied === null ? null : this.#fold(applied);
   }
 
@@ -99,7 +104,7 @@ export class WorkspaceClient {
     await this.connected();
 
     const snapshot = await this.#require().call("workspace.open", { path });
-    this.$workspace.set(snapshot);
+    this.workspaceCell.set(snapshot);
     return snapshot;
   }
 
@@ -107,21 +112,23 @@ export class WorkspaceClient {
   async documentState(): Promise<WorkspaceDocumentState | null> {
     await this.connected();
 
-    return this.#require().call("document.state", undefined);
+    const state = await this.#require().call("document.state", undefined);
+    this.documentStateCell.set(state);
+    return state;
   }
 
   /** Saves to the current target; rejects when the document still needs a path. */
   async save(): Promise<WorkspaceDocumentState> {
     await this.connected();
 
-    return this.#require().call("workspace.save", undefined);
+    return this.#setDocumentState(await this.#require().call("workspace.save", undefined));
   }
 
   /** Saves to `path` and adopts it as the document's target. */
   async saveAs(path: string): Promise<WorkspaceDocumentState> {
     await this.connected();
 
-    return this.#require().call("workspace.saveAs", { path });
+    return this.#setDocumentState(await this.#require().call("workspace.saveAs", { path }));
   }
 
   /** Pulls replace-grade glyph state (resync + editor open); id-addressed. */
@@ -132,11 +139,11 @@ export class WorkspaceClient {
   }
 
   #fold(applied: AppliedChange): AppliedChange {
-    const current = this.$workspace.peek();
+    const current = this.workspaceCell.peek();
     if (!current) return applied;
 
     if (applied.glyphs || applied.axes || applied.sources) {
-      this.$workspace.set({
+      this.workspaceCell.set({
         ...current,
         glyphs: applied.glyphs ?? current.glyphs,
         axes: applied.axes ?? current.axes,
@@ -149,13 +156,15 @@ export class WorkspaceClient {
 
   async #connect(): Promise<void> {
     if (this.#transport) {
-      this.#channel = new Channel<SyncCallMap, SyncEventMap>(await this.#transport());
-      this.$workspace.set(await this.#channel.call("workspace.snapshot", undefined));
+      const channel = new Channel<SyncCallMap, SyncEventMap>(await this.#transport());
+      this.#installChannel(channel);
+      this.workspaceCell.set(await channel.call("workspace.snapshot", undefined));
+      this.documentStateCell.set(await channel.call("document.state", undefined));
       return;
     }
 
     if (!this.#host) {
-      throw new Error("WorkspaceClient needs a ShiftHost or a transport option");
+      throw new Error("WorkspaceSession needs a ShiftHost or a transport option");
     }
 
     // Install the port listener before asking main to post the port.
@@ -168,11 +177,25 @@ export class WorkspaceClient {
       throw error;
     }
 
-    this.#channel = new Channel<SyncCallMap, SyncEventMap>(domPortTransport(await port.received));
+    const channel = new Channel<SyncCallMap, SyncEventMap>(domPortTransport(await port.received));
+    this.#installChannel(channel);
 
     // Catch-up pull: covers renderer reattach (Vite hot reload now, crash
     // recovery later). Ports are FIFO, so this cannot overtake a later create.
-    this.$workspace.set(await this.#channel.call("workspace.snapshot", undefined));
+    this.workspaceCell.set(await channel.call("workspace.snapshot", undefined));
+    this.documentStateCell.set(await channel.call("document.state", undefined));
+  }
+
+  #installChannel(channel: Channel<SyncCallMap, SyncEventMap>): void {
+    this.#channel = channel;
+    channel.listen("document.changed", (state) => {
+      this.documentStateCell.set(state);
+    });
+  }
+
+  #setDocumentState(state: WorkspaceDocumentState): WorkspaceDocumentState {
+    this.documentStateCell.set(state);
+    return state;
   }
 
   #nextWorkspacePort(): { received: Promise<MessagePort>; cancel: () => void } {

--- a/apps/desktop/src/renderer/src/store/appStore.ts
+++ b/apps/desktop/src/renderer/src/store/appStore.ts
@@ -6,6 +6,8 @@ import { Font } from "@/lib/model/Font";
 import { WorkspaceClient } from "@/lib/workspace/WorkspaceClient";
 import { WorkspaceEditQueue } from "@/lib/workspace/WorkspaceEditQueue";
 import { getShiftHost } from "@/host/shiftHost";
+import type { DocumentCallMap, DocumentEventMap } from "@shared/ipc/contract";
+import { domPortTransport, serveChannel, type ChannelServer } from "@shared/workspace/channel";
 
 let instance: GlyphInfo | null = null;
 export function getGlyphInfo(): GlyphInfo {
@@ -25,21 +27,55 @@ editor.setActiveTool("select");
 void workspace.connected();
 
 const host = getShiftHost();
+let documentRequests: ChannelServer<DocumentEventMap> | null = null;
 
-// Main resolves the save path, then asks us to issue the save on the edit
-// lane. The queue serializes it behind pending edits; the utility owns the
-// write and reports the result to main via document.changed.
-host.document.onSave(({ path }) => {
-  void editQueue.save(path).catch((error) => {
-    console.error("document save failed", error);
-  });
+void serveDocumentRequests().catch((error) => {
+  console.error("document request lane failed", error);
 });
 
-host.document.onOpen(({ path }) => {
-  workspace.open(path).catch((error) => {
-    console.error("document open failed", error);
+async function serveDocumentRequests(): Promise<void> {
+  const port = nextDocumentPort();
+
+  try {
+    await host.document.connect();
+  } catch (error) {
+    port.cancel();
+    throw error;
+  }
+
+  documentRequests?.dispose();
+  documentRequests = serveChannel<DocumentCallMap, DocumentEventMap>(
+    domPortTransport(await port.received),
+    {
+      "document.state": () => editQueue.state(),
+      "document.create": () => editQueue.create(),
+      "document.save": ({ path }) => editQueue.save(path),
+      "document.open": ({ path }) => editQueue.open(path),
+    },
+  );
+}
+
+function nextDocumentPort(): { received: Promise<MessagePort>; cancel: () => void } {
+  let cancel = () => {};
+
+  const received = new Promise<MessagePort>((resolve) => {
+    const listener = (event: MessageEvent) => {
+      if (event.origin !== window.location.origin) return;
+      if ((event.data as { type?: string } | null)?.type !== "document.port") return;
+
+      const port = event.ports[0];
+      if (!port) return;
+
+      window.removeEventListener("message", listener);
+      resolve(port);
+    };
+
+    cancel = () => window.removeEventListener("message", listener);
+    window.addEventListener("message", listener);
   });
-});
+
+  return { received, cancel };
+}
 
 export const getWorkspace = () => workspace;
 export const getEditor = () => editor;

--- a/apps/desktop/src/renderer/src/store/appStore.ts
+++ b/apps/desktop/src/renderer/src/store/appStore.ts
@@ -3,7 +3,7 @@ import { electronSystemClipboard } from "@/lib/clipboard";
 import { registerBuiltInTools } from "@/lib/tools/tools";
 import { defaultResources, GlyphInfo } from "@shift/glyph-info";
 import { Font } from "@/lib/model/Font";
-import { WorkspaceClient } from "@/lib/workspace/WorkspaceClient";
+import { WorkspaceSession } from "@/lib/workspace/WorkspaceSession";
 import { WorkspaceEditQueue } from "@/lib/workspace/WorkspaceEditQueue";
 import { getShiftHost } from "@/host/shiftHost";
 import type { DocumentCallMap, DocumentEventMap } from "@shared/ipc/contract";
@@ -15,9 +15,9 @@ export function getGlyphInfo(): GlyphInfo {
   return instance;
 }
 
-const workspace = new WorkspaceClient(getShiftHost());
+const workspace = new WorkspaceSession(getShiftHost());
 const editQueue = new WorkspaceEditQueue(workspace);
-const font = new Font(workspace.$workspace, editQueue);
+const font = new Font(workspace.workspaceCell, editQueue);
 const editor = new Editor({ font, clipboard: electronSystemClipboard });
 registerBuiltInTools(editor);
 
@@ -78,6 +78,7 @@ function nextDocumentPort(): { received: Promise<MessagePort>; cancel: () => voi
 }
 
 export const getWorkspace = () => workspace;
+export const getEditQueue = () => editQueue;
 export const getEditor = () => editor;
 export const getFont = () => font;
 

--- a/apps/desktop/src/renderer/src/testing/workspaceStack.ts
+++ b/apps/desktop/src/renderer/src/testing/workspaceStack.ts
@@ -5,12 +5,12 @@ import { MessageChannel, type MessagePort as NodeMessagePort } from "node:worker
 import { Channel, nodePortTransport } from "@shared/workspace/channel";
 import type { ShellCallMap, ShellEventMap } from "@shared/workspace/protocol";
 import { WorkspaceHost } from "../../../utility/workspace/WorkspaceHost";
-import { WorkspaceClient } from "@/lib/workspace/WorkspaceClient";
+import { WorkspaceSession } from "@/lib/workspace/WorkspaceSession";
 import { WorkspaceEditQueue } from "@/lib/workspace/WorkspaceEditQueue";
 import { Font } from "@/lib/model/Font";
 
 export type WorkspaceStack = {
-  client: WorkspaceClient;
+  client: WorkspaceSession;
   editQueue: WorkspaceEditQueue;
   font: Font;
 };
@@ -32,7 +32,7 @@ export function createWorkspaceStack(): WorkspaceStack {
   }).start();
   const shell = new Channel<ShellCallMap, ShellEventMap>(nodePortTransport(shellLane.port1));
 
-  const client = new WorkspaceClient(null, {
+  const client = new WorkspaceSession(null, {
     transport: async () => {
       const lane = new MessageChannel();
       await shell.call("workspace.connect", undefined, [lane.port1]);
@@ -40,7 +40,7 @@ export function createWorkspaceStack(): WorkspaceStack {
     },
   });
   const editQueue = new WorkspaceEditQueue(client);
-  const font = new Font(client.$workspace, editQueue);
+  const font = new Font(client.workspaceCell, editQueue);
 
   return { client, editQueue, font };
 }

--- a/apps/desktop/src/renderer/src/views/Landing.tsx
+++ b/apps/desktop/src/renderer/src/views/Landing.tsx
@@ -2,15 +2,15 @@ import logo from "@/assets/logo@1024.png";
 import { Button, Separator } from "@shift/ui";
 import { RecentFiles } from "./RecentFiles";
 import { Titlebar } from "@/components/chrome/Titlebar";
-import { getWorkspace } from "@/store/appStore";
 import { getShiftHost } from "@/host/shiftHost";
 
 export const Landing = () => {
   const host = getShiftHost();
-  const workspace = getWorkspace();
 
   const handleNewFont = () => {
-    void workspace.create().catch((error) => console.error("creating a new font failed", error));
+    void host.commands
+      .run("file.new")
+      .catch((error) => console.error("creating a new font failed", error));
   };
 
   const handleOpenFont = () => {

--- a/apps/desktop/src/shared/commands.ts
+++ b/apps/desktop/src/shared/commands.ts
@@ -6,6 +6,7 @@
  * behavior for each command.
  */
 export type CommandId =
+  | "file.new"
   | "file.open"
   | "file.save"
   | "file.saveAs"

--- a/apps/desktop/src/shared/errors.ts
+++ b/apps/desktop/src/shared/errors.ts
@@ -1,0 +1,21 @@
+/**
+ * Converts an unknown thrown value into a message suitable for IPC payloads.
+ *
+ * @param error - Value caught at an async or cross-process boundary.
+ * @returns a stable string message; never throws while formatting.
+ */
+export function errorToMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+
+  if (
+    error &&
+    typeof error === "object" &&
+    "message" in error &&
+    typeof error.message === "string"
+  ) {
+    return error.message;
+  }
+
+  return String(error);
+}

--- a/apps/desktop/src/shared/host/ShiftHost.ts
+++ b/apps/desktop/src/shared/host/ShiftHost.ts
@@ -1,5 +1,4 @@
 import type { CommandId } from "../commands";
-import type { DocumentOpenRequest, DocumentSaveRequest } from "../ipc/contract";
 
 /**
  * Renderer-facing API for Electron app-shell behavior.
@@ -20,16 +19,16 @@ export interface ShiftHost {
      */
     run: (id: CommandId) => Promise<void>;
   };
-  /** Narrow document lifecycle hooks owned by main. */
+  /** Connects the renderer to main-owned document requests. */
   document: {
     /**
-     * Subscribes to main's request to save; the renderer issues the save on its
-     * committed-op lane so it lands behind pending edits.
+     * Asks main to transfer a document request lane.
      *
-     * @returns an unsubscribe function.
+     * @remarks
+     * The renderer half arrives via the `document.port` postMessage relay;
+     * install that listener before calling.
      */
-    onSave: (callback: (request: DocumentSaveRequest) => void) => () => void;
-    onOpen: (callback: (request: DocumentOpenRequest) => void) => () => void;
+    connect: () => Promise<void>;
   };
   /** Connects the renderer to the workspace utility process. */
   workspace: {

--- a/apps/desktop/src/shared/ipc/contract.ts
+++ b/apps/desktop/src/shared/ipc/contract.ts
@@ -1,21 +1,14 @@
 import type { CommandId } from "../commands";
+import type { WorkspaceDocumentState } from "../workspace/protocol";
 
-/**
- * Tells the renderer to issue a save on its committed-op lane.
- *
- * @remarks
- * `path` is null for Save (current target) and a filesystem path for Save As —
- * main owns the dialog and resolves the path before sending. The renderer
- * enqueues the save behind its edits; main learns the outcome from the
- * utility's `document.changed` event, so this is one-way (no reply channel).
- */
-export type DocumentSaveRequest = {
-  path: string | null;
+export type DocumentCallMap = {
+  "document.state": { request: void; response: WorkspaceDocumentState | null };
+  "document.create": { request: void; response: void };
+  "document.save": { request: { path: string | null }; response: WorkspaceDocumentState };
+  "document.open": { request: { path: string }; response: void };
 };
 
-export type DocumentOpenRequest = {
-  path: string;
-};
+export type DocumentEventMap = Record<string, never>;
 
 /**
  * Defines request/response channels that the renderer may invoke on main.
@@ -26,6 +19,12 @@ export type DocumentOpenRequest = {
  */
 export type RendererToMain = {
   "commands.run": (id: CommandId) => void;
+  /**
+   * Asks main to transfer a document request lane to the renderer. The port
+   * arrives separately on the `document.port` postMessage channel because ports
+   * cannot travel through `invoke` responses.
+   */
+  "document.connect": () => void;
   /**
    * Asks main to wire a sync lane to the workspace process. The port itself
    * arrives separately on the `workspace.port` postMessage channel because
@@ -42,9 +41,6 @@ export type RendererToMain = {
  * merely reflects it.
  */
 export type MainToRenderer = {
-  /** Main resolved the save path; the renderer issues the save on its edit lane. */
-  "document.save": (request: DocumentSaveRequest) => void;
-  "document.open": (request: DocumentOpenRequest) => void;
   /** UI (chrome) zoom changed via the View menu or its accelerators. */
   "ui.zoomChanged": (percent: number) => void;
 };

--- a/apps/desktop/src/shared/workspace/channel.ts
+++ b/apps/desktop/src/shared/workspace/channel.ts
@@ -1,5 +1,6 @@
 import type { MessagePortMain, UtilityProcess } from "electron";
 import type { MessagePort as NodeMessagePort } from "node:worker_threads";
+import { errorToMessage } from "../errors";
 
 /** One delivered transport message: structured-clone payload plus transferred ports. */
 export type TransportMessage = { data: unknown; ports: readonly unknown[] };
@@ -211,9 +212,7 @@ export function serveChannel<Calls extends CallMap, Events extends EventMap>(
         kind: "response",
         id: request.id,
         ok: false,
-        error: {
-          message: error instanceof Error ? error.message : String(error),
-        },
+        error: { message: errorToMessage(error) },
       });
     }
   };

--- a/apps/desktop/src/shared/workspace/protocol.ts
+++ b/apps/desktop/src/shared/workspace/protocol.ts
@@ -82,11 +82,17 @@ export type SyncCallMap = {
    */
   "workspace.apply": {
     request: { intents: FontIntent[]; label?: string };
-    response: AppliedChange;
+    response: { applied: AppliedChange; documentState: WorkspaceDocumentState };
   };
   /** Replays the most recent ledger entry; null when the stack is empty. */
-  "workspace.undo": { request: void; response: AppliedChange | null };
-  "workspace.redo": { request: void; response: AppliedChange | null };
+  "workspace.undo": {
+    request: void;
+    response: { applied: AppliedChange | null; documentState: WorkspaceDocumentState | null };
+  };
+  "workspace.redo": {
+    request: void;
+    response: { applied: AppliedChange | null; documentState: WorkspaceDocumentState | null };
+  };
   /**
    * Saves to the current package target, or rejects when the document still
    * needs a path. Rides the edit lane so the utility serializes it behind every
@@ -106,4 +112,6 @@ export type SyncCallMap = {
   };
 };
 
-export type SyncEventMap = Record<string, never>;
+export type SyncEventMap = {
+  "document.changed": WorkspaceDocumentState | null;
+};

--- a/apps/desktop/src/shared/workspace/protocol.ts
+++ b/apps/desktop/src/shared/workspace/protocol.ts
@@ -74,6 +74,7 @@ export type ShellEventMap = {
 export type SyncCallMap = {
   "workspace.create": { request: void; response: WorkspaceSnapshot };
   "workspace.snapshot": { request: void; response: WorkspaceSnapshot | null };
+  "document.state": { request: void; response: WorkspaceDocumentState | null };
   /**
    * The one mutation verb. Requests carry intents; the response is pure
    * replace-grade state (never change records — the renderer substitutes,

--- a/apps/desktop/src/utility/workspace/WorkspaceHost.test.ts
+++ b/apps/desktop/src/utility/workspace/WorkspaceHost.test.ts
@@ -56,6 +56,25 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     return sync;
   }
 
+  async function applyWorkspace(
+    sync: SyncChannel,
+    request: SyncCallMap["workspace.apply"]["request"],
+  ): Promise<SyncCallMap["workspace.apply"]["response"]["applied"]> {
+    return (await sync.call("workspace.apply", request)).applied;
+  }
+
+  async function undoWorkspace(
+    sync: SyncChannel,
+  ): Promise<SyncCallMap["workspace.undo"]["response"]["applied"]> {
+    return (await sync.call("workspace.undo", undefined)).applied;
+  }
+
+  async function redoWorkspace(
+    sync: SyncChannel,
+  ): Promise<SyncCallMap["workspace.redo"]["response"]["applied"]> {
+    return (await sync.call("workspace.redo", undefined)).applied;
+  }
+
   beforeEach(() => {
     tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "shift-workspace-host-"));
     const lane = new MessageChannel();
@@ -221,9 +240,13 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
       needsSaveAs: true,
     });
 
-    await sync.call("workspace.apply", {
+    const applied = await sync.call("workspace.apply", {
       intents: [createGlyphA()],
       label: "Add Glyph",
+    });
+    expect(applied.documentState).toMatchObject({
+      dirty: true,
+      needsSaveAs: true,
     });
     await shell.call("document.state", undefined);
     expect(latestState).toMatchObject({
@@ -247,7 +270,7 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     const sync = await connectSyncLane();
     await sync.call("workspace.create", undefined);
 
-    const applied = await sync.call("workspace.apply", {
+    const applied = await applyWorkspace(sync, {
       intents: [createGlyphA()],
       label: "Add Glyph",
     });
@@ -263,7 +286,7 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
   it("workspace.save reports NeedsSaveAs for untitled workspaces", async () => {
     const sync = await connectSyncLane();
     await sync.call("workspace.create", undefined);
-    await sync.call("workspace.apply", {
+    await applyWorkspace(sync, {
       intents: [createGlyphA()],
       label: "Add Glyph",
     });
@@ -281,7 +304,7 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
   it("workspace.saveAs writes the package and clears dirty for later saves", async () => {
     const sync = await connectSyncLane();
     await sync.call("workspace.create", undefined);
-    await sync.call("workspace.apply", {
+    await applyWorkspace(sync, {
       intents: [createGlyphA()],
       label: "Add Glyph",
     });
@@ -297,7 +320,7 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     });
     expect(fs.existsSync(savePath)).toBe(true);
 
-    await sync.call("workspace.apply", {
+    await applyWorkspace(sync, {
       intents: [
         {
           kind: "createGlyph",
@@ -328,7 +351,7 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     // Issue the apply and the save back-to-back without awaiting the apply. The
     // host serializes both on one queue, so the save observes the glyph — if it
     // had raced ahead, the doc would read dirty once the apply landed.
-    const apply = sync.call("workspace.apply", { intents: [createGlyphA()], label: "Add Glyph" });
+    const apply = applyWorkspace(sync, { intents: [createGlyphA()], label: "Add Glyph" });
     const saved = await sync.call("workspace.saveAs", { path: savePath });
     await apply;
 
@@ -343,19 +366,19 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     const snapshot = await sync.call("workspace.create", undefined);
     const sourceId = snapshot.sources[0].id;
 
-    const created = await sync.call("workspace.apply", {
+    const created = await applyWorkspace(sync, {
       intents: [createGlyphA()],
       label: "Add Glyph",
     });
     const glyphId = created.glyphs?.[0].id;
     if (!glyphId) throw new Error("createGlyph must echo the record id");
 
-    const undone = await sync.call("workspace.undo", undefined);
+    const undone = await undoWorkspace(sync);
     expect(undone?.glyphs?.map((glyph) => glyph.name)).toEqual([]);
     expect(undone?.layers).toEqual([]);
     await expect(sync.call("workspace.glyph", { glyphId, sourceId })).resolves.toBeNull();
 
-    const redone = await sync.call("workspace.redo", undefined);
+    const redone = await redoWorkspace(sync);
     expect(redone?.glyphs?.map((glyph) => glyph.name)).toEqual(["A"]);
     expect(redone?.layers).toHaveLength(1);
     await expect(sync.call("workspace.glyph", { glyphId, sourceId })).resolves.not.toBeNull();
@@ -364,12 +387,12 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
   it("apply setXAdvance echoes values without structure or records", async () => {
     const sync = await connectSyncLane();
     await sync.call("workspace.create", undefined);
-    const created = await sync.call("workspace.apply", {
+    const created = await applyWorkspace(sync, {
       intents: [createGlyphA()],
     });
     const layerId = created.layers[0].layerId;
 
-    const applied = await sync.call("workspace.apply", {
+    const applied = await applyWorkspace(sync, {
       intents: [{ kind: "setXAdvance", setXAdvance: { layerId, width: 642 } }],
     });
 
@@ -383,15 +406,15 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     const sync = await connectSyncLane();
     await sync.call("workspace.create", undefined);
 
-    await expect(
-      sync.call("workspace.apply", { intents: [{ kind: "explodeFont" }] }),
-    ).rejects.toThrow("explodeFont");
+    await expect(applyWorkspace(sync, { intents: [{ kind: "explodeFont" }] })).rejects.toThrow(
+      "explodeFont",
+    );
   });
 
   it("pen intents apply atomically with client-minted ids through the channel", async () => {
     const sync = await connectSyncLane();
     await sync.call("workspace.create", undefined);
-    const created = await sync.call("workspace.apply", {
+    const created = await applyWorkspace(sync, {
       intents: [createGlyphA()],
     });
     const layerId = created.layers[0].layerId;
@@ -400,7 +423,7 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     const p1 = mintPointId();
     const p2 = mintPointId();
 
-    const applied = await sync.call("workspace.apply", {
+    const applied = await applyWorkspace(sync, {
       intents: [
         { kind: "addContour", addContour: { layerId, contourId, closed: false } },
         {
@@ -431,14 +454,14 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
   it("undo and redo replay ledger entries through the channel", async () => {
     const sync = await connectSyncLane();
     await sync.call("workspace.create", undefined);
-    const created = await sync.call("workspace.apply", {
+    const created = await applyWorkspace(sync, {
       intents: [createGlyphA()],
     });
     const layerId = created.layers[0].layerId;
     const contourId = mintContourId();
     const p1 = mintPointId();
 
-    await sync.call("workspace.apply", {
+    await applyWorkspace(sync, {
       intents: [
         { kind: "addContour", addContour: { layerId, contourId, closed: false } },
         {
@@ -453,10 +476,10 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
       label: "Draw",
     });
 
-    const undone = await sync.call("workspace.undo", undefined);
+    const undone = await undoWorkspace(sync);
     expect(undone?.layers[0].structure?.contours).toEqual([]);
 
-    const redone = await sync.call("workspace.redo", undefined);
+    const redone = await redoWorkspace(sync);
     expect(redone?.layers[0].structure?.contours[0].points.map((point) => point.id)).toEqual([p1]);
   });
 
@@ -464,15 +487,15 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     const sync = await connectSyncLane();
     await sync.call("workspace.create", undefined);
 
-    await expect(sync.call("workspace.undo", undefined)).resolves.toBeNull();
-    await expect(sync.call("workspace.redo", undefined)).resolves.toBeNull();
+    await expect(undoWorkspace(sync)).resolves.toBeNull();
+    await expect(redoWorkspace(sync)).resolves.toBeNull();
   });
 
   it("workspace.glyph pulls replace-grade state by stable id", async () => {
     const sync = await connectSyncLane();
     const snapshot = await sync.call("workspace.create", undefined);
     const sourceId = snapshot.sources[0].id;
-    const created = await sync.call("workspace.apply", {
+    const created = await applyWorkspace(sync, {
       intents: [createGlyphA()],
     });
     const glyphId = created.glyphs?.[0].id;
@@ -489,7 +512,7 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
   it("CS0 skeleton: measures the apply round trip through the full stack", async () => {
     const sync = await connectSyncLane();
     await sync.call("workspace.create", undefined);
-    const created = await sync.call("workspace.apply", {
+    const created = await applyWorkspace(sync, {
       intents: [createGlyphA()],
     });
     const layerId = created.layers[0].layerId;
@@ -497,7 +520,7 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     const samples: number[] = [];
     for (let i = 0; i < 100; i++) {
       const start = performance.now();
-      await sync.call("workspace.apply", {
+      await applyWorkspace(sync, {
         intents: [{ kind: "setXAdvance", setXAdvance: { layerId, width: 500 + i } }],
       });
       samples.push(performance.now() - start);

--- a/apps/desktop/src/utility/workspace/WorkspaceHost.ts
+++ b/apps/desktop/src/utility/workspace/WorkspaceHost.ts
@@ -81,20 +81,19 @@ export class WorkspaceHost {
       "workspace.apply": ({ intents, label }) =>
         this.#serialize(() => {
           const applied = this.#bridge.apply(intents, label);
-          this.#emitDocumentChanged();
-          return applied;
+          return { applied, documentState: this.#emitDocumentChanged() };
         }),
       "workspace.undo": () =>
         this.#serialize(() => {
           const applied = this.#bridge.undo();
-          if (applied) this.#emitDocumentChanged();
-          return applied;
+          const documentState = applied ? this.#emitDocumentChanged() : this.#documentState();
+          return { applied, documentState };
         }),
       "workspace.redo": () =>
         this.#serialize(() => {
           const applied = this.#bridge.redo();
-          if (applied) this.#emitDocumentChanged();
-          return applied;
+          const documentState = applied ? this.#emitDocumentChanged() : this.#documentState();
+          return { applied, documentState };
         }),
       // Save rides the edit lane: the same #serialize queue orders it behind
       // every committed apply/undo/redo, so it never writes stale state.
@@ -177,6 +176,7 @@ export class WorkspaceHost {
     }
 
     this.#shell?.emit("document.changed", state);
+    this.#sync?.emit("document.changed", state);
     return state;
   }
 

--- a/apps/desktop/src/utility/workspace/WorkspaceHost.ts
+++ b/apps/desktop/src/utility/workspace/WorkspaceHost.ts
@@ -77,6 +77,7 @@ export class WorkspaceHost {
         this.#serialize(() =>
           this.#documentId === null ? null : this.#snapshot(this.#documentId),
         ),
+      "document.state": () => this.#serialize(() => this.#documentState()),
       "workspace.apply": ({ intents, label }) =>
         this.#serialize(() => {
           const applied = this.#bridge.apply(intents, label);


### PR DESCRIPTION
## Summary

- Add a main-process document close guard with native Save / Don't Save / Cancel prompts.
- Route close, quit, open, and new-document replacement through renderer-served document operations so pending edits flush before dirty state is read.
- Add a `DocumentClient` channel and `AppLifecycle` coordinator to keep transport and lifecycle state out of `DocumentSession`.
- Carry utility-owned document dirty/path state through the renderer workspace session and expose `useDocumentChromeState()` for toolbar filename and dirty presentation.
- Add tool-level `isEditing` plus workspace commit lifecycle state so the toolbar stays dirty during preview and apply echo gaps.
- Reserve the dirty title width in the toolbar so `— Edited` does not shift surrounding chrome.

Closes #87.

## Validation

- `pnpm --filter @shift/desktop run typecheck`
- `pnpm --filter @shift/desktop exec vitest run src/renderer/src/lib/workspace/WorkspaceEditQueue.test.ts src/utility/workspace/WorkspaceHost.test.ts`
- pre-commit suite during commit: whitespace checks, oxlint, tsgo typecheck, deadcode strict, vitest
