### PR TITLE
Stabilize package identity for workspaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1945,6 +1945,7 @@ dependencies = [
 name = "shift-source"
 version = "0.1.0"
 dependencies = [
+ "getrandom",
  "serde",
  "serde_json",
  "shift-font",

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -255,6 +255,7 @@ These are allowed to jump around when energy is high, but they should not silent
 
 - [x] UFO format loading (via norad library)
 - [x] Binary font loading (TTF/OTF via skrifa library)
+- [x] Stable `.shift` package identity with package-instance working document bindings
 - [x] FontLoader with adaptor pattern for extensibility
 - [x] Font compilation to binary (via fontc)
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -75,6 +75,7 @@
     "shift-bridge": "workspace:*",
     "tailwind-merge": "^3.3.1",
     "throttle-debounce": "^5.0.2",
-    "zustand": "^5.0.6"
+    "zustand": "^5.0.6",
+    "zod": "^4.1.12"
   }
 }

--- a/apps/desktop/src/main/app/App.ts
+++ b/apps/desktop/src/main/app/App.ts
@@ -56,8 +56,12 @@ export class App {
   constructor(log: ShiftLogger = createShiftLogger("app")) {
     this.#log = log;
     this.#lifecycle = new AppLifecycle({
-      documentForWindow: (window) =>
-        this.#workspaces.getForBrowserWindow(window.window)?.document ?? null,
+      documentForWindow: (window) => {
+        const session = this.#workspaces.getForBrowserWindow(window.window);
+        if (!session || session.windows.size > 1) return null;
+
+        return session.document;
+      },
       documents: () => this.#workspaces.list().map((session) => session.document),
       log: this.#log,
     });

