### PR TITLE
Upgrade fontc compiler stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "ascii_plist_derive"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f0c89a8ae39c4110e866a25bb02910bf641d87b9df04e0f614631925caad4d"
+checksum = "fe2ef6f9d2f3579dc90b7f28c9f91c42daa4ea6c04225ad9336446f9ec45a363"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -257,7 +257,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -630,33 +630,20 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fea-rs"
-version = "0.20.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "610671b87ddc0e8207835dd0ce5f1ff3dd33cc7186c8c6f812465961759dc178"
+checksum = "c6acd5f994d5b0a5945942bd7db366873ab4304143b37c7e4008283475c87a1a"
 dependencies = [
  "ansi_term",
- "chrono",
  "env_logger",
- "fontdrasil 0.2.0",
+ "fontdrasil",
  "indexmap",
  "log",
- "ordered-float 4.6.0",
+ "ordered-float",
  "serde",
- "smol_str 0.2.2",
- "thiserror 1.0.69",
- "write-fonts 0.38.2",
-]
-
-[[package]]
-name = "filetime"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
- "windows-sys 0.59.0",
+ "smol_str",
+ "thiserror",
+ "write-fonts",
 ]
 
 [[package]]
@@ -678,7 +665,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02a596f5713680923a2080d86de50fe472fb290693cf0f701187a1c8b36996b7"
 dependencies = [
  "bytemuck",
- "serde",
 ]
 
 [[package]]
