### PR TITLE
[codex] Refine shift inspect CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1913,7 +1913,6 @@ dependencies = [
 name = "shift-cli"
 version = "0.1.0"
 dependencies = [
- "anstream",
  "anstyle",
  "clap",
  "comfy-table",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +140,30 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "base64"
@@ -314,6 +353,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "comfy-table"
+version = "7.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +420,29 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "document-features",
+ "parking_lot",
+ "rustix",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "ctor"
@@ -475,6 +548,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,7 +598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -835,6 +917,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "glyphs-reader"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,6 +1102,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,6 +1253,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1179,6 +1279,45 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "backtrace",
+ "backtrace-ext",
+ "cfg-if",
+ "miette-derive",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
 
 [[package]]
 name = "mutually_exclusive_features"
@@ -1319,6 +1458,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,6 +1499,12 @@ dependencies = [
  "rand",
  "serde",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "parking_lot"
@@ -1597,6 +1751,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,7 +1781,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1750,6 +1910,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "shift-cli"
+version = "0.1.0"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap",
+ "comfy-table",
+ "miette",
+ "serde",
+ "serde_json",
+ "shift-font",
+ "shift-source",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "shift-font"
 version = "0.1.0"
 dependencies = [
@@ -1873,6 +2050,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91"
+
+[[package]]
+name = "supports-unicode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+
+[[package]]
 name = "syn"
 version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1904,7 +2102,27 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "unicode-linebreak",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -2029,10 +2247,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Shift aims to redefine font editing by combining the power of Rust for performan
 │  shift-font        live font authoring model                 │
 │  shift-store       SQLite working store                      │
 │  shift-source      .shift source package IO                  │
+│  shift-cli         read-only package inspection CLI          │
 └──────────────────────────────────────────────────────────────┘
 ```
 
@@ -63,6 +64,18 @@ pnpm install
 pnpm build:native
 pnpm dev
 ```
+
+### Command-line inspection
+
+The `shift` CLI can inspect `.shift` source packages without modifying them:
+
+```bash
+cargo run -p shift-cli -- inspect path/to/Family.shift
+cargo run -p shift-cli -- inspect --view axes path/to/Family.shift
+cargo run -p shift-cli -- inspect --json path/to/Family.shift
+```
+
+See [crates/shift-cli/README.md](crates/shift-cli/README.md) for the supported views and development commands.
 
 ## Roadmap
 

--- a/crates/shift-cli/Cargo.toml
+++ b/crates/shift-cli/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "shift-cli"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "shift"
+path = "src/main.rs"
+
+[dependencies]
+anstream = "0.6"
+anstyle = "1"
+clap = { version = "4.5.40", features = ["derive"] }
+comfy-table = "7.2"
+miette = { version = "7", features = ["fancy"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+shift-font = { workspace = true }
+shift-source = { workspace = true }
+thiserror = "2"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/shift-cli/Cargo.toml
+++ b/crates/shift-cli/Cargo.toml
@@ -2,13 +2,14 @@
 name = "shift-cli"
 version = "0.1.0"
 edition = "2024"
+description = "Read-only command-line tools for Shift source packages"
+readme = "README.md"
 
 [[bin]]
 name = "shift"
 path = "src/main.rs"
 
 [dependencies]
-anstream = "0.6"
 anstyle = "1"
 clap = { version = "4.5.40", features = ["derive"] }
 comfy-table = "7.2"

--- a/crates/shift-cli/README.md
+++ b/crates/shift-cli/README.md
@@ -1,0 +1,30 @@
+# shift-cli
+
+Read-only command-line tools for `.shift` source packages.
+
+The crate builds the `shift` binary. Its first command is `inspect`, which opens a source package, summarizes the font model, and can emit stable JSON for scripts and CI.
+
+## Usage
+
+```sh
+cargo run -p shift-cli -- inspect path/to/Family.shift
+cargo run -p shift-cli -- inspect --view axes path/to/Family.shift
+cargo run -p shift-cli -- inspect --view sources path/to/Family.shift
+cargo run -p shift-cli -- inspect --json path/to/Family.shift
+```
+
+Human-readable output is quiet by default and uses plain text when stdout is redirected. Use `--json` when another tool needs the complete report.
+
+Available views:
+
+- `summary`: package metadata, counts, and sources
+- `axes`: variable font axes
+- `sources`: design sources and locations
+- `glyphs`: glyph names, Unicode values, and layer counts
+
+## Development
+
+```sh
+cargo test -p shift-cli
+cargo run -p shift-cli -- inspect --help
+```

--- a/crates/shift-cli/src/cli.rs
+++ b/crates/shift-cli/src/cli.rs
@@ -1,0 +1,62 @@
+use std::path::PathBuf;
+
+use anstyle::{AnsiColor, Effects};
+use clap::builder::styling::Styles;
+use clap::{ColorChoice, Parser, Subcommand, ValueHint};
+
+use crate::inspect::InspectView;
+
+const CLAP_STYLES: Styles = Styles::styled()
+    .header(AnsiColor::BrightCyan.on_default().effects(Effects::BOLD))
+    .usage(AnsiColor::BrightCyan.on_default().effects(Effects::BOLD))
+    .literal(AnsiColor::Green.on_default())
+    .placeholder(AnsiColor::BrightBlue.on_default())
+    .error(AnsiColor::Red.on_default().effects(Effects::BOLD))
+    .valid(AnsiColor::Green.on_default())
+    .invalid(AnsiColor::Red.on_default());
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "shift",
+    version,
+    about = "Command-line tools for Shift source packages",
+    color = ColorChoice::Auto,
+    styles = CLAP_STYLES
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// Inspect a .shift source package without modifying it.
+    Inspect(InspectArgs),
+}
+
+#[derive(Debug, Parser)]
+pub struct InspectArgs {
+    /// Path to the .shift source package to inspect.
+    #[arg(value_hint = ValueHint::FilePath)]
+    pub path: PathBuf,
+
+    /// Select the human-readable section to print.
+    #[arg(long, value_enum, default_value_t = InspectView::Summary)]
+    pub view: InspectView,
+
+    /// Emit stable JSON for scripts and CI.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::CommandFactory;
+
+    use super::*;
+
+    #[test]
+    fn command_definition_is_valid() {
+        Cli::command().debug_assert();
+    }
+}

--- a/crates/shift-cli/src/inspect.rs
+++ b/crates/shift-cli/src/inspect.rs
@@ -1,0 +1,621 @@
+use std::collections::HashMap;
+use std::fmt::Display;
+use std::path::{Path, PathBuf};
+
+use anstyle::AnsiColor;
+use comfy_table::presets::NOTHING;
+use comfy_table::{Attribute, Cell, CellAlignment, Color, ContentArrangement, Table};
+use miette::Diagnostic;
+use serde::Serialize;
+use shift_font::{Axis, Font, Glyph, Source, SourceId};
+use shift_source::{FORMAT_ID, SCHEMA_VERSION, ShiftSourcePackage, SourcePackageError};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+#[error("failed to inspect source package {path}")]
+pub struct InspectError {
+    path: PathBuf,
+    #[source]
+    source: SourcePackageError,
+}
+
+impl Diagnostic for InspectError {
+    fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        Some(Box::new("shift_cli::inspect::package"))
+    }
+
+    fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        Some(Box::new(
+            "Check that the path points to a readable .shift package.",
+        ))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InspectOutput {
+    Summary,
+    Axes,
+    Sources,
+    Glyphs,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RenderMode {
+    Plain,
+    Styled,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ManifestSummary {
+    pub format: String,
+    pub schema_version: u32,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MetadataSummary {
+    pub family_name: Option<String>,
+    pub style_name: Option<String>,
+    pub display_name: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AxisSummary {
+    pub id: String,
+    pub tag: String,
+    pub name: String,
+    pub minimum: f64,
+    pub default: f64,
+    pub maximum: f64,
+    pub hidden: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SourceSummary {
+    pub id: String,
+    pub name: String,
+    pub location: Vec<LocationValue>,
+    pub filename: Option<String>,
+    pub is_default: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocationValue {
+    pub axis_id: String,
+    pub axis_tag: String,
+    pub value: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GlyphSummary {
+    pub id: String,
+    pub name: String,
+    pub unicodes: Vec<String>,
+    pub layer_count: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InspectReport {
+    pub path: String,
+    pub file_name: String,
+    pub manifest: ManifestSummary,
+    pub metadata: MetadataSummary,
+    pub axes: Vec<AxisSummary>,
+    pub sources: Vec<SourceSummary>,
+    pub glyph_count: usize,
+    pub glyphs: Vec<GlyphSummary>,
+}
+
+impl InspectReport {
+    pub fn load(path: impl AsRef<Path>) -> Result<Self, InspectError> {
+        let path = path.as_ref();
+        let font = ShiftSourcePackage::load_font(path).map_err(|source| InspectError {
+            path: path.to_path_buf(),
+            source,
+        })?;
+
+        Ok(Self::from_font(path, &font))
+    }
+
+    fn from_font(path: &Path, font: &Font) -> Self {
+        let axes_by_id = axes_by_id(font.axes());
+        let default_source_id = font.default_source_id();
+        let glyphs = font.glyphs().map(GlyphSummary::from).collect::<Vec<_>>();
+
+        Self {
+            path: path.display().to_string(),
+            file_name: path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or_else(|| path.to_str().unwrap_or("<package>"))
+                .to_string(),
+            manifest: ManifestSummary {
+                format: FORMAT_ID.to_string(),
+                schema_version: SCHEMA_VERSION,
+            },
+            metadata: MetadataSummary {
+                family_name: font.metadata().family_name.clone(),
+                style_name: font.metadata().style_name.clone(),
+                display_name: font.metadata().display_name(),
+            },
+            axes: font.axes().iter().map(AxisSummary::from).collect(),
+            sources: font
+                .sources()
+                .iter()
+                .map(|source| SourceSummary::from_source(source, &axes_by_id, &default_source_id))
+                .collect(),
+            glyph_count: glyphs.len(),
+            glyphs,
+        }
+    }
+
+    pub fn render(&self, output: InspectOutput, mode: RenderMode) -> String {
+        match output {
+            InspectOutput::Summary => self.render_summary(mode),
+            InspectOutput::Axes => self.render_axes(mode),
+            InspectOutput::Sources => self.render_sources(mode),
+            InspectOutput::Glyphs => self.render_glyphs(mode),
+        }
+    }
+
+    fn render_summary(&self, mode: RenderMode) -> String {
+        let mut lines = vec![
+            styled_title(&self.file_name, mode),
+            format_kv("format", &self.manifest.format, mode),
+            format_kv("schema", &self.manifest.schema_version.to_string(), mode),
+            String::new(),
+            format_count("axes", self.axes.len(), mode),
+            format_count("sources", self.sources.len(), mode),
+            format_count("glyphs", self.glyph_count, mode),
+        ];
+
+        if !self.sources.is_empty() {
+            lines.push(String::new());
+            lines.push(styled_section("Sources", mode));
+            lines.push(self.sources_table(mode));
+        }
+
+        lines.join("\n")
+    }
+
+    fn render_axes(&self, mode: RenderMode) -> String {
+        if self.axes.is_empty() {
+            return format!(
+                "{}\n{}",
+                styled_section("Axes", mode),
+                muted_text("No axes", mode)
+            );
+        }
+
+        let mut table = base_table();
+        table.set_header(vec![
+            header("tag", mode),
+            header("name", mode),
+            header("id", mode),
+            header("min", mode),
+            header("default", mode),
+            header("max", mode),
+            header("hidden", mode),
+        ]);
+        for axis in &self.axes {
+            table.add_row(vec![
+                accent(&axis.tag, mode),
+                Cell::new(axis.name.clone()),
+                muted(compact_id(&axis.id), mode),
+                number(axis.minimum),
+                number(axis.default),
+                number(axis.maximum),
+                Cell::new(axis.hidden.to_string()).set_alignment(CellAlignment::Right),
+            ]);
+        }
+        align_right(&mut table, &[3, 4, 5, 6]);
+
+        format!("{}\n{}", styled_section("Axes", mode), table)
+    }
+
+    fn render_sources(&self, mode: RenderMode) -> String {
+        if self.sources.is_empty() {
+            return format!(
+                "{}\n{}",
+                styled_section("Sources", mode),
+                muted_text("No sources", mode)
+            );
+        }
+
+        format!(
+            "{}\n{}",
+            styled_section("Sources", mode),
+            self.sources_table(mode)
+        )
+    }
+
+    fn render_glyphs(&self, mode: RenderMode) -> String {
+        if self.glyphs.is_empty() {
+            return format!(
+                "{}\n{}",
+                styled_section("Glyphs", mode),
+                muted_text("No glyphs", mode)
+            );
+        }
+
+        let mut table = base_table();
+        table.set_header(vec![
+            header("name", mode),
+            header("id", mode),
+            header("unicode", mode),
+            header("layers", mode),
+        ]);
+        for glyph in &self.glyphs {
+            table.add_row(vec![
+                Cell::new(glyph.name.clone()),
+                muted(compact_id(&glyph.id), mode),
+                Cell::new(if glyph.unicodes.is_empty() {
+                    "-".to_string()
+                } else {
+                    glyph.unicodes.join(" ")
+                }),
+                Cell::new(glyph.layer_count.to_string()).set_alignment(CellAlignment::Right),
+            ]);
+        }
+        align_right(&mut table, &[3]);
+
+        format!("{}\n{}", styled_section("Glyphs", mode), table)
+    }
+
+    fn sources_table(&self, mode: RenderMode) -> String {
+        let mut table = base_table();
+        table.set_header(vec![
+            header("name", mode),
+            header("id", mode),
+            header("location", mode),
+            header("file", mode),
+        ]);
+        for source in &self.sources {
+            let name = if source.is_default {
+                format!("{}*", source.name)
+            } else {
+                source.name.clone()
+            };
+            table.add_row(vec![
+                Cell::new(name),
+                muted(compact_id(&source.id), mode),
+                Cell::new(format_location(&source.location)),
+                Cell::new(source.filename.as_deref().unwrap_or("-")),
+            ]);
+        }
+
+        table.to_string()
+    }
+}
+
+impl From<&Axis> for AxisSummary {
+    fn from(axis: &Axis) -> Self {
+        Self {
+            id: axis.id().to_string(),
+            tag: axis.tag().to_string(),
+            name: axis.name().to_string(),
+            minimum: axis.minimum(),
+            default: axis.default(),
+            maximum: axis.maximum(),
+            hidden: axis.is_hidden(),
+        }
+    }
+}
+
+impl SourceSummary {
+    fn from_source(
+        source: &Source,
+        axes_by_id: &HashMap<String, String>,
+        default_source_id: &Option<SourceId>,
+    ) -> Self {
+        let mut location = source
+            .location()
+            .iter()
+            .map(|(axis_id, value)| {
+                let axis_id = axis_id.to_string();
+                let axis_tag = axes_by_id
+                    .get(&axis_id)
+                    .cloned()
+                    .unwrap_or_else(|| axis_id.clone());
+                LocationValue {
+                    axis_id,
+                    axis_tag,
+                    value: format_number(*value),
+                }
+            })
+            .collect::<Vec<_>>();
+        location.sort_by(|left, right| left.axis_tag.cmp(&right.axis_tag));
+
+        Self {
+            id: source.id().to_string(),
+            name: source.name().to_string(),
+            location,
+            filename: source.filename().map(ToOwned::to_owned),
+            is_default: default_source_id
+                .as_ref()
+                .is_some_and(|source_id| *source_id == source.id()),
+        }
+    }
+}
+
+impl From<&Glyph> for GlyphSummary {
+    fn from(glyph: &Glyph) -> Self {
+        Self {
+            id: glyph.id().to_string(),
+            name: glyph.name().to_string(),
+            unicodes: glyph
+                .unicodes()
+                .iter()
+                .map(|unicode| format!("U+{unicode:04X}"))
+                .collect(),
+            layer_count: glyph.layers().len(),
+        }
+    }
+}
+
+fn axes_by_id(axes: &[Axis]) -> HashMap<String, String> {
+    axes.iter()
+        .map(|axis| (axis.id().to_string(), axis.tag().to_string()))
+        .collect()
+}
+
+fn base_table() -> Table {
+    let mut table = Table::new();
+    table.load_preset(NOTHING);
+    table.set_content_arrangement(ContentArrangement::Dynamic);
+    table
+}
+
+fn align_right(table: &mut Table, columns: &[usize]) {
+    for column in columns {
+        if let Some(column) = table.column_mut(*column) {
+            column.set_cell_alignment(CellAlignment::Right);
+        }
+    }
+}
+
+fn header(value: &str, mode: RenderMode) -> Cell {
+    match mode {
+        RenderMode::Plain => Cell::new(value),
+        RenderMode::Styled => Cell::new(value)
+            .add_attribute(Attribute::Bold)
+            .fg(Color::DarkGrey),
+    }
+}
+
+fn accent(value: &str, mode: RenderMode) -> Cell {
+    match mode {
+        RenderMode::Plain => Cell::new(value),
+        RenderMode::Styled => Cell::new(value).fg(Color::Cyan),
+    }
+}
+
+fn muted(value: impl Into<String>, mode: RenderMode) -> Cell {
+    let value = value.into();
+    match mode {
+        RenderMode::Plain => Cell::new(value),
+        RenderMode::Styled => Cell::new(value).fg(Color::DarkGrey),
+    }
+}
+
+fn muted_text(value: &str, mode: RenderMode) -> String {
+    match mode {
+        RenderMode::Plain => value.to_string(),
+        RenderMode::Styled => format!(
+            "{}{}{}",
+            anstyle::Style::new()
+                .fg_color(Some(AnsiColor::BrightBlack.into()))
+                .render(),
+            value,
+            anstyle::Reset.render()
+        ),
+    }
+}
+
+fn number(value: f64) -> Cell {
+    Cell::new(format_number(value)).set_alignment(CellAlignment::Right)
+}
+
+fn styled_title(value: &str, mode: RenderMode) -> String {
+    match mode {
+        RenderMode::Plain => value.to_string(),
+        RenderMode::Styled => format!(
+            "{}{}{}",
+            anstyle::Style::new().bold().render(),
+            value,
+            anstyle::Reset.render()
+        ),
+    }
+}
+
+fn styled_section(value: &str, mode: RenderMode) -> String {
+    match mode {
+        RenderMode::Plain => value.to_string(),
+        RenderMode::Styled => format!(
+            "{}{}{}",
+            anstyle::Style::new()
+                .bold()
+                .fg_color(Some(AnsiColor::BrightCyan.into()))
+                .render(),
+            value,
+            anstyle::Reset.render()
+        ),
+    }
+}
+
+fn format_kv(label: &str, value: &str, mode: RenderMode) -> String {
+    match mode {
+        RenderMode::Plain => format!("{label:<8}{value}"),
+        RenderMode::Styled => format!(
+            "{}{label:<8}{}{}",
+            anstyle::Style::new()
+                .fg_color(Some(AnsiColor::BrightBlack.into()))
+                .render(),
+            anstyle::Reset.render(),
+            value
+        ),
+    }
+}
+
+fn format_count(label: &str, value: usize, mode: RenderMode) -> String {
+    format_kv(label, &value.to_string(), mode)
+}
+
+fn format_location(location: &[LocationValue]) -> String {
+    if location.is_empty() {
+        "{}".to_string()
+    } else {
+        location
+            .iter()
+            .map(|entry| format!("{}={}", entry.axis_tag, entry.value))
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+}
+
+fn format_number(value: f64) -> String {
+    if value.fract().abs() < f64::EPSILON {
+        return format!("{value:.0}");
+    }
+
+    let mut text = format!("{value:.4}");
+    while text.contains('.') && text.ends_with('0') {
+        text.pop();
+    }
+    if text.ends_with('.') {
+        text.pop();
+    }
+    text
+}
+
+fn compact_id(value: &str) -> String {
+    const MAX: usize = 22;
+    const HEAD: usize = 16;
+
+    if value.len() <= MAX {
+        value.to_string()
+    } else {
+        format!("{}...", &value[..HEAD])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shift_font::{Axis, AxisId, Font, Glyph, GlyphLayer, LayerId, Location, Source, SourceId};
+    use shift_source::ShiftSourcePackage;
+
+    #[test]
+    fn inspect_report_extracts_summary_from_font() {
+        let report = InspectReport::from_font(Path::new("/tmp/Dogfood.shift"), &sample_font());
+
+        assert_eq!(report.file_name, "Dogfood.shift");
+        assert_eq!(report.manifest.format, "shift-source");
+        assert_eq!(report.manifest.schema_version, 1);
+        assert_eq!(report.metadata.display_name, "Dogfood Sans Regular");
+        assert_eq!(report.axes.len(), 1);
+        assert_eq!(report.sources.len(), 2);
+        assert_eq!(report.glyph_count, 1);
+        assert_eq!(report.sources[1].location[0].axis_tag, "wght");
+        assert_eq!(report.sources[1].location[0].value, "700");
+    }
+
+    #[test]
+    fn load_reads_shift_source_package() {
+        let temp = tempfile::tempdir().unwrap();
+        let package_path = temp.path().join("Dogfood.shift");
+        ShiftSourcePackage::save_font(&package_path, &sample_font()).unwrap();
+
+        let report = InspectReport::load(&package_path).unwrap();
+
+        assert_eq!(report.file_name, "Dogfood.shift");
+        assert_eq!(report.axes[0].tag, "wght");
+        assert_eq!(report.sources.len(), 2);
+        assert_eq!(report.glyph_count, 1);
+    }
+
+    #[test]
+    fn summary_render_is_quiet_and_aligned() {
+        let report = InspectReport::from_font(Path::new("/tmp/Dogfood.shift"), &sample_font());
+        let output = report.render(InspectOutput::Summary, RenderMode::Plain);
+
+        assert!(output.contains("Dogfood.shift"));
+        assert!(output.contains("format  shift-source"));
+        assert!(output.contains("axes    1"));
+        assert!(output.contains("Sources"));
+        assert!(output.contains("Bold*"));
+        assert!(output.contains("wght=700"));
+    }
+
+    #[test]
+    fn axes_view_has_empty_state() {
+        let report = InspectReport::from_font(Path::new("/tmp/Empty.shift"), &Font::new());
+
+        assert_eq!(
+            report.render(InspectOutput::Axes, RenderMode::Plain),
+            "Axes\nNo axes"
+        );
+    }
+
+    #[test]
+    fn json_output_includes_stable_sections() {
+        let report = InspectReport::from_font(Path::new("/tmp/Dogfood.shift"), &sample_font());
+        let json = serde_json::to_value(report).unwrap();
+
+        assert_eq!(json["manifest"]["format"], "shift-source");
+        assert_eq!(json["axes"][0]["tag"], "wght");
+        assert_eq!(json["sources"][1]["location"][0]["axisTag"], "wght");
+        assert_eq!(json["glyphs"][0]["unicodes"][0], "U+0041");
+    }
+
+    fn sample_font() -> Font {
+        let mut font = Font::empty();
+        font.metadata_mut().family_name = Some("Dogfood Sans".to_string());
+        font.metadata_mut().style_name = Some("Regular".to_string());
+
+        let axis_id = AxisId::from_raw("weight");
+        font.add_axis(Axis::with_id(
+            axis_id.clone(),
+            "wght".to_string(),
+            "Weight".to_string(),
+            100.0,
+            400.0,
+            900.0,
+        ));
+
+        let regular_id = SourceId::from_raw("regular");
+        font.add_source(Source::with_id(
+            regular_id.clone(),
+            "Regular".to_string(),
+            Location::new(),
+            None,
+        ));
+
+        let bold_id = SourceId::from_raw("bold");
+        let mut bold_location = Location::new();
+        bold_location.set(axis_id, 700.0);
+        font.add_source(Source::with_id(
+            bold_id.clone(),
+            "Bold".to_string(),
+            bold_location,
+            Some("Bold.ufo".to_string()),
+        ));
+        font.set_default_source_id(bold_id.clone());
+
+        let mut glyph = Glyph::with_unicode("A", 0x41);
+        glyph.set_layer(GlyphLayer::with_width(
+            LayerId::from_raw("A_bold"),
+            bold_id,
+            600.0,
+        ));
+        font.insert_glyph(glyph).unwrap();
+
+        font
+    }
+}

--- a/crates/shift-cli/src/inspect.rs
+++ b/crates/shift-cli/src/inspect.rs
@@ -1,515 +1,28 @@
-use std::collections::HashMap;
-use std::fmt::Display;
-use std::path::{Path, PathBuf};
+mod render;
+mod report;
 
-use anstyle::AnsiColor;
-use comfy_table::presets::NOTHING;
-use comfy_table::{Attribute, Cell, CellAlignment, Color, ContentArrangement, Table};
-use miette::Diagnostic;
-use serde::Serialize;
-use shift_font::{Axis, Font, Glyph, Source, SourceId};
-use shift_source::{FORMAT_ID, SCHEMA_VERSION, ShiftSourcePackage, SourcePackageError};
-use thiserror::Error;
+use clap::ValueEnum;
 
-#[derive(Debug, Error)]
-#[error("failed to inspect source package {path}")]
-pub struct InspectError {
-    path: PathBuf,
-    #[source]
-    source: SourcePackageError,
-}
+pub use render::RenderMode;
+pub use report::InspectReport;
 
-impl Diagnostic for InspectError {
-    fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
-        Some(Box::new("shift_cli::inspect::package"))
-    }
-
-    fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
-        Some(Box::new(
-            "Check that the path points to a readable .shift package.",
-        ))
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum InspectOutput {
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum InspectView {
     Summary,
     Axes,
     Sources,
     Glyphs,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum RenderMode {
-    Plain,
-    Styled,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ManifestSummary {
-    pub format: String,
-    pub schema_version: u32,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct MetadataSummary {
-    pub family_name: Option<String>,
-    pub style_name: Option<String>,
-    pub display_name: String,
-}
-
-#[derive(Clone, Debug, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AxisSummary {
-    pub id: String,
-    pub tag: String,
-    pub name: String,
-    pub minimum: f64,
-    pub default: f64,
-    pub maximum: f64,
-    pub hidden: bool,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SourceSummary {
-    pub id: String,
-    pub name: String,
-    pub location: Vec<LocationValue>,
-    pub filename: Option<String>,
-    pub is_default: bool,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct LocationValue {
-    pub axis_id: String,
-    pub axis_tag: String,
-    pub value: String,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct GlyphSummary {
-    pub id: String,
-    pub name: String,
-    pub unicodes: Vec<String>,
-    pub layer_count: usize,
-}
-
-#[derive(Clone, Debug, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct InspectReport {
-    pub path: String,
-    pub file_name: String,
-    pub manifest: ManifestSummary,
-    pub metadata: MetadataSummary,
-    pub axes: Vec<AxisSummary>,
-    pub sources: Vec<SourceSummary>,
-    pub glyph_count: usize,
-    pub glyphs: Vec<GlyphSummary>,
-}
-
-impl InspectReport {
-    pub fn load(path: impl AsRef<Path>) -> Result<Self, InspectError> {
-        let path = path.as_ref();
-        let font = ShiftSourcePackage::load_font(path).map_err(|source| InspectError {
-            path: path.to_path_buf(),
-            source,
-        })?;
-
-        Ok(Self::from_font(path, &font))
-    }
-
-    fn from_font(path: &Path, font: &Font) -> Self {
-        let axes_by_id = axes_by_id(font.axes());
-        let default_source_id = font.default_source_id();
-        let glyphs = font.glyphs().map(GlyphSummary::from).collect::<Vec<_>>();
-
-        Self {
-            path: path.display().to_string(),
-            file_name: path
-                .file_name()
-                .and_then(|name| name.to_str())
-                .unwrap_or_else(|| path.to_str().unwrap_or("<package>"))
-                .to_string(),
-            manifest: ManifestSummary {
-                format: FORMAT_ID.to_string(),
-                schema_version: SCHEMA_VERSION,
-            },
-            metadata: MetadataSummary {
-                family_name: font.metadata().family_name.clone(),
-                style_name: font.metadata().style_name.clone(),
-                display_name: font.metadata().display_name(),
-            },
-            axes: font.axes().iter().map(AxisSummary::from).collect(),
-            sources: font
-                .sources()
-                .iter()
-                .map(|source| SourceSummary::from_source(source, &axes_by_id, &default_source_id))
-                .collect(),
-            glyph_count: glyphs.len(),
-            glyphs,
-        }
-    }
-
-    pub fn render(&self, output: InspectOutput, mode: RenderMode) -> String {
-        match output {
-            InspectOutput::Summary => self.render_summary(mode),
-            InspectOutput::Axes => self.render_axes(mode),
-            InspectOutput::Sources => self.render_sources(mode),
-            InspectOutput::Glyphs => self.render_glyphs(mode),
-        }
-    }
-
-    fn render_summary(&self, mode: RenderMode) -> String {
-        let mut lines = vec![
-            styled_title(&self.file_name, mode),
-            format_kv("format", &self.manifest.format, mode),
-            format_kv("schema", &self.manifest.schema_version.to_string(), mode),
-            String::new(),
-            format_count("axes", self.axes.len(), mode),
-            format_count("sources", self.sources.len(), mode),
-            format_count("glyphs", self.glyph_count, mode),
-        ];
-
-        if !self.sources.is_empty() {
-            lines.push(String::new());
-            lines.push(styled_section("Sources", mode));
-            lines.push(self.sources_table(mode));
-        }
-
-        lines.join("\n")
-    }
-
-    fn render_axes(&self, mode: RenderMode) -> String {
-        if self.axes.is_empty() {
-            return format!(
-                "{}\n{}",
-                styled_section("Axes", mode),
-                muted_text("No axes", mode)
-            );
-        }
-
-        let mut table = base_table();
-        table.set_header(vec![
-            header("tag", mode),
-            header("name", mode),
-            header("id", mode),
-            header("min", mode),
-            header("default", mode),
-            header("max", mode),
-            header("hidden", mode),
-        ]);
-        for axis in &self.axes {
-            table.add_row(vec![
-                accent(&axis.tag, mode),
-                Cell::new(axis.name.clone()),
-                muted(compact_id(&axis.id), mode),
-                number(axis.minimum),
-                number(axis.default),
-                number(axis.maximum),
-                Cell::new(axis.hidden.to_string()).set_alignment(CellAlignment::Right),
-            ]);
-        }
-        align_right(&mut table, &[3, 4, 5, 6]);
-
-        format!("{}\n{}", styled_section("Axes", mode), table)
-    }
-
-    fn render_sources(&self, mode: RenderMode) -> String {
-        if self.sources.is_empty() {
-            return format!(
-                "{}\n{}",
-                styled_section("Sources", mode),
-                muted_text("No sources", mode)
-            );
-        }
-
-        format!(
-            "{}\n{}",
-            styled_section("Sources", mode),
-            self.sources_table(mode)
-        )
-    }
-
-    fn render_glyphs(&self, mode: RenderMode) -> String {
-        if self.glyphs.is_empty() {
-            return format!(
-                "{}\n{}",
-                styled_section("Glyphs", mode),
-                muted_text("No glyphs", mode)
-            );
-        }
-
-        let mut table = base_table();
-        table.set_header(vec![
-            header("name", mode),
-            header("id", mode),
-            header("unicode", mode),
-            header("layers", mode),
-        ]);
-        for glyph in &self.glyphs {
-            table.add_row(vec![
-                Cell::new(glyph.name.clone()),
-                muted(compact_id(&glyph.id), mode),
-                Cell::new(if glyph.unicodes.is_empty() {
-                    "-".to_string()
-                } else {
-                    glyph.unicodes.join(" ")
-                }),
-                Cell::new(glyph.layer_count.to_string()).set_alignment(CellAlignment::Right),
-            ]);
-        }
-        align_right(&mut table, &[3]);
-
-        format!("{}\n{}", styled_section("Glyphs", mode), table)
-    }
-
-    fn sources_table(&self, mode: RenderMode) -> String {
-        let mut table = base_table();
-        table.set_header(vec![
-            header("name", mode),
-            header("id", mode),
-            header("location", mode),
-            header("file", mode),
-        ]);
-        for source in &self.sources {
-            let name = if source.is_default {
-                format!("{}*", source.name)
-            } else {
-                source.name.clone()
-            };
-            table.add_row(vec![
-                Cell::new(name),
-                muted(compact_id(&source.id), mode),
-                Cell::new(format_location(&source.location)),
-                Cell::new(source.filename.as_deref().unwrap_or("-")),
-            ]);
-        }
-
-        table.to_string()
-    }
-}
-
-impl From<&Axis> for AxisSummary {
-    fn from(axis: &Axis) -> Self {
-        Self {
-            id: axis.id().to_string(),
-            tag: axis.tag().to_string(),
-            name: axis.name().to_string(),
-            minimum: axis.minimum(),
-            default: axis.default(),
-            maximum: axis.maximum(),
-            hidden: axis.is_hidden(),
-        }
-    }
-}
-
-impl SourceSummary {
-    fn from_source(
-        source: &Source,
-        axes_by_id: &HashMap<String, String>,
-        default_source_id: &Option<SourceId>,
-    ) -> Self {
-        let mut location = source
-            .location()
-            .iter()
-            .map(|(axis_id, value)| {
-                let axis_id = axis_id.to_string();
-                let axis_tag = axes_by_id
-                    .get(&axis_id)
-                    .cloned()
-                    .unwrap_or_else(|| axis_id.clone());
-                LocationValue {
-                    axis_id,
-                    axis_tag,
-                    value: format_number(*value),
-                }
-            })
-            .collect::<Vec<_>>();
-        location.sort_by(|left, right| left.axis_tag.cmp(&right.axis_tag));
-
-        Self {
-            id: source.id().to_string(),
-            name: source.name().to_string(),
-            location,
-            filename: source.filename().map(ToOwned::to_owned),
-            is_default: default_source_id
-                .as_ref()
-                .is_some_and(|source_id| *source_id == source.id()),
-        }
-    }
-}
-
-impl From<&Glyph> for GlyphSummary {
-    fn from(glyph: &Glyph) -> Self {
-        Self {
-            id: glyph.id().to_string(),
-            name: glyph.name().to_string(),
-            unicodes: glyph
-                .unicodes()
-                .iter()
-                .map(|unicode| format!("U+{unicode:04X}"))
-                .collect(),
-            layer_count: glyph.layers().len(),
-        }
-    }
-}
-
-fn axes_by_id(axes: &[Axis]) -> HashMap<String, String> {
-    axes.iter()
-        .map(|axis| (axis.id().to_string(), axis.tag().to_string()))
-        .collect()
-}
-
-fn base_table() -> Table {
-    let mut table = Table::new();
-    table.load_preset(NOTHING);
-    table.set_content_arrangement(ContentArrangement::Dynamic);
-    table
-}
-
-fn align_right(table: &mut Table, columns: &[usize]) {
-    for column in columns {
-        if let Some(column) = table.column_mut(*column) {
-            column.set_cell_alignment(CellAlignment::Right);
-        }
-    }
-}
-
-fn header(value: &str, mode: RenderMode) -> Cell {
-    match mode {
-        RenderMode::Plain => Cell::new(value),
-        RenderMode::Styled => Cell::new(value)
-            .add_attribute(Attribute::Bold)
-            .fg(Color::DarkGrey),
-    }
-}
-
-fn accent(value: &str, mode: RenderMode) -> Cell {
-    match mode {
-        RenderMode::Plain => Cell::new(value),
-        RenderMode::Styled => Cell::new(value).fg(Color::Cyan),
-    }
-}
-
-fn muted(value: impl Into<String>, mode: RenderMode) -> Cell {
-    let value = value.into();
-    match mode {
-        RenderMode::Plain => Cell::new(value),
-        RenderMode::Styled => Cell::new(value).fg(Color::DarkGrey),
-    }
-}
-
-fn muted_text(value: &str, mode: RenderMode) -> String {
-    match mode {
-        RenderMode::Plain => value.to_string(),
-        RenderMode::Styled => format!(
-            "{}{}{}",
-            anstyle::Style::new()
-                .fg_color(Some(AnsiColor::BrightBlack.into()))
-                .render(),
-            value,
-            anstyle::Reset.render()
-        ),
-    }
-}
-
-fn number(value: f64) -> Cell {
-    Cell::new(format_number(value)).set_alignment(CellAlignment::Right)
-}
-
-fn styled_title(value: &str, mode: RenderMode) -> String {
-    match mode {
-        RenderMode::Plain => value.to_string(),
-        RenderMode::Styled => format!(
-            "{}{}{}",
-            anstyle::Style::new().bold().render(),
-            value,
-            anstyle::Reset.render()
-        ),
-    }
-}
-
-fn styled_section(value: &str, mode: RenderMode) -> String {
-    match mode {
-        RenderMode::Plain => value.to_string(),
-        RenderMode::Styled => format!(
-            "{}{}{}",
-            anstyle::Style::new()
-                .bold()
-                .fg_color(Some(AnsiColor::BrightCyan.into()))
-                .render(),
-            value,
-            anstyle::Reset.render()
-        ),
-    }
-}
-
-fn format_kv(label: &str, value: &str, mode: RenderMode) -> String {
-    match mode {
-        RenderMode::Plain => format!("{label:<8}{value}"),
-        RenderMode::Styled => format!(
-            "{}{label:<8}{}{}",
-            anstyle::Style::new()
-                .fg_color(Some(AnsiColor::BrightBlack.into()))
-                .render(),
-            anstyle::Reset.render(),
-            value
-        ),
-    }
-}
-
-fn format_count(label: &str, value: usize, mode: RenderMode) -> String {
-    format_kv(label, &value.to_string(), mode)
-}
-
-fn format_location(location: &[LocationValue]) -> String {
-    if location.is_empty() {
-        "{}".to_string()
-    } else {
-        location
-            .iter()
-            .map(|entry| format!("{}={}", entry.axis_tag, entry.value))
-            .collect::<Vec<_>>()
-            .join(" ")
-    }
-}
-
-fn format_number(value: f64) -> String {
-    if value.fract().abs() < f64::EPSILON {
-        return format!("{value:.0}");
-    }
-
-    let mut text = format!("{value:.4}");
-    while text.contains('.') && text.ends_with('0') {
-        text.pop();
-    }
-    if text.ends_with('.') {
-        text.pop();
-    }
-    text
-}
-
-fn compact_id(value: &str) -> String {
-    const MAX: usize = 22;
-    const HEAD: usize = 16;
-
-    if value.len() <= MAX {
-        value.to_string()
-    } else {
-        format!("{}...", &value[..HEAD])
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::path::Path;
+
+    use serde_json::json;
     use shift_font::{Axis, AxisId, Font, Glyph, GlyphLayer, LayerId, Location, Source, SourceId};
     use shift_source::ShiftSourcePackage;
+
+    use super::*;
 
     #[test]
     fn inspect_report_extracts_summary_from_font() {
@@ -523,7 +36,7 @@ mod tests {
         assert_eq!(report.sources.len(), 2);
         assert_eq!(report.glyph_count, 1);
         assert_eq!(report.sources[1].location[0].axis_tag, "wght");
-        assert_eq!(report.sources[1].location[0].value, "700");
+        assert_eq!(report.sources[1].location[0].value, 700.0);
     }
 
     #[test]
@@ -543,7 +56,7 @@ mod tests {
     #[test]
     fn summary_render_is_quiet_and_aligned() {
         let report = InspectReport::from_font(Path::new("/tmp/Dogfood.shift"), &sample_font());
-        let output = report.render(InspectOutput::Summary, RenderMode::Plain);
+        let output = report.render(InspectView::Summary, RenderMode::Plain);
 
         assert!(output.contains("Dogfood.shift"));
         assert!(output.contains("format  shift-source"));
@@ -558,7 +71,7 @@ mod tests {
         let report = InspectReport::from_font(Path::new("/tmp/Empty.shift"), &Font::new());
 
         assert_eq!(
-            report.render(InspectOutput::Axes, RenderMode::Plain),
+            report.render(InspectView::Axes, RenderMode::Plain),
             "Axes\nNo axes"
         );
     }
@@ -571,6 +84,7 @@ mod tests {
         assert_eq!(json["manifest"]["format"], "shift-source");
         assert_eq!(json["axes"][0]["tag"], "wght");
         assert_eq!(json["sources"][1]["location"][0]["axisTag"], "wght");
+        assert_eq!(json["sources"][1]["location"][0]["value"], json!(700.0));
         assert_eq!(json["glyphs"][0]["unicodes"][0], "U+0041");
     }
 
@@ -591,7 +105,7 @@ mod tests {
 
         let regular_id = SourceId::from_raw("regular");
         font.add_source(Source::with_id(
-            regular_id.clone(),
+            regular_id,
             "Regular".to_string(),
             Location::new(),
             None,

--- a/crates/shift-cli/src/inspect/render.rs
+++ b/crates/shift-cli/src/inspect/render.rs
@@ -1,0 +1,303 @@
+use anstyle::AnsiColor;
+use comfy_table::presets::NOTHING;
+use comfy_table::{Attribute, Cell, CellAlignment, Color, ContentArrangement, Table};
+
+use super::InspectView;
+use super::report::{InspectReport, LocationValue};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RenderMode {
+    Plain,
+    Styled,
+}
+
+impl InspectReport {
+    pub fn render(&self, view: InspectView, mode: RenderMode) -> String {
+        match view {
+            InspectView::Summary => self.render_summary(mode),
+            InspectView::Axes => self.render_axes(mode),
+            InspectView::Sources => self.render_sources(mode),
+            InspectView::Glyphs => self.render_glyphs(mode),
+        }
+    }
+
+    fn render_summary(&self, mode: RenderMode) -> String {
+        let mut lines = vec![
+            styled_title(&self.file_name, mode),
+            format_kv("format", &self.manifest.format, mode),
+            format_kv("schema", &self.manifest.schema_version.to_string(), mode),
+            String::new(),
+            format_count("axes", self.axes.len(), mode),
+            format_count("sources", self.sources.len(), mode),
+            format_count("glyphs", self.glyph_count, mode),
+        ];
+
+        if !self.sources.is_empty() {
+            lines.push(String::new());
+            lines.push(styled_section("Sources", mode));
+            lines.push(self.sources_table(mode));
+        }
+
+        lines.join("\n")
+    }
+
+    fn render_axes(&self, mode: RenderMode) -> String {
+        if self.axes.is_empty() {
+            return empty_section("Axes", "No axes", mode);
+        }
+
+        let mut table = base_table();
+        table.set_header(vec![
+            header("tag", mode),
+            header("name", mode),
+            header("id", mode),
+            header("min", mode),
+            header("default", mode),
+            header("max", mode),
+            header("hidden", mode),
+        ]);
+        for axis in &self.axes {
+            table.add_row(vec![
+                accent(&axis.tag, mode),
+                Cell::new(axis.name.clone()),
+                muted(compact_id(&axis.id), mode),
+                number(axis.minimum),
+                number(axis.default),
+                number(axis.maximum),
+                right(axis.hidden),
+            ]);
+        }
+        align_right(&mut table, &[3, 4, 5, 6]);
+
+        section_with_table("Axes", table, mode)
+    }
+
+    fn render_sources(&self, mode: RenderMode) -> String {
+        if self.sources.is_empty() {
+            return empty_section("Sources", "No sources", mode);
+        }
+
+        format!(
+            "{}\n{}",
+            styled_section("Sources", mode),
+            self.sources_table(mode)
+        )
+    }
+
+    fn render_glyphs(&self, mode: RenderMode) -> String {
+        if self.glyphs.is_empty() {
+            return empty_section("Glyphs", "No glyphs", mode);
+        }
+
+        let mut table = base_table();
+        table.set_header(vec![
+            header("name", mode),
+            header("id", mode),
+            header("unicode", mode),
+            header("layers", mode),
+        ]);
+        for glyph in &self.glyphs {
+            table.add_row(vec![
+                Cell::new(glyph.name.clone()),
+                muted(compact_id(&glyph.id), mode),
+                Cell::new(display_list(&glyph.unicodes)),
+                right(glyph.layer_count),
+            ]);
+        }
+        align_right(&mut table, &[3]);
+
+        section_with_table("Glyphs", table, mode)
+    }
+
+    fn sources_table(&self, mode: RenderMode) -> String {
+        let mut table = base_table();
+        table.set_header(vec![
+            header("name", mode),
+            header("id", mode),
+            header("location", mode),
+            header("file", mode),
+        ]);
+        for source in &self.sources {
+            table.add_row(vec![
+                Cell::new(source_name(source.name.as_str(), source.is_default)),
+                muted(compact_id(&source.id), mode),
+                Cell::new(format_location(&source.location)),
+                Cell::new(source.filename.as_deref().unwrap_or("-")),
+            ]);
+        }
+
+        table.to_string()
+    }
+}
+
+fn base_table() -> Table {
+    let mut table = Table::new();
+    table.load_preset(NOTHING);
+    table.set_content_arrangement(ContentArrangement::Dynamic);
+    table
+}
+
+fn align_right(table: &mut Table, columns: &[usize]) {
+    for column in columns {
+        if let Some(column) = table.column_mut(*column) {
+            column.set_cell_alignment(CellAlignment::Right);
+        }
+    }
+}
+
+fn header(value: &str, mode: RenderMode) -> Cell {
+    match mode {
+        RenderMode::Plain => Cell::new(value),
+        RenderMode::Styled => Cell::new(value)
+            .add_attribute(Attribute::Bold)
+            .fg(Color::DarkGrey),
+    }
+}
+
+fn accent(value: &str, mode: RenderMode) -> Cell {
+    match mode {
+        RenderMode::Plain => Cell::new(value),
+        RenderMode::Styled => Cell::new(value).fg(Color::Cyan),
+    }
+}
+
+fn muted(value: impl Into<String>, mode: RenderMode) -> Cell {
+    let value = value.into();
+    match mode {
+        RenderMode::Plain => Cell::new(value),
+        RenderMode::Styled => Cell::new(value).fg(Color::DarkGrey),
+    }
+}
+
+fn muted_text(value: &str, mode: RenderMode) -> String {
+    match mode {
+        RenderMode::Plain => value.to_string(),
+        RenderMode::Styled => format!(
+            "{}{}{}",
+            anstyle::Style::new()
+                .fg_color(Some(AnsiColor::BrightBlack.into()))
+                .render(),
+            value,
+            anstyle::Reset.render()
+        ),
+    }
+}
+
+fn number(value: f64) -> Cell {
+    Cell::new(format_number(value)).set_alignment(CellAlignment::Right)
+}
+
+fn right(value: impl ToString) -> Cell {
+    Cell::new(value.to_string()).set_alignment(CellAlignment::Right)
+}
+
+fn styled_title(value: &str, mode: RenderMode) -> String {
+    match mode {
+        RenderMode::Plain => value.to_string(),
+        RenderMode::Styled => format!(
+            "{}{}{}",
+            anstyle::Style::new().bold().render(),
+            value,
+            anstyle::Reset.render()
+        ),
+    }
+}
+
+fn styled_section(value: &str, mode: RenderMode) -> String {
+    match mode {
+        RenderMode::Plain => value.to_string(),
+        RenderMode::Styled => format!(
+            "{}{}{}",
+            anstyle::Style::new()
+                .bold()
+                .fg_color(Some(AnsiColor::BrightCyan.into()))
+                .render(),
+            value,
+            anstyle::Reset.render()
+        ),
+    }
+}
+
+fn format_kv(label: &str, value: &str, mode: RenderMode) -> String {
+    match mode {
+        RenderMode::Plain => format!("{label:<8}{value}"),
+        RenderMode::Styled => format!(
+            "{}{label:<8}{}{}",
+            anstyle::Style::new()
+                .fg_color(Some(AnsiColor::BrightBlack.into()))
+                .render(),
+            anstyle::Reset.render(),
+            value
+        ),
+    }
+}
+
+fn format_count(label: &str, value: usize, mode: RenderMode) -> String {
+    format_kv(label, &value.to_string(), mode)
+}
+
+fn empty_section(title: &str, message: &str, mode: RenderMode) -> String {
+    format!(
+        "{}\n{}",
+        styled_section(title, mode),
+        muted_text(message, mode)
+    )
+}
+
+fn section_with_table(title: &str, table: Table, mode: RenderMode) -> String {
+    format!("{}\n{}", styled_section(title, mode), table)
+}
+
+fn source_name(name: &str, is_default: bool) -> String {
+    if is_default {
+        format!("{name}*")
+    } else {
+        name.to_string()
+    }
+}
+
+fn display_list(values: &[String]) -> String {
+    if values.is_empty() {
+        "-".to_string()
+    } else {
+        values.join(" ")
+    }
+}
+
+fn format_location(location: &[LocationValue]) -> String {
+    if location.is_empty() {
+        "{}".to_string()
+    } else {
+        location
+            .iter()
+            .map(|entry| format!("{}={}", entry.axis_tag, format_number(entry.value)))
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+}
+
+fn format_number(value: f64) -> String {
+    if value.fract().abs() < f64::EPSILON {
+        return format!("{value:.0}");
+    }
+
+    let mut text = format!("{value:.4}");
+    while text.contains('.') && text.ends_with('0') {
+        text.pop();
+    }
+    if text.ends_with('.') {
+        text.pop();
+    }
+    text
+}
+
+fn compact_id(value: &str) -> String {
+    const MAX: usize = 22;
+    const HEAD: usize = 16;
+
+    if value.chars().count() <= MAX {
+        value.to_string()
+    } else {
+        format!("{}...", value.chars().take(HEAD).collect::<String>())
+    }
+}

--- a/crates/shift-cli/src/inspect/report.rs
+++ b/crates/shift-cli/src/inspect/report.rs
@@ -1,0 +1,213 @@
+use std::collections::HashMap;
+use std::fmt::Display;
+use std::path::{Path, PathBuf};
+
+use miette::Diagnostic;
+use serde::Serialize;
+use shift_font::{Axis, AxisId, Font, Glyph, Source, SourceId};
+use shift_source::{FORMAT_ID, SCHEMA_VERSION, ShiftSourcePackage, SourcePackageError};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+#[error("failed to inspect source package {path}")]
+pub struct InspectError {
+    path: PathBuf,
+    #[source]
+    source: SourcePackageError,
+}
+
+impl Diagnostic for InspectError {
+    fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        Some(Box::new("shift_cli::inspect::package"))
+    }
+
+    fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        Some(Box::new(
+            "Check that the path points to a readable .shift package.",
+        ))
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ManifestSummary {
+    pub format: String,
+    pub schema_version: u32,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MetadataSummary {
+    pub family_name: Option<String>,
+    pub style_name: Option<String>,
+    pub display_name: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AxisSummary {
+    pub id: String,
+    pub tag: String,
+    pub name: String,
+    pub minimum: f64,
+    pub default: f64,
+    pub maximum: f64,
+    pub hidden: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SourceSummary {
+    pub id: String,
+    pub name: String,
+    pub location: Vec<LocationValue>,
+    pub filename: Option<String>,
+    pub is_default: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocationValue {
+    pub axis_id: String,
+    pub axis_tag: String,
+    pub value: f64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GlyphSummary {
+    pub id: String,
+    pub name: String,
+    pub unicodes: Vec<String>,
+    pub layer_count: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InspectReport {
+    pub path: String,
+    pub file_name: String,
+    pub manifest: ManifestSummary,
+    pub metadata: MetadataSummary,
+    pub axes: Vec<AxisSummary>,
+    pub sources: Vec<SourceSummary>,
+    pub glyph_count: usize,
+    pub glyphs: Vec<GlyphSummary>,
+}
+
+impl InspectReport {
+    pub fn load(path: impl AsRef<Path>) -> Result<Self, InspectError> {
+        let path = path.as_ref();
+        let font = ShiftSourcePackage::load_font(path).map_err(|source| InspectError {
+            path: path.to_path_buf(),
+            source,
+        })?;
+
+        Ok(Self::from_font(path, &font))
+    }
+
+    pub(crate) fn from_font(path: &Path, font: &Font) -> Self {
+        let axes_by_id = axes_by_id(font.axes());
+        let default_source_id = font.default_source_id();
+        let glyphs = font.glyphs().map(GlyphSummary::from).collect::<Vec<_>>();
+
+        Self {
+            path: path.display().to_string(),
+            file_name: file_name(path),
+            manifest: ManifestSummary {
+                format: FORMAT_ID.to_string(),
+                schema_version: SCHEMA_VERSION,
+            },
+            metadata: MetadataSummary {
+                family_name: font.metadata().family_name.clone(),
+                style_name: font.metadata().style_name.clone(),
+                display_name: font.metadata().display_name(),
+            },
+            axes: font.axes().iter().map(AxisSummary::from).collect(),
+            sources: font
+                .sources()
+                .iter()
+                .map(|source| SourceSummary::from_source(source, &axes_by_id, &default_source_id))
+                .collect(),
+            glyph_count: glyphs.len(),
+            glyphs,
+        }
+    }
+}
+
+impl From<&Axis> for AxisSummary {
+    fn from(axis: &Axis) -> Self {
+        Self {
+            id: axis.id().to_string(),
+            tag: axis.tag().to_string(),
+            name: axis.name().to_string(),
+            minimum: axis.minimum(),
+            default: axis.default(),
+            maximum: axis.maximum(),
+            hidden: axis.is_hidden(),
+        }
+    }
+}
+
+impl SourceSummary {
+    fn from_source(
+        source: &Source,
+        axes_by_id: &HashMap<AxisId, String>,
+        default_source_id: &Option<SourceId>,
+    ) -> Self {
+        let mut location = source
+            .location()
+            .iter()
+            .map(|(axis_id, value)| {
+                let axis_tag = axes_by_id
+                    .get(axis_id)
+                    .cloned()
+                    .unwrap_or_else(|| axis_id.to_string());
+                LocationValue {
+                    axis_id: axis_id.to_string(),
+                    axis_tag,
+                    value: *value,
+                }
+            })
+            .collect::<Vec<_>>();
+        location.sort_by(|left, right| left.axis_tag.cmp(&right.axis_tag));
+
+        Self {
+            id: source.id().to_string(),
+            name: source.name().to_string(),
+            location,
+            filename: source.filename().map(ToOwned::to_owned),
+            is_default: default_source_id
+                .as_ref()
+                .is_some_and(|source_id| *source_id == source.id()),
+        }
+    }
+}
+
+impl From<&Glyph> for GlyphSummary {
+    fn from(glyph: &Glyph) -> Self {
+        Self {
+            id: glyph.id().to_string(),
+            name: glyph.name().to_string(),
+            unicodes: glyph
+                .unicodes()
+                .iter()
+                .map(|unicode| format!("U+{unicode:04X}"))
+                .collect(),
+            layer_count: glyph.layers().len(),
+        }
+    }
+}
+
+fn axes_by_id(axes: &[Axis]) -> HashMap<AxisId, String> {
+    axes.iter()
+        .map(|axis| (axis.id(), axis.tag().to_string()))
+        .collect()
+}
+
+fn file_name(path: &Path) -> String {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_else(|| path.to_str().unwrap_or("<package>"))
+        .to_string()
+}

--- a/crates/shift-cli/src/main.rs
+++ b/crates/shift-cli/src/main.rs
@@ -1,0 +1,91 @@
+mod inspect;
+
+use std::io::IsTerminal;
+use std::path::PathBuf;
+
+use anstyle::{AnsiColor, Effects};
+use clap::builder::styling::Styles;
+use clap::{ColorChoice, Parser, Subcommand, ValueEnum};
+use inspect::{InspectOutput, InspectReport, RenderMode};
+use miette::IntoDiagnostic;
+
+const CLAP_STYLES: Styles = Styles::styled()
+    .header(AnsiColor::BrightCyan.on_default().effects(Effects::BOLD))
+    .usage(AnsiColor::BrightCyan.on_default().effects(Effects::BOLD))
+    .literal(AnsiColor::Green.on_default())
+    .placeholder(AnsiColor::BrightBlue.on_default())
+    .error(AnsiColor::Red.on_default().effects(Effects::BOLD))
+    .valid(AnsiColor::Green.on_default())
+    .invalid(AnsiColor::Red.on_default());
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "shift",
+    version,
+    about = "Command-line tools for Shift source packages",
+    color = ColorChoice::Auto,
+    styles = CLAP_STYLES
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Inspect a .shift source package.
+    Inspect(InspectArgs),
+}
+
+#[derive(Debug, Parser)]
+struct InspectArgs {
+    /// Path to a .shift source package.
+    path: PathBuf,
+
+    /// Focus the human-readable output on one section.
+    #[arg(value_enum, default_value_t = InspectView::Summary)]
+    view: InspectView,
+
+    /// Emit stable JSON for scripts and CI.
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum InspectView {
+    Summary,
+    Axes,
+    Sources,
+    Glyphs,
+}
+
+fn main() -> miette::Result<()> {
+    match Cli::parse().command {
+        Command::Inspect(args) => inspect(args),
+    }
+}
+
+fn inspect(args: InspectArgs) -> miette::Result<()> {
+    let report = InspectReport::load(&args.path)?;
+    if args.json {
+        anstream::println!(
+            "{}",
+            serde_json::to_string_pretty(&report).into_diagnostic()?
+        );
+        return Ok(());
+    }
+
+    let output = match args.view {
+        InspectView::Summary => InspectOutput::Summary,
+        InspectView::Axes => InspectOutput::Axes,
+        InspectView::Sources => InspectOutput::Sources,
+        InspectView::Glyphs => InspectOutput::Glyphs,
+    };
+    let mode = if std::io::stdout().is_terminal() {
+        RenderMode::Styled
+    } else {
+        RenderMode::Plain
+    };
+    anstream::println!("{}", report.render(output, mode));
+    Ok(())
+}

--- a/crates/shift-cli/src/main.rs
+++ b/crates/shift-cli/src/main.rs
@@ -1,63 +1,12 @@
+mod cli;
 mod inspect;
 
-use std::io::IsTerminal;
-use std::path::PathBuf;
+use std::io::{self, IsTerminal, Write};
 
-use anstyle::{AnsiColor, Effects};
-use clap::builder::styling::Styles;
-use clap::{ColorChoice, Parser, Subcommand, ValueEnum};
-use inspect::{InspectOutput, InspectReport, RenderMode};
+use clap::Parser;
+use cli::{Cli, Command};
+use inspect::{InspectReport, RenderMode};
 use miette::IntoDiagnostic;
-
-const CLAP_STYLES: Styles = Styles::styled()
-    .header(AnsiColor::BrightCyan.on_default().effects(Effects::BOLD))
-    .usage(AnsiColor::BrightCyan.on_default().effects(Effects::BOLD))
-    .literal(AnsiColor::Green.on_default())
-    .placeholder(AnsiColor::BrightBlue.on_default())
-    .error(AnsiColor::Red.on_default().effects(Effects::BOLD))
-    .valid(AnsiColor::Green.on_default())
-    .invalid(AnsiColor::Red.on_default());
-
-#[derive(Debug, Parser)]
-#[command(
-    name = "shift",
-    version,
-    about = "Command-line tools for Shift source packages",
-    color = ColorChoice::Auto,
-    styles = CLAP_STYLES
-)]
-struct Cli {
-    #[command(subcommand)]
-    command: Command,
-}
-
-#[derive(Debug, Subcommand)]
-enum Command {
-    /// Inspect a .shift source package.
-    Inspect(InspectArgs),
-}
-
-#[derive(Debug, Parser)]
-struct InspectArgs {
-    /// Path to a .shift source package.
-    path: PathBuf,
-
-    /// Focus the human-readable output on one section.
-    #[arg(value_enum, default_value_t = InspectView::Summary)]
-    view: InspectView,
-
-    /// Emit stable JSON for scripts and CI.
-    #[arg(long)]
-    json: bool,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
-enum InspectView {
-    Summary,
-    Axes,
-    Sources,
-    Glyphs,
-}
 
 fn main() -> miette::Result<()> {
     match Cli::parse().command {
@@ -65,27 +14,30 @@ fn main() -> miette::Result<()> {
     }
 }
 
-fn inspect(args: InspectArgs) -> miette::Result<()> {
+fn inspect(args: cli::InspectArgs) -> miette::Result<()> {
     let report = InspectReport::load(&args.path)?;
-    if args.json {
-        anstream::println!(
-            "{}",
-            serde_json::to_string_pretty(&report).into_diagnostic()?
-        );
-        return Ok(());
-    }
-
-    let output = match args.view {
-        InspectView::Summary => InspectOutput::Summary,
-        InspectView::Axes => InspectOutput::Axes,
-        InspectView::Sources => InspectOutput::Sources,
-        InspectView::Glyphs => InspectOutput::Glyphs,
+    let output = if args.json {
+        serde_json::to_string_pretty(&report).into_diagnostic()?
+    } else {
+        report.render(args.view, render_mode())
     };
-    let mode = if std::io::stdout().is_terminal() {
+
+    write_stdout(&output)
+}
+
+fn render_mode() -> RenderMode {
+    if std::io::stdout().is_terminal() {
         RenderMode::Styled
     } else {
         RenderMode::Plain
-    };
-    anstream::println!("{}", report.render(output, mode));
-    Ok(())
+    }
+}
+
+fn write_stdout(output: &str) -> miette::Result<()> {
+    let mut stdout = io::stdout().lock();
+    match writeln!(stdout, "{output}") {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::BrokenPipe => Ok(()),
+        Err(error) => Err(error).into_diagnostic(),
+    }
 }

--- a/crates/shift-source/src/lib.rs
+++ b/crates/shift-source/src/lib.rs
@@ -1,7 +1,7 @@
 mod package;
 
 pub use package::{
-    AXES_FILE, FEATURES_FILE, FONT_FILE, GLYPHS_DIR, KERNING_FILE, LIB_MODULE_FILE, MANIFEST_FILE,
-    MODULES_DIR, PackageTree, SOURCES_FILE, ShiftSourcePackage, SourcePackageError, font_to_tree,
-    read_tree, tree_to_font, write_tree_atomic,
+    AXES_FILE, FEATURES_FILE, FONT_FILE, FORMAT_ID, GLYPHS_DIR, KERNING_FILE, LIB_MODULE_FILE,
+    MANIFEST_FILE, MODULES_DIR, PackageTree, SCHEMA_VERSION, SOURCES_FILE, ShiftSourcePackage,
+    SourcePackageError, font_to_tree, read_tree, tree_to_font, write_tree_atomic,
 };

--- a/crates/shift-source/src/package.rs
+++ b/crates/shift-source/src/package.rs
@@ -25,8 +25,8 @@ pub const GLYPHS_DIR: &str = "glyphs";
 pub const MODULES_DIR: &str = "modules";
 pub const LIB_MODULE_FILE: &str = "modules/shift.libData.json";
 
-const FORMAT_ID: &str = "shift-source";
-const SCHEMA_VERSION: u32 = 1;
+pub const FORMAT_ID: &str = "shift-source";
+pub const SCHEMA_VERSION: u32 = 1;
 const KERNING_SCHEMA_VERSION: u32 = 1;
 const LIB_MODULE_OWNER: &str = "shift";
 const LIB_MODULE_NAME: &str = "libData";


### PR DESCRIPTION
## Summary

- Split the new `shift inspect` CLI into smaller modules for clap parsing, report extraction, and terminal rendering.
- Make the human-readable command shape clearer with `shift inspect [OPTIONS] <PATH>` and `--view`.
- Keep JSON output more script-friendly by serializing source location values as numbers.
- Add readme coverage for the CLI crate and root project docs.

## Validation

- `cargo test -p shift-cli`
- `cargo fmt --check`
- `cargo clippy -p shift-cli --all-targets -- -D warnings`
- `cargo run -p shift-cli -- inspect --help`
- Commit pre-commit hooks: cargo check, cargo fmt, cargo clippy, cargo test, oxfmt