--- a/apps/desktop/src/main/app/App.ts
+++ b/apps/desktop/src/main/app/App.ts
@@ -258,7 +258,18 @@ export class App {
     if (!openPath) return;
 
     const session = await this.#workspaces.openPath(openPath);
+    if (this.#focusExistingWorkspaceWindow(opener, session)) return;
+
     this.#openWorkspaceWindow(opener, session);
+  }
+
+  #focusExistingWorkspaceWindow(opener: Window, session: WorkspaceSession): boolean {
+    const existingWindow = session.activeWindow();
+    if (!existingWindow) return false;
+
+    existingWindow.focus();
+    if (this.#workspaces.getForBrowserWindow(opener.window) === null) opener.close();
+    return true;
   }
 
   #openWorkspaceWindow(opener: Window, session: WorkspaceSession): void {

--- a/apps/desktop/src/main/docs/DOCS.md
+++ b/apps/desktop/src/main/docs/DOCS.md
@@ -1,114 +1,103 @@
 # Main
 
-Electron main process: application lifecycle, window management, menus, document state, and external file opening.
+Electron main process: app startup, windows, menus, document dialogs, and workspace session ownership.
 
 ## Architecture Invariants
 
-- **Architecture Invariant:** All managers receive dependencies via constructor injection in `main.ts`. `DocumentState` is the root dependency; `WindowManager` depends on it; `MenuManager` depends on both; `AppLifecycle` depends on all three.
-- **Architecture Invariant:** `DocumentState` is the single source of truth for dirty state and file path. All save/close dialogs flow through `DocumentState.confirmClose`. No manager may show its own save dialog.
-- **Architecture Invariant:** IPC channels are type-safe. All `ipcMain.handle` calls use the typed `ipc.handle` wrapper from `shared/ipc/main`, and all `webContents.send` calls use the typed `ipc.send` wrapper. Channel names and payload types are defined in `RendererToMain` and `MainToRenderer`.
-- **Architecture Invariant: CRITICAL:** `main.ts` enforces a single-instance lock via `app.requestSingleInstanceLock()`. The second instance forwards its argv to the first instance via the `second-instance` event and then quits. Removing this breaks file-association double-click on all platforms.
-- **Architecture Invariant: CRITICAL:** The `before-quit` handler in `AppLifecycle` must call `event.preventDefault()` before the async `confirmClose` check. If the guard is removed, the app quits before the save dialog can appear.
-- **Architecture Invariant:** `.shift` is the only direct writable source format (`DocumentState.isWritableFormat`). Imported font formats can be opened, but saving them triggers Save As to a `.shift` package. Export is a separate workflow.
+- **Architecture Invariant:** `WorkspaceManager` owns live workspace sessions. Windows attach to sessions; commands and IPC resolve the session from the focused window or sender.
+- **Architecture Invariant:** Each workspace session owns one `WorkspaceProcess`, one `DocumentClient`, and one `DocumentSession`. Main never reads or mutates font data directly.
+- **Architecture Invariant:** Dirty state and save targets come from the utility-owned workspace state. Main shows native dialogs, but state reads and saves go through the renderer document lane so pending edits flush first.
+- **Architecture Invariant:** A `.shift` package session is reused by `(packageId, canonicalPath)`, not by the path string the user selected and not by the current document id.
+- **Architecture Invariant:** Closing the last window for a workspace runs `DocumentSession.confirmClose`. Clean documents and explicitly discarded dirty documents are closed through the utility process so package bindings and SQLite documents are pruned.
+- **Architecture Invariant:** IPC channels are type-safe. `ipcMain.handle` calls use the typed wrapper from `shared/ipc/main`, and channel names and payload types live in `shared/ipc/contract.ts` and `shared/workspace/protocol.ts`.
 
 ## Codemap
 
-```
+```text
 src/main/
-  main.ts                       # Entry point: single-instance lock, manager wiring
-  managers/
-    AppLifecycle.ts              # App events, quit flow, external file open queue, IPC for theme/dialog/debug/fs
-    WindowManager.ts             # BrowserWindow creation, close handling, IPC for window/document channels
-    DocumentState.ts             # Dirty tracking, file path, save/confirmClose dialogs, autosave
-    MenuManager.ts               # Application menu (File/Edit/View/Debug), theme switching, zoom, debug overlays
-    openFontPath.ts              # Font path validation and argv extraction
-    openFontPath.test.ts         # Tests for openFontPath
-    index.ts                     # Re-exports
+  main.ts                         -- Electron entry point
+  app/
+    App.ts                        -- app service graph, IPC handlers, command context
+    AppLifecycle.ts               -- close/quit confirmation flow
+    AppIcon.ts                    -- dock/tray icon asset helper
+  commands/
+    Command.ts                    -- command registry and command context types
+    Commands.ts                   -- built-in shell commands
+  document/
+    DocumentClient.ts             -- main client for the renderer document lane
+    DocumentSession.ts            -- native save/save-as/close workflow
+    openFontDialog.ts             -- native open dialog
+  menu/
+    ApplicationMenu.ts            -- Electron application menu
+  windows/
+    Window.ts                     -- BrowserWindow wrapper
+    WindowManager.ts              -- live window registry
+  workspace/
+    WorkspaceManager.ts           -- live workspace session registry and package-session dedupe
+    WorkspaceProcess.ts           -- utility-process shell-lane controller
+    WorkspaceSession.ts           -- process/document/window grouping for one workspace
 ```
 
 ## Key Types
 
-- `ThemeName` -- `"light" | "dark" | "system"`, stored in `MenuManager.currentTheme`
-- `Debug` -- aggregates `reactScanEnabled`, `debugPanelOpen`, and `DebugOverlays`; only used in dev builds
-- `DebugOverlays` -- per-overlay booleans (`tightBounds`, `hitRadii`, `segmentBounds`, `glyphBbox`)
-- `RendererToMain` -- renderer-to-main request/response channels (invoke/handle)
-- `MainToRenderer` -- main-to-renderer broadcast channels (send/on)
-- `SUPPORTED_FONT_EXTENSIONS` -- the set of file extensions accepted for opening (`.shift`, `.ufo`, `.ttf`, `.otf`, `.glyphs`, `.glyphspackage`, `.designspace`)
+- `WorkspaceManager` -- registry for live workspace sessions and window attachments.
+- `WorkspaceSession` -- owns the utility process, renderer document lane, document workflow, and attached windows for one workspace.
+- `WorkspaceProcess` -- starts the utility process and exposes shell-lane calls such as create, inspect package, open, close, and document state.
+- `DocumentClient` -- request client for renderer-served document state/save calls.
+- `DocumentSession` -- native document workflow for Save, Save As, and close confirmation.
+- `AppLifecycle` -- coordinates Electron window close and app quit around document vetoes.
+- `WorkspaceDocumentState` -- utility-owned lifecycle state mirrored into main and renderer.
 
 ## How it works
 
 ### Startup
 
-`main.ts` checks `electron-squirrel-startup` (Windows installer events), then acquires a single-instance lock. If this is the second instance, it quits and the first instance receives `second-instance` with the new argv. Otherwise, it constructs the four managers and calls `AppLifecycle.handleLaunchArgs` (to queue any CLI font path) then `AppLifecycle.initialize`.
+`main.ts` constructs `App` and calls `start()`. `App` registers commands and IPC handlers, starts `AppLifecycle`, sets the user-data-backed `working-documents` root, creates the launcher window, and installs the application menu.
 
-### Window creation
+### Workspace Creation And Open
 
-`WindowManager.create` builds a frameless `BrowserWindow` (hidden traffic lights, custom title bar), maximizes it, wires `DocumentState` for title updates, starts autosave, and loads the Vite dev server URL or the built `index.html`. The window's `close` event delegates to `DocumentState.confirmClose` when dirty.
+File -> New asks `WorkspaceManager.createUntitled()` for a session. File -> Open shows `showOpenFontDialog()` and then asks `WorkspaceManager.openPath(path)`.
 
-### Quit flow
+For `.shift` paths, `WorkspaceManager` starts a provisional utility process and calls `workspace.inspectPackage` before opening. If a live session already owns the same `(packageId, canonicalPath)`, the provisional process is stopped and the existing session is returned. Otherwise the process opens the package and the resulting state is registered.
 
-Any quit trigger (Cmd+Q, menu, window close button) eventually hits `AppLifecycle`'s `before-quit` handler. It calls `event.preventDefault()`, runs the async `DocumentState.confirmClose` dialog, and only if the user confirms does it set `isQuitting = true`, mark `WindowManager` as quitting (to skip the per-window close dialog), stop autosave, and call `app.quit()` again.
+### Window Attachment
 
-### External file opening
+`App` creates a BrowserWindow, attaches it to the returned `WorkspaceSession`, and loads the workspace route. Multiple windows may attach to the same session. Closing one of several windows does not close the document; closing the last window does.
 
-Files arrive via three paths: CLI launch args (`handleLaunchArgs`), second-instance argv (`handleSecondInstance`), and macOS `open-file` events. All three funnel through `enqueueExternalOpenPath`, which validates via `normalizeFontPath` and pushes to `pendingExternalOpenPaths`. The queue is drained serially by `processPendingExternalOpenPaths`, which waits for the window to finish loading, then calls `openExternalFont`. If the current document is dirty, `confirmClose` runs first; on confirmation the path is sent to the renderer via the `external:open-font` IPC event.
+### Save And Close
 
-### Save and autosave
+Save and Save As start in `DocumentSession`, but the actual save request goes through `DocumentClient` to the renderer document lane. The renderer flushes queued edits through the workspace sync lane before calling `workspace.save` or `workspace.saveAs`.
 
-`DocumentState.save` checks `isWritableFormat` -- only `.shift` packages can be saved in-place. Imported formats and Save As show the save dialog with Shift Source Package as the default filter. On save, the main process sends `menu:save-font` to the renderer, which writes through the Rust workspace and calls back `document:saveCompleted`. Autosave runs on a 30-second interval (`AUTOSAVE_INTERVAL_MS`) and only fires if dirty and the file is writable.
+Close and quit call `DocumentSession.confirmClose`. If the document is clean, or the user saves successfully, or the user chooses discard, `DocumentSession` calls `workspace.close` in the utility process. The utility drops the Rust workspace handle, removes package bindings, and deletes the clean/discarded SQLite document. Dirty divergent documents created by package-source conflicts are orphaned by the utility process, not by main.
 
-### Menu
+### IPC
 
-`MenuManager.create` rebuilds the entire menu template each time it is called (to update radio/checkbox state). It includes File (new/open/save), Edit (undo/redo/delete/select-all forwarded to renderer), View (zoom, theme, devtools), and a Debug menu (only in dev builds) for React Scan, debug panel, snapshot dumps, and overlay toggles. File -> New Font and File -> Open Font both run through `DocumentState.confirmClose` before asking the renderer to replace the current document.
+Renderer IPC in `App` is limited to shell capabilities: command execution, clipboard, document-lane port transfer, and workspace sync-lane port transfer. Font data stays on the workspace sync lane between renderer and utility.
 
-### IPC registration
+## Workflow Recipes
 
-IPC handlers are split across managers. `WindowManager` registers window-control and document-state channels in its constructor. `AppLifecycle` registers theme, debug, dialog, and filesystem channels in `registerIpcHandlers`.
+### Add a workspace shell call
 
-## Workflow recipes
+1. Add the request/response type to `shared/workspace/protocol.ts`.
+2. Serve it in `utility/workspace/WorkspaceHost.ts`.
+3. Add a method on `main/workspace/WorkspaceProcess.ts` if main needs to call it.
+4. Add or update `WorkspaceHost.test.ts` with observable state assertions.
 
-### Add a new IPC command (renderer calls main)
+### Add a File menu command
 
-1. Add the channel signature to `RendererToMain` in `shared/ipc/contract.ts`.
-2. Add the handler using `ipc.handle(ipcMain, "your:channel", ...)` in whichever manager owns the domain.
-3. Expose it in the preload layer (see preload DOCS.md).
-
-### Add a new main-to-renderer event
-
-1. Add the channel signature to `MainToRenderer` in `shared/ipc/contract.ts`.
-2. Send via `ipc.send(webContents, "your:channel", ...)` from a manager.
-3. Listen in the renderer via the preload bridge.
-
-### Add a menu item
-
-1. Add a new entry in `MenuManager.create`'s template array under the appropriate submenu.
-2. If it triggers a renderer action, add a channel to `MainToRenderer` and send it through the typed IPC wrapper.
-3. Call `this.create()` if the menu item state needs to update after clicking (checkboxes, radios).
-
-### Support a new writable format
-
-1. Update `DocumentState.isWritableFormat` to accept the new extension.
-2. Update the save dialog filter in `DocumentState.save`.
-3. Update `SUPPORTED_FONT_EXTENSIONS` in `openFontPath.ts` if the format should also be openable.
-
-## Gotchas
-
-- `MenuManager.create` rebuilds the entire Electron menu from scratch. This is intentional -- Electron menus are immutable once built. Mutating the template object has no effect; you must call `Menu.setApplicationMenu` again.
-- The `before-quit` handler uses a re-entrant pattern: it prevents quit, does async work, then calls `app.quit()` again with `isQuitting = true` to skip the guard on the second pass. Breaking this flag logic causes an infinite quit loop.
-- `WindowManager` registers its IPC handlers in the constructor, before `create` is called. This means `this.window` is null during handler registration and handlers must null-check it.
-- The Debug menu is conditionally included only when `!app.isPackaged`. Debug IPC handlers are always registered regardless, but they are harmless in production since no menu triggers them.
-- `processPendingExternalOpenPaths` is designed to be re-entrant safe via the `processingExternalOpenPath` flag. It processes one file at a time and recurses through `.finally()`.
+1. Add a command in `commands/Commands.ts`.
+2. Implement it through the command context in `app/App.ts`.
+3. Keep native dialogs in `document/` and workspace ownership in `workspace/`.
 
 ## Verification
 
-- `npx vitest run apps/desktop/src/main/managers/openFontPath.test.ts` -- openFontPath unit tests
-- Manual: launch with a font path argument, verify it opens
-- Manual: edit a document, Cmd+Q, verify save dialog appears
-- Manual: open a .ttf, Cmd+S, verify Save As dialog defaults to .shift
+- `pnpm --filter @shift/desktop test src/utility/workspace/WorkspaceHost.test.ts`
+- `pnpm typecheck`
+- Manual: open the same `.shift` package twice and verify the existing workspace session is reused.
+- Manual: edit a package, close the last window, and verify the save/discard prompt appears.
 
 ## Related
 
-- `RendererToMain`, `MainToRenderer` -- type-safe IPC channel definitions in `shared/ipc/contract.ts`
-- `ipc.send`, `ipc.handle` -- typed wrappers in `shared/ipc/main.ts`
-- `ThemeName`, `Debug`, `DebugOverlays` -- shared types in `shared/ipc/types.ts`
-- Preload bridge -- exposes IPC to renderer (see preload DOCS.md)
+- `shared/workspace/protocol.ts` -- utility shell/sync channel types.
+- `utility/workspace/WorkspaceHost.ts` -- utility-process owner of the Rust bridge and working documents.
+- `@shift/bridge` -- runtime native bridge package.

--- a/apps/desktop/src/main/document/DocumentSession.ts
+++ b/apps/desktop/src/main/document/DocumentSession.ts
@@ -1,9 +1,4 @@
-import {
-  dialog,
-  type MessageBoxOptions,
-  type OpenDialogOptions,
-  type SaveDialogOptions,
-} from "electron";
+import { dialog, type MessageBoxOptions, type SaveDialogOptions } from "electron";
 import path from "node:path";
 import { errorToMessage } from "../../shared/errors";
 import type { WorkspaceDocumentState } from "../../shared/workspace/protocol";
@@ -11,25 +6,16 @@ import type { Window } from "../windows/Window";
 import type { Document } from "./DocumentClient";
 import { createShiftLogger, type ShiftLogger } from "../logging";
 
-const OPEN_FONT_EXTENSIONS = [
-  "shift",
-  "ttf",
-  "otf",
-  "glyphs",
-  "glyphspackage",
-  "ufo",
-  "designspace",
-];
-
 export type DocumentSessionOptions = {
   document: Document;
+  closeDocument: (discard: boolean) => Promise<void>;
   dialogWindow: () => Window | null;
   windows: () => readonly Window[];
   applicationName: () => string;
   log?: ShiftLogger;
 };
 
-export type CloseReason = "window" | "quit" | "replace-document";
+export type CloseReason = "window" | "quit";
 type DirtyDocumentChoice = "save" | "discard" | "cancel";
 
 /**
@@ -42,6 +28,7 @@ type DirtyDocumentChoice = "save" | "discard" | "cancel";
  */
 export class DocumentSession {
   readonly #document: Document;
+  readonly #closeDocument: (discard: boolean) => Promise<void>;
   readonly #dialogWindow: () => Window | null;
   readonly #windows: () => readonly Window[];
   readonly #applicationName: () => string;
@@ -51,47 +38,11 @@ export class DocumentSession {
 
   constructor(options: DocumentSessionOptions) {
     this.#document = options.document;
+    this.#closeDocument = options.closeDocument;
     this.#dialogWindow = options.dialogWindow;
     this.#windows = options.windows;
     this.#applicationName = options.applicationName;
     this.#log = options.log ?? createShiftLogger("document.session");
-  }
-
-  /** Creates an untitled workspace through the renderer edit lane. */
-  async create(): Promise<void> {
-    this.#log.info("new document requested");
-    if (!(await this.confirmClose("replace-document"))) {
-      this.#log.info("new document canceled by close guard");
-      return;
-    }
-
-    await this.#document.create();
-    this.#log.info("new document created");
-  }
-
-  /** Runs Open from main with a native open dialog. */
-  async open(): Promise<void> {
-    this.#log.info("open document requested");
-    const openPath = await this.#showOpenDialog();
-    if (!openPath) {
-      this.#log.info("open document canceled before file selection");
-      return;
-    }
-
-    if (!(await this.confirmClose("replace-document"))) {
-      this.#log.info("open document canceled by close guard", { path: openPath });
-      return;
-    }
-
-    try {
-      await this.#requestOpen(openPath);
-    } catch (error) {
-      this.#log.warn("open document failed", { path: openPath }, error);
-      await this.#showOpenFailedDialog(openPath, error);
-      return;
-    }
-
-    this.#log.info("open document completed", { path: openPath });
   }
 
   /** Returns whether a close transition needs document confirmation. */
@@ -126,6 +77,7 @@ export class DocumentSession {
     }
 
     if (!state.dirty) {
+      await this.#closeDocument(false);
       this.#log.info("close guard allowed: document is clean", { reason });
       return true;
     }
@@ -144,11 +96,13 @@ export class DocumentSession {
     }
 
     if (choice === "discard") {
+      await this.#closeDocument(true);
       this.#log.info("close guard allowed: changes discarded", { reason });
       return true;
     }
 
     const saved = await this.#saveDirtyDocument(state);
+    if (saved) await this.#closeDocument(false);
     this.#log.info(
       saved ? "close guard allowed: document saved" : "close guard blocked: save failed",
       {
@@ -263,11 +217,6 @@ export class DocumentSession {
     return state;
   }
 
-  async #requestOpen(openPath: string): Promise<void> {
-    this.#log.info("document open sent to renderer", { path: openPath });
-    await this.#document.open(openPath);
-  }
-
   async #showSaveDialog(state: WorkspaceDocumentState): Promise<string | null> {
     const options: SaveDialogOptions = {
       title: "Save Shift Document",
@@ -329,55 +278,8 @@ export class DocumentSession {
     await dialog.showMessageBox(options);
   }
 
-  async #showOpenFailedDialog(openPath: string, error: unknown): Promise<void> {
-    const options: MessageBoxOptions = {
-      type: "error",
-      buttons: ["OK"],
-      defaultId: 0,
-      title: this.#applicationName(),
-      message: "The font could not be loaded.",
-      detail: `${openPath}\n\n${errorToMessage(error)}`,
-    };
-
-    const window = this.#dialogWindow();
-    if (window) {
-      await dialog.showMessageBox(window.window, options);
-      return;
-    }
-
-    await dialog.showMessageBox(options);
-  }
-
-  #dirtyDocumentMessage(reason: CloseReason, name: string): string {
-    if (reason === "replace-document") {
-      return `Save changes to ${name} before replacing it?`;
-    }
-
+  #dirtyDocumentMessage(_reason: CloseReason, name: string): string {
     return `Save changes to ${name} before closing?`;
-  }
-
-  async #showOpenDialog(): Promise<string | null> {
-    const options: OpenDialogOptions = {
-      title: "Open Font",
-      filters: [
-        { name: "Supported Fonts", extensions: OPEN_FONT_EXTENSIONS },
-        { name: "Shift Source Package", extensions: ["shift"] },
-        { name: "TrueType/OpenType", extensions: ["ttf", "otf"] },
-        { name: "Glyphs", extensions: ["glyphs", "glyphspackage"] },
-        { name: "UFO/Designspace", extensions: ["ufo", "designspace"] },
-      ],
-      properties: process.platform === "darwin" ? ["openFile", "openDirectory"] : ["openFile"],
-    };
-
-    const window = this.#dialogWindow();
-    const result = window
-      ? await dialog.showOpenDialog(window.window, options)
-      : await dialog.showOpenDialog(options);
-
-    if (result.canceled) return null;
-    if (result.filePaths.length !== 1) return null;
-
-    return result.filePaths[0];
   }
 
   #updateWindowTitle(): void {

--- a/apps/desktop/src/main/windows/Window.ts
+++ b/apps/desktop/src/main/windows/Window.ts
@@ -84,6 +84,15 @@ export class Window {
     this.#window.close();
   }
 
+  focus(): void {
+    if (this.#window.isMinimized()) {
+      this.#window.restore();
+    }
+
+    this.#window.show();
+    this.#window.focus();
+  }
+
   /** Updates the native window title shown by the operating system. */
   setTitle(title: string): void {
     this.#window.setTitle(title);

--- a/apps/desktop/src/main/workspace/PackageSessionIndex.test.ts
+++ b/apps/desktop/src/main/workspace/PackageSessionIndex.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import type {
+  WorkspaceDocumentState,
+  WorkspacePackageIdentity,
+} from "../../shared/workspace/protocol";
+import { PackageSessionIndex, type IndexedPackageSession } from "./PackageSessionIndex";
+import type { WorkspaceId } from "./WorkspaceSession";
+
+class DocumentChangeSource {
+  readonly #listeners = new Set<(state: WorkspaceDocumentState | null) => void>();
+
+  onDocumentChanged(listener: (state: WorkspaceDocumentState | null) => void): () => void {
+    this.#listeners.add(listener);
+
+    return () => {
+      this.#listeners.delete(listener);
+    };
+  }
+
+  emit(state: WorkspaceDocumentState | null): void {
+    for (const listener of this.#listeners) listener(state);
+  }
+}
+
+describe("PackageSessionIndex keeps one live session per package address", () => {
+  function session(workspaceId: WorkspaceId): {
+    source: DocumentChangeSource;
+    session: IndexedPackageSession;
+  } {
+    const source = new DocumentChangeSource();
+    return {
+      source,
+      session: {
+        workspaceId,
+        workspaceProcess: source,
+      },
+    };
+  }
+
+  function identity(packageId: string, canonicalPath: string): WorkspacePackageIdentity {
+    return {
+      packageId,
+      canonicalPath,
+      fingerprint: "",
+    };
+  }
+
+  function packageState(
+    workspaceId: WorkspaceId,
+    packageId: string,
+    canonicalPath: string,
+  ): WorkspaceDocumentState {
+    return {
+      documentId: workspaceId,
+      sourceKind: "package",
+      saveTarget: canonicalPath,
+      packageId,
+      canonicalPath,
+      dirty: false,
+      needsSaveAs: false,
+    };
+  }
+
+  function untitledState(workspaceId: WorkspaceId): WorkspaceDocumentState {
+    return {
+      documentId: workspaceId,
+      sourceKind: "untitled",
+      saveTarget: null,
+      packageId: null,
+      canonicalPath: null,
+      dirty: false,
+      needsSaveAs: true,
+    };
+  }
+
+  it("indexes a package-backed document state by package identity", () => {
+    const index = new PackageSessionIndex();
+    const state = packageState("workspace_a", "package_a", "/font-a.shift");
+
+    index.update("workspace_a", state);
+
+    expect(index.workspaceIdForPackage(identity("package_a", "/font-a.shift"))).toBe("workspace_a");
+    expect(index.workspaceIdForState(state)).toBe("workspace_a");
+  });
+
+  it("reindexes when a session moves to another package address", () => {
+    const index = new PackageSessionIndex();
+
+    index.update("workspace_a", packageState("workspace_a", "package_a", "/font-a.shift"));
+    index.update("workspace_a", packageState("workspace_a", "package_b", "/font-b.shift"));
+
+    expect(index.workspaceIdForPackage(identity("package_a", "/font-a.shift"))).toBeNull();
+    expect(index.workspaceIdForPackage(identity("package_b", "/font-b.shift"))).toBe("workspace_a");
+  });
+
+  it("removes package ownership when a session stops being package-backed", () => {
+    const index = new PackageSessionIndex();
+
+    index.update("workspace_a", packageState("workspace_a", "package_a", "/font-a.shift"));
+    index.update("workspace_a", untitledState("workspace_a"));
+
+    expect(index.workspaceIdForPackage(identity("package_a", "/font-a.shift"))).toBeNull();
+  });
+
+  it("tracks document changed events and untracks disposed sessions", () => {
+    const index = new PackageSessionIndex();
+    const tracked = session("workspace_a");
+
+    index.track(tracked.session);
+    tracked.source.emit(packageState("workspace_a", "package_a", "/font-a.shift"));
+    expect(index.workspaceIdForPackage(identity("package_a", "/font-a.shift"))).toBe("workspace_a");
+
+    index.untrack("workspace_a");
+    tracked.source.emit(packageState("workspace_a", "package_b", "/font-b.shift"));
+
+    expect(index.workspaceIdForPackage(identity("package_a", "/font-a.shift"))).toBeNull();
+    expect(index.workspaceIdForPackage(identity("package_b", "/font-b.shift"))).toBeNull();
+  });
+
+  it("rejects two live sessions for one package address", () => {
+    const index = new PackageSessionIndex();
+    const state = packageState("workspace_a", "package_a", "/font-a.shift");
+
+    index.update("workspace_a", state);
+
+    expect(() =>
+      index.update("workspace_b", packageState("workspace_b", "package_a", "/font-a.shift")),
+    ).toThrow("Package session already registered");
+  });
+
+  it("keeps the previous package key when a reindex is rejected", () => {
+    const index = new PackageSessionIndex();
+
+    index.update("workspace_a", packageState("workspace_a", "package_a", "/font-a.shift"));
+    index.update("workspace_b", packageState("workspace_b", "package_b", "/font-b.shift"));
+
+    expect(() =>
+      index.update("workspace_a", packageState("workspace_a", "package_b", "/font-b.shift")),
+    ).toThrow("Package session already registered");
+
+    expect(index.workspaceIdForPackage(identity("package_a", "/font-a.shift"))).toBe("workspace_a");
+    expect(index.workspaceIdForPackage(identity("package_b", "/font-b.shift"))).toBe("workspace_b");
+  });
+});

--- a/apps/desktop/src/main/workspace/PackageSessionIndex.ts
+++ b/apps/desktop/src/main/workspace/PackageSessionIndex.ts
@@ -1,0 +1,126 @@
+import type {
+  WorkspaceDocumentState,
+  WorkspacePackageIdentity,
+} from "../../shared/workspace/protocol";
+import type { WorkspaceProcess } from "./WorkspaceProcess";
+import type { WorkspaceId } from "./WorkspaceSession";
+
+export type IndexedPackageSession = {
+  readonly workspaceId: WorkspaceId;
+  readonly workspaceProcess: Pick<WorkspaceProcess, "onDocumentChanged">;
+};
+
+/**
+ * Indexes live workspace sessions by package address.
+ *
+ * @remarks
+ * This is main-process live-session bookkeeping. It enforces that at most one
+ * live {@link WorkspaceId} owns a package address, and it follows document
+ * state changes because Save As can move a session between package addresses.
+ */
+export class PackageSessionIndex {
+  readonly #workspaceIdByPackageKey = new Map<string, WorkspaceId>();
+  readonly #packageKeyByWorkspaceId = new Map<WorkspaceId, string>();
+  readonly #unlistenByWorkspaceId = new Map<WorkspaceId, () => void>();
+
+  /**
+   * Tracks document state changes for one live workspace session.
+   *
+   * @param session - live workspace session with a document-change source.
+   * @throws {Error} when the session is already tracked.
+   */
+  track(session: IndexedPackageSession): void {
+    if (this.#unlistenByWorkspaceId.has(session.workspaceId)) {
+      throw new Error(`Package session already tracked: ${session.workspaceId}`);
+    }
+
+    this.#unlistenByWorkspaceId.set(
+      session.workspaceId,
+      session.workspaceProcess.onDocumentChanged((state) => {
+        this.update(session.workspaceId, state);
+      }),
+    );
+  }
+
+  /**
+   * Stops tracking a live workspace session and removes its package ownership.
+   *
+   * @param workspaceId - session identity being unregistered.
+   */
+  untrack(workspaceId: WorkspaceId): void {
+    this.#remove(workspaceId);
+
+    const unlisten = this.#unlistenByWorkspaceId.get(workspaceId);
+    if (unlisten) unlisten();
+    this.#unlistenByWorkspaceId.delete(workspaceId);
+  }
+
+  /**
+   * Updates the package address owned by a workspace session.
+   *
+   * @param workspaceId - live workspace session receiving document state.
+   * @param state - latest document state; null clears package ownership.
+   * @throws {Error} when another live session already owns the package address.
+   */
+  update(workspaceId: WorkspaceId, state: WorkspaceDocumentState | null): void {
+    const key = state ? packageKeyForState(state) : null;
+    if (key) {
+      const existing = this.#workspaceIdByPackageKey.get(key);
+      if (existing && existing !== workspaceId) {
+        throw new Error(`Package session already registered: ${state.packageId}`);
+      }
+    }
+
+    this.#remove(workspaceId);
+    if (!key) return;
+
+    this.#workspaceIdByPackageKey.set(key, workspaceId);
+    this.#packageKeyByWorkspaceId.set(workspaceId, key);
+  }
+
+  /**
+   * Resolves the live workspace session id for a package identity.
+   *
+   * @param identity - package id and canonical source path to look up.
+   * @returns null when no live session owns the package address.
+   */
+  workspaceIdForPackage(identity: WorkspacePackageIdentity): WorkspaceId | null {
+    return this.#workspaceIdByPackageKey.get(packageKey(identity)) ?? null;
+  }
+
+  /**
+   * Resolves the live workspace session id for document package state.
+   *
+   * @param state - document state emitted by the utility process.
+   * @returns null when the state is not package-backed or is not indexed.
+   */
+  workspaceIdForState(state: WorkspaceDocumentState): WorkspaceId | null {
+    const key = packageKeyForState(state);
+    return key ? (this.#workspaceIdByPackageKey.get(key) ?? null) : null;
+  }
+
+  #remove(workspaceId: WorkspaceId): void {
+    const previousKey = this.#packageKeyByWorkspaceId.get(workspaceId);
+    if (!previousKey) return;
+
+    if (this.#workspaceIdByPackageKey.get(previousKey) === workspaceId) {
+      this.#workspaceIdByPackageKey.delete(previousKey);
+    }
+    this.#packageKeyByWorkspaceId.delete(workspaceId);
+  }
+}
+
+function packageKeyForState(state: WorkspaceDocumentState): string | null {
+  if (!state.packageId || !state.canonicalPath) return null;
+
+  return packageKey({
+    packageId: state.packageId,
+    canonicalPath: state.canonicalPath,
+  });
+}
+
+function packageKey(
+  identity: Pick<WorkspacePackageIdentity, "packageId" | "canonicalPath">,
+): string {
+  return `${identity.packageId}\0${identity.canonicalPath}`;
+}

--- a/apps/desktop/src/main/workspace/WorkspaceManager.test.ts
+++ b/apps/desktop/src/main/workspace/WorkspaceManager.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import type { WorkspaceDocumentState } from "../../shared/workspace/protocol";
+import type { WorkspaceProcess } from "./WorkspaceProcess";
+import type { WorkspaceSession } from "./WorkspaceSession";
+import { WorkspaceManager } from "./WorkspaceManager";
+
+class DocumentChangeSource {
+  readonly #listeners = new Set<(state: WorkspaceDocumentState | null) => void>();
+
+  onDocumentChanged(listener: (state: WorkspaceDocumentState | null) => void): () => void {
+    this.#listeners.add(listener);
+
+    return () => {
+      this.#listeners.delete(listener);
+    };
+  }
+
+  emit(state: WorkspaceDocumentState | null): void {
+    for (const listener of this.#listeners) listener(state);
+  }
+}
+
+describe("WorkspaceManager package session cleanup", () => {
+  function packageState(
+    documentId: string,
+    packageId: string,
+    canonicalPath: string,
+  ): WorkspaceDocumentState {
+    return {
+      documentId,
+      sourceKind: "package",
+      saveTarget: canonicalPath,
+      packageId,
+      canonicalPath,
+      dirty: false,
+      needsSaveAs: false,
+    };
+  }
+
+  function session(workspaceId: string): {
+    source: DocumentChangeSource;
+    session: WorkspaceSession;
+  } {
+    const source = new DocumentChangeSource();
+    return {
+      source,
+      session: {
+        workspaceId,
+        workspaceProcess: source as Pick<WorkspaceProcess, "onDocumentChanged">,
+        document: {
+          acceptState() {},
+        },
+        windows: new Set(),
+        dispose() {},
+      } as unknown as WorkspaceSession,
+    };
+  }
+
+  it("unregister removes package ownership and ignores later document events", () => {
+    const manager = new WorkspaceManager({
+      documentsRoot: () => "/tmp",
+      applicationName: () => "Shift",
+    });
+    const tracked = session("workspace_a");
+
+    manager.register(tracked.session);
+    tracked.source.emit(packageState("workspace_a", "package_a", "/font-a.shift"));
+    manager.unregister("workspace_a");
+    tracked.source.emit(packageState("workspace_a", "package_b", "/font-b.shift"));
+    const replacement = session("workspace_b");
+
+    manager.register(replacement.session);
+    expect(() =>
+      replacement.source.emit(packageState("workspace_b", "package_b", "/font-b.shift")),
+    ).not.toThrow();
+
+    expect(manager.list().map((session) => session.workspaceId)).toEqual(["workspace_b"]);
+  });
+
+  it("does not keep duplicate registered sessions after unregister", () => {
+    const manager = new WorkspaceManager({
+      documentsRoot: () => "/tmp",
+      applicationName: () => "Shift",
+    });
+    const first = session("workspace_a");
+    const second = session("workspace_a");
+
+    manager.register(first.session);
+    expect(() => manager.register(second.session)).toThrow("Workspace session already registered");
+
+    manager.unregister("workspace_a");
+    manager.register(second.session);
+
+    expect(manager.list().map((session) => session.workspaceId)).toEqual(["workspace_a"]);
+  });
+});

--- a/apps/desktop/src/main/workspace/WorkspaceManager.ts
+++ b/apps/desktop/src/main/workspace/WorkspaceManager.ts
@@ -109,8 +109,8 @@ export class WorkspaceManager {
       throw new Error(`Workspace session already registered: ${session.workspaceId}`);
     }
 
-    this.#sessionsById.set(session.workspaceId, session);
     this.#packageSessions.track(session);
+    this.#sessionsById.set(session.workspaceId, session);
   }
 
   /**
@@ -235,7 +235,13 @@ export class WorkspaceManager {
 
     session.document.acceptState(state);
     this.register(session);
-    this.#packageSessions.update(session.workspaceId, state);
+    try {
+      this.#packageSessions.update(session.workspaceId, state);
+    } catch (error) {
+      this.unregister(session.workspaceId);
+      throw error;
+    }
+
     return session;
   }
 

--- a/apps/desktop/src/main/workspace/WorkspaceManager.ts
+++ b/apps/desktop/src/main/workspace/WorkspaceManager.ts
@@ -1,7 +1,11 @@
 import { BrowserWindow, type WebContents } from "electron";
+import path from "node:path";
 import { DocumentClient } from "../document/DocumentClient";
 import type { Window } from "../windows/Window";
-import type { WorkspaceDocumentState } from "../../shared/workspace/protocol";
+import type {
+  WorkspaceDocumentState,
+  WorkspacePackageIdentity,
+} from "../../shared/workspace/protocol";
 import { WorkspaceProcess } from "./WorkspaceProcess";
 import { type WorkspaceId, WorkspaceSession } from "./WorkspaceSession";
 
@@ -25,6 +29,9 @@ export class WorkspaceManager {
   readonly #applicationName: () => string;
   readonly #sessionsById = new Map<WorkspaceId, WorkspaceSession>();
   readonly #sessionIdByWindowId = new Map<number, WorkspaceId>();
+  readonly #sessionIdByPackageKey = new Map<string, WorkspaceId>();
+  readonly #packageKeyBySessionId = new Map<WorkspaceId, string>();
+  readonly #unlistenPackageIndexBySessionId = new Map<WorkspaceId, () => void>();
 
   /**
    * Creates a manager for live font workspace sessions.
@@ -52,7 +59,34 @@ export class WorkspaceManager {
    * @returns a live session for the opened source; existing sessions are reused by workspace id.
    */
   async openPath(sourcePath: string): Promise<WorkspaceSession> {
-    return this.#createSession((workspaceProcess) => workspaceProcess.openWorkspace(sourcePath));
+    const workspaceProcess = new WorkspaceProcess();
+    workspaceProcess.start(this.#documentsRoot());
+
+    try {
+      await workspaceProcess.whenReady();
+
+      const identity = isShiftPackagePath(sourcePath)
+        ? await workspaceProcess.inspectPackage(sourcePath)
+        : null;
+      const existingBeforeOpen = identity ? this.#sessionForPackage(identity) : null;
+      if (existingBeforeOpen) {
+        workspaceProcess.stop();
+        return existingBeforeOpen;
+      }
+
+      const state = await workspaceProcess.openWorkspace(sourcePath);
+      const existingAfterOpen = this.#sessionForDocumentState(state);
+      if (existingAfterOpen) {
+        workspaceProcess.stop();
+        existingAfterOpen.document.acceptState(state);
+        return existingAfterOpen;
+      }
+
+      return this.#registerLoadedSession(workspaceProcess, state);
+    } catch (error) {
+      workspaceProcess.stop();
+      throw error;
+    }
   }
 
   /**
@@ -77,6 +111,12 @@ export class WorkspaceManager {
     }
 
     this.#sessionsById.set(session.workspaceId, session);
+    this.#unlistenPackageIndexBySessionId.set(
+      session.workspaceId,
+      session.workspaceProcess.onDocumentChanged((state) => {
+        this.#indexPackageSession(session.workspaceId, state);
+      }),
+    );
   }
 
   /**
@@ -91,6 +131,10 @@ export class WorkspaceManager {
     for (const window of session.windows) {
       this.#sessionIdByWindowId.delete(window.window.id);
     }
+    this.#removePackageIndex(workspaceId);
+    const unlistenPackageIndex = this.#unlistenPackageIndexBySessionId.get(workspaceId);
+    if (unlistenPackageIndex) unlistenPackageIndex();
+    this.#unlistenPackageIndexBySessionId.delete(workspaceId);
     this.#sessionsById.delete(workspaceId);
     session.dispose();
   }
@@ -180,19 +224,82 @@ export class WorkspaceManager {
         return existing;
       }
 
-      const session = new WorkspaceSession({
-        workspaceId: state.documentId,
-        workspaceProcess,
-        documentClient: new DocumentClient(),
-        applicationName: this.#applicationName,
-      });
-
-      session.document.acceptState(state);
-      this.register(session);
-      return session;
+      return this.#registerLoadedSession(workspaceProcess, state);
     } catch (error) {
       workspaceProcess.stop();
       throw error;
     }
   }
+
+  #registerLoadedSession(
+    workspaceProcess: WorkspaceProcess,
+    state: WorkspaceDocumentState,
+  ): WorkspaceSession {
+    const session = new WorkspaceSession({
+      workspaceId: state.documentId,
+      workspaceProcess,
+      documentClient: new DocumentClient(),
+      applicationName: this.#applicationName,
+    });
+
+    session.document.acceptState(state);
+    this.register(session);
+    this.#indexPackageSession(session.workspaceId, state);
+    return session;
+  }
+
+  #sessionForDocumentState(state: WorkspaceDocumentState): WorkspaceSession | null {
+    const byDocumentId = this.get(state.documentId);
+    if (byDocumentId) return byDocumentId;
+    if (!state.packageId || !state.canonicalPath) return null;
+
+    return this.#sessionForPackage({
+      packageId: state.packageId,
+      canonicalPath: state.canonicalPath,
+      fingerprint: "",
+    });
+  }
+
+  #sessionForPackage(identity: WorkspacePackageIdentity): WorkspaceSession | null {
+    const workspaceId = this.#sessionIdByPackageKey.get(packageKey(identity));
+    return workspaceId ? this.get(workspaceId) : null;
+  }
+
+  #indexPackageSession(workspaceId: WorkspaceId, state: WorkspaceDocumentState | null): void {
+    this.#removePackageIndex(workspaceId);
+    if (!state?.packageId || !state.canonicalPath) return;
+
+    const key = packageKey({
+      packageId: state.packageId,
+      canonicalPath: state.canonicalPath,
+      fingerprint: "",
+    });
+    const existing = this.#sessionIdByPackageKey.get(key);
+    if (existing && existing !== workspaceId) {
+      throw new Error(`Package session already registered: ${state.packageId}`);
+    }
+
+    this.#sessionIdByPackageKey.set(key, workspaceId);
+    this.#packageKeyBySessionId.set(workspaceId, key);
+  }
+
+  #removePackageIndex(workspaceId: WorkspaceId): void {
+    const previousKey = this.#packageKeyBySessionId.get(workspaceId);
+    if (!previousKey) return;
+
+    if (this.#sessionIdByPackageKey.get(previousKey) === workspaceId) {
+      this.#sessionIdByPackageKey.delete(previousKey);
+    }
+    this.#packageKeyBySessionId.delete(workspaceId);
+  }
+}
+
+function packageKey(
+  identity: Pick<WorkspacePackageIdentity, "packageId" | "canonicalPath">,
+): string {
+  return `${identity.packageId}\0${identity.canonicalPath}`;
+}
+
+function isShiftPackagePath(sourcePath: string): boolean {
+  return path.extname(sourcePath).toLowerCase() === ".shift";
 }

--- a/apps/desktop/src/main/workspace/WorkspaceManager.ts
+++ b/apps/desktop/src/main/workspace/WorkspaceManager.ts
@@ -8,6 +8,7 @@ import type {
 } from "../../shared/workspace/protocol";
 import { WorkspaceProcess } from "./WorkspaceProcess";
 import { type WorkspaceId, WorkspaceSession } from "./WorkspaceSession";
+import { PackageSessionIndex } from "./PackageSessionIndex";
 
 /** Provides app-owned values required when a workspace session is created. */
 export interface WorkspaceManagerOptions {
@@ -29,9 +30,7 @@ export class WorkspaceManager {
   readonly #applicationName: () => string;
   readonly #sessionsById = new Map<WorkspaceId, WorkspaceSession>();
   readonly #sessionIdByWindowId = new Map<number, WorkspaceId>();
-  readonly #sessionIdByPackageKey = new Map<string, WorkspaceId>();
-  readonly #packageKeyBySessionId = new Map<WorkspaceId, string>();
-  readonly #unlistenPackageIndexBySessionId = new Map<WorkspaceId, () => void>();
+  readonly #packageSessions = new PackageSessionIndex();
 
   /**
    * Creates a manager for live font workspace sessions.
@@ -111,12 +110,7 @@ export class WorkspaceManager {
     }
 
     this.#sessionsById.set(session.workspaceId, session);
-    this.#unlistenPackageIndexBySessionId.set(
-      session.workspaceId,
-      session.workspaceProcess.onDocumentChanged((state) => {
-        this.#indexPackageSession(session.workspaceId, state);
-      }),
-    );
+    this.#packageSessions.track(session);
   }
 
   /**
@@ -131,10 +125,7 @@ export class WorkspaceManager {
     for (const window of session.windows) {
       this.#sessionIdByWindowId.delete(window.window.id);
     }
-    this.#removePackageIndex(workspaceId);
-    const unlistenPackageIndex = this.#unlistenPackageIndexBySessionId.get(workspaceId);
-    if (unlistenPackageIndex) unlistenPackageIndex();
-    this.#unlistenPackageIndexBySessionId.delete(workspaceId);
+    this.#packageSessions.untrack(workspaceId);
     this.#sessionsById.delete(workspaceId);
     session.dispose();
   }
@@ -244,60 +235,22 @@ export class WorkspaceManager {
 
     session.document.acceptState(state);
     this.register(session);
-    this.#indexPackageSession(session.workspaceId, state);
+    this.#packageSessions.update(session.workspaceId, state);
     return session;
   }
 
   #sessionForDocumentState(state: WorkspaceDocumentState): WorkspaceSession | null {
     const byDocumentId = this.get(state.documentId);
     if (byDocumentId) return byDocumentId;
-    if (!state.packageId || !state.canonicalPath) return null;
 
-    return this.#sessionForPackage({
-      packageId: state.packageId,
-      canonicalPath: state.canonicalPath,
-      fingerprint: "",
-    });
-  }
-
-  #sessionForPackage(identity: WorkspacePackageIdentity): WorkspaceSession | null {
-    const workspaceId = this.#sessionIdByPackageKey.get(packageKey(identity));
+    const workspaceId = this.#packageSessions.workspaceIdForState(state);
     return workspaceId ? this.get(workspaceId) : null;
   }
 
-  #indexPackageSession(workspaceId: WorkspaceId, state: WorkspaceDocumentState | null): void {
-    this.#removePackageIndex(workspaceId);
-    if (!state?.packageId || !state.canonicalPath) return;
-
-    const key = packageKey({
-      packageId: state.packageId,
-      canonicalPath: state.canonicalPath,
-      fingerprint: "",
-    });
-    const existing = this.#sessionIdByPackageKey.get(key);
-    if (existing && existing !== workspaceId) {
-      throw new Error(`Package session already registered: ${state.packageId}`);
-    }
-
-    this.#sessionIdByPackageKey.set(key, workspaceId);
-    this.#packageKeyBySessionId.set(workspaceId, key);
+  #sessionForPackage(identity: WorkspacePackageIdentity): WorkspaceSession | null {
+    const workspaceId = this.#packageSessions.workspaceIdForPackage(identity);
+    return workspaceId ? this.get(workspaceId) : null;
   }
-
-  #removePackageIndex(workspaceId: WorkspaceId): void {
-    const previousKey = this.#packageKeyBySessionId.get(workspaceId);
-    if (!previousKey) return;
-
-    if (this.#sessionIdByPackageKey.get(previousKey) === workspaceId) {
-      this.#sessionIdByPackageKey.delete(previousKey);
-    }
-    this.#packageKeyBySessionId.delete(workspaceId);
-  }
-}
-
-function packageKey(
-  identity: Pick<WorkspacePackageIdentity, "packageId" | "canonicalPath">,
-): string {
-  return `${identity.packageId}\0${identity.canonicalPath}`;
 }
 
 function isShiftPackagePath(sourcePath: string): boolean {

--- a/apps/desktop/src/main/workspace/WorkspaceProcess.ts
+++ b/apps/desktop/src/main/workspace/WorkspaceProcess.ts
@@ -5,6 +5,7 @@ import type {
   ShellCallMap,
   ShellEventMap,
   WorkspaceDocumentState,
+  WorkspacePackageIdentity,
 } from "../../shared/workspace/protocol";
 import { createShiftLogger, type ShiftLogger } from "../logging";
 
@@ -96,6 +97,17 @@ export class WorkspaceProcess {
   }
 
   /**
+   * Reads package identity before opening a package-backed workspace.
+   *
+   * @param path - User-selected `.shift` source path.
+   * @returns stable package identity for active-session reuse.
+   * @throws {Error} when the utility process is not running or rejects the package.
+   */
+  inspectPackage(path: string): Promise<WorkspacePackageIdentity> {
+    return this.#requireChannel().call("workspace.inspectPackage", { path });
+  }
+
+  /**
    * Opens a workspace from a source path through the shell lane.
    *
    * @param path - User-selected source path to open.
@@ -104,6 +116,16 @@ export class WorkspaceProcess {
    */
   openWorkspace(path: string): Promise<WorkspaceDocumentState> {
     return this.#requireChannel().call("workspace.open", { path });
+  }
+
+  /**
+   * Closes the utility-owned workspace and lets it prune clean/discarded state.
+   *
+   * @param discard - true only when the user chose to discard dirty changes.
+   * @throws {Error} when the utility process rejects the close transition.
+   */
+  closeWorkspace(discard: boolean): Promise<null> {
+    return this.#requireChannel().call("workspace.close", { discard });
   }
 
   /**

--- a/apps/desktop/src/main/workspace/WorkspaceSession.ts
+++ b/apps/desktop/src/main/workspace/WorkspaceSession.ts
@@ -55,6 +55,9 @@ export class WorkspaceSession {
     this.documentClient = options.documentClient;
     this.document = new DocumentSession({
       document: this.documentClient,
+      closeDocument: async (discard) => {
+        await this.workspaceProcess.closeWorkspace(discard);
+      },
       dialogWindow: () => this.activeWindow(),
       windows: () => this.allWindows(),
       applicationName: options.applicationName,

--- a/apps/desktop/src/shared/workspace/protocol.ts
+++ b/apps/desktop/src/shared/workspace/protocol.ts
@@ -42,6 +42,13 @@ export type WorkspaceGlyphSnapshot = {
 
 export type WorkspaceDocumentSourceKind = "untitled" | "package" | "imported";
 
+/** Identifies one concrete `.shift` package instance on disk. */
+export type WorkspacePackageIdentity = {
+  packageId: string;
+  canonicalPath: string;
+  fingerprint: string;
+};
+
 /**
  * Main-visible document lifecycle state owned by the utility workspace.
  *
@@ -55,6 +62,8 @@ export type WorkspaceDocumentState = {
   documentId: string;
   sourceKind: WorkspaceDocumentSourceKind;
   saveTarget: string | null;
+  packageId: string | null;
+  canonicalPath: string | null;
   dirty: boolean;
   needsSaveAs: boolean;
 };
@@ -72,7 +81,9 @@ export type WorkspaceDocumentState = {
  */
 export type ShellCallMap = {
   "workspace.create": { request: void; response: WorkspaceDocumentState };
+  "workspace.inspectPackage": { request: { path: string }; response: WorkspacePackageIdentity };
   "workspace.open": { request: { path: string }; response: WorkspaceDocumentState };
+  "workspace.close": { request: { discard: boolean }; response: null };
   "workspace.connect": { request: void; response: void };
   "document.state": { request: void; response: WorkspaceDocumentState | null };
 };

--- a/apps/desktop/src/utility/workspace/DocumentStorage.ts
+++ b/apps/desktop/src/utility/workspace/DocumentStorage.ts
@@ -1,17 +1,16 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import type { DraftAllocation } from "./types";
+import type { DocumentAllocation, OrphanedDocument, PackageAddress, PackageBinding } from "./types";
 
 /**
- * Allocates working-store locations under the utility-owned documents root.
+ * Owns utility-process document allocations and package bindings.
  *
  * @remarks
- * Moved from main: the utility process owns everything durable, so document
- * ids are minted and store paths allocated here. Drafts are RETAINED across
- * restarts — an authored font must never die with the process (the
- * data-loss class three ADRs were written against). Reopen/resume UX and
- * pruning land with the durability series.
+ * SQLite databases live under `documents/<documentId>`. Package source files
+ * are bound to those databases through JSON files under
+ * `packages/<packageId>/<pathHash>.json`, so changing a binding is an atomic
+ * file replace rather than a database move.
  */
 export class DocumentStorage {
   readonly #rootPath: string;
@@ -22,37 +21,173 @@ export class DocumentStorage {
     this.#createId = createId;
   }
 
-  /** Mints a document id and allocates its draft store directory on disk. */
-  createDraft(): DraftAllocation {
+  /**
+   * Mints a document id and creates its SQLite directory.
+   *
+   * @returns a fresh allocation owned by the caller.
+   */
+  createDocument(): DocumentAllocation {
     const documentId = this.#createId();
-    const directoryPath = path.join(this.#rootPath, "drafts", documentId);
+    const allocation = this.document(documentId);
 
-    fs.mkdirSync(directoryPath, { recursive: true });
+    fs.mkdirSync(path.dirname(allocation.storePath), { recursive: true });
+    return allocation;
+  }
 
+  /**
+   * Resolves the SQLite location for an existing document id.
+   *
+   * @param documentId - utility-minted document identity.
+   * @returns the allocation path; the directory is not created.
+   */
+  document(documentId: string): DocumentAllocation {
+    assertSafeSegment("document id", documentId);
     return {
       documentId,
-      storePath: path.join(directoryPath, "document.sqlite"),
+      storePath: path.join(this.#rootPath, "documents", documentId, "document.sqlite"),
     };
   }
 
-  /** Lists retained draft stores that can be inspected for recovery. */
-  listDrafts(): DraftAllocation[] {
-    const draftsRoot = path.join(this.#rootPath, "drafts");
-    if (!fs.existsSync(draftsRoot)) return [];
+  /**
+   * Reads the package binding for an exact package address.
+   *
+   * @param address - package id plus canonical source path.
+   * @returns the binding, or null when the package instance has no document.
+   */
+  packageBinding(address: PackageAddress): PackageBinding | null {
+    const bindingPath = this.#bindingPath(address);
+    if (!fs.existsSync(bindingPath)) return null;
 
-    const drafts: DraftAllocation[] = [];
-    for (const entry of fs.readdirSync(draftsRoot, { withFileTypes: true })) {
-      if (!entry.isDirectory()) continue;
+    return readPackageBinding(bindingPath);
+  }
 
-      const storePath = path.join(draftsRoot, entry.name, "document.sqlite");
-      if (!fs.existsSync(storePath)) continue;
+  /**
+   * Lists bindings for all known paths of one package id.
+   *
+   * @param packageId - stable identity stored in a `.shift` manifest.
+   * @returns bindings sorted by canonical path for deterministic callers.
+   */
+  listPackageBindings(packageId: string): PackageBinding[] {
+    assertSafeSegment("package id", packageId);
+    const directoryPath = path.join(this.#rootPath, "packages", packageId);
+    if (!fs.existsSync(directoryPath)) return [];
 
-      drafts.push({
-        documentId: entry.name,
-        storePath,
-      });
+    const bindings: PackageBinding[] = [];
+    for (const entry of fs.readdirSync(directoryPath, { withFileTypes: true })) {
+      if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+
+      bindings.push(readPackageBinding(path.join(directoryPath, entry.name)));
     }
 
-    return drafts;
+    return bindings.sort((left, right) => left.canonicalPath.localeCompare(right.canonicalPath));
   }
+
+  /**
+   * Atomically binds a package address to a document id.
+   *
+   * @param address - package instance being opened.
+   * @param documentId - existing utility-owned document allocation.
+   * @returns the durable binding that now owns the package address.
+   */
+  writePackageBinding(address: PackageAddress, documentId: string): PackageBinding {
+    const binding: PackageBinding = {
+      ...address,
+      documentId,
+      storePath: this.document(documentId).storePath,
+      updatedAt: new Date().toISOString(),
+    };
+
+    writeJsonAtomic(this.#bindingPath(address), binding);
+    return binding;
+  }
+
+  /**
+   * Removes the binding for an exact package address.
+   *
+   * @param address - package instance whose binding should be removed.
+   */
+  removePackageBinding(address: PackageAddress): void {
+    fs.rmSync(this.#bindingPath(address), { force: true });
+  }
+
+  /**
+   * Records a detached dirty document for future explicit recovery UI.
+   *
+   * @param binding - package binding that used to own the document.
+   * @param reason - stable reason string for diagnostics.
+   * @returns the orphan record written to disk.
+   */
+  orphanDocument(binding: PackageBinding, reason: string): OrphanedDocument {
+    const orphan: OrphanedDocument = {
+      documentId: binding.documentId,
+      storePath: binding.storePath,
+      packageId: binding.packageId,
+      canonicalPath: binding.canonicalPath,
+      reason,
+      orphanedAt: new Date().toISOString(),
+    };
+
+    writeJsonAtomic(path.join(this.#rootPath, "orphaned", `${binding.documentId}.json`), orphan);
+    return orphan;
+  }
+
+  /**
+   * Deletes a document allocation and its SQLite database.
+   *
+   * @param documentId - utility-owned document id to remove.
+   */
+  deleteDocument(documentId: string): void {
+    const allocation = this.document(documentId);
+    fs.rmSync(path.dirname(allocation.storePath), { recursive: true, force: true });
+  }
+
+  #bindingPath(address: PackageAddress): string {
+    assertSafeSegment("package id", address.packageId);
+    const hash = crypto.createHash("sha256").update(address.canonicalPath).digest("hex");
+    return path.join(this.#rootPath, "packages", address.packageId, `${hash}.json`);
+  }
+}
+
+function readPackageBinding(bindingPath: string): PackageBinding {
+  return parsePackageBinding(JSON.parse(fs.readFileSync(bindingPath, "utf8")), bindingPath);
+}
+
+function parsePackageBinding(value: unknown, bindingPath: string): PackageBinding {
+  if (!isRecord(value)) throw new Error(`invalid package binding: ${bindingPath}`);
+
+  const { packageId, canonicalPath, documentId, storePath, updatedAt } = value;
+  if (
+    typeof packageId !== "string" ||
+    typeof canonicalPath !== "string" ||
+    typeof documentId !== "string" ||
+    typeof storePath !== "string" ||
+    typeof updatedAt !== "string"
+  ) {
+    throw new Error(`invalid package binding: ${bindingPath}`);
+  }
+
+  return { packageId, canonicalPath, documentId, storePath, updatedAt };
+}
+
+function writeJsonAtomic(targetPath: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  const tempPath = path.join(path.dirname(targetPath), `.${path.basename(targetPath)}.tmp`);
+
+  try {
+    fs.writeFileSync(tempPath, `${JSON.stringify(value, null, 2)}\n`);
+    fs.renameSync(tempPath, targetPath);
+  } catch (error) {
+    fs.rmSync(tempPath, { force: true });
+    throw error;
+  }
+}
+
+function assertSafeSegment(label: string, value: string): void {
+  if (/^[A-Za-z0-9._-]+$/.test(value) && value !== "." && value !== "..") return;
+
+  throw new Error(`invalid ${label}: ${value}`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/apps/desktop/src/utility/workspace/DocumentStorage.ts
+++ b/apps/desktop/src/utility/workspace/DocumentStorage.ts
@@ -1,7 +1,18 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { z } from "zod";
 import type { DocumentAllocation, OrphanedDocument, PackageAddress, PackageBinding } from "./types";
+
+const packageBindingSchema = z
+  .object({
+    packageId: z.string(),
+    canonicalPath: z.string(),
+    documentId: z.string(),
+    storePath: z.string(),
+    updatedAt: z.string(),
+  })
+  .strict();
 
 /**
  * Owns utility-process document allocations and package bindings.
@@ -153,20 +164,19 @@ function readPackageBinding(bindingPath: string): PackageBinding {
 }
 
 function parsePackageBinding(value: unknown, bindingPath: string): PackageBinding {
-  if (!isRecord(value)) throw new Error(`invalid package binding: ${bindingPath}`);
+  const result = packageBindingSchema.safeParse(value);
+  if (!result.success) {
+    const details = result.error.issues
+      .map((issue) => {
+        const path = issue.path.join(".");
+        return path ? `${path}: ${issue.message}` : issue.message;
+      })
+      .join("; ");
 
-  const { packageId, canonicalPath, documentId, storePath, updatedAt } = value;
-  if (
-    typeof packageId !== "string" ||
-    typeof canonicalPath !== "string" ||
-    typeof documentId !== "string" ||
-    typeof storePath !== "string" ||
-    typeof updatedAt !== "string"
-  ) {
-    throw new Error(`invalid package binding: ${bindingPath}`);
+    throw new Error(`invalid package binding: ${bindingPath}: ${details}`);
   }
 
-  return { packageId, canonicalPath, documentId, storePath, updatedAt };
+  return result.data;
 }
 
 function writeJsonAtomic(targetPath: string, value: unknown): void {
@@ -186,8 +196,4 @@ function assertSafeSegment(label: string, value: string): void {
   if (/^[A-Za-z0-9._-]+$/.test(value) && value !== "." && value !== "..") return;
 
   throw new Error(`invalid ${label}: ${value}`);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/apps/desktop/src/utility/workspace/PackageOpener.test.ts
+++ b/apps/desktop/src/utility/workspace/PackageOpener.test.ts
@@ -1,0 +1,203 @@
+import { createBridge, type ShiftBridge } from "@shift/bridge";
+import { mintGlyphId, type FontIntent, type GlyphName, type Unicode } from "@shift/types";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { WorkspacePackageIdentity } from "../../shared/workspace/protocol";
+import { DocumentStorage } from "./DocumentStorage";
+import { PackageOpener } from "./PackageOpener";
+import { PackageAddress } from "./types";
+
+const createGlyph = (name: GlyphName, unicode: Unicode): FontIntent => ({
+  kind: "createGlyph",
+  createGlyph: {
+    glyphId: mintGlyphId(),
+    name,
+    unicodes: [unicode],
+  },
+});
+
+const createGlyphA = (): FontIntent => createGlyph("A" as GlyphName, 65 as Unicode);
+
+describe("PackageOpener preserves package-backed document bindings", () => {
+  let tmpRoot: string;
+  let storage: DocumentStorage;
+  let documentIndex = 0;
+  let externalIndex = 0;
+  let bridges: ShiftBridge[] = [];
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "shift-package-opener-"));
+    documentIndex = 0;
+    externalIndex = 0;
+    bridges = [];
+    storage = new DocumentStorage(tmpRoot, () => `doc_${++documentIndex}`);
+  });
+
+  afterEach(() => {
+    for (const bridge of bridges) {
+      try {
+        bridge.closeWorkspace();
+      } catch {
+        // The bridge may have only inspected package metadata.
+      }
+    }
+
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  function makeBridge(): ShiftBridge {
+    const bridge = createBridge();
+    bridges.push(bridge);
+    return bridge;
+  }
+
+  function inspectPackage(bridge: ShiftBridge, sourcePath: string): WorkspacePackageIdentity {
+    const identity = bridge.inspectPackage(sourcePath);
+    return {
+      packageId: identity.packageId,
+      canonicalPath: identity.canonicalPath,
+      fingerprint: identity.fingerprint,
+    };
+  }
+
+  function createPackageSource(name: string): {
+    sourcePath: string;
+    identity: WorkspacePackageIdentity;
+  } {
+    const bridge = makeBridge();
+    const sourcePath = path.join(tmpRoot, name);
+    const storePath = path.join(tmpRoot, "external", `${name}.sqlite`);
+
+    fs.mkdirSync(path.dirname(storePath), { recursive: true });
+    bridge.createUntitledWorkspace(storePath);
+    bridge.setDocumentId(`external_${++externalIndex}`);
+    bridge.apply([createGlyphA()], "Add Glyph");
+    bridge.saveWorkspaceAs(sourcePath);
+
+    const identity = inspectPackage(bridge, sourcePath);
+    bridge.closeWorkspace();
+    return { sourcePath, identity };
+  }
+
+  function externallyAddGlyph(
+    sourcePath: string,
+    name: GlyphName,
+    unicode: Unicode,
+  ): WorkspacePackageIdentity {
+    const bridge = makeBridge();
+    const storePath = path.join(tmpRoot, "external", `${String(name)}.sqlite`);
+
+    fs.mkdirSync(path.dirname(storePath), { recursive: true });
+    bridge.openWorkspace(sourcePath, storePath);
+    bridge.setDocumentId(`external_${++externalIndex}`);
+    bridge.apply([createGlyph(name, unicode)], "External Edit");
+    bridge.saveWorkspace();
+
+    const identity = inspectPackage(bridge, sourcePath);
+    bridge.closeWorkspace();
+    return identity;
+  }
+
+  function openPackage(
+    bridge: ShiftBridge,
+    identity: WorkspacePackageIdentity,
+  ): ReturnType<PackageOpener["open"]> {
+    return new PackageOpener(bridge, storage).open(identity);
+  }
+
+  function glyphNames(bridge: ShiftBridge): GlyphName[] {
+    return bridge.getGlyphs().map((glyph) => glyph.name);
+  }
+
+  it("hydrates a package with no binding into a fresh document", () => {
+    const { identity } = createPackageSource("Hydrate.shift");
+    const bridge = makeBridge();
+
+    const opened = openPackage(bridge, identity);
+
+    expect(opened.document.documentId).toBe("doc_1");
+    expect(opened.address).toMatchObject({
+      packageId: identity.packageId,
+      canonicalPath: identity.canonicalPath,
+    });
+    expect(storage.packageBinding(opened.address)?.documentId).toBe(opened.document.documentId);
+    expect(glyphNames(bridge)).toEqual(["A"]);
+  });
+
+  it("resumes a dirty binding when the package fingerprint still matches", () => {
+    const { identity } = createPackageSource("Resume.shift");
+    const firstBridge = makeBridge();
+    const firstOpen = openPackage(firstBridge, identity);
+    firstBridge.apply([createGlyph("B" as GlyphName, 66 as Unicode)], "Add Glyph");
+    firstBridge.closeWorkspace();
+    const nextBridge = makeBridge();
+
+    const reopened = openPackage(nextBridge, identity);
+
+    expect(reopened.document.documentId).toBe(firstOpen.document.documentId);
+    expect(glyphNames(nextBridge)).toEqual(["A", "B"]);
+    expect(nextBridge.documentState()).toMatchObject({
+      dirty: true,
+      saveTarget: identity.canonicalPath,
+    });
+  });
+
+  it("replaces a clean binding with a fresh document", () => {
+    const { identity } = createPackageSource("Replace.shift");
+    const firstBridge = makeBridge();
+    const firstOpen = openPackage(firstBridge, identity);
+    const oldDocumentPath = path.dirname(firstOpen.document.storePath);
+    firstBridge.closeWorkspace();
+    const nextBridge = makeBridge();
+
+    const reopened = openPackage(nextBridge, identity);
+
+    expect(reopened.document.documentId).not.toBe(firstOpen.document.documentId);
+    expect(fs.existsSync(oldDocumentPath)).toBe(false);
+    expect(glyphNames(nextBridge)).toEqual(["A"]);
+    expect(storage.packageBinding(reopened.address)?.documentId).toBe(reopened.document.documentId);
+  });
+
+  it("orphans a dirty binding when the source package diverges", () => {
+    const { sourcePath, identity } = createPackageSource("Diverged.shift");
+    const firstBridge = makeBridge();
+    const firstOpen = openPackage(firstBridge, identity);
+    firstBridge.apply([createGlyph("B" as GlyphName, 66 as Unicode)], "Add Glyph");
+    const oldDocumentPath = path.dirname(firstOpen.document.storePath);
+    const divergedIdentity = externallyAddGlyph(sourcePath, "C" as GlyphName, 67 as Unicode);
+    firstBridge.closeWorkspace();
+    const nextBridge = makeBridge();
+
+    const reopened = openPackage(nextBridge, divergedIdentity);
+
+    expect(reopened.document.documentId).not.toBe(firstOpen.document.documentId);
+    expect(glyphNames(nextBridge)).toEqual(["A", "C"]);
+    expect(fs.existsSync(oldDocumentPath)).toBe(true);
+    expect(
+      fs.existsSync(path.join(tmpRoot, "orphaned", `${firstOpen.document.documentId}.json`)),
+    ).toBe(true);
+  });
+
+  it("resumes and relinks a dirty binding for a moved package", () => {
+    const { sourcePath, identity } = createPackageSource("Original.shift");
+    const movedPath = path.join(tmpRoot, "Moved.shift");
+    const oldAddress = PackageAddress.fromIdentity(identity);
+    const firstBridge = makeBridge();
+    const firstOpen = openPackage(firstBridge, identity);
+    firstBridge.apply([createGlyph("B" as GlyphName, 66 as Unicode)], "Add Glyph");
+    fs.renameSync(sourcePath, movedPath);
+    firstBridge.closeWorkspace();
+    const nextBridge = makeBridge();
+    const movedIdentity = inspectPackage(nextBridge, movedPath);
+    const movedAddress = PackageAddress.fromIdentity(movedIdentity);
+
+    const reopened = openPackage(nextBridge, movedIdentity);
+
+    expect(reopened.document.documentId).toBe(firstOpen.document.documentId);
+    expect(glyphNames(nextBridge)).toEqual(["A", "B"]);
+    expect(storage.packageBinding(oldAddress)).toBeNull();
+    expect(storage.packageBinding(movedAddress)?.documentId).toBe(firstOpen.document.documentId);
+  });
+});

--- a/apps/desktop/src/utility/workspace/PackageOpener.ts
+++ b/apps/desktop/src/utility/workspace/PackageOpener.ts
@@ -1,0 +1,171 @@
+import type { ShiftBridge } from "@shift/bridge";
+import fs from "node:fs";
+import type { WorkspacePackageIdentity } from "../../shared/workspace/protocol";
+import type { DocumentStorage } from "./DocumentStorage";
+import {
+  PackageAddress,
+  type DocumentAllocation,
+  type PackageBinding,
+  type PackageOpenAction,
+  type PackageOpenResult,
+} from "./types";
+
+/**
+ * Opens package-backed workspaces while preserving dirty local documents.
+ *
+ * @remarks
+ * Package opens resolve through a small action machine over the durable binding,
+ * the source fingerprint, and the saved draft metadata. Dirty matching drafts
+ * resume; clean drafts are replaceable; dirty divergent drafts are orphaned
+ * before a fresh hydrate. Moved packages resume only when exactly one missing
+ * old path matches the package id and base fingerprint.
+ */
+export class PackageOpener {
+  readonly #bridge: ShiftBridge;
+  readonly #documents: DocumentStorage;
+
+  /**
+   * Creates a package opener bound to the utility process services.
+   *
+   * @param bridge - live Rust bridge mutated when workspaces open or resume.
+   * @param documents - durable document and package binding storage.
+   */
+  constructor(bridge: ShiftBridge, documents: DocumentStorage) {
+    this.#bridge = bridge;
+    this.#documents = documents;
+  }
+
+  /**
+   * Opens a package identity and returns the document the host should adopt.
+   *
+   * @param identity - current package id, canonical source path, and source fingerprint.
+   * @returns the document allocation and package address after bindings are settled.
+   * @throws {Error} when a stored binding points at a different package id.
+   */
+  open(identity: WorkspacePackageIdentity): PackageOpenResult {
+    const action = this.#actionFor(identity);
+
+    switch (action.kind) {
+      case "hydrate":
+        return this.#hydrate(identity);
+      case "resume":
+        return this.#resume(identity, action.binding);
+      case "replace":
+        return this.#replace(identity, action.binding);
+      case "orphan":
+        return this.#orphan(identity, action.binding);
+      case "move":
+        return this.#move(identity, action.binding);
+      default:
+        assertNever(action);
+    }
+  }
+
+  #actionFor(identity: WorkspacePackageIdentity): PackageOpenAction {
+    const address = PackageAddress.fromIdentity(identity);
+    const binding = this.#documents.packageBinding(address);
+    if (!binding) {
+      const moved = this.#movedBinding(identity);
+      return moved ? { kind: "move", binding: moved } : { kind: "hydrate" };
+    }
+
+    const draft = this.#bridge.inspectPackageDraft(binding.storePath);
+    if (draft.packageId !== identity.packageId) {
+      throw new Error(
+        `package binding ${binding.documentId} points at ${draft.packageId}, expected ${identity.packageId}`,
+      );
+    }
+
+    if (!draft.dirty) return { kind: "replace", binding };
+    if (draft.baseFingerprint === identity.fingerprint) return { kind: "resume", binding };
+
+    return { kind: "orphan", binding };
+  }
+
+  #movedBinding(identity: WorkspacePackageIdentity): PackageBinding | null {
+    const candidates: PackageBinding[] = [];
+
+    for (const binding of this.#documents.listPackageBindings(identity.packageId)) {
+      if (binding.canonicalPath === identity.canonicalPath) continue;
+      if (pathExists(binding.canonicalPath)) continue;
+
+      const draft = this.#inspectDraftOrNull(binding);
+      if (!draft?.dirty) continue;
+      if (draft.packageId !== identity.packageId) continue;
+      if (draft.baseFingerprint !== identity.fingerprint) continue;
+
+      candidates.push(binding);
+    }
+
+    return candidates.length === 1 ? candidates[0] : null;
+  }
+
+  #inspectDraftOrNull(
+    binding: PackageBinding,
+  ): ReturnType<ShiftBridge["inspectPackageDraft"]> | null {
+    try {
+      return this.#bridge.inspectPackageDraft(binding.storePath);
+    } catch {
+      return null;
+    }
+  }
+
+  #hydrate(identity: WorkspacePackageIdentity): PackageOpenResult {
+    const document = this.#createDocument(identity);
+    return { document, address: PackageAddress.fromIdentity(identity) };
+  }
+
+  #resume(identity: WorkspacePackageIdentity, binding: PackageBinding): PackageOpenResult {
+    this.#bridge.resumeWorkspaceForSource(binding.storePath, identity.canonicalPath);
+    this.#bridge.setDocumentId(binding.documentId);
+    return { document: binding, address: PackageAddress.fromIdentity(identity) };
+  }
+
+  #replace(identity: WorkspacePackageIdentity, binding: PackageBinding): PackageOpenResult {
+    const opened = this.#hydrate(identity);
+    this.#documents.deleteDocument(binding.documentId);
+    return opened;
+  }
+
+  #orphan(identity: WorkspacePackageIdentity, binding: PackageBinding): PackageOpenResult {
+    const opened = this.#hydrate(identity);
+    this.#documents.orphanDocument(binding, "source-diverged");
+    return opened;
+  }
+
+  #move(identity: WorkspacePackageIdentity, binding: PackageBinding): PackageOpenResult {
+    this.#bridge.resumeWorkspaceForSource(binding.storePath, identity.canonicalPath);
+    this.#bridge.setDocumentId(binding.documentId);
+    this.#documents.writePackageBinding(PackageAddress.fromIdentity(identity), binding.documentId);
+    this.#documents.removePackageBinding({
+      packageId: binding.packageId,
+      canonicalPath: binding.canonicalPath,
+    });
+    return { document: binding, address: PackageAddress.fromIdentity(identity) };
+  }
+
+  #createDocument(identity: WorkspacePackageIdentity): DocumentAllocation {
+    const document = this.#documents.createDocument();
+
+    try {
+      this.#bridge.openWorkspace(identity.canonicalPath, document.storePath);
+      this.#bridge.setDocumentId(document.documentId);
+      this.#documents.writePackageBinding(
+        PackageAddress.fromIdentity(identity),
+        document.documentId,
+      );
+      return document;
+    } catch (error) {
+      this.#documents.deleteDocument(document.documentId);
+      throw error;
+    }
+  }
+}
+
+function pathExists(sourcePath: string): boolean {
+  return fs.existsSync(sourcePath);
+}
+
+function assertNever(value: never): never {
+  throw new Error(`unknown package open action: ${JSON.stringify(value)}`);
+}

--- a/apps/desktop/src/utility/workspace/WorkspaceHost.test.ts
+++ b/apps/desktop/src/utility/workspace/WorkspaceHost.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { createBridge } from "@shift/bridge";
 import { MessageChannel, type MessagePort as NodeMessagePort } from "node:worker_threads";
 import fs from "node:fs";
 import os from "node:os";
@@ -29,14 +30,21 @@ import { WorkspaceHost } from "./WorkspaceHost";
 
 type ShellChannel = Channel<ShellCallMap, ShellEventMap>;
 
-const createGlyphA = (glyphId: GlyphId = mintGlyphId()): FontIntent => ({
+const createGlyph = (
+  name: GlyphName,
+  unicode: Unicode,
+  glyphId: GlyphId = mintGlyphId(),
+): FontIntent => ({
   kind: "createGlyph",
   createGlyph: {
     glyphId,
-    name: "A" as GlyphName,
-    unicodes: [65 as Unicode],
+    name,
+    unicodes: [unicode],
   },
 });
+
+const createGlyphA = (glyphId: GlyphId = mintGlyphId()): FontIntent =>
+  createGlyph("A" as GlyphName, 65 as Unicode, glyphId);
 
 const createGlyphLayer = (
   glyphId: GlyphId,
@@ -126,6 +134,17 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     return snapshot;
   }
 
+  function externallyAddGlyph(sourcePath: string, name: GlyphName, unicode: Unicode): void {
+    const bridge = createBridge();
+    const storePath = path.join(tmpRoot, "external", `${String(name)}.sqlite`);
+
+    fs.mkdirSync(path.dirname(storePath), { recursive: true });
+    bridge.openWorkspace(sourcePath, storePath);
+    bridge.apply([createGlyph(name, unicode)], "External Edit");
+    bridge.saveWorkspace();
+    bridge.closeWorkspace();
+  }
+
   beforeEach(() => {
     tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "shift-workspace-host-"));
     const lane = new MessageChannel();
@@ -151,12 +170,12 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     await expect(ready).resolves.toBeUndefined();
   });
 
-  it("retains existing drafts across host restarts", async () => {
+  it("retains existing documents across host restarts", async () => {
     // An authored draft must never die with the process: the data-loss
     // class the durability ADRs were written against.
     const sync = await connectSyncLane();
     const { documentId } = await createWorkspace(sync);
-    const storePath = path.join(tmpRoot, "drafts", documentId, "document.sqlite");
+    const storePath = path.join(tmpRoot, "documents", documentId, "document.sqlite");
     expect(fs.existsSync(storePath)).toBe(true);
 
     const lane = new MessageChannel();
@@ -215,7 +234,7 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
 
     const { documentId } = await createWorkspace(sync);
 
-    const storePath = path.join(tmpRoot, "drafts", documentId, "document.sqlite");
+    const storePath = path.join(tmpRoot, "documents", documentId, "document.sqlite");
     expect(fs.existsSync(storePath)).toBe(true);
   });
 
@@ -246,7 +265,7 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     expect(opened.glyphs.map((glyph) => glyph.name)).toEqual(["A"]);
     await expect(unopenedShell.call("document.state", undefined)).resolves.toMatchObject({
       sourceKind: "package",
-      saveTarget: savePath,
+      saveTarget: fs.realpathSync(savePath),
       dirty: false,
       needsSaveAs: false,
     });
@@ -268,7 +287,7 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
 
     expect(state).toMatchObject({
       sourceKind: "package",
-      saveTarget: savePath,
+      saveTarget: fs.realpathSync(savePath),
       dirty: false,
       needsSaveAs: false,
     });
@@ -313,9 +332,126 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     await expect(restartedShell.call("document.state", undefined)).resolves.toMatchObject({
       documentId: created.documentId,
       sourceKind: "package",
-      saveTarget: savePath,
+      saveTarget: fs.realpathSync(savePath),
       dirty: true,
       needsSaveAs: false,
+    });
+  });
+
+  it("opening a clean package binding hydrates a fresh document", async () => {
+    const source = await connectSyncLane();
+    const created = await createWorkspace(source);
+    await source.call("workspace.apply", { intents: [createGlyphA()], label: "Add Glyph" });
+    const savePath = path.join(tmpRoot, "CleanBinding.shift");
+    await source.call("workspace.saveAs", { path: savePath });
+    const oldStorePath = path.join(tmpRoot, "documents", created.documentId, "document.sqlite");
+
+    const lane = new MessageChannel();
+    const restartedShell: ShellChannel = new Channel(nodePortTransport(lane.port1));
+    channels.push(restartedShell);
+    startHost(nodePortTransport(lane.port2));
+    const restarted = await connectSyncLane(restartedShell);
+
+    const opened = await openWorkspace(restarted, restartedShell, savePath);
+
+    expect(opened.documentId).not.toBe(created.documentId);
+    expect(opened.glyphs.map((glyph) => glyph.name)).toEqual(["A"]);
+    expect(fs.existsSync(oldStorePath)).toBe(false);
+    await expect(restartedShell.call("document.state", undefined)).resolves.toMatchObject({
+      packageId: expect.stringMatching(/^package_/),
+      canonicalPath: fs.realpathSync(savePath),
+      dirty: false,
+    });
+  });
+
+  it("opening a dirty binding after the source changes hydrates fresh and orphans the old document", async () => {
+    const source = await connectSyncLane();
+    const created = await createWorkspace(source);
+    await source.call("workspace.apply", { intents: [createGlyphA()], label: "Add Glyph" });
+    const savePath = path.join(tmpRoot, "Diverged.shift");
+    await source.call("workspace.saveAs", { path: savePath });
+    await source.call("workspace.apply", {
+      intents: [createGlyph("B" as GlyphName, 66 as Unicode)],
+      label: "Add Glyph",
+    });
+    externallyAddGlyph(savePath, "C" as GlyphName, 67 as Unicode);
+
+    const lane = new MessageChannel();
+    const restartedShell: ShellChannel = new Channel(nodePortTransport(lane.port1));
+    channels.push(restartedShell);
+    startHost(nodePortTransport(lane.port2));
+    const restarted = await connectSyncLane(restartedShell);
+
+    const opened = await openWorkspace(restarted, restartedShell, savePath);
+
+    expect(opened.documentId).not.toBe(created.documentId);
+    expect(opened.glyphs.map((glyph) => glyph.name)).toEqual(["A", "C"]);
+    expect(fs.existsSync(path.join(tmpRoot, "documents", created.documentId))).toBe(true);
+    expect(fs.existsSync(path.join(tmpRoot, "orphaned", `${created.documentId}.json`))).toBe(true);
+    await expect(restartedShell.call("document.state", undefined)).resolves.toMatchObject({
+      dirty: false,
+      canonicalPath: fs.realpathSync(savePath),
+    });
+  });
+
+  it("opening a moved package resumes the dirty document and relinks the binding", async () => {
+    const source = await connectSyncLane();
+    const created = await createWorkspace(source);
+    await source.call("workspace.apply", { intents: [createGlyphA()], label: "Add Glyph" });
+    const savePath = path.join(tmpRoot, "Original.shift");
+    const movedPath = path.join(tmpRoot, "Moved.shift");
+    await source.call("workspace.saveAs", { path: savePath });
+    await source.call("workspace.apply", {
+      intents: [createGlyph("B" as GlyphName, 66 as Unicode)],
+      label: "Add Glyph",
+    });
+    fs.renameSync(savePath, movedPath);
+
+    const lane = new MessageChannel();
+    const restartedShell: ShellChannel = new Channel(nodePortTransport(lane.port1));
+    channels.push(restartedShell);
+    startHost(nodePortTransport(lane.port2));
+    const restarted = await connectSyncLane(restartedShell);
+
+    const opened = await openWorkspace(restarted, restartedShell, movedPath);
+
+    expect(opened.documentId).toBe(created.documentId);
+    expect(opened.glyphs.map((glyph) => glyph.name)).toEqual(["A", "B"]);
+    await expect(restartedShell.call("document.state", undefined)).resolves.toMatchObject({
+      documentId: created.documentId,
+      saveTarget: fs.realpathSync(movedPath),
+      canonicalPath: fs.realpathSync(movedPath),
+      dirty: true,
+    });
+  });
+
+  it("opening a copied package while the original exists hydrates a separate clean document", async () => {
+    const source = await connectSyncLane();
+    const created = await createWorkspace(source);
+    await source.call("workspace.apply", { intents: [createGlyphA()], label: "Add Glyph" });
+    const savePath = path.join(tmpRoot, "OriginalForCopy.shift");
+    const copyPath = path.join(tmpRoot, "Copy.shift");
+    await source.call("workspace.saveAs", { path: savePath });
+    await source.call("workspace.apply", {
+      intents: [createGlyph("B" as GlyphName, 66 as Unicode)],
+      label: "Add Glyph",
+    });
+    fs.copyFileSync(savePath, copyPath);
+
+    const lane = new MessageChannel();
+    const restartedShell: ShellChannel = new Channel(nodePortTransport(lane.port1));
+    channels.push(restartedShell);
+    startHost(nodePortTransport(lane.port2));
+    const restarted = await connectSyncLane(restartedShell);
+
+    const opened = await openWorkspace(restarted, restartedShell, copyPath);
+
+    expect(opened.documentId).not.toBe(created.documentId);
+    expect(opened.glyphs.map((glyph) => glyph.name)).toEqual(["A"]);
+    await expect(restartedShell.call("document.state", undefined)).resolves.toMatchObject({
+      saveTarget: fs.realpathSync(copyPath),
+      canonicalPath: fs.realpathSync(copyPath),
+      dirty: false,
     });
   });
 
@@ -351,6 +487,42 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     });
 
     unlisten();
+  });
+
+  it("workspace.close deletes a clean document and emits null state", async () => {
+    let latestState: WorkspaceDocumentState | null | undefined;
+    const unlisten = shell.listen("document.changed", (state) => {
+      latestState = state;
+    });
+    const sync = await connectSyncLane();
+    const created = await createWorkspace(sync);
+    const storePath = path.join(tmpRoot, "documents", created.documentId, "document.sqlite");
+
+    await expect(shell.call("workspace.close", { discard: false })).resolves.toBeNull();
+
+    expect(latestState).toBeNull();
+    expect(fs.existsSync(storePath)).toBe(false);
+    await expect(shell.call("document.state", undefined)).resolves.toBeNull();
+    await expect(sync.call("workspace.snapshot", undefined)).resolves.toBeNull();
+    unlisten();
+  });
+
+  it("workspace.close requires discard for dirty documents", async () => {
+    const sync = await connectSyncLane();
+    const created = await createWorkspace(sync);
+    await sync.call("workspace.apply", { intents: [createGlyphA()], label: "Add Glyph" });
+    const storePath = path.join(tmpRoot, "documents", created.documentId, "document.sqlite");
+
+    await expect(shell.call("workspace.close", { discard: false })).rejects.toThrow(
+      "cannot close a dirty workspace without discard",
+    );
+    await expect(shell.call("document.state", undefined)).resolves.toMatchObject({
+      documentId: created.documentId,
+      dirty: true,
+    });
+
+    await expect(shell.call("workspace.close", { discard: true })).resolves.toBeNull();
+    expect(fs.existsSync(storePath)).toBe(false);
   });
 
   it("a reconnected sync lane still serves the open workspace", async () => {

--- a/apps/desktop/src/utility/workspace/WorkspaceHost.ts
+++ b/apps/desktop/src/utility/workspace/WorkspaceHost.ts
@@ -1,5 +1,4 @@
 import { createBridge, type ShiftBridge } from "@shift/bridge";
-import fs from "node:fs";
 import path from "node:path";
 import { serveChannel, type ChannelServer, type Transport } from "../../shared/workspace/channel";
 import type {
@@ -14,12 +13,8 @@ import type {
   WorkspaceSnapshot,
 } from "../../shared/workspace/protocol";
 import { DocumentStorage } from "./DocumentStorage";
-import type {
-  DocumentAllocation,
-  PackageAddress,
-  PackageBinding,
-  PackageOpenTransition,
-} from "./types";
+import { PackageOpener } from "./PackageOpener";
+import { PackageAddress, type DocumentAllocation } from "./types";
 
 /**
  * Construction options for {@link WorkspaceHost}.
@@ -48,6 +43,7 @@ export type WorkspaceHostOptions = {
 export class WorkspaceHost {
   readonly #bridge: ShiftBridge;
   readonly #documents: DocumentStorage;
+  readonly #packageOpener: PackageOpener;
   readonly #shellTransport: Transport;
   readonly #syncTransport: (port: unknown) => Transport;
   #shell: ChannelServer<ShellEventMap> | null = null;
@@ -59,6 +55,7 @@ export class WorkspaceHost {
   constructor(options: WorkspaceHostOptions) {
     this.#bridge = createBridge();
     this.#documents = new DocumentStorage(options.documentsRoot);
+    this.#packageOpener = new PackageOpener(this.#bridge, this.#documents);
     this.#shellTransport = options.shell;
     this.#syncTransport = options.syncTransport;
   }
@@ -165,132 +162,10 @@ export class WorkspaceHost {
 
   #openPackage(sourcePath: string): WorkspaceDocumentState {
     const identity = this.#inspectPackage(sourcePath);
-    const transition = this.#packageOpenTransition(identity);
+    const opened = this.#packageOpener.open(identity);
 
-    switch (transition.kind) {
-      case "hydrateFresh":
-        this.#hydrateFreshPackage(transition.identity);
-        break;
-      case "resumeExact":
-        this.#resumePackageBinding(transition.identity, transition.binding);
-        break;
-      case "replaceClean":
-        this.#replaceCleanPackageBinding(transition.identity, transition.binding);
-        break;
-      case "orphanDiverged":
-        this.#orphanDivergedPackageBinding(transition.identity, transition.binding);
-        break;
-      case "resumeMoved":
-        this.#resumeMovedPackageBinding(transition.identity, transition.binding);
-        break;
-      default:
-        assertNever(transition);
-    }
-
+    this.#adoptDocument(opened.document, opened.address);
     return this.#emitDocumentChanged();
-  }
-
-  #packageOpenTransition(identity: WorkspacePackageIdentity): PackageOpenTransition {
-    const address = packageAddress(identity);
-    const binding = this.#documents.packageBinding(address);
-    if (!binding) {
-      const moved = this.#movedPackageBinding(identity);
-      return moved
-        ? { kind: "resumeMoved", identity, binding: moved }
-        : { kind: "hydrateFresh", identity };
-    }
-
-    const draft = this.#bridge.inspectPackageDraft(binding.storePath);
-    if (draft.packageId !== identity.packageId) {
-      throw new Error(
-        `package binding ${binding.documentId} points at ${draft.packageId}, expected ${identity.packageId}`,
-      );
-    }
-
-    if (!draft.dirty) return { kind: "replaceClean", identity, binding };
-    if (draft.baseFingerprint === identity.fingerprint) {
-      return { kind: "resumeExact", identity, binding };
-    }
-
-    return { kind: "orphanDiverged", identity, binding };
-  }
-
-  #movedPackageBinding(identity: WorkspacePackageIdentity): PackageBinding | null {
-    const candidates: PackageBinding[] = [];
-
-    for (const binding of this.#documents.listPackageBindings(identity.packageId)) {
-      if (binding.canonicalPath === identity.canonicalPath) continue;
-      if (pathExists(binding.canonicalPath)) continue;
-
-      const draft = this.#inspectPackageDraftOrNull(binding);
-      if (!draft?.dirty) continue;
-      if (draft.packageId !== identity.packageId) continue;
-      if (draft.baseFingerprint !== identity.fingerprint) continue;
-
-      candidates.push(binding);
-    }
-
-    return candidates.length === 1 ? candidates[0] : null;
-  }
-
-  #inspectPackageDraftOrNull(
-    binding: PackageBinding,
-  ): ReturnType<ShiftBridge["inspectPackageDraft"]> | null {
-    try {
-      return this.#bridge.inspectPackageDraft(binding.storePath);
-    } catch {
-      return null;
-    }
-  }
-
-  #hydrateFreshPackage(identity: WorkspacePackageIdentity): void {
-    const document = this.#createPackageDocument(identity);
-    this.#adoptDocument(document, packageAddress(identity));
-  }
-
-  #replaceCleanPackageBinding(identity: WorkspacePackageIdentity, binding: PackageBinding): void {
-    const document = this.#createPackageDocument(identity);
-    this.#documents.writePackageBinding(packageAddress(identity), document.documentId);
-    this.#documents.deleteDocument(binding.documentId);
-    this.#adoptDocument(document, packageAddress(identity));
-  }
-
-  #orphanDivergedPackageBinding(identity: WorkspacePackageIdentity, binding: PackageBinding): void {
-    const document = this.#createPackageDocument(identity);
-    this.#documents.writePackageBinding(packageAddress(identity), document.documentId);
-    this.#documents.orphanDocument(binding, "source-diverged");
-    this.#adoptDocument(document, packageAddress(identity));
-  }
-
-  #resumePackageBinding(identity: WorkspacePackageIdentity, binding: PackageBinding): void {
-    this.#bridge.resumeWorkspaceForSource(binding.storePath, identity.canonicalPath);
-    this.#bridge.setDocumentId(binding.documentId);
-    this.#adoptDocument(binding, packageAddress(identity));
-  }
-
-  #resumeMovedPackageBinding(identity: WorkspacePackageIdentity, binding: PackageBinding): void {
-    this.#bridge.resumeWorkspaceForSource(binding.storePath, identity.canonicalPath);
-    this.#bridge.setDocumentId(binding.documentId);
-    this.#documents.writePackageBinding(packageAddress(identity), binding.documentId);
-    this.#documents.removePackageBinding({
-      packageId: binding.packageId,
-      canonicalPath: binding.canonicalPath,
-    });
-    this.#adoptDocument(binding, packageAddress(identity));
-  }
-
-  #createPackageDocument(identity: WorkspacePackageIdentity): DocumentAllocation {
-    const document = this.#documents.createDocument();
-
-    try {
-      this.#bridge.openWorkspace(identity.canonicalPath, document.storePath);
-      this.#bridge.setDocumentId(document.documentId);
-      this.#documents.writePackageBinding(packageAddress(identity), document.documentId);
-      return document;
-    } catch (error) {
-      this.#documents.deleteDocument(document.documentId);
-      throw error;
-    }
   }
 
   #adoptDocument(document: DocumentAllocation, address: PackageAddress | null): void {
@@ -308,11 +183,11 @@ export class WorkspaceHost {
 
     this.#bridge.saveWorkspaceAs(savePath);
     const identity = this.#inspectPackage(savePath);
-    const newAddress = packageAddress(identity);
+    const newAddress = PackageAddress.fromIdentity(identity);
     const documentId = this.#requireDocumentId();
 
     this.#documents.writePackageBinding(newAddress, documentId);
-    if (oldAddress && !samePackageAddress(oldAddress, newAddress)) {
+    if (oldAddress && !PackageAddress.equals(oldAddress, newAddress)) {
       this.#documents.removePackageBinding(oldAddress);
     }
     this.#packageAddress = newAddress;
@@ -397,23 +272,4 @@ function parseDocumentSourceKind(sourceKind: string): WorkspaceDocumentSourceKin
 
 function isShiftPackagePath(sourcePath: string): boolean {
   return path.extname(sourcePath).toLowerCase() === ".shift";
-}
-
-function packageAddress(identity: WorkspacePackageIdentity): PackageAddress {
-  return {
-    packageId: identity.packageId,
-    canonicalPath: identity.canonicalPath,
-  };
-}
-
-function samePackageAddress(left: PackageAddress, right: PackageAddress): boolean {
-  return left.packageId === right.packageId && left.canonicalPath === right.canonicalPath;
-}
-
-function pathExists(sourcePath: string): boolean {
-  return fs.existsSync(sourcePath);
-}
-
-function assertNever(value: never): never {
-  throw new Error(`unknown package open transition: ${JSON.stringify(value)}`);
 }

--- a/apps/desktop/src/utility/workspace/WorkspaceHost.ts
+++ b/apps/desktop/src/utility/workspace/WorkspaceHost.ts
@@ -1,4 +1,5 @@
 import { createBridge, type ShiftBridge } from "@shift/bridge";
+import fs from "node:fs";
 import path from "node:path";
 import { serveChannel, type ChannelServer, type Transport } from "../../shared/workspace/channel";
 import type {
@@ -9,9 +10,16 @@ import type {
   WorkspaceDocumentSourceKind,
   WorkspaceDocumentState,
   WorkspaceGlyphSnapshot,
+  WorkspacePackageIdentity,
   WorkspaceSnapshot,
 } from "../../shared/workspace/protocol";
 import { DocumentStorage } from "./DocumentStorage";
+import type {
+  DocumentAllocation,
+  PackageAddress,
+  PackageBinding,
+  PackageOpenTransition,
+} from "./types";
 
 /**
  * Construction options for {@link WorkspaceHost}.
@@ -45,6 +53,7 @@ export class WorkspaceHost {
   #shell: ChannelServer<ShellEventMap> | null = null;
   #sync: ChannelServer<SyncEventMap> | null = null;
   #documentId: string | null = null;
+  #packageAddress: PackageAddress | null = null;
   #operations: Promise<void> = Promise.resolve();
 
   constructor(options: WorkspaceHostOptions) {
@@ -58,7 +67,9 @@ export class WorkspaceHost {
   start(): void {
     this.#shell = serveChannel<ShellCallMap, ShellEventMap>(this.#shellTransport, {
       "workspace.create": () => this.#serialize(() => this.#create()),
+      "workspace.inspectPackage": ({ path }) => this.#serialize(() => this.#inspectPackage(path)),
       "workspace.open": ({ path }) => this.#serialize(() => this.#open(path)),
+      "workspace.close": ({ discard }) => this.#serialize(() => this.#close(discard)),
       "workspace.connect": (_payload, context) => {
         this.#connectSyncLane(context.ports);
       },
@@ -108,13 +119,23 @@ export class WorkspaceHost {
   }
 
   #create(): WorkspaceDocumentState {
-    const draft = this.#documents.createDraft();
+    const document = this.#documents.createDocument();
 
-    this.#bridge.createUntitledWorkspace(draft.storePath);
-    this.#bridge.setDocumentId(draft.documentId);
-    this.#documentId = draft.documentId;
+    this.#bridge.createUntitledWorkspace(document.storePath);
+    this.#bridge.setDocumentId(document.documentId);
+    this.#documentId = document.documentId;
+    this.#packageAddress = null;
 
     return this.#emitDocumentChanged();
+  }
+
+  #inspectPackage(path: string): WorkspacePackageIdentity {
+    const identity = this.#bridge.inspectPackage(path);
+    return {
+      packageId: identity.packageId,
+      canonicalPath: identity.canonicalPath,
+      fingerprint: identity.fingerprint,
+    };
   }
 
   #snapshot(documentId: string): WorkspaceSnapshot {
@@ -128,22 +149,153 @@ export class WorkspaceHost {
     };
   }
 
-  #open(path: string): WorkspaceDocumentState {
-    const recovery = isShiftPackagePath(path)
-      ? this.#bridge.findRecoverableWorkspace(path, this.#documents.listDrafts())
-      : null;
-    const document = recovery ?? this.#documents.createDraft();
-
-    if (recovery) {
-      this.#bridge.resumeWorkspaceForSource(recovery.storePath, path);
-    } else {
-      this.#bridge.openWorkspace(path, document.storePath);
+  #open(sourcePath: string): WorkspaceDocumentState {
+    if (isShiftPackagePath(sourcePath)) {
+      return this.#openPackage(sourcePath);
     }
 
+    const document = this.#documents.createDocument();
+    this.#bridge.openWorkspace(sourcePath, document.storePath);
     this.#bridge.setDocumentId(document.documentId);
     this.#documentId = document.documentId;
+    this.#packageAddress = null;
 
     return this.#emitDocumentChanged();
+  }
+
+  #openPackage(sourcePath: string): WorkspaceDocumentState {
+    const identity = this.#inspectPackage(sourcePath);
+    const transition = this.#packageOpenTransition(identity);
+
+    switch (transition.kind) {
+      case "hydrateFresh":
+        this.#hydrateFreshPackage(transition.identity);
+        break;
+      case "resumeExact":
+        this.#resumePackageBinding(transition.identity, transition.binding);
+        break;
+      case "replaceClean":
+        this.#replaceCleanPackageBinding(transition.identity, transition.binding);
+        break;
+      case "orphanDiverged":
+        this.#orphanDivergedPackageBinding(transition.identity, transition.binding);
+        break;
+      case "resumeMoved":
+        this.#resumeMovedPackageBinding(transition.identity, transition.binding);
+        break;
+      default:
+        assertNever(transition);
+    }
+
+    return this.#emitDocumentChanged();
+  }
+
+  #packageOpenTransition(identity: WorkspacePackageIdentity): PackageOpenTransition {
+    const address = packageAddress(identity);
+    const binding = this.#documents.packageBinding(address);
+    if (!binding) {
+      const moved = this.#movedPackageBinding(identity);
+      return moved
+        ? { kind: "resumeMoved", identity, binding: moved }
+        : { kind: "hydrateFresh", identity };
+    }
+
+    const draft = this.#bridge.inspectPackageDraft(binding.storePath);
+    if (draft.packageId !== identity.packageId) {
+      throw new Error(
+        `package binding ${binding.documentId} points at ${draft.packageId}, expected ${identity.packageId}`,
+      );
+    }
+
+    if (!draft.dirty) return { kind: "replaceClean", identity, binding };
+    if (draft.baseFingerprint === identity.fingerprint) {
+      return { kind: "resumeExact", identity, binding };
+    }
+
+    return { kind: "orphanDiverged", identity, binding };
+  }
+
+  #movedPackageBinding(identity: WorkspacePackageIdentity): PackageBinding | null {
+    const candidates: PackageBinding[] = [];
+
+    for (const binding of this.#documents.listPackageBindings(identity.packageId)) {
+      if (binding.canonicalPath === identity.canonicalPath) continue;
+      if (pathExists(binding.canonicalPath)) continue;
+
+      const draft = this.#inspectPackageDraftOrNull(binding);
+      if (!draft?.dirty) continue;
+      if (draft.packageId !== identity.packageId) continue;
+      if (draft.baseFingerprint !== identity.fingerprint) continue;
+
+      candidates.push(binding);
+    }
+
+    return candidates.length === 1 ? candidates[0] : null;
+  }
+
+  #inspectPackageDraftOrNull(
+    binding: PackageBinding,
+  ): ReturnType<ShiftBridge["inspectPackageDraft"]> | null {
+    try {
+      return this.#bridge.inspectPackageDraft(binding.storePath);
+    } catch {
+      return null;
+    }
+  }
+
+  #hydrateFreshPackage(identity: WorkspacePackageIdentity): void {
+    const document = this.#createPackageDocument(identity);
+    this.#adoptDocument(document, packageAddress(identity));
+  }
+
+  #replaceCleanPackageBinding(identity: WorkspacePackageIdentity, binding: PackageBinding): void {
+    const document = this.#createPackageDocument(identity);
+    this.#documents.writePackageBinding(packageAddress(identity), document.documentId);
+    this.#documents.deleteDocument(binding.documentId);
+    this.#adoptDocument(document, packageAddress(identity));
+  }
+
+  #orphanDivergedPackageBinding(identity: WorkspacePackageIdentity, binding: PackageBinding): void {
+    const document = this.#createPackageDocument(identity);
+    this.#documents.writePackageBinding(packageAddress(identity), document.documentId);
+    this.#documents.orphanDocument(binding, "source-diverged");
+    this.#adoptDocument(document, packageAddress(identity));
+  }
+
+  #resumePackageBinding(identity: WorkspacePackageIdentity, binding: PackageBinding): void {
+    this.#bridge.resumeWorkspaceForSource(binding.storePath, identity.canonicalPath);
+    this.#bridge.setDocumentId(binding.documentId);
+    this.#adoptDocument(binding, packageAddress(identity));
+  }
+
+  #resumeMovedPackageBinding(identity: WorkspacePackageIdentity, binding: PackageBinding): void {
+    this.#bridge.resumeWorkspaceForSource(binding.storePath, identity.canonicalPath);
+    this.#bridge.setDocumentId(binding.documentId);
+    this.#documents.writePackageBinding(packageAddress(identity), binding.documentId);
+    this.#documents.removePackageBinding({
+      packageId: binding.packageId,
+      canonicalPath: binding.canonicalPath,
+    });
+    this.#adoptDocument(binding, packageAddress(identity));
+  }
+
+  #createPackageDocument(identity: WorkspacePackageIdentity): DocumentAllocation {
+    const document = this.#documents.createDocument();
+
+    try {
+      this.#bridge.openWorkspace(identity.canonicalPath, document.storePath);
+      this.#bridge.setDocumentId(document.documentId);
+      this.#documents.writePackageBinding(packageAddress(identity), document.documentId);
+      return document;
+    } catch (error) {
+      this.#documents.deleteDocument(document.documentId);
+      throw error;
+    }
+  }
+
+  #adoptDocument(document: DocumentAllocation, address: PackageAddress | null): void {
+    this.#documentId = document.documentId;
+    this.#packageAddress = address;
   }
 
   #save(): WorkspaceDocumentState {
@@ -151,19 +303,56 @@ export class WorkspaceHost {
     return this.#emitDocumentChanged();
   }
 
-  #saveAs(path: string): WorkspaceDocumentState {
-    this.#bridge.saveWorkspaceAs(path);
+  #saveAs(savePath: string): WorkspaceDocumentState {
+    const oldAddress = this.#packageAddress;
+
+    this.#bridge.saveWorkspaceAs(savePath);
+    const identity = this.#inspectPackage(savePath);
+    const newAddress = packageAddress(identity);
+    const documentId = this.#requireDocumentId();
+
+    this.#documents.writePackageBinding(newAddress, documentId);
+    if (oldAddress && !samePackageAddress(oldAddress, newAddress)) {
+      this.#documents.removePackageBinding(oldAddress);
+    }
+    this.#packageAddress = newAddress;
+
     return this.#emitDocumentChanged();
+  }
+
+  #close(discard: boolean): null {
+    const state = this.#documentState();
+    if (!state) return null;
+    if (state.dirty && !discard) {
+      throw new Error("cannot close a dirty workspace without discard");
+    }
+
+    const documentId = state.documentId;
+    const address = this.#packageAddress;
+
+    this.#bridge.closeWorkspace();
+    this.#documentId = null;
+    this.#packageAddress = null;
+
+    if (address) this.#documents.removePackageBinding(address);
+    this.#documents.deleteDocument(documentId);
+    this.#shell?.emit("document.changed", null);
+    this.#sync?.emit("document.changed", null);
+
+    return null;
   }
 
   #documentState(): WorkspaceDocumentState | null {
     if (this.#documentId === null) return null;
     const state = this.#bridge.documentState();
+    const address = this.#packageAddress;
 
     return {
       documentId: this.#documentId,
       sourceKind: parseDocumentSourceKind(state.sourceKind),
       saveTarget: state.saveTarget ?? null,
+      packageId: address?.packageId ?? null,
+      canonicalPath: address?.canonicalPath ?? null,
       dirty: state.dirty,
       needsSaveAs: state.needsSaveAs,
     };
@@ -188,6 +377,14 @@ export class WorkspaceHost {
     );
     return run;
   }
+
+  #requireDocumentId(): string {
+    if (this.#documentId === null) {
+      throw new Error("no workspace is open");
+    }
+
+    return this.#documentId;
+  }
 }
 
 function parseDocumentSourceKind(sourceKind: string): WorkspaceDocumentSourceKind {
@@ -200,4 +397,23 @@ function parseDocumentSourceKind(sourceKind: string): WorkspaceDocumentSourceKin
 
 function isShiftPackagePath(sourcePath: string): boolean {
   return path.extname(sourcePath).toLowerCase() === ".shift";
+}
+
+function packageAddress(identity: WorkspacePackageIdentity): PackageAddress {
+  return {
+    packageId: identity.packageId,
+    canonicalPath: identity.canonicalPath,
+  };
+}
+
+function samePackageAddress(left: PackageAddress, right: PackageAddress): boolean {
+  return left.packageId === right.packageId && left.canonicalPath === right.canonicalPath;
+}
+
+function pathExists(sourcePath: string): boolean {
+  return fs.existsSync(sourcePath);
+}
+
+function assertNever(value: never): never {
+  throw new Error(`unknown package open transition: ${JSON.stringify(value)}`);
 }

--- a/apps/desktop/src/utility/workspace/types.ts
+++ b/apps/desktop/src/utility/workspace/types.ts
@@ -6,11 +6,49 @@ export type DocumentAllocation = {
   storePath: string;
 };
 
-/** Identifies one package instance by package id and canonical source path. */
-export type PackageAddress = {
-  packageId: string;
-  canonicalPath: string;
-};
+/**
+ * Identifies one package instance by package id and canonical source path.
+ *
+ * @remarks
+ * Package addresses intentionally ignore source fingerprints. They identify the
+ * durable binding slot; fingerprint comparisons belong to package open actions.
+ */
+export class PackageAddress {
+  readonly packageId: string;
+  readonly canonicalPath: string;
+
+  /**
+   * Creates a package address from durable package identity fields.
+   *
+   * @param packageId - stable id stored in the `.shift` manifest.
+   * @param canonicalPath - canonical source path for this package instance.
+   */
+  constructor(packageId: string, canonicalPath: string) {
+    this.packageId = packageId;
+    this.canonicalPath = canonicalPath;
+  }
+
+  /**
+   * Builds a package address from an inspected package identity.
+   *
+   * @param identity - package identity returned by Rust for the current source path.
+   * @returns package id and canonical path; the source fingerprint is excluded.
+   */
+  static fromIdentity(identity: WorkspacePackageIdentity): PackageAddress {
+    return new PackageAddress(identity.packageId, identity.canonicalPath);
+  }
+
+  /**
+   * Compares package addresses by durable package id and canonical source path.
+   *
+   * @param left - first package address.
+   * @param right - second package address.
+   * @returns true when both addresses identify the same package path.
+   */
+  static equals(left: PackageAddress, right: PackageAddress): boolean {
+    return left.packageId === right.packageId && left.canonicalPath === right.canonicalPath;
+  }
+}
 
 /** Binds one package instance to its current working document. */
 export type PackageBinding = PackageAddress &
@@ -26,10 +64,16 @@ export type OrphanedDocument = DocumentAllocation & {
   orphanedAt: string;
 };
 
-/** Describes the package-open transition chosen before mutating bindings. */
-export type PackageOpenTransition =
-  | { kind: "hydrateFresh"; identity: WorkspacePackageIdentity }
-  | { kind: "resumeExact"; identity: WorkspacePackageIdentity; binding: PackageBinding }
-  | { kind: "replaceClean"; identity: WorkspacePackageIdentity; binding: PackageBinding }
-  | { kind: "orphanDiverged"; identity: WorkspacePackageIdentity; binding: PackageBinding }
-  | { kind: "resumeMoved"; identity: WorkspacePackageIdentity; binding: PackageBinding };
+/** Describes the package-open action chosen before mutating bindings. */
+export type PackageOpenAction =
+  | { kind: "hydrate" }
+  | { kind: "resume"; binding: PackageBinding }
+  | { kind: "replace"; binding: PackageBinding }
+  | { kind: "orphan"; binding: PackageBinding }
+  | { kind: "move"; binding: PackageBinding };
+
+/** Document and package address settled by a package open. */
+export type PackageOpenResult = {
+  document: DocumentAllocation;
+  address: PackageAddress;
+};

--- a/apps/desktop/src/utility/workspace/types.ts
+++ b/apps/desktop/src/utility/workspace/types.ts
@@ -1,10 +1,35 @@
-/**
- * Filesystem allocation for one draft document.
- *
- * @remarks
- * Utility-process internal: store paths never cross to main or the renderer.
- */
-export type DraftAllocation = {
+import type { WorkspacePackageIdentity } from "../../shared/workspace/protocol";
+
+/** Identifies one utility-owned SQLite document allocation. */
+export type DocumentAllocation = {
   documentId: string;
   storePath: string;
 };
+
+/** Identifies one package instance by package id and canonical source path. */
+export type PackageAddress = {
+  packageId: string;
+  canonicalPath: string;
+};
+
+/** Binds one package instance to its current working document. */
+export type PackageBinding = PackageAddress &
+  DocumentAllocation & {
+    updatedAt: string;
+  };
+
+/** Records a dirty working document detached from its package binding. */
+export type OrphanedDocument = DocumentAllocation & {
+  packageId: string;
+  canonicalPath: string;
+  reason: string;
+  orphanedAt: string;
+};
+
+/** Describes the package-open transition chosen before mutating bindings. */
+export type PackageOpenTransition =
+  | { kind: "hydrateFresh"; identity: WorkspacePackageIdentity }
+  | { kind: "resumeExact"; identity: WorkspacePackageIdentity; binding: PackageBinding }
+  | { kind: "replaceClean"; identity: WorkspacePackageIdentity; binding: PackageBinding }
+  | { kind: "orphanDiverged"; identity: WorkspacePackageIdentity; binding: PackageBinding }
+  | { kind: "resumeMoved"; identity: WorkspacePackageIdentity; binding: PackageBinding };

--- a/crates/shift-bridge/docs/DOCS.md
+++ b/crates/shift-bridge/docs/DOCS.md
@@ -14,6 +14,8 @@ NAPI bindings that expose the Rust font engine to Node.js and Electron as a `Bri
 
 **Architecture Invariant:** Export uses a clone/COW `FontSaveSnapshot` of the current workspace font. **WHY:** Async export can run from a stable view without coupling output generation to renderer focus state.
 
+**Architecture Invariant:** Package inspection methods are read-only and may run without an open workspace. **WHY:** Electron main/utility code must inspect package identity before deciding whether to reuse, hydrate, relink, or orphan a working document.
+
 ## Codemap
 
 ```
@@ -31,10 +33,11 @@ crates/shift-bridge/
 - `Bridge` -- the exported `#[napi]` class holding the current `FontWorkspace` and document versions.
 - `LayerId` -- mutation-side identity for the glyph layer being edited.
 - `FontSaveSnapshot` -- clone/COW export view of the current workspace font.
+- `NapiPackageIdentity` / `NapiPackageDraft` -- package source and working-store inspection DTOs for utility-process lifecycle decisions.
 - `ExportFontTask` -- NAPI `Task` implementation for async font export.
 - `BridgeError` -- typed bridge error enum converted once at the NAPI boundary.
-- `GlyphStructureChange` / `GlyphValueChange` -- canonical wire DTOs returned by mutations.
-- `NapiGlyphStructureChange` / `NapiGlyphValueChange` -- NAPI adapters for those DTOs.
+- `NapiAppliedChange` -- replace-grade mutation response returned by apply/undo/redo.
+- `NapiLayerReplaced` -- NAPI adapter for one replaced glyph layer in an applied change.
 
 ## How it works
 
@@ -43,7 +46,9 @@ crates/shift-bridge/
 3. `Bridge` parses boundary strings and asks `FontWorkspace` to run the edit against that layer.
 4. The bridge returns a `shift-wire` change DTO and bumps the live version.
 5. `saveWorkspace()` / `saveWorkspaceAs(path)` update the `.shift` source package target and record the persisted version.
-6. `exportWorkspace(request)` creates a `FontSaveSnapshot` and exports asynchronously through `shift-backends`.
+6. `inspectPackage(path)` and `inspectPackageDraft(storePath)` expose source/package identity for the utility process without choosing a recovery policy.
+7. `closeWorkspace()` drops the live Rust workspace handle before the utility process deletes a clean or discarded SQLite document.
+8. `exportWorkspace(request)` creates a `FontSaveSnapshot` and exports asynchronously through `shift-backends`.
 
 ## Type Boundary
 

--- a/crates/shift-bridge/index.d.ts
+++ b/crates/shift-bridge/index.d.ts
@@ -16,10 +16,12 @@ export declare class Bridge {
   createUntitledWorkspace(storePath: string, options?: NapiNewWorkspace | undefined | null): void
   exportWorkspace(request: NapiFontExportRequest): Promise<NapiFontExportResult>
   documentState(): NapiDocumentState
+  inspectPackage(path: string): NapiPackageIdentity
+  inspectPackageDraft(storePath: string): NapiPackageDraft
+  closeWorkspace(): void
   openWorkspace(path: string, storePath: string): void
   resumeWorkspaceForSource(storePath: string, sourcePath: string): void
   setDocumentId(documentId: string): NapiDocumentState
-  findRecoverableWorkspace(sourcePath: string, candidates: Array<NapiWorkspaceRecoveryCandidate>): NapiWorkspaceRecoveryMatch | null
   saveWorkspace(): NapiDocumentState
   saveWorkspaceAs(path: string): NapiDocumentState
   getMetadata(): NapiFontMetadata
@@ -71,16 +73,18 @@ export interface NapiNewWorkspace {
   unitsPerEm?: number
 }
 
-export interface NapiWorkspaceRecoveryCandidate {
-  documentId: string
-  storePath: string
+export interface NapiPackageDraft {
+  documentId?: string
+  packageId: string
+  sourcePath: string
+  baseFingerprint: string
+  dirty: boolean
 }
 
-export interface NapiWorkspaceRecoveryMatch {
-  documentId: string
-  storePath: string
-  matchKind: string
-  dirty: boolean
+export interface NapiPackageIdentity {
+  packageId: string
+  canonicalPath: string
+  fingerprint: string
 }
 export interface NapiAddAnchorsIntent {
   layerId: LayerId

--- a/crates/shift-bridge/src/bridge.rs
+++ b/crates/shift-bridge/src/bridge.rs
@@ -20,8 +20,7 @@ use shift_wire::{
   GlyphSnapshot, GlyphSnapshotRequest, GlyphState, GlyphStructure, Source,
 };
 use shift_workspace::{
-  FontWorkspace, NewWorkspace, RecoverySelection, WorkspaceError, WorkspaceRecoveryCandidate,
-  WorkspaceSource,
+  FontWorkspace, NewWorkspace, PackageDraft, PackageIdentity, WorkspaceError, WorkspaceSource,
 };
 use std::{path::Path, sync::Arc};
 
@@ -54,16 +53,18 @@ pub struct NapiDocumentState {
 }
 
 #[napi(object)]
-pub struct NapiWorkspaceRecoveryCandidate {
-  pub document_id: String,
-  pub store_path: String,
+pub struct NapiPackageIdentity {
+  pub package_id: String,
+  pub canonical_path: String,
+  pub fingerprint: String,
 }
 
 #[napi(object)]
-pub struct NapiWorkspaceRecoveryMatch {
-  pub document_id: String,
-  pub store_path: String,
-  pub match_kind: String,
+pub struct NapiPackageDraft {
+  pub document_id: Option<String>,
+  pub package_id: String,
+  pub source_path: String,
+  pub base_fingerprint: String,
   pub dirty: bool,
 }
 
@@ -103,6 +104,32 @@ impl From<FontExportResult> for NapiFontExportResult {
       path: result.path.to_string_lossy().into_owned(),
       format: result.format.as_str().to_string(),
     }
+  }
+}
+
+impl TryFrom<PackageIdentity> for NapiPackageIdentity {
+  type Error = BridgeError;
+
+  fn try_from(identity: PackageIdentity) -> BridgeResult<Self> {
+    Ok(Self {
+      package_id: identity.package_id,
+      canonical_path: path_to_string(&identity.canonical_path)?,
+      fingerprint: identity.fingerprint,
+    })
+  }
+}
+
+impl TryFrom<PackageDraft> for NapiPackageDraft {
+  type Error = BridgeError;
+
+  fn try_from(draft: PackageDraft) -> BridgeResult<Self> {
+    Ok(Self {
+      document_id: draft.document_id,
+      package_id: draft.package_id,
+      source_path: path_to_string(&draft.source_path)?,
+      base_fingerprint: draft.base_fingerprint,
+      dirty: draft.dirty,
+    })
   }
 }
 
@@ -282,6 +309,22 @@ impl Bridge {
   }
 
   #[napi]
+  pub fn inspect_package(&self, path: String) -> errors::Result<NapiPackageIdentity> {
+    FontWorkspace::inspect_package(path)?.try_into()
+  }
+
+  #[napi]
+  pub fn inspect_package_draft(&self, store_path: String) -> errors::Result<NapiPackageDraft> {
+    FontWorkspace::inspect_package_draft(store_path)?.try_into()
+  }
+
+  #[napi]
+  pub fn close_workspace(&mut self) {
+    self.workspace = None;
+    self.reset_versions();
+  }
+
+  #[napi]
   pub fn open_workspace(&mut self, path: String, store_path: String) -> errors::Result<()> {
     self.workspace = Some(FontWorkspace::open(path, store_path)?);
     self.reset_versions();
@@ -303,36 +346,6 @@ impl Bridge {
   pub fn set_document_id(&mut self, document_id: String) -> errors::Result<NapiDocumentState> {
     self.workspace_mut()?.set_document_id(document_id)?;
     self.document_state_snapshot()
-  }
-
-  #[napi]
-  pub fn find_recoverable_workspace(
-    &self,
-    source_path: String,
-    candidates: Vec<NapiWorkspaceRecoveryCandidate>,
-  ) -> errors::Result<Option<NapiWorkspaceRecoveryMatch>> {
-    let candidates = candidates
-      .into_iter()
-      .map(|candidate| WorkspaceRecoveryCandidate {
-        document_id: candidate.document_id,
-        store_path: candidate.store_path.into(),
-      })
-      .collect::<Vec<_>>();
-    let recovery_match =
-      match FontWorkspace::find_recoverable_package_workspace(source_path, &candidates)? {
-        RecoverySelection::None => return Ok(None),
-        RecoverySelection::One(recovery_match) => recovery_match,
-        RecoverySelection::Ambiguous(matches) => {
-          return Err(WorkspaceError::AmbiguousRecoveryCandidates(matches.len()).into());
-        }
-      };
-
-    Ok(Some(NapiWorkspaceRecoveryMatch {
-      document_id: recovery_match.document_id,
-      store_path: path_to_string(&recovery_match.store_path)?,
-      match_kind: recovery_match.match_kind.as_str().to_string(),
-      dirty: recovery_match.dirty,
-    }))
   }
 
   #[napi]

--- a/crates/shift-source/Cargo.toml
+++ b/crates/shift-source/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+getrandom = "0.3.3"
 shift-font = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/shift-source/docs/DOCS.md
+++ b/crates/shift-source/docs/DOCS.md
@@ -5,6 +5,7 @@ Source-package crate for Shift's user-authored `.shift` format.
 ## Architecture Invariants
 
 - **Architecture Invariant:** `.shift` is a single zip file containing deterministic JSON entries. `manifest.json` is stored uncompressed as the first zip entry.
+- **Architecture Invariant:** Every `.shift` manifest carries a stable `packageId`. Filesystem moves and byte-for-byte copies preserve it; Save As mints a new one.
 - **Architecture Invariant:** This crate owns the stable source schema DTOs and converts to/from `shift_font::Font`. It does not expose serde for private `shift-font` storage structs as the file contract.
 - **Architecture Invariant:** Serialization is tree-first: `font_to_tree` emits `Vec<(path, bytes)>`; `write_tree_atomic` is the zip container layer. A future loose-directory container can reuse the same tree schema.
 - **Architecture Invariant:** `.shift` is separate from the app-managed SQLite working store. SQLite import/export wiring belongs in `shift-workspace`, not here.
@@ -20,6 +21,7 @@ crates/shift-source/src/
 ## Key Types
 
 - `ShiftSourcePackage` -- opened or newly written `.shift` zip file.
+- `PackageId` -- stable package identity stored in `manifest.json`.
 - `SourcePackageError` -- typed package IO, zip, JSON, schema, and conversion failures.
 - `PackageTree` -- deterministic file tree as `(path, bytes)` entries.
 
@@ -76,11 +78,13 @@ Current `shift_font::LibData` is preserved in `modules/shift.libData.json`, a
 Shift-owned, schema-versioned module. Core font/glyph/layer JSON documents do
 not grow arbitrary `lib` fields.
 
-## How It Works
+## How it works
 
 `font_to_tree(font)` converts the live `Font` projection into deterministic JSON entries. `tree_to_font(tree)` validates the manifest and rebuilds a `Font` through public `shift-font` constructors and mutators.
 
 `ShiftSourcePackage::save_font(path, font)` writes `path.tmp`, syncs it, then atomically renames it to `path`. `ShiftSourcePackage::load_font(path)` reads the zip tree and returns a rebuilt `Font`.
+
+`ShiftSourcePackage::save_font(path, font)` preserves the package id when `path` already contains a valid `.shift` package. `ShiftSourcePackage::save_font_as(path, font)` always mints a new package id for Save As semantics.
 
 `ShiftSourcePackage::create_empty(path)` writes an empty default `Font` package and refuses to overwrite an existing path.
 

--- a/crates/shift-source/src/lib.rs
+++ b/crates/shift-source/src/lib.rs
@@ -2,7 +2,7 @@ mod package;
 
 pub use package::{
     AXES_FILE, DATA_DIR, FEATURES_FILE, FONT_FILE, FONTINFO_MODULE_FILE, FORMAT_ID, GLYPHS_DIR,
-    IMAGES_DIR, KERNING_FILE, LIB_MODULE_FILE, MANIFEST_FILE, MODULES_DIR, PackageTree,
+    IMAGES_DIR, KERNING_FILE, LIB_MODULE_FILE, MANIFEST_FILE, MODULES_DIR, PackageId, PackageTree,
     SCHEMA_VERSION, SOURCES_FILE, ShiftSourcePackage, SourcePackageError, font_to_tree, read_tree,
     tree_to_font, write_tree_atomic,
 };

--- a/crates/shift-source/src/package.rs
+++ b/crates/shift-source/src/package.rs
@@ -30,6 +30,8 @@ pub const FONTINFO_MODULE_FILE: &str = "modules/shift.fontInfo.json";
 
 pub const FORMAT_ID: &str = "shift-source";
 pub const SCHEMA_VERSION: u32 = 1;
+const PACKAGE_ID_PREFIX: &str = "package_";
+const PACKAGE_ID_BYTES: usize = 16;
 const KERNING_SCHEMA_VERSION: u32 = 1;
 const LIB_MODULE_OWNER: &str = "shift";
 const LIB_MODULE_NAME: &str = "libData";
@@ -38,6 +40,60 @@ const FONTINFO_MODULE_NAME: &str = "fontInfo";
 const FONTINFO_MODULE_SCHEMA_VERSION: u32 = 1;
 
 pub type PackageTree = Vec<(String, Vec<u8>)>;
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct PackageId(String);
+
+impl PackageId {
+    pub fn new() -> Self {
+        let mut bytes = [0; PACKAGE_ID_BYTES];
+        getrandom::fill(&mut bytes).expect("secure random package ID generation failed");
+        let suffix = bytes
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+
+        Self(format!("{PACKAGE_ID_PREFIX}{suffix}"))
+    }
+
+    pub fn from_raw(raw: impl std::fmt::Display) -> Self {
+        let raw = raw.to_string();
+        if raw.starts_with(PACKAGE_ID_PREFIX) {
+            Self(raw)
+        } else {
+            Self(format!("{PACKAGE_ID_PREFIX}{raw}"))
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Default for PackageId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for PackageId {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for PackageId {
+    type Err = SourcePackageError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let suffix = value.strip_prefix(PACKAGE_ID_PREFIX).unwrap_or_default();
+        if suffix.is_empty() {
+            return Err(SourcePackageError::InvalidPackageId(value.to_string()));
+        }
+
+        Ok(Self(value.to_string()))
+    }
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum SourcePackageError {
@@ -67,6 +123,9 @@ pub enum SourcePackageError {
 
     #[error("unsupported source package schema version: {0}")]
     UnsupportedSchemaVersion(u32),
+
+    #[error("invalid source package ID: {0}")]
+    InvalidPackageId(String),
 
     #[error("glyph file path {path} does not match glyph id {id}")]
     MismatchedGlyphFileId { path: String, id: String },
@@ -136,6 +195,7 @@ pub enum SourcePackageError {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ShiftSourcePackage {
     path: PathBuf,
+    package_id: PackageId,
 }
 
 impl ShiftSourcePackage {
@@ -154,24 +214,47 @@ impl ShiftSourcePackage {
             return Err(SourcePackageError::AlreadyExists(path.to_path_buf()));
         }
 
-        Self::save_font(path, &Font::new())
+        Self::save_font_as(path, &Font::new())
     }
 
     pub fn save_font(path: impl AsRef<Path>, font: &Font) -> Result<Self, SourcePackageError> {
         let path = path.as_ref();
         validate_shift_extension(path)?;
-        write_tree_atomic(path, font_to_tree(font)?)?;
+        let package_id = if path.exists() {
+            Self::open(path)?.package_id
+        } else {
+            PackageId::new()
+        };
+
+        Self::write(path, package_id, font)
+    }
+
+    pub fn save_font_as(path: impl AsRef<Path>, font: &Font) -> Result<Self, SourcePackageError> {
+        let path = path.as_ref();
+        validate_shift_extension(path)?;
+
+        Self::write(path, PackageId::new(), font)
+    }
+
+    pub fn save(&self, font: &Font) -> Result<Self, SourcePackageError> {
+        Self::write(&self.path, self.package_id.clone(), font)
+    }
+
+    fn write(path: &Path, package_id: PackageId, font: &Font) -> Result<Self, SourcePackageError> {
+        write_tree_atomic(path, font_to_tree(&package_id, font)?)?;
         Ok(Self {
             path: path.to_path_buf(),
+            package_id,
         })
     }
 
     pub fn open(path: impl AsRef<Path>) -> Result<Self, SourcePackageError> {
         let path = path.as_ref();
         validate_shift_extension(path)?;
-        validate_package(path)?;
+        let package_id = validate_package(path)?;
         Ok(Self {
             path: path.to_path_buf(),
+            package_id,
         })
     }
 
@@ -184,6 +267,10 @@ impl ShiftSourcePackage {
     pub fn path(&self) -> &Path {
         &self.path
     }
+
+    pub fn package_id(&self) -> &PackageId {
+        &self.package_id
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -191,6 +278,7 @@ impl ShiftSourcePackage {
 struct ManifestDoc {
     format: String,
     schema_version: u32,
+    package_id: String,
     default_source_id: Option<String>,
 }
 
@@ -465,10 +553,14 @@ enum LibValueDoc {
     Uid(u64),
 }
 
-pub fn font_to_tree(font: &Font) -> Result<PackageTree, SourcePackageError> {
+pub fn font_to_tree(
+    package_id: &PackageId,
+    font: &Font,
+) -> Result<PackageTree, SourcePackageError> {
     let manifest = ManifestDoc {
         format: FORMAT_ID.to_string(),
         schema_version: SCHEMA_VERSION,
+        package_id: package_id.to_string(),
         default_source_id: font.default_source_id().map(|id| id.to_string()),
     };
 
@@ -655,10 +747,9 @@ pub fn tree_to_font(tree: PackageTree) -> Result<Font, SourcePackageError> {
     Ok(font)
 }
 
-fn validate_package(path: &Path) -> Result<(), SourcePackageError> {
+fn validate_package(path: &Path) -> Result<PackageId, SourcePackageError> {
     let mut archive = open_archive(path)?;
-    validate_archive_manifest(&mut archive)?;
-    Ok(())
+    validate_archive_manifest(&mut archive)
 }
 
 pub fn read_tree(path: impl AsRef<Path>) -> Result<PackageTree, SourcePackageError> {
@@ -730,7 +821,7 @@ fn open_archive(path: &Path) -> Result<ZipArchive<File>, SourcePackageError> {
 
 fn validate_archive_manifest<R: Read + Seek>(
     archive: &mut ZipArchive<R>,
-) -> Result<(), SourcePackageError> {
+) -> Result<PackageId, SourcePackageError> {
     if archive.is_empty() {
         return Err(SourcePackageError::MissingEntry(MANIFEST_FILE.to_string()));
     }
@@ -750,7 +841,7 @@ fn validate_archive_manifest<R: Read + Seek>(
     validate_manifest(&manifest)
 }
 
-fn validate_manifest(manifest: &ManifestDoc) -> Result<(), SourcePackageError> {
+fn validate_manifest(manifest: &ManifestDoc) -> Result<PackageId, SourcePackageError> {
     if manifest.format != FORMAT_ID {
         return Err(SourcePackageError::UnsupportedFormat(
             manifest.format.clone(),
@@ -763,7 +854,7 @@ fn validate_manifest(manifest: &ManifestDoc) -> Result<(), SourcePackageError> {
         ));
     }
 
-    Ok(())
+    manifest.package_id.parse()
 }
 
 /// Extracts the path relative to `dir` for binary package entries, rejecting

--- a/crates/shift-source/tests/package_test.rs
+++ b/crates/shift-source/tests/package_test.rs
@@ -1,4 +1,4 @@
-use std::fs::File;
+use std::fs::{self, File};
 
 use shift_font::{
     Axis, AxisId, Font, KerningPair, LibValue, Location, Source, SourceId, SourceRole,
@@ -6,8 +6,8 @@ use shift_font::{
 };
 use shift_source::{
     AXES_FILE, DATA_DIR, FEATURES_FILE, FONT_FILE, FONTINFO_MODULE_FILE, GLYPHS_DIR, IMAGES_DIR,
-    KERNING_FILE, LIB_MODULE_FILE, MANIFEST_FILE, PackageTree, SOURCES_FILE, ShiftSourcePackage,
-    SourcePackageError, font_to_tree, tree_to_font, write_tree_atomic,
+    KERNING_FILE, LIB_MODULE_FILE, MANIFEST_FILE, PackageId, PackageTree, SOURCES_FILE,
+    ShiftSourcePackage, SourcePackageError, font_to_tree, tree_to_font, write_tree_atomic,
 };
 use zip::{CompressionMethod, ZipArchive};
 
@@ -24,6 +24,10 @@ fn replace_tree_entry(tree: &mut PackageTree, path: &str, from: &str, to: &str) 
     entry.1 = json.replacen(from, to, 1).into_bytes();
 }
 
+fn test_package_id() -> PackageId {
+    PackageId::from_raw("test")
+}
+
 #[test]
 fn creates_zip_package_with_manifest_first_and_stored() {
     let temp = tempfile::tempdir().unwrap();
@@ -37,6 +41,51 @@ fn creates_zip_package_with_manifest_first_and_stored() {
     let manifest = archive.by_index(0).unwrap();
     assert_eq!(manifest.name(), MANIFEST_FILE);
     assert_eq!(manifest.compression(), CompressionMethod::Stored);
+}
+
+#[test]
+fn created_package_has_stable_identity() {
+    let temp = tempfile::tempdir().unwrap();
+    let package_path = temp.path().join("Dogfood.shift");
+
+    let created = ShiftSourcePackage::save_font(&package_path, &sample_font()).unwrap();
+    let saved = ShiftSourcePackage::save_font(&package_path, &sample_font()).unwrap();
+
+    assert!(created.package_id().as_str().starts_with("package_"));
+    assert_eq!(saved.package_id(), created.package_id());
+}
+
+#[test]
+fn package_identity_survives_move_and_filesystem_copy() {
+    let temp = tempfile::tempdir().unwrap();
+    let package_path = temp.path().join("Dogfood.shift");
+    let moved_path = temp.path().join("Moved.shift");
+    let copied_path = temp.path().join("Copied.shift");
+    let created = ShiftSourcePackage::save_font(&package_path, &sample_font()).unwrap();
+
+    fs::rename(&package_path, &moved_path).unwrap();
+    fs::copy(&moved_path, &copied_path).unwrap();
+
+    assert_eq!(
+        ShiftSourcePackage::open(&moved_path).unwrap().package_id(),
+        created.package_id()
+    );
+    assert_eq!(
+        ShiftSourcePackage::open(&copied_path).unwrap().package_id(),
+        created.package_id()
+    );
+}
+
+#[test]
+fn save_as_mints_new_package_identity() {
+    let temp = tempfile::tempdir().unwrap();
+    let first_path = temp.path().join("First.shift");
+    let second_path = temp.path().join("Second.shift");
+    let first = ShiftSourcePackage::save_font(&first_path, &sample_font()).unwrap();
+
+    let second = ShiftSourcePackage::save_font_as(&second_path, &sample_font()).unwrap();
+
+    assert_ne!(second.package_id(), first.package_id());
 }
 
 #[test]
@@ -97,7 +146,7 @@ fn shift_round_trip_preserves_exotic_lib_values_binaries_and_remainders() {
 fn source_tree_round_trip_preserves_whole_font() {
     let original = sample_font();
 
-    let loaded = tree_to_font(font_to_tree(&original).unwrap()).unwrap();
+    let loaded = tree_to_font(font_to_tree(&test_package_id(), &original).unwrap()).unwrap();
 
     assert_eq!(loaded, original);
 }
@@ -106,8 +155,8 @@ fn source_tree_round_trip_preserves_whole_font() {
 fn serializes_same_font_to_byte_identical_tree() {
     let font = sample_font();
 
-    let first = font_to_tree(&font).unwrap();
-    let second = font_to_tree(&font).unwrap();
+    let first = font_to_tree(&test_package_id(), &font).unwrap();
+    let second = font_to_tree(&test_package_id(), &font).unwrap();
 
     assert_eq!(first, second);
     assert_eq!(
@@ -142,7 +191,7 @@ fn rejects_kerning_references_to_unknown_glyph_names() {
         -80.0,
     ));
 
-    let error = font_to_tree(&font).unwrap_err();
+    let error = font_to_tree(&test_package_id(), &font).unwrap_err();
 
     assert!(matches!(
         error,
@@ -161,6 +210,7 @@ fn parses_minimal_handwritten_tree() {
             br#"{
   "format": "shift-source",
   "schemaVersion": 1,
+  "packageId": "package_minimal",
   "defaultSourceId": "source_regular"
 }
 "#
@@ -238,7 +288,7 @@ fn parses_minimal_handwritten_tree() {
 
 #[test]
 fn rejects_glyph_file_id_mismatch() {
-    let mut tree = font_to_tree(&sample_font()).unwrap();
+    let mut tree = font_to_tree(&test_package_id(), &sample_font()).unwrap();
     let glyph_entry = tree
         .iter_mut()
         .find(|(path, _)| path.starts_with(GLYPHS_DIR))
@@ -262,7 +312,7 @@ fn rejects_non_finite_metric_values_before_json_serialization() {
     let mut font = sample_font();
     font.metrics_mut().ascender = f64::NAN;
 
-    let error = font_to_tree(&font).unwrap_err();
+    let error = font_to_tree(&test_package_id(), &font).unwrap_err();
 
     assert!(matches!(
         error,
@@ -291,7 +341,7 @@ fn rejects_non_finite_source_location_values() {
         None,
     ));
 
-    let error = font_to_tree(&font).unwrap_err();
+    let error = font_to_tree(&test_package_id(), &font).unwrap_err();
 
     assert!(matches!(
         error,
@@ -302,7 +352,7 @@ fn rejects_non_finite_source_location_values() {
 
 #[test]
 fn rejects_invalid_axis_ranges_on_load() {
-    let mut tree = font_to_tree(&Font::new()).unwrap();
+    let mut tree = font_to_tree(&test_package_id(), &Font::new()).unwrap();
     let axes_entry = tree
         .iter_mut()
         .find(|(path, _)| path == AXES_FILE)
@@ -333,7 +383,7 @@ fn rejects_invalid_axis_ranges_on_load() {
 
 #[test]
 fn rejects_dangling_default_source_id() {
-    let mut tree = font_to_tree(&sample_font()).unwrap();
+    let mut tree = font_to_tree(&test_package_id(), &sample_font()).unwrap();
     replace_tree_entry(
         &mut tree,
         MANIFEST_FILE,
@@ -352,7 +402,7 @@ fn rejects_dangling_default_source_id() {
 
 #[test]
 fn rejects_glyph_layers_that_reference_missing_sources() {
-    let mut tree = font_to_tree(&sample_font()).unwrap();
+    let mut tree = font_to_tree(&test_package_id(), &sample_font()).unwrap();
     let glyph_path = format!("{GLYPHS_DIR}/glyph_A.json");
     replace_tree_entry(
         &mut tree,
@@ -395,7 +445,7 @@ fn does_not_overwrite_existing_package_when_creating_empty() {
 fn writes_handwritten_tree_as_openable_zip() {
     let temp = tempfile::tempdir().unwrap();
     let package_path = temp.path().join("Minimal.shift");
-    let tree = font_to_tree(&Font::new()).unwrap();
+    let tree = font_to_tree(&test_package_id(), &Font::new()).unwrap();
 
     write_tree_atomic(&package_path, tree).unwrap();
 

--- a/crates/shift-workspace/docs/DOCS.md
+++ b/crates/shift-workspace/docs/DOCS.md
@@ -6,6 +6,7 @@ Backend runtime object for an open Shift font workspace.
 
 - **Architecture Invariant:** `FontWorkspace` composes the live `shift-font::Font`, the user-selected `shift-source` package, and the working `shift-store` database.
 - **Architecture Invariant:** The `.shift` source package path and SQLite working store path are separate inputs.
+- **Architecture Invariant:** Package recovery policy is not ranked in Rust. `FontWorkspace` exposes package and working-store inspection primitives; the utility process owns binding and lifecycle decisions.
 - **Architecture Invariant:** The workspace is the domain object future bridge or utility-process transports should wrap.
 
 ## Codemap
@@ -14,6 +15,7 @@ Backend runtime object for an open Shift font workspace.
 crates/shift-workspace/src/
   lib.rs           -- public API barrel
   new_workspace.rs -- creation options for a fresh workspace
+  source_identity.rs -- package identity snapshots and source-save validation
   workspace.rs     -- `FontWorkspace` and workspace errors
 ```
 
@@ -21,6 +23,8 @@ crates/shift-workspace/src/
 
 - `FontWorkspace` -- live backend object for one open font project.
 - `NewWorkspace` -- options used when creating a new source package and working store.
+- `PackageIdentity` -- package id, canonical path, and fingerprint for one `.shift` source.
+- `PackageDraft` -- package ownership and dirty/base fingerprint state read from a working store.
 - `WorkspaceSource` -- explicit source state: saved `.shift` package or imported external file.
 - `WorkspaceError` -- source-package and store failures.
 
@@ -31,6 +35,10 @@ crates/shift-workspace/src/
 `FontWorkspace::open(path, store_path)` detects `.shift` paths as source packages. Other supported font paths are imported through `shift-backends` into an unsaved workspace with no save target.
 
 `FontWorkspace::save()` succeeds for saved `.shift` workspaces and returns `NeedsSaveAs` for imported workspaces. `save_as(path)` creates a `.shift` package and makes it the save target.
+
+`FontWorkspace::inspect_package(path)` reads a `.shift` package without opening it as the live workspace. It returns the stable package id, canonical path, and fingerprint used by the utility process to address a package instance.
+
+`FontWorkspace::inspect_package_draft(store_path)` reads the working-store package ownership record without resuming it. It returns the package id, source path, base fingerprint, document id, and dirty flag so the utility process can choose an explicit open transition.
 
 ## Verification
 

--- a/crates/shift-workspace/src/lib.rs
+++ b/crates/shift-workspace/src/lib.rs
@@ -5,7 +5,5 @@ mod workspace;
 
 pub use ledger::{LayerPair, Ledger, LedgerEntry, LedgerStep};
 pub use new_workspace::NewWorkspace;
-pub use source_identity::{
-    RecoverySelection, SourceMatchKind, WorkspaceRecoveryCandidate, WorkspaceRecoveryMatch,
-};
+pub use source_identity::{PackageDraft, PackageIdentity};
 pub use workspace::{FontWorkspace, WorkspaceError, WorkspaceSource};

--- a/crates/shift-workspace/src/source_identity.rs
+++ b/crates/shift-workspace/src/source_identity.rs
@@ -5,67 +5,25 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use shift_store::{
-    Evidence, FileIdentity, ShiftStore, SourceIdentitySnapshot, WorkspaceSourceKind,
-};
+use shift_source::ShiftSourcePackage;
+use shift_store::{FileIdentity, SourceIdentitySnapshot};
 
 use crate::WorkspaceError;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub enum SourceMatchKind {
-    PossiblePackageMove,
-    SamePath,
-    SamePathAndFingerprint,
-    SameFileMoved,
-    SamePathAndFile,
-}
-
-impl SourceMatchKind {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::SamePathAndFile => "samePathAndFile",
-            Self::SamePathAndFingerprint => "samePathAndFingerprint",
-            Self::SameFileMoved => "sameFileMoved",
-            Self::SamePath => "samePath",
-            Self::PossiblePackageMove => "possiblePackageMove",
-        }
-    }
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PackageIdentity {
+    pub package_id: String,
+    pub canonical_path: PathBuf,
+    pub fingerprint: String,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct WorkspaceRecoveryCandidate {
-    pub document_id: String,
-    pub store_path: PathBuf,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct WorkspaceRecoveryMatch {
-    pub document_id: String,
-    pub store_path: PathBuf,
-    pub match_kind: SourceMatchKind,
+pub struct PackageDraft {
+    pub document_id: Option<String>,
+    pub package_id: String,
+    pub source_path: PathBuf,
+    pub base_fingerprint: String,
     pub dirty: bool,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum RecoverySelection {
-    None,
-    One(WorkspaceRecoveryMatch),
-    Ambiguous(Vec<WorkspaceRecoveryMatch>),
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
-struct RecoveryRank {
-    dirty: bool,
-    match_kind: SourceMatchKind,
-}
-
-impl RecoveryRank {
-    fn new(recovery_match: &WorkspaceRecoveryMatch) -> Self {
-        Self {
-            dirty: recovery_match.dirty,
-            match_kind: recovery_match.match_kind,
-        }
-    }
 }
 
 pub(crate) fn source_identity_snapshot(
@@ -84,15 +42,35 @@ pub(crate) fn source_identity_snapshot(
     let source_size = Some(metadata.len());
     let source_mtime_ms = metadata.modified().ok().map(system_time_ms);
     let source_fingerprint = Some(file_fingerprint(path)?);
+    let source_package_id = Some(ShiftSourcePackage::open(path)?.package_id().to_string());
 
     Ok(SourceIdentitySnapshot {
         source_path: Some(path.to_path_buf()),
         canonical_source_path,
-        source_package_id: None,
+        source_package_id,
         source_file_identity,
         source_size,
         source_mtime_ms,
         source_fingerprint,
+    })
+}
+
+pub(crate) fn package_identity(path: impl AsRef<Path>) -> Result<PackageIdentity, WorkspaceError> {
+    let snapshot = source_identity_snapshot(path)?;
+    let package_id = snapshot.source_package_id.ok_or_else(|| {
+        WorkspaceError::CorruptWorkingStore("package identity missing package ID".into())
+    })?;
+    let canonical_path = snapshot.canonical_source_path.ok_or_else(|| {
+        WorkspaceError::CorruptWorkingStore("package identity missing canonical path".into())
+    })?;
+    let fingerprint = snapshot.source_fingerprint.ok_or_else(|| {
+        WorkspaceError::CorruptWorkingStore("package identity missing fingerprint".into())
+    })?;
+
+    Ok(PackageIdentity {
+        package_id,
+        canonical_path,
+        fingerprint,
     })
 }
 
@@ -112,99 +90,6 @@ pub(crate) fn validate_source_identity_for_save(
     }
 
     Ok(())
-}
-
-pub(crate) fn select_recoverable_package_workspace(
-    source_path: impl AsRef<Path>,
-    candidates: &[WorkspaceRecoveryCandidate],
-) -> Result<RecoverySelection, WorkspaceError> {
-    let requested = source_identity_snapshot(source_path)?;
-    let mut best_rank: Option<RecoveryRank> = None;
-    let mut best_matches: Vec<WorkspaceRecoveryMatch> = Vec::new();
-
-    for candidate in candidates {
-        let Ok(store) = ShiftStore::open(&candidate.store_path) else {
-            // Retained draft directories are a recovery cache. A corrupt or
-            // temporarily locked DB must not block opening the requested source.
-            continue;
-        };
-        let Ok(Some(state)) = store.workspace_state() else {
-            // Older or broken draft DBs may not carry workspace metadata yet.
-            // Ignore them here; explicit recovery UI can surface them later.
-            continue;
-        };
-        if state.source_kind != WorkspaceSourceKind::Package {
-            // Untitled/imported drafts are recoverable, but not by opening a
-            // package source path. Keep this selector package-only.
-            continue;
-        }
-        if !state.dirty && state.source_identity().fingerprint_changed_from(&requested) {
-            // A clean DB is just a cache of the source package. If the package
-            // changed on disk, hydrate fresh from the package instead.
-            continue;
-        }
-        let Some(match_kind) = classify_source_match(&state.source_identity(), &requested) else {
-            continue;
-        };
-
-        let candidate_match = WorkspaceRecoveryMatch {
-            document_id: candidate.document_id.clone(),
-            store_path: candidate.store_path.clone(),
-            match_kind,
-            dirty: state.dirty,
-        };
-        keep_best_recovery_match(candidate_match, &mut best_rank, &mut best_matches);
-    }
-
-    Ok(match best_matches.len() {
-        0 => RecoverySelection::None,
-        1 => RecoverySelection::One(best_matches.remove(0)),
-        _ => RecoverySelection::Ambiguous(best_matches),
-    })
-}
-
-fn keep_best_recovery_match(
-    candidate: WorkspaceRecoveryMatch,
-    best_rank: &mut Option<RecoveryRank>,
-    best_matches: &mut Vec<WorkspaceRecoveryMatch>,
-) {
-    let candidate_rank = RecoveryRank::new(&candidate);
-    match best_rank {
-        None => {
-            *best_rank = Some(candidate_rank);
-            best_matches.push(candidate);
-        }
-        Some(current_rank) if candidate_rank > *current_rank => {
-            *best_rank = Some(candidate_rank);
-            best_matches.clear();
-            best_matches.push(candidate);
-        }
-        Some(current_rank) if candidate_rank == *current_rank => {
-            best_matches.push(candidate);
-        }
-        Some(_) => {}
-    }
-}
-
-fn classify_source_match(
-    stored: &SourceIdentitySnapshot,
-    requested: &SourceIdentitySnapshot,
-) -> Option<SourceMatchKind> {
-    let same_path = stored.same_path_as(requested);
-    let file_identity = stored.file_identity_match(requested);
-    let fingerprint = stored.fingerprint_match(requested);
-    let package_id = stored.package_id_match(requested);
-
-    match (same_path, file_identity, fingerprint, package_id) {
-        (true, Evidence::Same, _, _) => Some(SourceMatchKind::SamePathAndFile),
-        (_, Evidence::Same, _, _) => Some(SourceMatchKind::SameFileMoved),
-        (true, _, Evidence::Same, _) => Some(SourceMatchKind::SamePathAndFingerprint),
-        (true, Evidence::Unknown, Evidence::Unknown, _) => Some(SourceMatchKind::SamePath),
-        (_, _, Evidence::Same, _) | (_, _, _, Evidence::Same) if stored.source_path_missing() => {
-            Some(SourceMatchKind::PossiblePackageMove)
-        }
-        _ => None,
-    }
 }
 
 fn file_fingerprint(path: &Path) -> Result<String, WorkspaceError> {

--- a/crates/shift-workspace/src/workspace.rs
+++ b/crates/shift-workspace/src/workspace.rs
@@ -14,8 +14,8 @@ use shift_store::{ShiftStore, SourceIdentitySnapshot, WorkspaceSourceKind, Works
 use crate::NewWorkspace;
 use crate::ledger::{GlyphIdentity, LayerPair, Ledger, LedgerEntry, LedgerStep};
 use crate::source_identity::{
-    RecoverySelection, WorkspaceRecoveryCandidate, select_recoverable_package_workspace,
-    source_identity_snapshot, validate_source_identity_for_save,
+    PackageDraft, PackageIdentity, package_identity, source_identity_snapshot,
+    validate_source_identity_for_save,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -46,9 +46,6 @@ pub enum WorkspaceError {
 
     #[error("source package was modified outside Shift: {0}")]
     SourceExternallyModified(PathBuf),
-
-    #[error("ambiguous recoverable workspaces for source: {0} candidates")]
-    AmbiguousRecoveryCandidates(usize),
 
     #[error("corrupt working store: {0}")]
     CorruptWorkingStore(String),
@@ -132,7 +129,7 @@ impl FontWorkspace {
     }
 
     pub fn save_as(&mut self, source_path: impl AsRef<Path>) -> Result<(), WorkspaceError> {
-        let source_package = ShiftSourcePackage::save_font(source_path, &self.font)?;
+        let source_package = ShiftSourcePackage::save_font_as(source_path, &self.font)?;
         let identity = source_identity_snapshot(source_package.path())?;
         self.source = WorkspaceSource::Package {
             path: source_package.path().to_path_buf(),
@@ -168,11 +165,42 @@ impl FontWorkspace {
         Ok(workspace)
     }
 
-    pub fn find_recoverable_package_workspace(
+    pub fn inspect_package(
         source_path: impl AsRef<Path>,
-        candidates: &[WorkspaceRecoveryCandidate],
-    ) -> Result<RecoverySelection, WorkspaceError> {
-        select_recoverable_package_workspace(source_path, candidates)
+    ) -> Result<PackageIdentity, WorkspaceError> {
+        package_identity(source_path)
+    }
+
+    pub fn inspect_package_draft(
+        store_path: impl AsRef<Path>,
+    ) -> Result<PackageDraft, WorkspaceError> {
+        let store = ShiftStore::open(store_path)?;
+        let state = store
+            .workspace_state()?
+            .ok_or_else(|| WorkspaceError::CorruptWorkingStore("missing workspace_state".into()))?;
+        if state.source_kind != WorkspaceSourceKind::Package {
+            return Err(WorkspaceError::CorruptWorkingStore(
+                "working store is not package-backed".into(),
+            ));
+        }
+
+        let package_id = state.source_package_id.ok_or_else(|| {
+            WorkspaceError::CorruptWorkingStore("package draft missing package ID".into())
+        })?;
+        let source_path = state.source_path.ok_or_else(|| {
+            WorkspaceError::CorruptWorkingStore("package draft missing source path".into())
+        })?;
+        let base_fingerprint = state.source_fingerprint.ok_or_else(|| {
+            WorkspaceError::CorruptWorkingStore("package draft missing base fingerprint".into())
+        })?;
+
+        Ok(PackageDraft {
+            document_id: state.document_id,
+            package_id,
+            source_path,
+            base_fingerprint,
+            dirty: state.dirty,
+        })
     }
 
     pub fn export(&self, request: FontExportRequest) -> Result<FontExportResult, WorkspaceError> {

--- a/crates/shift-workspace/tests/workspace_test.rs
+++ b/crates/shift-workspace/tests/workspace_test.rs
@@ -6,10 +6,7 @@ use shift_font::{
     error::CoreError,
 };
 use shift_source::ShiftSourcePackage;
-use shift_workspace::{
-    FontWorkspace, NewWorkspace, RecoverySelection, SourceMatchKind, WorkspaceError,
-    WorkspaceRecoveryCandidate, WorkspaceSource,
-};
+use shift_workspace::{FontWorkspace, NewWorkspace, WorkspaceError, WorkspaceSource};
 
 fn create_glyph_intent(name: &str, unicodes: Vec<u32>) -> FontIntent {
     FontIntent::CreateGlyph {
@@ -299,7 +296,85 @@ fn save_rejects_package_target_replaced_by_another_file() {
 }
 
 #[test]
-fn moved_package_open_can_recover_dirty_workspace_by_file_identity() {
+fn inspect_package_reports_stable_package_identity() {
+    let temp = tempfile::tempdir().unwrap();
+    let store_path = temp.path().join("working.sqlite");
+    let save_path = temp.path().join("SavedFont.shift");
+
+    let mut workspace = FontWorkspace::create_untitled(&store_path, NewWorkspace::new()).unwrap();
+    workspace.save_as(&save_path).unwrap();
+
+    let package = ShiftSourcePackage::open(&save_path).unwrap();
+    let identity = FontWorkspace::inspect_package(&save_path).unwrap();
+
+    assert_eq!(identity.package_id, package.package_id().to_string());
+    assert_eq!(
+        identity.canonical_path,
+        fs::canonicalize(&save_path).unwrap()
+    );
+    assert!(identity.fingerprint.starts_with("fnv1a64:"));
+}
+
+#[test]
+fn inspect_package_draft_reports_bound_package_and_dirty_state() {
+    let temp = tempfile::tempdir().unwrap();
+    let store_path = temp.path().join("working.sqlite");
+    let save_path = temp.path().join("SavedFont.shift");
+
+    let mut workspace = FontWorkspace::create_untitled(&store_path, NewWorkspace::new()).unwrap();
+    workspace.save_as(&save_path).unwrap();
+    workspace.set_document_id("doc-1".to_string()).unwrap();
+
+    let package = FontWorkspace::inspect_package(&save_path).unwrap();
+    let clean_draft = FontWorkspace::inspect_package_draft(&store_path).unwrap();
+
+    assert_eq!(clean_draft.document_id.as_deref(), Some("doc-1"));
+    assert_eq!(clean_draft.package_id, package.package_id);
+    assert_eq!(clean_draft.source_path, save_path);
+    assert_eq!(clean_draft.base_fingerprint, package.fingerprint);
+    assert!(!clean_draft.dirty);
+
+    create_glyph(&mut workspace, "A", vec![65]);
+    let dirty_draft = FontWorkspace::inspect_package_draft(&store_path).unwrap();
+
+    assert_eq!(dirty_draft.document_id.as_deref(), Some("doc-1"));
+    assert_eq!(dirty_draft.base_fingerprint, clean_draft.base_fingerprint);
+    assert!(dirty_draft.dirty);
+}
+
+#[test]
+fn save_preserves_package_identity_and_save_as_mints_a_new_identity() {
+    let temp = tempfile::tempdir().unwrap();
+    let store_path = temp.path().join("working.sqlite");
+    let first_path = temp.path().join("First.shift");
+    let second_path = temp.path().join("Second.shift");
+
+    let mut workspace = FontWorkspace::create_untitled(&store_path, NewWorkspace::new()).unwrap();
+    workspace.save_as(&first_path).unwrap();
+    let first_id = ShiftSourcePackage::open(&first_path)
+        .unwrap()
+        .package_id()
+        .to_string();
+
+    create_glyph(&mut workspace, "A", vec![65]);
+    workspace.save().unwrap();
+    let saved_id = ShiftSourcePackage::open(&first_path)
+        .unwrap()
+        .package_id()
+        .to_string();
+
+    workspace.save_as(&second_path).unwrap();
+    let second_id = ShiftSourcePackage::open(&second_path)
+        .unwrap()
+        .package_id()
+        .to_string();
+
+    assert_eq!(saved_id, first_id);
+    assert_ne!(second_id, first_id);
+}
+
+#[test]
+fn resume_for_source_relinks_package_identity_after_move() {
     let temp = tempfile::tempdir().unwrap();
     let store_path = temp.path().join("working.sqlite");
     let save_path = temp.path().join("SavedFont.shift");
@@ -313,20 +388,6 @@ fn moved_package_open_can_recover_dirty_workspace_by_file_identity() {
     }
     fs::rename(&save_path, &moved_path).unwrap();
 
-    let RecoverySelection::One(recovery) = FontWorkspace::find_recoverable_package_workspace(
-        &moved_path,
-        &[WorkspaceRecoveryCandidate {
-            document_id: "doc-1".to_string(),
-            store_path: store_path.clone(),
-        }],
-    )
-    .unwrap() else {
-        panic!("renamed source should match retained dirty store");
-    };
-
-    assert_eq!(recovery.document_id, "doc-1");
-    assert_eq!(recovery.match_kind, SourceMatchKind::SameFileMoved);
-
     let mut workspace = FontWorkspace::resume_for_source(&store_path, &moved_path).unwrap();
     assert_eq!(workspace.save_target(), Some(moved_path.as_path()));
     assert!(workspace.font().glyph_id_by_name("B").is_some());
@@ -335,94 +396,6 @@ fn moved_package_open_can_recover_dirty_workspace_by_file_identity() {
 
     let saved = ShiftSourcePackage::load_font(&moved_path).unwrap();
     assert!(saved.glyph_id_by_name("B").is_some());
-}
-
-#[test]
-fn copied_then_deleted_package_can_recover_dirty_workspace_by_fingerprint() {
-    let temp = tempfile::tempdir().unwrap();
-    let store_path = temp.path().join("working.sqlite");
-    let save_path = temp.path().join("SavedFont.shift");
-    let moved_path = temp.path().join("MovedFont.shift");
-
-    {
-        let mut workspace =
-            FontWorkspace::create_untitled(&store_path, NewWorkspace::new()).unwrap();
-        workspace.save_as(&save_path).unwrap();
-        create_glyph(&mut workspace, "B", vec![66]);
-    }
-    fs::copy(&save_path, &moved_path).unwrap();
-    fs::remove_file(&save_path).unwrap();
-
-    let RecoverySelection::One(recovery) = FontWorkspace::find_recoverable_package_workspace(
-        &moved_path,
-        &[WorkspaceRecoveryCandidate {
-            document_id: "doc-1".to_string(),
-            store_path,
-        }],
-    )
-    .unwrap() else {
-        panic!("moved source with new file identity should match by fingerprint");
-    };
-
-    assert_eq!(recovery.document_id, "doc-1");
-    assert_eq!(recovery.match_kind, SourceMatchKind::PossiblePackageMove);
-}
-
-#[test]
-fn copied_package_does_not_recover_original_dirty_workspace_while_original_exists() {
-    let temp = tempfile::tempdir().unwrap();
-    let store_path = temp.path().join("working.sqlite");
-    let save_path = temp.path().join("SavedFont.shift");
-    let copy_path = temp.path().join("CopyFont.shift");
-
-    {
-        let mut workspace =
-            FontWorkspace::create_untitled(&store_path, NewWorkspace::new()).unwrap();
-        workspace.save_as(&save_path).unwrap();
-        create_glyph(&mut workspace, "B", vec![66]);
-    }
-    fs::copy(&save_path, &copy_path).unwrap();
-
-    let recovery = FontWorkspace::find_recoverable_package_workspace(
-        &copy_path,
-        &[WorkspaceRecoveryCandidate {
-            document_id: "doc-1".to_string(),
-            store_path,
-        }],
-    )
-    .unwrap();
-
-    assert_eq!(recovery, RecoverySelection::None);
-}
-
-#[test]
-fn clean_package_workspace_is_not_recovered_after_source_file_changes() {
-    let temp = tempfile::tempdir().unwrap();
-    let store_path = temp.path().join("working.sqlite");
-    let save_path = temp.path().join("SavedFont.shift");
-    let replacement_path = temp.path().join("Replacement.shift");
-
-    {
-        let mut workspace =
-            FontWorkspace::create_untitled(&store_path, NewWorkspace::new()).unwrap();
-        workspace.save_as(&save_path).unwrap();
-        assert!(!workspace.is_dirty().unwrap());
-    }
-    let mut replacement = shift_font::Font::new();
-    replacement.metadata_mut().family_name = Some("Replacement".to_string());
-    ShiftSourcePackage::save_font(&replacement_path, &replacement).unwrap();
-    fs::copy(&replacement_path, &save_path).unwrap();
-
-    let recovery = FontWorkspace::find_recoverable_package_workspace(
-        &save_path,
-        &[WorkspaceRecoveryCandidate {
-            document_id: "doc-1".to_string(),
-            store_path,
-        }],
-    )
-    .unwrap();
-
-    assert_eq!(recovery, RecoverySelection::None);
 }
 
 fn set_x_advance_intents(layer_id: LayerId, width: f64) -> FontIntentSet {

--- a/packages/types/docs/DOCS.md
+++ b/packages/types/docs/DOCS.md
@@ -21,19 +21,20 @@ packages/types/src/
     generated.ts         -- generated from shift-bridge/index.d.ts
 ```
 
-## Bridge DTOs
+## Key Types
 
 Import from `@shift/types`.
 
 - `BridgeApi` -- type-only native bridge API surface.
 - `FontMetadata` / `FontMetrics` -- font-level DTOs returned by `Bridge`.
 - `GlyphRecord` -- committed glyph list record: stable id, name, unicodes, component base glyph IDs.
+- `PackageIdentity` / `PackageDraft` -- bridge DTOs used by the desktop utility process to inspect package source identity and working-store ownership.
 - `GlyphStructure` -- stable glyph structure: contours, anchors, components.
-- `GlyphStructureChange` -- structural edit result: new structure, `Float64Array` values, changed IDs.
-- `GlyphValueChange` -- hot-path value edit result: `Float64Array` values, changed IDs.
+- `AppliedChange` -- replace-grade mutation response returned by apply/undo/redo.
+- `LayerReplaced` -- one replaced glyph layer in an applied change.
 - `PointType` -- bridge point type union.
 
-## Generation
+## How it works
 
 `shift-bridge` owns the low-level NAPI declaration file at `crates/shift-bridge/index.d.ts`. `scripts/generate-bridge-types.mjs` reads that declaration file and emits `src/bridge/generated.ts`.
 
@@ -42,7 +43,7 @@ The generator:
 - removes the runtime `Bridge` class and emits a type-only `BridgeApi`;
 - strips `Napi` prefixes from exported DTO names;
 - preserves branded ID imports from `../ids`;
-- preserves typed arrays such as `Float64Array` and `BigUint64Array`.
+- preserves typed arrays such as `Float64Array`.
 
 Turbo owns the cache key:
 

--- a/packages/types/src/bridge/generated.ts
+++ b/packages/types/src/bridge/generated.ts
@@ -21,10 +21,12 @@ export interface BridgeApi {
   createUntitledWorkspace(storePath: string, options?: NewWorkspace | undefined | null): void
   exportWorkspace(request: FontExportRequest): Promise<FontExportResult>
   documentState(): DocumentState
+  inspectPackage(path: string): PackageIdentity
+  inspectPackageDraft(storePath: string): PackageDraft
+  closeWorkspace(): void
   openWorkspace(path: string, storePath: string): void
   resumeWorkspaceForSource(storePath: string, sourcePath: string): void
   setDocumentId(documentId: string): DocumentState
-  findRecoverableWorkspace(sourcePath: string, candidates: Array<WorkspaceRecoveryCandidate>): WorkspaceRecoveryMatch | null
   saveWorkspace(): DocumentState
   saveWorkspaceAs(path: string): DocumentState
   getMetadata(): FontMetadata
@@ -76,16 +78,18 @@ export interface NewWorkspace {
   unitsPerEm?: number
 }
 
-export interface WorkspaceRecoveryCandidate {
-  documentId: string
-  storePath: string
+export interface PackageDraft {
+  documentId?: string
+  packageId: string
+  sourcePath: string
+  baseFingerprint: string
+  dirty: boolean
 }
 
-export interface WorkspaceRecoveryMatch {
-  documentId: string
-  storePath: string
-  matchKind: string
-  dirty: boolean
+export interface PackageIdentity {
+  packageId: string
+  canonicalPath: string
+  fingerprint: string
 }
 export interface AddAnchorsIntent {
   layerId: LayerId

--- a/packages/types/src/bridge/index.ts
+++ b/packages/types/src/bridge/index.ts
@@ -40,6 +40,8 @@ export type {
   GlyphVariationData,
   LayerReplaced,
   Location,
+  PackageDraft,
+  PackageIdentity,
   PointData,
   PointSeed,
   PointType,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -91,6 +91,8 @@ export type {
   GlyphVariationData,
   LayerReplaced,
   Location,
+  PackageDraft,
+  PackageIdentity,
   PointData,
   PointSeed,
   PointType,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       throttle-debounce:
         specifier: ^5.0.2
         version: 5.0.2
+      zod:
+        specifier: ^4.1.12
+        version: 4.3.6
       zustand:
         specifier: ^5.0.6
         version: 5.0.6(@types/react@19.1.8)(react@19.1.0)(use-sync-external-store@1.6.0(react@19.1.0))


### PR DESCRIPTION
## Summary

Closes #139.

This PR replaces path/fingerprint-first workspace identity with stable source package identity:

- embeds and persists a durable `packageId` in `.shift` package manifests
- returns package identity through the source package/open/save APIs and generated bridge types
- keys desktop workspace sessions by package identity instead of mutable paths
- preserves identity on save and mints a new identity on Save As
- rejects saving over a different package identity
- relinks moved/copied packages by their embedded identity
- removes the older workspace/session semantics that treated path/fingerprint as the source of truth
- updates docs, roadmap, bridge declarations, and workspace/package tests

## Why

A package path can move, and a fingerprint can change whenever the package contents change. Neither is a durable identity for long-lived workspace sessions. The new invariant is that package identity is inside the package and survives normal save/open/move flows; Save As intentionally creates a new package identity.

## Validation

- `pnpm typecheck`
- `pnpm lint:check`
- `cargo test --package shift-source --package shift-workspace --package shift-bridge`
- `cargo clippy --package shift-source --package shift-workspace --package shift-bridge`
- pre-commit hooks during commit: whitespace/end-of-file/YAML/large-file/conflict checks, NAPI dead methods, cargo check/fmt/clippy/test, oxfmt, oxlint, tsgo typecheck, deadcode strict, vitest

## Notes

The later dogfooding "missing point" edit failure is not included here. That appears to be a separate renderer/source-layer cache or duplicate-location editing invariant issue and should stay out of this PR.
