### PR TITLE
[codex] Use short readable entity IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1930,13 +1930,13 @@ name = "shift-font"
 version = "0.1.0"
 dependencies = [
  "fontdrasil 0.4.0",
+ "getrandom",
  "indexmap",
  "kurbo 0.13.0",
  "linesweeper",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "uuid",
 ]
 
 [[package]]

--- a/apps/desktop/src/utility/workspace/WorkspaceHost.test.ts
+++ b/apps/desktop/src/utility/workspace/WorkspaceHost.test.ts
@@ -559,7 +559,7 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     expect(state?.layerId).toBe(layerId);
     expect(state?.structure.contours).toEqual([]);
 
-    const missing = `layer_${crypto.randomUUID()}` as LayerId;
+    const missing = mintLayerId();
     await expect(sync.call("workspace.layer", { layerId: missing })).resolves.toBeNull();
   });
 

--- a/crates/shift-bridge/__test__/index.spec.mjs
+++ b/crates/shift-bridge/__test__/index.spec.mjs
@@ -7,7 +7,20 @@ import { join } from "path";
 const require = createRequire(import.meta.url);
 const { Bridge } = require("../index.js");
 
-const mintId = (prefix) => `${prefix}_${crypto.randomUUID()}`;
+const shortIdAlphabet = "useandom-26T198340PX75pxJACKVERYMINDBUSHWOLF_GQZbfghjklqvwyzrict";
+const shortIdLength = 10;
+const shortIdAlphabetMask = shortIdAlphabet.length - 1;
+
+function mintId(prefix) {
+  const bytes = new Uint8Array(shortIdLength);
+  crypto.getRandomValues(bytes);
+
+  let suffix = "";
+  for (let i = 0; i < bytes.length; i++) {
+    suffix += shortIdAlphabet[bytes[i] & shortIdAlphabetMask];
+  }
+  return `${prefix}_${suffix}`;
+}
 
 describe("Bridge", () => {
   let bridge;

--- a/crates/shift-font/Cargo.toml
+++ b/crates/shift-font/Cargo.toml
@@ -18,7 +18,7 @@ kurbo = "0.13.0"
 linesweeper = "0.3.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 thiserror = "2.0.18"
-uuid = { version = "1.17.0", features = ["v4"] }
+getrandom = "0.3.3"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/crates/shift-font/src/ir/entity.rs
+++ b/crates/shift-font/src/ir/entity.rs
@@ -1,5 +1,10 @@
 use serde::{Deserialize, Serialize};
 
+const SHORT_ID_ALPHABET: &[u8; 64] =
+    b"useandom-26T198340PX75pxJACKVERYMINDBUSHWOLF_GQZbfghjklqvwyzrict";
+const SHORT_ID_SUFFIX_LENGTH: usize = 10;
+const SHORT_ID_ALPHABET_MASK: u8 = (SHORT_ID_ALPHABET.len() - 1) as u8;
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct EntityId(String);
 
@@ -101,7 +106,17 @@ impl std::fmt::Display for InvalidEntityId {
 impl std::error::Error for InvalidEntityId {}
 
 fn prefixed_id(prefix: &str) -> String {
-    format!("{prefix}_{}", uuid::Uuid::new_v4().simple())
+    format!("{prefix}_{}", short_id_suffix())
+}
+
+fn short_id_suffix() -> String {
+    let mut bytes = [0; SHORT_ID_SUFFIX_LENGTH];
+    getrandom::fill(&mut bytes).expect("secure random ID generation failed");
+
+    bytes
+        .iter()
+        .map(|byte| SHORT_ID_ALPHABET[(byte & SHORT_ID_ALPHABET_MASK) as usize] as char)
+        .collect()
 }
 
 typed_id!(PointId, "point");
@@ -123,6 +138,17 @@ mod tests {
         let id1 = EntityId::new();
         let id2 = EntityId::new();
         assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn typed_id_new_uses_short_readable_suffix() {
+        let id = SourceId::new();
+        let Some(suffix) = id.as_str().strip_prefix("source_") else {
+            panic!("source id should keep its typed prefix");
+        };
+
+        assert_eq!(suffix.len(), SHORT_ID_SUFFIX_LENGTH);
+        assert!(suffix.bytes().all(|byte| SHORT_ID_ALPHABET.contains(&byte)));
     }
 
     #[test]

--- a/packages/types/src/ids.ts
+++ b/packages/types/src/ids.ts
@@ -2,7 +2,7 @@
  * Branded ID types for type-safe identification of font entities.
  *
  * These types ensure compile-time safety when working with IDs across the
- * TS/Rust boundary. Ids are prefixed strings (`point_<uuid>`). The renderer
+ * TS/Rust boundary. Ids are prefixed strings (`point_<short-id>`). The renderer
  * MINTS ids for entities it creates (client-minted ids: verbs return
  * identity synchronously; Rust validates and honors them); all other ids
  * come from Rust.
@@ -219,44 +219,78 @@ export function isValidSourceId(id: unknown): id is SourceId {
   return typeof id === "string" && id.length > 0;
 }
 
+const SHORT_ID_ALPHABET = "useandom-26T198340PX75pxJACKVERYMINDBUSHWOLF_GQZbfghjklqvwyzrict";
+const SHORT_ID_SUFFIX_LENGTH = 10;
+const SHORT_ID_ALPHABET_MASK = SHORT_ID_ALPHABET.length - 1;
+
+type MintedIdByPrefix = {
+  point: PointId;
+  contour: ContourId;
+  anchor: AnchorId;
+  axis: AxisId;
+  component: ComponentId;
+  guideline: GuidelineId;
+  glyph: GlyphId;
+  layer: LayerId;
+  source: SourceId;
+};
+
 // Web Crypto's global, present in both the renderer and node >= 19. The
 // shared lib config deliberately includes neither DOM nor node types.
-declare const crypto: { randomUUID(): string };
+declare const crypto: { getRandomValues<T extends Uint8Array>(array: T): T };
+
+function mintShortIdSuffix(): string {
+  const bytes = new Uint8Array(SHORT_ID_SUFFIX_LENGTH);
+  crypto.getRandomValues(bytes);
+
+  let suffix = "";
+  for (let i = 0; i < bytes.length; i++) {
+    const byte = bytes[i];
+    suffix += SHORT_ID_ALPHABET[byte & SHORT_ID_ALPHABET_MASK];
+  }
+  return suffix;
+}
+
+function mintPrefixedId<Prefix extends keyof MintedIdByPrefix>(
+  prefix: Prefix,
+): MintedIdByPrefix[Prefix] {
+  return `${prefix}_${mintShortIdSuffix()}` as MintedIdByPrefix[Prefix];
+}
 
 /**
  * Mints a new point id. Client-minted ids let editing verbs return identity
  * synchronously; Rust honors them and rejects duplicates.
  */
 export function mintPointId(): PointId {
-  return `point_${crypto.randomUUID()}` as PointId;
+  return mintPrefixedId("point");
 }
 
 /** Mints a new contour id. See {@link mintPointId}. */
 export function mintContourId(): ContourId {
-  return `contour_${crypto.randomUUID()}` as ContourId;
+  return mintPrefixedId("contour");
 }
 
 /** Mints a new anchor id. See {@link mintPointId}. */
 export function mintAnchorId(): AnchorId {
-  return `anchor_${crypto.randomUUID()}` as AnchorId;
+  return mintPrefixedId("anchor");
 }
 
 /** Mints a new axis id. See {@link mintPointId}. */
 export function mintAxisId(): AxisId {
-  return `axis_${crypto.randomUUID()}` as AxisId;
+  return mintPrefixedId("axis");
 }
 
 /** Mints a new glyph id. See {@link mintPointId}. */
 export function mintGlyphId(): GlyphId {
-  return `glyph_${crypto.randomUUID()}` as GlyphId;
+  return mintPrefixedId("glyph");
 }
 
 /** Mints a new layer id. See {@link mintPointId}. */
 export function mintLayerId(): LayerId {
-  return `layer_${crypto.randomUUID()}` as LayerId;
+  return mintPrefixedId("layer");
 }
 
 /** Mints a new source id. See {@link mintPointId}. */
 export function mintSourceId(): SourceId {
-  return `source_${crypto.randomUUID()}` as SourceId;
+  return mintPrefixedId("source");
 }


### PR DESCRIPTION
## Summary

- Replace UUID-style font entity ID minting with 10-character Nano ID-style suffixes in TypeScript and Rust.
- Keep renderer client-minted IDs and Rust-minted IDs on the same alphabet/length policy.
- Update bridge/workspace tests that minted synthetic entity IDs to use the short ID style.

## Details

The suffix uses Nano ID's URL-safe 64-character alphabet with length 10, giving 60 bits of entropy while keeping .shift JSON easier to inspect. Rust now uses getrandom directly for entity IDs instead of uuid.

## Validation

- Pre-commit hook passed: cargo check, cargo fmt, cargo clippy, cargo test, oxfmt, oxlint, tsgo typecheck, strict deadcode, vitest.
- pnpm --filter @shift/types typecheck
- pnpm --filter @shift/desktop typecheck
- pnpm --filter shift-bridge test
- cargo test -p shift-font
- git diff --check