@@ -693,43 +679,40 @@ dependencies = [
 
 [[package]]
 name = "fontbe"
-version = "0.2.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deabf867654561b3d5e3a23c7bbf913b5f0518dfb35ec52811835f4ed6727f00"
+checksum = "dd2bfaf75c83f49e0c79bbb2807260a005f3224fcd149d3d489f1a6f72d67efd"
 dependencies = [
  "bincode",
  "chrono",
- "env_logger",
  "fea-rs",
- "fontdrasil 0.2.0",
+ "fontdrasil",
  "fontir",
  "icu_properties",
  "indexmap",
- "kurbo 0.11.2",
+ "kurbo 0.12.0",
  "log",
- "ordered-float 4.6.0",
+ "ordered-float",
  "parking_lot",
  "serde",
- "smol_str 0.2.2",
- "thiserror 1.0.69",
+ "smol_str",
+ "thiserror",
  "tinystr",
- "write-fonts 0.38.2",
+ "write-fonts",
 ]
 
 [[package]]
 name = "fontc"
-version = "0.2.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6dcb549357fd10d17fd870567cfdcc9dd4f56dc17a914c1f5417d469175e70"
+checksum = "5c8c306082eb13e786be3c0efff8c523866c4b89ab1b2a5b30b611c3f0ce65f7"
 dependencies = [
- "bincode",
  "bitflags",
  "clap",
  "crossbeam-channel",
  "env_logger",
- "filetime",
  "fontbe",
- "fontdrasil 0.2.0",
+ "fontdrasil",
  "fontir",
  "fontra2fontir",
  "glyphs2fontir",
@@ -739,22 +722,10 @@ dependencies = [
  "regex",
  "serde",
  "serde_yaml",
- "thiserror 1.0.69",
+ "thiserror",
  "ufo2fontir",
  "vergen-gitcl",
- "write-fonts 0.38.2",
-]
-
-[[package]]
-name = "fontdrasil"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7486f5a01d9b86a45a53e4d2f46172d731af11e801a3c7c24af30cab055b9d0"
-dependencies = [
- "ordered-float 4.6.0",
- "serde",
- "smol_str 0.2.2",
- "write-fonts 0.38.2",
+ "write-fonts",
 ]
 
 [[package]]
@@ -766,54 +737,52 @@ dependencies = [
  "env_logger",
  "kurbo 0.12.0",
  "log",
- "ordered-float 5.3.0",
+ "ordered-float",
  "serde",
- "smol_str 0.3.6",
- "thiserror 2.0.18",
- "write-fonts 0.44.1",
+ "smol_str",
+ "thiserror",
+ "write-fonts",
 ]
 
 [[package]]
 name = "fontir"
-version = "0.2.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beb598f361af1baaa0c6ee886b855b42a1e00f7d3f56f37a39b212e13b7bdff5"
+checksum = "8eb683c35e2e661c2b44e388443ca6e102558a9d76fba6ca0c8bbe1626a86a6c"
 dependencies = [
- "bincode",
  "bitflags",
  "chrono",
  "env_logger",
- "filetime",
- "fontdrasil 0.2.0",
+ "fontdrasil",
  "indexmap",
- "kurbo 0.11.2",
+ "kurbo 0.12.0",
  "log",
- "ordered-float 4.6.0",
+ "ordered-float",
  "parking_lot",
  "serde",
  "serde_yaml",
- "smol_str 0.2.2",
- "thiserror 1.0.69",
- "write-fonts 0.38.2",
+ "smol_str",
+ "thiserror",
+ "write-fonts",
 ]
 
 [[package]]
 name = "fontra2fontir"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4511cace96f3243fef1350e87abf326900ce3a7af6c3646e7cb6e3b26b295baf"
+checksum = "ba9ec46c21a672919b050939c95ac1fd166873e6f0bf60d2a0ba2757890a2012"
 dependencies = [
  "env_logger",
- "fontdrasil 0.2.0",
+ "fontdrasil",
  "fontir",
  "indexmap",
- "kurbo 0.11.2",
+ "kurbo 0.12.0",
  "log",
- "ordered-float 4.6.0",
+ "ordered-float",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
- "write-fonts 0.38.2",
+ "thiserror",
+ "write-fonts",
 ]
 
 [[package]]
@@ -924,45 +893,45 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glyphs-reader"
-version = "0.2.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce345345178c5488fa9d3d0dc65bacba07fada99d386c4db7144058bc332b3c"
+checksum = "28c8e651ada659aa00811baff00b5412d554e8493d1bb3d74002c70fc847e530"
 dependencies = [
  "ascii_plist_derive",
- "bincode",
  "chrono",
  "env_logger",
- "fontdrasil 0.2.0",
+ "fontdrasil",
  "icu_properties",
  "indexmap",
- "kurbo 0.11.2",
+ "kurbo 0.12.0",
  "log",
- "ordered-float 4.6.0",
- "quick-xml 0.37.5",
+ "ordered-float",
+ "quick-xml 0.38.4",
  "regex",
  "serde",
- "smol_str 0.2.2",
- "thiserror 1.0.69",
+ "smol_str",
+ "thiserror",
+ "write-fonts",
 ]
 
 [[package]]
 name = "glyphs2fontir"
-version = "0.2.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66204b6a2d374b221a9676b22b64de7a711482dc58f6a13da1c4b20978a3d43"
+checksum = "529b103c7fe9be8c4b41e32a89af2ab037fc3b227b643f0c60b63490fc7045b1"
 dependencies = [
  "chrono",
  "env_logger",
- "fontdrasil 0.2.0",
+ "fontdrasil",
  "fontir",
  "glyphs-reader",
  "indexmap",
- "kurbo 0.11.2",
+ "kurbo 0.12.0",
  "log",
- "ordered-float 4.6.0",
- "smol_str 0.2.2",
- "thiserror 1.0.69",
- "write-fonts 0.38.2",
+ "ordered-float",
+ "smol_str",
+ "thiserror",
+ "write-fonts",
 ]
 
 [[package]]
@@ -1157,17 +1126,6 @@ dependencies = [
 
 [[package]]
 name = "kurbo"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1077d333efea6170d9ccb96d3c3026f300ca0773da4938cc4c811daa6df68b0c"
-dependencies = [
- "arrayvec",
- "serde",
- "smallvec",
-]
-
-[[package]]
-name = "kurbo"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce9729cc38c18d86123ab736fd2e7151763ba226ac2490ec092d1dd148825e32"
@@ -1204,17 +1162,6 @@ checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
 dependencies = [
  "cfg-if",
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "libredox"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
-dependencies = [
- "bitflags",
- "libc",
- "redox_syscall",
 ]
 
 [[package]]
@@ -1390,19 +1337,19 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "norad"
-version = "0.15.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33bdd481053f7843c922973d36c51a636309dee0e75d7a24d1edfc73a6747a27"
+checksum = "af78fa33027e25d57ac99c174a885632f58fd427598e646ae4913f42baf09b49"
 dependencies = [
  "base64",
  "close_already",
  "indexmap",
  "plist",
- "quick-xml 0.37.5",
+ "quick-xml 0.38.4",
  "serde",
  "serde_derive",
  "serde_repr",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -1420,7 +1367,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_repr",
- "thiserror 2.0.18",
+ "thiserror",
  "uuid",
 ]
 
@@ -1478,17 +1425,6 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
-
-[[package]]
-name = "ordered-float"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
-dependencies = [
- "num-traits",
- "rand",
- "serde",
-]
 
 [[package]]
 name = "ordered-float"
@@ -1675,17 +1611,6 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "read-fonts"
-version = "0.29.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04ca636dac446b5664bd16c069c00a9621806895b8bb02c2dc68542b23b8f25d"
-dependencies = [
- "bytemuck",
- "font-types 0.9.0",
- "serde",
 ]
 
 [[package]]
@@ -1903,7 +1828,7 @@ dependencies = [
  "shift-source",
  "skrifa",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -1919,7 +1844,7 @@ dependencies = [
  "shift-font",
  "shift-wire",
  "shift-workspace",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -1935,21 +1860,21 @@ dependencies = [
  "shift-font",
  "shift-source",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "shift-font"
 version = "0.1.0"
 dependencies = [
- "fontdrasil 0.4.0",
+ "fontdrasil",
  "getrandom",
  "indexmap",
  "kurbo 0.13.0",
  "linesweeper",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -1961,7 +1886,7 @@ dependencies = [
  "serde_json",
  "shift-font",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "zip",
 ]
 
@@ -1973,14 +1898,14 @@ dependencies = [
  "serde_json",
  "shift-font",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "shift-wire"
 version = "0.0.0"
 dependencies = [
- "fontdrasil 0.4.0",
+ "fontdrasil",
  "napi",
  "napi-derive",
  "serde",
@@ -1996,7 +1921,7 @@ dependencies = [
  "shift-source",
  "shift-store",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "windows-sys 0.61.2",
 ]
 
@@ -2027,15 +1952,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "smol_str"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
 dependencies = [
  "serde",
 ]
@@ -2140,31 +2056,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2233,24 +2129,24 @@ dependencies = [
 
 [[package]]
 name = "ufo2fontir"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d6a943c02f505748a2d076447518ef08fdd6fa7d6b12fd6352681fb873c5c27"
+checksum = "b7b4f33808a2d82be0bdafecbaed4402d61a01160fa59af499fbc98b3f6cb62e"
 dependencies = [
  "chrono",
  "env_logger",
- "fontdrasil 0.2.0",
+ "fontdrasil",
  "fontir",
  "indexmap",
- "kurbo 0.11.2",
+ "kurbo 0.12.0",
  "log",
- "norad 0.15.0",
- "ordered-float 4.6.0",
+ "norad 0.16.1",
+ "ordered-float",
  "plist",
  "serde",
  "serde_yaml",
- "thiserror 1.0.69",
- "write-fonts 0.38.2",
+ "thiserror",
+ "write-fonts",
 ]
 
 [[package]]
@@ -2587,20 +2483,6 @@ dependencies = [
 
 [[package]]
 name = "write-fonts"
-version = "0.38.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60491c1d7e5873e721607fa05fd9b9fc66b0f0179b2b5f0f26a2022aafdcc61e"
-dependencies = [
- "font-types 0.9.0",
- "indexmap",
- "kurbo 0.11.2",
- "log",
- "read-fonts 0.29.3",
- "serde",
-]
-
-[[package]]
-name = "write-fonts"
 version = "0.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "187aca250ee00f9d9ad3a1ebc9ed65c9c921fdd4690b095ca6e5a8df7246d871"
@@ -2709,5 +2591,5 @@ dependencies = [
  "displaydoc",
  "indexmap",
  "memchr",
- "thiserror 2.0.18",
+ "thiserror",
 ]

--- a/crates/shift-backends/Cargo.toml
+++ b/crates/shift-backends/Cargo.toml
@@ -14,10 +14,10 @@ shift-source = { workspace = true }
 
 norad = "0.18.4"
 skrifa = "0.32.0"
-fontc = "0.2.0"
-glyphs-reader = "0.2.0"
+fontc = "0.6"
+glyphs-reader = "0.5"
 plist = "1"
-quick-xml = "0.37.5"
+quick-xml = { version = "0.37.5", features = ["serialize"] }
 serde = "1"
 tempfile = "3"
 thiserror = "2.0.18"

--- a/crates/shift-backends/src/export.rs
+++ b/crates/shift-backends/src/export.rs
@@ -1,5 +1,4 @@
 use std::path::{Path, PathBuf};
-use std::time::Instant;
 
 use crate::traits::FontView;
 use crate::ufo::UfoWriter;
@@ -121,7 +120,7 @@ fn compile_ttf(input_path: &str, build_dir: &Path, output_path: &Path) -> Result
     let mut args = fontc::Args::new(build_dir, input_path.into());
     args.output_file = Some(output_path.to_path_buf());
 
-    let timer = JobTimer::new(Instant::now());
+    let timer = JobTimer::new();
     fontc::run(args, timer).map_err(|source| ExportError::CompileTtf {
         message: source.to_string(),
     })

--- a/crates/shift-backends/src/glyphs/reader.rs
+++ b/crates/shift-backends/src/glyphs/reader.rs
@@ -101,7 +101,7 @@ impl GlyphsReader {
             {
                 KerningSide::Group(format!("{UFO_SIDE1_PREFIX}{group}"))
             } else {
-                KerningSide::Glyph(first.clone().into())
+                KerningSide::Glyph(first.to_string().into())
             };
 
             let second_side = if let Some(group) = second
@@ -110,7 +110,7 @@ impl GlyphsReader {
             {
                 KerningSide::Group(format!("{UFO_SIDE2_PREFIX}{group}"))
             } else {
-                KerningSide::Glyph(second.clone().into())
+                KerningSide::Glyph(second.to_string().into())
             };
 
             kerning.add_pair(KerningPair::new(
@@ -167,8 +167,8 @@ impl FontReader for GlyphsReader {
         let mut font = Font::empty();
 
         // Metadata and metrics from default master.
-        if let Some(family_name) = glyphs_font.names.get("familyNames") {
-            font.metadata_mut().family_name = Some(family_name.clone());
+        if let Some(family_name) = glyphs_font.get_default_name("familyNames") {
+            font.metadata_mut().family_name = Some(family_name.to_string());
         }
         if let Some(default_master) = glyphs_font.masters.get(glyphs_font.default_master_idx) {
             font.metadata_mut().style_name = Some(default_master.name.clone());


### PR DESCRIPTION
## What changed

- upgrade `fontc` from 0.2 to the 0.6 compatibility line
- align `glyphs-reader` with the 0.5 version used by the current compiler stack
- adapt the timer and Glyphs metadata APIs
- explicitly enable quick-xml serialization instead of relying on transitive feature unification

## Why

The newer compiler exposes the in-memory `generate_font(Box<dyn fontir::source::Source>, ...)` entry point needed for a native Shift-to-fontir frontend. Aligning the companion Glyphs reader also removes the duplicate 0.2 compiler type stack.

## Impact

Existing temporary-UFO TTF export behavior is unchanged. This PR only updates the compiler foundation and preserves successful TTF compilation/readback.

## Validation

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- repository pre-commit suite
