### PR TITLE
Add variable source and axis sidebar flows

### DIFF
--- a/apps/desktop/src/renderer/src/components/editor/LeftSidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/editor/LeftSidebar.tsx
@@ -3,16 +3,30 @@ import { Separator } from "@shift/ui";
 import { CollapsibleSection, SidebarActionButton } from "@/components/sidebar";
 import { AxesPanel } from "@/components/variation/AxesPanel";
 import { CreateAxisDialog } from "@/components/variation/CreateAxisDialog";
+import { CreateSourceDialog } from "@/components/variation/CreateSourceDialog";
 import { Sources } from "@/components/variation/Sources";
 
 import PlusIcon from "@/assets/plus.svg";
 
 export const LeftSidebar = () => {
   const [createAxisOpen, setCreateAxisOpen] = useState(false);
+  const [createSourceOpen, setCreateSourceOpen] = useState(false);
 
   return (
     <aside className="h-full w-full min-w-0 bg-panel border-r border-line-subtle flex flex-col overflow-hidden">
       <div className="px-1 py-3 flex flex-col gap-2">
+        <CollapsibleSection
+          title="Sources"
+          defaultOpen
+          actions={
+            <SidebarActionButton label="Create source" onClick={() => setCreateSourceOpen(true)}>
+              <PlusIcon className="w-3 h-3" />
+            </SidebarActionButton>
+          }
+        >
+          <Sources />
+        </CollapsibleSection>
+        <Separator />
         <CollapsibleSection
           title="Axes"
           defaultOpen
@@ -24,12 +38,9 @@ export const LeftSidebar = () => {
         >
           <AxesPanel />
         </CollapsibleSection>
-        <Separator />
-        <CollapsibleSection title="Sources" defaultOpen>
-          <Sources />
-        </CollapsibleSection>
       </div>
       <CreateAxisDialog open={createAxisOpen} onOpenChange={setCreateAxisOpen} />
+      <CreateSourceDialog open={createSourceOpen} onOpenChange={setCreateSourceOpen} />
     </aside>
   );
 };

--- a/apps/desktop/src/renderer/src/components/sidebar/CollapsibleSection.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/CollapsibleSection.tsx
@@ -7,6 +7,7 @@ import {
   cn,
 } from "@shift/ui";
 import type { ReactNode } from "react";
+import { SidebarActionSlot } from "./SidebarActionRow";
 
 export interface CollapsibleSectionProps {
   title: string;
@@ -24,7 +25,7 @@ export const CollapsibleSection = ({
   children,
 }: CollapsibleSectionProps) => (
   <Collapsible defaultOpen={defaultOpen} className={cn("flex flex-col", className)}>
-    <div className="group flex items-center gap-1 rounded transition-colors hover:bg-hover/50">
+    <div className="group grid grid-cols-[minmax(0,1fr)_1.5rem] items-center rounded transition-colors hover:bg-hover/50">
       <CollapsibleTrigger
         render={
           <Button
@@ -37,12 +38,8 @@ export const CollapsibleSection = ({
         <CollapsibleChevron />
         <h3 className="truncate text-ui font-medium text-[#232323]">{title}</h3>
       </CollapsibleTrigger>
-      {actions && (
-        <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
-          {actions}
-        </div>
-      )}
+      {actions && <SidebarActionSlot>{actions}</SidebarActionSlot>}
     </div>
-    <CollapsiblePanel className="px-2 pt-2">{children}</CollapsiblePanel>
+    <CollapsiblePanel className="pt-2">{children}</CollapsiblePanel>
   </Collapsible>
 );

--- a/apps/desktop/src/renderer/src/components/sidebar/SidebarActionRow.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/SidebarActionRow.tsx
@@ -18,25 +18,36 @@ export const SidebarActionRow = ({
   className,
   contentClassName,
 }: SidebarActionRowProps) => (
-  <div className={cn("group flex min-w-0 items-center gap-1 w-full", className)}>
+  <div
+    className={cn(
+      "group grid min-w-0 w-full grid-cols-[minmax(0,1fr)_1.5rem] items-center rounded transition-colors",
+      "hover:bg-hover/50 data-[active]:bg-hover/50",
+      className,
+    )}
+    data-active={isActive ? true : undefined}
+  >
     {onClick ? (
       <Button
         variant="ghost"
         size="sm"
-        isActive={isActive}
         onClick={onClick}
-        className={cn("min-w-0 flex-1 justify-start px-2", contentClassName)}
+        className={cn(
+          "min-w-0 flex-1 justify-start bg-transparent px-2 hover:bg-transparent data-[active]:bg-transparent",
+          contentClassName,
+        )}
       >
         {children}
       </Button>
     ) : (
       <div className={cn("min-w-0 flex-1 px-2", contentClassName)}>{children}</div>
     )}
-    {actions && (
-      <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
-        {actions}
-      </div>
-    )}
+    {actions && <SidebarActionSlot>{actions}</SidebarActionSlot>}
+  </div>
+);
+
+export const SidebarActionSlot = ({ children }: { children?: ReactNode }) => (
+  <div className="flex h-6 w-6 shrink-0 items-center justify-center opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+    {children}
   </div>
 );
 
@@ -56,7 +67,7 @@ export const SidebarActionButton = ({
     size="icon-sm"
     aria-label={label}
     title={label}
-    className={cn("h-6 w-6 text-muted hover:text-primary", className)}
+    className={cn("h-6 w-6 p-0.5 text-muted hover:text-primary", className)}
     {...props}
   >
     {children}

--- a/apps/desktop/src/renderer/src/components/sidebar/index.ts
+++ b/apps/desktop/src/renderer/src/components/sidebar/index.ts
@@ -1,2 +1,2 @@
 export { CollapsibleSection, type CollapsibleSectionProps } from "./CollapsibleSection";
-export { SidebarActionButton, SidebarActionRow } from "./SidebarActionRow";
+export { SidebarActionButton, SidebarActionRow, SidebarActionSlot } from "./SidebarActionRow";

--- a/apps/desktop/src/renderer/src/components/variation/AxesPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/variation/AxesPanel.tsx
@@ -42,11 +42,11 @@ export const AxesPanel = () => {
       {axes.length > 0 &&
         axes.map((axis) => (
           <div key={axis.id} className="flex flex-col gap-1">
-            <div className="flex items-center justify-between">
+            <div className="flex items-center justify-between px-2">
               <span className="text-ui text-secondary">{axis.name}</span>
             </div>
 
-            <div className="flex items-center gap-4">
+            <div className="grid grid-cols-[3.5rem_minmax(0,1fr)_1.5rem] items-center gap-4 pl-2">
               <EditableSidebarInput
                 value={axisValue(location, axis)}
                 className="w-14"
@@ -102,12 +102,12 @@ const AxisActionsMenu = ({ axis, onReset, onDelete }: AxisActionsMenuProps) => (
         <Button
           variant="ghost"
           size="icon-sm"
-          className="h-6 w-6 p-0"
+          className="h-6 w-6 p-0.5"
           aria-label={`Actions for ${axis.name}`}
         />
       }
     >
-      <VerticalElipsis className="w-4 h-4" />
+      <VerticalElipsis className="h-5 w-5" />
     </MenuTrigger>
     <MenuPortal>
       <MenuPositioner sideOffset={4} align="end">

--- a/apps/desktop/src/renderer/src/components/variation/CreateSourceDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/variation/CreateSourceDialog.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useState, type ChangeEvent, type FormEvent } from "react";
+import {
+  Button,
+  Dialog,
+  DialogBackdrop,
+  DialogClose,
+  DialogPopup,
+  DialogPortal,
+  DialogTitle,
+  Input,
+  X,
+  cn,
+} from "@shift/ui";
+import type { Axis, AxisId, Source } from "@shift/types";
+import { useAxes } from "@/hooks/useAxes";
+import { useSources } from "@/hooks/useSources";
+import { getEditor } from "@/store/appStore";
+
+interface CreateSourceDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+interface CreateSourceFormValues {
+  name: string;
+  location: Record<string, string>;
+}
+
+const emptyValues: CreateSourceFormValues = {
+  name: "",
+  location: {},
+};
+
+function defaultSourceName(sources: readonly Source[]): string {
+  if (!sources.some((source) => source.name === "Bold")) return "Bold";
+
+  let index = sources.length + 1;
+  let name = `Source ${index}`;
+  while (sources.some((source) => source.name === name)) {
+    index += 1;
+    name = `Source ${index}`;
+  }
+  return name;
+}
+
+function defaultValues(axes: readonly Axis[], sources: readonly Source[]): CreateSourceFormValues {
+  return {
+    name: defaultSourceName(sources),
+    location: Object.fromEntries(axes.map((axis) => [axis.id, String(axis.maximum)])),
+  };
+}
+
+export const CreateSourceDialog = ({ open, onOpenChange }: CreateSourceDialogProps) => {
+  const editor = getEditor();
+  const axes = useAxes();
+  const sources = useSources();
+  const [values, setValues] = useState<CreateSourceFormValues>(emptyValues);
+
+  useEffect(() => {
+    if (open) setValues(defaultValues(axes, sources));
+  }, [open, axes, sources]);
+
+  const updateName = (event: ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.currentTarget;
+    setValues((current) => ({ ...current, name: value }));
+  };
+
+  const updateAxisValue = (axisId: AxisId) => (event: ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.currentTarget;
+    setValues((current) => ({
+      ...current,
+      location: { ...current.location, [axisId]: value },
+    }));
+  };
+
+  const trimmedName = values.name.trim();
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const location = {
+      values: Object.fromEntries(
+        axes.map((axis) => [axis.id, Number(values.location[axis.id])]),
+      ) as Record<AxisId, number>,
+    };
+    editor.font.createSource(trimmedName, location);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogPortal>
+        <DialogBackdrop />
+        <DialogPopup
+          className={cn(
+            "fixed left-1/2 top-1/2 w-[360px] -translate-x-1/2 -translate-y-1/2",
+            "rounded-lg border border-line-subtle bg-canvas p-5 shadow-lg",
+          )}
+        >
+          <div className="mb-4 flex items-center justify-between">
+            <DialogTitle className="text-sm font-medium text-primary">Create source</DialogTitle>
+            <DialogClose
+              className={cn(
+                "inline-flex h-7 w-7 cursor-pointer items-center justify-center rounded",
+                "text-primary/70 transition-colors hover:bg-hover hover:text-primary",
+              )}
+              aria-label="Close"
+            >
+              <X className="h-4 w-4" />
+            </DialogClose>
+          </div>
+
+          <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+            <div className="grid grid-cols-[72px_minmax(0,1fr)] items-center gap-x-3 gap-y-2">
+              <label className="text-ui text-secondary">Name</label>
+              <Input value={values.name} onChange={updateName} className="h-7 text-sm bg-white" />
+
+              {axes.map((axis) => (
+                <div key={axis.id} className="contents">
+                  <label className="min-w-0 truncate text-ui text-secondary" title={axis.name}>
+                    {axis.name}
+                  </label>
+                  <Input
+                    value={values.location[axis.id] ?? ""}
+                    onChange={updateAxisValue(axis.id)}
+                    className="h-7 text-sm bg-white"
+                    inputMode="decimal"
+                  />
+                </div>
+              ))}
+            </div>
+
+            <div className="flex justify-end gap-2">
+              <DialogClose
+                render={
+                  <Button type="button" variant="ghost" size="sm">
+                    Cancel
+                  </Button>
+                }
+              />
+              <Button type="submit" size="sm">
+                Create
+              </Button>
+            </div>
+          </form>
+        </DialogPopup>
+      </DialogPortal>
+    </Dialog>
+  );
+};

--- a/apps/desktop/src/renderer/src/components/variation/Sources.tsx
+++ b/apps/desktop/src/renderer/src/components/variation/Sources.tsx
@@ -1,7 +1,19 @@
+import {
+  Button,
+  Menu,
+  MenuItem,
+  MenuPopup,
+  MenuPortal,
+  MenuPositioner,
+  MenuTrigger,
+} from "@shift/ui";
+import type { SourceId } from "@shift/types";
 import { useSources } from "@/hooks/useSources";
 import { useEditSourceId } from "@/hooks/useEditSourceId";
 import { getEditor } from "@/store/appStore";
 import { SidebarActionRow } from "@/components/sidebar";
+
+import VerticalElipsis from "@/assets/vertical-ellipsis.svg";
 
 export const Sources = () => {
   const sources = useSources();
@@ -9,6 +21,14 @@ export const Sources = () => {
   const editor = getEditor();
 
   if (sources.length === 0) return null;
+
+  const deleteSource = (sourceId: SourceId) => {
+    const fallbackSource = sources.find((source) => source.id !== sourceId);
+    if (editSourceId === sourceId && fallbackSource) {
+      editor.selectSource(fallbackSource.id);
+    }
+    editor.font.deleteSource(sourceId);
+  };
 
   return (
     <div className="flex justify-start items-start flex-col gap-1">
@@ -18,6 +38,13 @@ export const Sources = () => {
           isActive={s.id === editSourceId}
           onClick={() => editor.selectSource(s.id)}
           contentClassName="h-6 text-ui"
+          actions={
+            <SourceActionsMenu
+              sourceName={s.name}
+              canDelete={sources.length > 1}
+              onDelete={() => deleteSource(s.id)}
+            />
+          }
         >
           {s.name}
         </SidebarActionRow>
@@ -25,3 +52,39 @@ export const Sources = () => {
     </div>
   );
 };
+
+const SourceActionsMenu = ({
+  sourceName,
+  canDelete,
+  onDelete,
+}: {
+  sourceName: string;
+  canDelete: boolean;
+  onDelete: () => void;
+}) => (
+  <Menu modal={false}>
+    <MenuTrigger
+      render={
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className="h-6 w-6 p-0.5"
+          aria-label={`Actions for ${sourceName}`}
+        />
+      }
+    >
+      <VerticalElipsis className="h-5 w-5" />
+    </MenuTrigger>
+    <MenuPortal>
+      <MenuPositioner sideOffset={4} align="end">
+        <MenuPopup>
+          <MenuItem>Rename source</MenuItem>
+          <MenuItem>Duplicate source</MenuItem>
+          <MenuItem variant="danger" disabled={!canDelete} onClick={onDelete}>
+            Delete source
+          </MenuItem>
+        </MenuPopup>
+      </MenuPositioner>
+    </MenuPortal>
+  </Menu>
+);

--- a/apps/desktop/src/renderer/src/lib/model/Font.test.ts
+++ b/apps/desktop/src/renderer/src/lib/model/Font.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   mintAxisId,
   mintGlyphId,
+  mintSourceId,
   type AxisId,
   type GlyphId,
   type GlyphName,
@@ -126,16 +127,20 @@ describe("font-level intents make the font variable", () => {
     expect(stack.font.getAxes().map((axis) => axis.tag)).toEqual(["wght"]);
     expect(stack.font.isVariable()).toBe(true);
 
+    const boldSourceId = mintSourceId();
     const applied = await stack.client.apply([
       {
         kind: "createSource",
         createSource: {
+          sourceId: boldSourceId,
           name: "Bold",
           location: { values: { [weightAxisId]: 700 } as Record<AxisId, number> },
         },
       },
     ]);
-    expect(stack.font.sources.map((source) => source.name)).toContain("Bold");
+    const bold = stack.font.sources.find((source) => source.name === "Bold");
+    expect(bold?.id).toBe(boldSourceId);
+    expect(applied.sources?.find((source) => source.name === "Bold")?.id).toBe(boldSourceId);
     expect(applied.layers.length).toBe(1); // eager layer for the existing glyph
   });
 });

--- a/apps/desktop/src/renderer/src/lib/model/Font.ts
+++ b/apps/desktop/src/renderer/src/lib/model/Font.ts
@@ -10,8 +10,9 @@ import type {
   SourceId,
   Unicode,
   AxisId,
+  Location,
 } from "@shift/types";
-import { mintAxisId, mintGlyphId } from "@shift/types";
+import { mintAxisId, mintGlyphId, mintSourceId } from "@shift/types";
 import { computed, type Signal } from "@/lib/signals/signal";
 import type { WorkspaceEditQueue } from "@/lib/workspace/WorkspaceEditQueue";
 import type { WorkspaceSnapshot } from "@shared/workspace/protocol";
@@ -790,6 +791,16 @@ export class Font {
     return glyphSource;
   }
 
+  createSource(name: string, location: Location): SourceId {
+    const sourceId = mintSourceId();
+    this.editQueue.push({
+      kind: "createSource",
+      createSource: { sourceId, name, location },
+    });
+
+    return sourceId;
+  }
+
   /** @knipclassignore — used by VariationPanel component */
   createAxis(
     name: string,
@@ -813,6 +824,13 @@ export class Font {
     this.editQueue.push({
       kind: "deleteAxis",
       deleteAxis: { axisId },
+    });
+  }
+
+  deleteSource(sourceId: SourceId): void {
+    this.editQueue.push({
+      kind: "deleteSource",
+      deleteSource: { sourceId },
     });
   }
 

--- a/apps/desktop/src/renderer/src/lib/model/variation.test.ts
+++ b/apps/desktop/src/renderer/src/lib/model/variation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeEach } from "vitest";
 import type { AxisId, GlyphId, GlyphName, LayerId, Source, Unicode } from "@shift/types";
-import { mintAxisId, mintContourId, mintGlyphId, mintPointId } from "@shift/types";
+import { mintAxisId, mintContourId, mintGlyphId, mintPointId, mintSourceId } from "@shift/types";
 import { defaultAxisLocation, withAxisValue } from "@/lib/variation/location";
 import { createWorkspaceStack, type WorkspaceStack } from "@/testing/workspaceStack";
 
@@ -78,10 +78,12 @@ async function variableFont(): Promise<{
       },
     },
   ]);
+  const boldSourceId = mintSourceId();
   const sourced = await stack.client.apply([
     {
       kind: "createSource",
       createSource: {
+        sourceId: boldSourceId,
         name: "Bold",
         location: { values: { [weightAxisId]: 700 } as Record<AxisId, number> },
       },
@@ -89,6 +91,7 @@ async function variableFont(): Promise<{
   ]);
   const boldLayerId = sourced.layers[0]!.layerId;
   const bold = sourced.sources!.find((source) => source.name === "Bold")!;
+  expect(bold.id).toBe(boldSourceId);
 
   // Author both masters before any glyph model opens so the pulled
   // variation deltas cover them.

--- a/crates/shift-bridge/index.d.ts
+++ b/crates/shift-bridge/index.d.ts
@@ -197,10 +197,11 @@ export interface NapiCreateGlyphIntent {
 }
 
 /**
- * Font-level source creation. Rust mints the source id; the echo's
- * `sources` list carries it back.
+ * Font-level source creation. The source id is client-minted so verbs can
+ * return identity synchronously; Rust honors it and rejects duplicates.
  */
 export interface NapiCreateSourceIntent {
+  sourceId: SourceId
   name: string
   /** Axis id → design-space value for the new source. */
   location: NapiLocation
@@ -209,6 +210,11 @@ export interface NapiCreateSourceIntent {
 /** Font-level axis deletion. Removing an axis also reshapes source locations. */
 export interface NapiDeleteAxisIntent {
   axisId: AxisId
+}
+
+/** Font-level source deletion. Removing a source also removes its glyph layers. */
+export interface NapiDeleteSourceIntent {
+  sourceId: SourceId
 }
 
 /**
@@ -223,7 +229,7 @@ export interface NapiFontIntent {
    * "removeAnchors" | "reverseContour" | "translatePoints" |
    * "setXAdvance" | "applyBooleanOp".
    * Create kinds: "createGlyph" | "createAxis" | "createSource". Delete
-   * kinds: "deleteAxis". Every
+   * kinds: "deleteAxis" | "deleteSource". Every
    * kind shares the same apply path; one set = one undo step.
    */
   kind: string
@@ -245,6 +251,7 @@ export interface NapiFontIntent {
   createAxis?: NapiCreateAxisIntent
   deleteAxis?: NapiDeleteAxisIntent
   createSource?: NapiCreateSourceIntent
+  deleteSource?: NapiDeleteSourceIntent
 }
 
 export interface NapiFontMetadata {

--- a/crates/shift-bridge/src/bridge.rs
+++ b/crates/shift-bridge/src/bridge.rs
@@ -783,11 +783,20 @@ fn map_intent(intent: NapiFontIntent) -> errors::Result<FontIntent> {
         axis_id: parse::<AxisId>(&payload.axis_id)?,
       })
     }
+    "deleteSource" => {
+      let payload = intent
+        .delete_source
+        .ok_or_else(|| missing("deleteSource"))?;
+      Ok(FontIntent::DeleteSource {
+        source_id: parse::<SourceId>(&payload.source_id)?,
+      })
+    }
     "createSource" => {
       let payload = intent
         .create_source
         .ok_or_else(|| missing("createSource"))?;
       Ok(FontIntent::CreateSource {
+        source_id: parse::<SourceId>(&payload.source_id)?,
         name: payload.name,
         location: map_location(payload.location)?,
       })
@@ -845,8 +854,8 @@ mod tests {
   use super::*;
   use shift_wire::bridges::napi::{
     NapiAddAnchorsIntent, NapiAddContourIntent, NapiAddPointsIntent, NapiCreateAxisIntent,
-    NapiCreateGlyphIntent, NapiCreateSourceIntent, NapiDeleteAxisIntent, NapiLocation,
-    NapiMoveAnchorsIntent, NapiMovePointsIntent, NapiPointSeed, NapiPointType,
+    NapiCreateGlyphIntent, NapiCreateSourceIntent, NapiDeleteAxisIntent, NapiDeleteSourceIntent,
+    NapiLocation, NapiMoveAnchorsIntent, NapiMovePointsIntent, NapiPointSeed, NapiPointType,
     NapiRemoveAnchorsIntent, NapiRemovePointsIntent, NapiReverseContourIntent,
     NapiSetContourClosedIntent, NapiSetPointSmoothIntent, NapiSetXAdvanceIntent,
     NapiTranslatePointsIntent,
@@ -876,6 +885,7 @@ mod tests {
       create_axis: None,
       delete_axis: None,
       create_source: None,
+      delete_source: None,
     }
   }
 
@@ -1717,9 +1727,19 @@ mod tests {
     }
   }
 
-  fn create_source_intent(name: &str, location: &[(&str, f64)]) -> NapiFontIntent {
+  fn delete_source_intent(source_id: &str) -> NapiFontIntent {
+    NapiFontIntent {
+      delete_source: Some(NapiDeleteSourceIntent {
+        source_id: source_id.to_string(),
+      }),
+      ..skeleton_intent("deleteSource")
+    }
+  }
+
+  fn create_source_intent(source_id: &str, name: &str, location: &[(&str, f64)]) -> NapiFontIntent {
     NapiFontIntent {
       create_source: Some(NapiCreateSourceIntent {
+        source_id: source_id.to_string(),
         name: name.to_string(),
         location: NapiLocation {
           values: location
@@ -1803,7 +1823,11 @@ mod tests {
 
     let applied = bridge
       .apply(
-        vec![create_source_intent("Bold", &[("axis_weight", 700.0)])],
+        vec![create_source_intent(
+          "source_bold",
+          "Bold",
+          &[("axis_weight", 700.0)],
+        )],
         None,
       )
       .unwrap();
@@ -1814,6 +1838,7 @@ mod tests {
       .iter()
       .find(|source| source.name == "Bold")
       .expect("new source must be in the echo");
+    assert_eq!(bold.id, "source_bold");
     assert_eq!(bold.location.values.get("axis_weight"), Some(&700.0));
     // one eager layer per existing glyph, replace-grade
     assert_eq!(applied.layers.len(), 1);
@@ -1829,7 +1854,11 @@ mod tests {
 
     let applied = bridge
       .apply(
-        vec![create_source_intent("Bold", &[("axis_weight", 700.0)])],
+        vec![create_source_intent(
+          "source_bold",
+          "Bold",
+          &[("axis_weight", 700.0)],
+        )],
         None,
       )
       .unwrap();
@@ -1856,7 +1885,11 @@ mod tests {
     bridge.apply(vec![weight_axis_intent()], None).unwrap();
 
     let result = bridge.apply(
-      vec![create_source_intent("Wide", &[("axis_width", 125.0)])],
+      vec![create_source_intent(
+        "source_wide",
+        "Wide",
+        &[("axis_width", 125.0)],
+      )],
       None,
     );
 
@@ -1870,7 +1903,94 @@ mod tests {
     bridge.apply(vec![weight_axis_intent()], None).unwrap();
 
     // the untitled workspace already has a "Regular" source
-    let result = bridge.apply(vec![create_source_intent("Regular", &[])], None);
+    let result = bridge.apply(
+      vec![create_source_intent(
+        "source_regular_duplicate",
+        "Regular",
+        &[],
+      )],
+      None,
+    );
+
+    assert!(result.is_err());
+    assert_eq!(bridge.get_sources().unwrap().len(), 1);
+  }
+
+  #[test]
+  fn apply_create_source_rejects_duplicate_source_ids() {
+    let mut bridge = bridge_with_workspace();
+    bridge.apply(vec![weight_axis_intent()], None).unwrap();
+    bridge
+      .apply(
+        vec![create_source_intent(
+          "source_bold",
+          "Bold",
+          &[("axis_weight", 700.0)],
+        )],
+        None,
+      )
+      .unwrap();
+
+    let result = bridge.apply(
+      vec![create_source_intent(
+        "source_bold",
+        "Bold Again",
+        &[("axis_weight", 800.0)],
+      )],
+      None,
+    );
+
+    assert!(result.is_err());
+    assert_eq!(bridge.get_sources().unwrap().len(), 2);
+  }
+
+  #[test]
+  fn apply_delete_source_echoes_sources_and_removes_layers() {
+    let mut bridge = bridge_with_workspace();
+    let default_layer_id = create_default_glyph_layer(&mut bridge, "A", Some(65));
+    bridge.apply(vec![weight_axis_intent()], None).unwrap();
+    bridge
+      .apply(
+        vec![create_source_intent(
+          "source_bold",
+          "Bold",
+          &[("axis_weight", 700.0)],
+        )],
+        None,
+      )
+      .unwrap();
+    let glyph_id = bridge.get_glyphs().unwrap()[0].id.clone();
+    assert!(bridge
+      .get_glyph(glyph_id.clone(), "source_bold".to_string())
+      .unwrap()
+      .is_some());
+
+    let applied = bridge
+      .apply(vec![delete_source_intent("source_bold")], None)
+      .unwrap();
+
+    let sources = applied.sources.expect("deleteSource must echo sources");
+    assert_eq!(sources.len(), 1);
+    assert_eq!(sources[0].name, "Regular");
+    assert!(applied.glyphs.is_none());
+    assert!(applied.layers.is_empty());
+    assert!(bridge
+      .get_glyph(glyph_id.clone(), "source_bold".to_string())
+      .unwrap()
+      .is_none());
+    let default_state = bridge
+      .get_glyph(glyph_id, default_source_id(&bridge))
+      .unwrap()
+      .expect("default source must keep its layer");
+    assert_eq!(default_state.layer_id, default_layer_id);
+  }
+
+  #[test]
+  fn apply_delete_source_rejects_last_source() {
+    let mut bridge = bridge_with_workspace();
+    let source_id = default_source_id(&bridge);
+
+    let result = bridge.apply(vec![delete_source_intent(&source_id)], None);
 
     assert!(result.is_err());
     assert_eq!(bridge.get_sources().unwrap().len(), 1);
@@ -1882,7 +2002,11 @@ mod tests {
     bridge.apply(vec![weight_axis_intent()], None).unwrap();
     bridge
       .apply(
-        vec![create_source_intent("Bold", &[("axis_weight", 700.0)])],
+        vec![create_source_intent(
+          "source_bold",
+          "Bold",
+          &[("axis_weight", 700.0)],
+        )],
         None,
       )
       .unwrap();

--- a/crates/shift-font/src/error.rs
+++ b/crates/shift-font/src/error.rs
@@ -56,6 +56,9 @@ pub enum CoreError {
     #[error("source {0} not found")]
     SourceNotFound(SourceId),
 
+    #[error("source id {0} already exists")]
+    DuplicateSourceId(SourceId),
+
     #[error("layer {0} not found")]
     LayerNotFound(LayerId),
 
@@ -94,6 +97,9 @@ pub enum CoreError {
 
     #[error("source name {0} already exists")]
     DuplicateSourceName(String),
+
+    #[error("cannot delete the last source")]
+    CannotDeleteLastSource,
 }
 
 pub type CoreResult<T> = Result<T, CoreError>;

--- a/crates/shift-font/src/intents.rs
+++ b/crates/shift-font/src/intents.rs
@@ -132,8 +132,12 @@ pub enum FontIntent {
     DeleteAxis {
         axis_id: AxisId,
     },
+    DeleteSource {
+        source_id: SourceId,
+    },
     /// Creates the source plus one eager layer per existing glyph.
     CreateSource {
+        source_id: SourceId,
         name: String,
         location: Location,
     },
@@ -162,6 +166,7 @@ impl FontIntent {
             | Self::UpdateGlyph { .. }
             | Self::CreateAxis { .. }
             | Self::DeleteAxis { .. }
+            | Self::DeleteSource { .. }
             | Self::CreateSource { .. } => None,
         }
     }
@@ -280,9 +285,15 @@ impl Font {
                 self.apply_delete_axis(axis_id, changes)?;
                 Ok(Vec::new())
             }
-            FontIntent::CreateSource { name, location } => {
-                self.apply_create_source(name, location, changes)
+            FontIntent::DeleteSource { source_id } => {
+                self.apply_delete_source(source_id, changes)?;
+                Ok(Vec::new())
             }
+            FontIntent::CreateSource {
+                source_id,
+                name,
+                location,
+            } => self.apply_create_source(source_id.clone(), name, location, changes),
             _ => unreachable!("editing intents take the layer path"),
         }
     }
@@ -353,8 +364,37 @@ impl Font {
         Ok(())
     }
 
+    fn apply_delete_source(
+        &mut self,
+        source_id: &SourceId,
+        changes: &mut FontChangeSet,
+    ) -> CoreResult<()> {
+        if self.sources().len() <= 1 {
+            return Err(CoreError::CannotDeleteLastSource);
+        }
+
+        let layer_ids: Vec<LayerId> = self
+            .glyphs()
+            .filter_map(|glyph| {
+                glyph
+                    .layer_for_source(source_id.clone())
+                    .map(|layer| layer.id())
+            })
+            .collect();
+
+        for layer_id in layer_ids {
+            self.remove_glyph_layer(layer_id)?;
+        }
+
+        self.remove_source(source_id.clone())
+            .ok_or_else(|| CoreError::SourceNotFound(source_id.clone()))?;
+        changes.push(FontChange::source_deleted(source_id.clone()));
+        Ok(())
+    }
+
     fn apply_create_source(
         &mut self,
+        source_id: SourceId,
         name: &str,
         location: &Location,
         changes: &mut FontChangeSet,
@@ -366,6 +406,9 @@ impl Font {
         if self.sources().iter().any(|source| source.name() == name) {
             return Err(CoreError::DuplicateSourceName(name.to_string()));
         }
+        if self.sources().iter().any(|source| source.id() == source_id) {
+            return Err(CoreError::DuplicateSourceId(source_id));
+        }
 
         for (axis_id, _) in location.iter() {
             if !self.axes().iter().any(|axis| axis.id() == *axis_id) {
@@ -373,8 +416,7 @@ impl Font {
             }
         }
 
-        let source = Source::new(name.to_string(), location.clone());
-        let source_id = source.id();
+        let source = Source::with_id(source_id.clone(), name.to_string(), location.clone(), None);
         changes.push(FontChange::source_created(&source));
         self.add_source(source);
 
@@ -705,6 +747,7 @@ impl Font {
             | FontIntent::UpdateGlyph { .. }
             | FontIntent::CreateAxis { .. }
             | FontIntent::DeleteAxis { .. }
+            | FontIntent::DeleteSource { .. }
             | FontIntent::CreateSource { .. } => {
                 unreachable!("font-level intents take the apply_font_intent path")
             }

--- a/crates/shift-wire/src/bridges/napi/mod.rs
+++ b/crates/shift-wire/src/bridges/napi/mod.rs
@@ -480,7 +480,7 @@ pub struct NapiFontIntent {
     /// "removeAnchors" | "reverseContour" | "translatePoints" |
     /// "setXAdvance" | "applyBooleanOp".
     /// Create kinds: "createGlyph" | "createAxis" | "createSource". Delete
-    /// kinds: "deleteAxis". Every
+    /// kinds: "deleteAxis" | "deleteSource". Every
     /// kind shares the same apply path; one set = one undo step.
     pub kind: String,
     pub add_points: Option<NapiAddPointsIntent>,
@@ -501,6 +501,7 @@ pub struct NapiFontIntent {
     pub create_axis: Option<NapiCreateAxisIntent>,
     pub delete_axis: Option<NapiDeleteAxisIntent>,
     pub create_source: Option<NapiCreateSourceIntent>,
+    pub delete_source: Option<NapiDeleteSourceIntent>,
 }
 
 /// Font-level glyph creation. The glyph id is client-minted (decision 6:
@@ -549,10 +550,19 @@ pub struct NapiDeleteAxisIntent {
     pub axis_id: String,
 }
 
-/// Font-level source creation. Rust mints the source id; the echo's
-/// `sources` list carries it back.
+/// Font-level source deletion. Removing a source also removes its glyph layers.
+#[napi(object)]
+pub struct NapiDeleteSourceIntent {
+    #[napi(ts_type = "SourceId")]
+    pub source_id: String,
+}
+
+/// Font-level source creation. The source id is client-minted so verbs can
+/// return identity synchronously; Rust honors it and rejects duplicates.
 #[napi(object)]
 pub struct NapiCreateSourceIntent {
+    #[napi(ts_type = "SourceId")]
+    pub source_id: String,
     pub name: String,
     /// Axis id → design-space value for the new source.
     pub location: NapiLocation,

--- a/crates/shift-workspace/tests/workspace_test.rs
+++ b/crates/shift-workspace/tests/workspace_test.rs
@@ -1,7 +1,7 @@
 use std::{fs, path::PathBuf};
 
 use shift_font::{
-    Axis, AxisId, FontChange, FontIntent, FontIntentSet, GlyphId, LayerId, Location,
+    Axis, AxisId, FontChange, FontIntent, FontIntentSet, GlyphId, LayerId, Location, SourceId,
     error::CoreError,
 };
 use shift_source::ShiftSourcePackage;
@@ -516,6 +516,7 @@ fn mixed_font_level_batch_undoes_axis_source_and_glyph_together() {
                         ),
                     },
                     FontIntent::CreateSource {
+                        source_id: SourceId::from_raw("bold"),
                         name: "Bold".to_string(),
                         location,
                     },

--- a/packages/types/src/bridge/generated.ts
+++ b/packages/types/src/bridge/generated.ts
@@ -202,10 +202,11 @@ export interface CreateGlyphIntent {
 }
 
 /**
- * Font-level source creation. Rust mints the source id; the echo's
- * `sources` list carries it back.
+ * Font-level source creation. The source id is client-minted so verbs can
+ * return identity synchronously; Rust honors it and rejects duplicates.
  */
 export interface CreateSourceIntent {
+  sourceId: SourceId
   name: string
   /** Axis id → design-space value for the new source. */
   location: Location
@@ -214,6 +215,11 @@ export interface CreateSourceIntent {
 /** Font-level axis deletion. Removing an axis also reshapes source locations. */
 export interface DeleteAxisIntent {
   axisId: AxisId
+}
+
+/** Font-level source deletion. Removing a source also removes its glyph layers. */
+export interface DeleteSourceIntent {
+  sourceId: SourceId
 }
 
 /**
@@ -228,7 +234,7 @@ export interface FontIntent {
    * "removeAnchors" | "reverseContour" | "translatePoints" |
    * "setXAdvance" | "applyBooleanOp".
    * Create kinds: "createGlyph" | "createAxis" | "createSource". Delete
-   * kinds: "deleteAxis". Every
+   * kinds: "deleteAxis" | "deleteSource". Every
    * kind shares the same apply path; one set = one undo step.
    */
   kind: string
@@ -250,6 +256,7 @@ export interface FontIntent {
   createAxis?: CreateAxisIntent
   deleteAxis?: DeleteAxisIntent
   createSource?: CreateSourceIntent
+  deleteSource?: DeleteSourceIntent
 }
 
 export interface FontMetadata {

--- a/packages/types/src/bridge/index.ts
+++ b/packages/types/src/bridge/index.ts
@@ -24,6 +24,7 @@ export type {
   ContourData,
   CreateAxisIntent,
   DeleteAxisIntent,
+  DeleteSourceIntent,
   CreateSourceIntent,
   FontIntent,
   FontMetadata,

--- a/packages/types/src/ids.ts
+++ b/packages/types/src/ids.ts
@@ -250,3 +250,8 @@ export function mintAxisId(): AxisId {
 export function mintGlyphId(): GlyphId {
   return `glyph_${crypto.randomUUID()}` as GlyphId;
 }
+
+/** Mints a new source id. See {@link mintPointId}. */
+export function mintSourceId(): SourceId {
+  return `source_${crypto.randomUUID()}` as SourceId;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -38,6 +38,7 @@ export {
   mintAxisId,
   mintPointId,
   mintGlyphId,
+  mintSourceId,
 } from "./ids";
 
 export type {
@@ -64,6 +65,7 @@ export type {
   ContourData,
   CreateAxisIntent,
   DeleteAxisIntent,
+  DeleteSourceIntent,
   CreateSourceIntent,
   FontIntent,
   FontMetadata,


### PR DESCRIPTION
## Summary

- Adds shared sidebar action affordances for collapsible sections and rows.
- Wires axis/source creation entry points from the left sidebar.
- Adds a source creation dialog and client-minted source ids.
- Adds delete-axis and delete-source bridge/model intents, including source-layer cleanup.
- Adds source row action menus with delete guarded for the last remaining source.

## Notes

Undo/redo semantics for axis/source deletion need a more robust design around source locations, eager layers, persistence, and native menu routing. Tracked separately in #95.

## Validation

- `git diff --check`
- `cargo test -p shift-font -p shift-bridge -p shift-workspace`
- `pnpm typecheck`
- `pnpm --filter @shift/desktop test -- src/renderer/src/lib/model/Font.test.ts src/renderer/src/lib/model/variation.test.ts`
- pre-commit hooks on commit, including Rust checks, lint/typecheck, deadcode, and Vitest
