### PR TITLE
Move glyph interpolation into shift-font

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1911,7 +1911,6 @@ dependencies = [
 name = "shift-wire"
 version = "0.0.0"
 dependencies = [
- "fontdrasil",
  "napi",
  "napi-derive",
  "serde",

--- a/crates/shift-bridge/docs/DOCS.md
+++ b/crates/shift-bridge/docs/DOCS.md
@@ -47,10 +47,11 @@ crates/shift-bridge/
 2. JS calls a mutation such as `closeContour(layerId, contourId)`.
 3. `Bridge` parses boundary strings and asks `FontWorkspace` to run the edit against that layer.
 4. The bridge returns a `shift-wire` change DTO and bumps the live version.
-5. `saveWorkspace()` / `saveWorkspaceAs(path)` update the `.shift` source package target and record the persisted version.
-6. `inspectPackage(path)` and `inspectPackageDraft(storePath)` expose source/package identity for the utility process without choosing a recovery policy.
-7. `closeWorkspace()` drops the live Rust workspace handle before the utility process deletes a clean or discarded SQLite document.
-8. `exportWorkspace(request)` creates a `FontSaveSnapshot` and exports asynchronously through `shift-backends`.
+5. Read-only glyph snapshots ask `shift-font` for native interpolation and use `shift-wire` only to adapt its regions and deltas into renderer DTOs.
+6. `saveWorkspace()` / `saveWorkspaceAs(path)` update the `.shift` source package target and record the persisted version.
+7. `inspectPackage(path)` and `inspectPackageDraft(storePath)` expose source/package identity for the utility process without choosing a recovery policy.
+8. `closeWorkspace()` drops the live Rust workspace handle before the utility process deletes a clean or discarded SQLite document.
+9. `exportWorkspace(request)` creates a `FontSaveSnapshot` and exports asynchronously through `shift-backends`.
 
 ## Type Boundary
 

--- a/crates/shift-bridge/index.d.ts
+++ b/crates/shift-bridge/index.d.ts
@@ -393,15 +393,6 @@ export interface NapiGlyphLayerSnapshot {
   state: NapiGlyphState
 }
 
-export interface NapiGlyphMaster {
-  sourceId: SourceId
-  sourceName: string
-  isDefaultSource: boolean
-  location: NapiLocation
-  structure: NapiGlyphStructure
-  values: Float64Array
-}
-
 export interface NapiGlyphRecord {
   id: GlyphId
   name: GlyphName

--- a/crates/shift-bridge/src/bridge.rs
+++ b/crates/shift-bridge/src/bridge.rs
@@ -18,7 +18,7 @@ use shift_wire::{
     NapiGlyphSnapshot, NapiGlyphSnapshotRequest, NapiLayerReplaced, NapiLocation,
     NapiNamedInstance, NapiPointSeed, NapiSource,
   },
-  interpolation::{build_glyph_variation_data, build_masters, GlyphVariationBuild},
+  interpolation::glyph_variation_data,
   Axis, AxisMapping, FontMetadata, FontMetrics, GlyphChangedEntities, GlyphLayerSnapshot,
   GlyphRecord, GlyphSnapshot, GlyphSnapshotRequest, GlyphState, GlyphStructure, NamedInstance,
   Source,
@@ -547,9 +547,10 @@ impl Bridge {
         continue;
       };
 
-      let variation_data = self
-        .variation_build_for_glyph(glyph)?
-        .and_then(|(_, build)| build.variation_data);
+      let variation_data = font
+        .glyph_interpolation(&glyph_id)?
+        .map(|interpolation| glyph_variation_data(&interpolation, font.axes()))
+        .transpose()?;
 
       let layers = glyph
         .layers()
@@ -638,19 +639,6 @@ impl Bridge {
 
   fn save_snapshot(&self) -> BridgeResult<FontSaveSnapshot> {
     Ok(FontSaveSnapshot::new(self.font()?.clone(), None))
-  }
-
-  fn variation_build_for_glyph(
-    &self,
-    glyph: &Glyph,
-  ) -> BridgeResult<Option<(usize, GlyphVariationBuild)>> {
-    let font = self.font()?;
-
-    Ok(build_masters(font, glyph).map(|masters| {
-      let master_count = masters.len();
-      let build = build_glyph_variation_data(&masters, font.axes());
-      (master_count, build)
-    }))
   }
 
   fn workspace(&self) -> BridgeResult<&FontWorkspace> {

--- a/crates/shift-font/docs/DOCS.md
+++ b/crates/shift-font/docs/DOCS.md
@@ -18,6 +18,9 @@ crates/shift-font/src/
   changes.rs       -- replace-grade semantic change records
   layer_edit.rs    -- glyph-layer geometry mutations
   variation.rs     -- external-to-design mapping evaluation
+  interpolation.rs -- source compatibility, glyph values, variation models
+  projection.rs    -- location-bound resolved glyph views
+  composite.rs     -- recursive component flattening
 ```
 
 ## Key Types
@@ -30,6 +33,9 @@ crates/shift-font/src/
 - `Source` is an editable designspace position with a name and location.
 - `Glyph` is a glyph concept identified by `GlyphId`.
 - `GlyphLayer` is authored editable data for one glyph at one source.
+- `GlyphInterpolation` is a reusable model built from one glyph's compatible authored source layers. Its default-source template owns topology; its regions and deltas own native interpolation semantics.
+- `FontProjection` is a read-only, location-bound view that reuses resolved component layers across one or many glyph requests.
+- `ResolvedGlyph` is derived, flattened geometry plus x advance. An existing blank glyph resolves to an empty contour list; a missing glyph resolves to `None`.
 - `Contour` and `Point` describe outline geometry inside a glyph layer.
 
 ## Identity
@@ -48,11 +54,18 @@ Stable IDs are identity. Names and Unicode values are editable metadata.
 - Own font authoring data structures such as `Font`, `Glyph`, `GlyphLayer`, `Contour`, `Point`, `Source`, and `Axis`.
 - Keep object-level mutation behavior near the objects it mutates.
 - Provide model-native helpers for layer editing, component resolution, variation behavior, axis mapping evaluation, and geometry-derived behavior.
+- Own canonical glyph interpolation value ordering, source compatibility, variation-model construction, interpolation evaluation, and location-bound glyph resolution.
 - Stay independent of TypeScript, NAPI, and bridge DTOs.
+
+`Font::glyph_interpolation(glyph_id)` builds a reusable model from compatible master-source layers. The default source defines structural topology. Incompatible non-default layers and nonviable models do not become transport errors; callers receive `None` and may use their documented authored-layer fallback.
+
+`Font::projection(location)` expects an internal authoring location. Apply external axis mappings before creating the projection. Resolution prefers an exact authored layer, then compatible interpolation, then the default or preferred authored layer. Component branches resolve at the same location and are flattened into each `ResolvedGlyph`.
 
 ## Boundaries
 
 `shift-font` should not expose TypeScript-facing wire contracts. Those belong in `shift-wire`.
+
+`shift-wire` may translate native interpolation regions and deltas into transport DTOs, but it must not rebuild source samples, define topology compatibility, or evaluate variation models.
 
 `shift-font` should not perform SQLite persistence. Durable working-store reads and writes belong in `shift-store`.
 

--- a/crates/shift-font/src/composite.rs
+++ b/crates/shift-font/src/composite.rs
@@ -280,6 +280,28 @@ pub fn flatten_component_contours_for_layer(
         .collect()
 }
 
+/// Resolves root and component contours for one derived glyph layer.
+///
+/// Root points receive fresh identities because the result is read-only
+/// derived geometry. Components use the supplied provider and skip cyclic
+/// branches without dropping other contours.
+pub fn resolved_contours_for_layer(
+    provider: &impl GlyphLayerProvider,
+    layer: &GlyphLayer,
+    root_glyph_id: &GlyphId,
+) -> Vec<ResolvedContour> {
+    let mut contours = layer
+        .contours_iter()
+        .map(|contour| transform_contour_points(contour, Transform::identity()))
+        .collect::<Vec<_>>();
+    contours.extend(flatten_component_contours_for_layer(
+        provider,
+        layer,
+        root_glyph_id,
+    ));
+    contours
+}
+
 /// Resolves root-level component instances with provenance data.
 ///
 /// Each returned instance corresponds to a direct component of `layer` and

--- a/crates/shift-font/src/interpolation.rs
+++ b/crates/shift-font/src/interpolation.rs
@@ -1,0 +1,400 @@
+//! Native glyph interpolation over Shift sources and internal locations.
+
+use std::collections::{HashMap, HashSet};
+use std::str::FromStr;
+
+use fontdrasil::coords::{NormalizedCoord, NormalizedLocation};
+use fontdrasil::types::Tag;
+use fontdrasil::variations::VariationModel;
+
+use crate::{Axis, AxisId, CoreError, CoreResult, Font, GlyphId, GlyphLayer, Location};
+
+mod values;
+
+pub use values::GlyphInterpolationValues;
+
+/// Normalized support for one authoring axis within an interpolation region.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AxisSupport {
+    axis_id: AxisId,
+    minimum: f64,
+    peak: f64,
+    maximum: f64,
+}
+
+impl AxisSupport {
+    pub fn axis_id(&self) -> AxisId {
+        self.axis_id.clone()
+    }
+
+    pub fn minimum(&self) -> f64 {
+        self.minimum
+    }
+
+    pub fn peak(&self) -> f64 {
+        self.peak
+    }
+
+    pub fn maximum(&self) -> f64 {
+        self.maximum
+    }
+}
+
+/// Multi-axis support associated with one glyph interpolation delta.
+#[derive(Clone, Debug, PartialEq)]
+pub struct InterpolationRegion {
+    supports: Vec<AxisSupport>,
+}
+
+impl InterpolationRegion {
+    pub fn supports(&self) -> &[AxisSupport] {
+        &self.supports
+    }
+}
+
+/// Reusable interpolation for one glyph's compatible authored source layers.
+#[derive(Clone, Debug, PartialEq)]
+pub struct GlyphInterpolation {
+    template: GlyphLayer,
+    regions: Vec<InterpolationRegion>,
+    deltas: Vec<GlyphInterpolationValues>,
+}
+
+impl GlyphInterpolation {
+    /// Returns the default-source layer that defines compatible topology.
+    pub fn template(&self) -> &GlyphLayer {
+        &self.template
+    }
+
+    pub fn regions(&self) -> &[InterpolationRegion] {
+        &self.regions
+    }
+
+    pub fn deltas(&self) -> &[GlyphInterpolationValues] {
+        &self.deltas
+    }
+
+    /// Resolves an owned glyph layer at an internal authoring location.
+    ///
+    /// Missing axis coordinates use authoring defaults. The returned layer
+    /// preserves the default source's topology and identities but is a derived
+    /// value; mutating it does not change the font.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError::AxisNotFound`] if `axes` does not contain every
+    /// support axis, or a glyph-value shape error if the interpolation model
+    /// and its structural template are inconsistent.
+    pub fn resolve(&self, location: &Location, axes: &[Axis]) -> CoreResult<GlyphLayer> {
+        let mut layer = self.template.clone();
+        let values = self.values_at(location, axes)?;
+        layer.apply_interpolation_values(&values)?;
+        Ok(layer)
+    }
+
+    fn values_at(
+        &self,
+        location: &Location,
+        axes: &[Axis],
+    ) -> CoreResult<GlyphInterpolationValues> {
+        let value_count = self
+            .deltas
+            .first()
+            .map_or(0, |delta| delta.as_slice().len());
+        let mut values = vec![0.0; value_count];
+
+        for (region, deltas) in self.regions.iter().zip(&self.deltas) {
+            let scalar = region_scalar(region, location, axes)?;
+            if scalar == 0.0 {
+                continue;
+            }
+
+            for (value, delta) in values.iter_mut().zip(deltas.as_slice()) {
+                *value += scalar * delta;
+            }
+        }
+
+        Ok(GlyphInterpolationValues::new(values))
+    }
+}
+
+impl Font {
+    /// Builds interpolation for one glyph from compatible authored sources.
+    ///
+    /// The default source defines topology. Incompatible non-default source
+    /// layers are ignored. `None` means the font is static or no viable model
+    /// can be formed; callers may then use their documented source fallback.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError::GlyphNotFound`] when `glyph_id` is not in the font.
+    pub fn glyph_interpolation(
+        &self,
+        glyph_id: &GlyphId,
+    ) -> CoreResult<Option<GlyphInterpolation>> {
+        let glyph = self
+            .glyph(glyph_id.clone())
+            .ok_or_else(|| CoreError::GlyphNotFound(glyph_id.clone()))?;
+        if !self.is_variable() {
+            return Ok(None);
+        }
+
+        let Some(default_source_id) = self.default_source_id() else {
+            return Ok(None);
+        };
+        let Some(default_layer) = glyph.layer_for_source(default_source_id.clone()) else {
+            return Ok(None);
+        };
+
+        let tagged_axes = self
+            .axes()
+            .iter()
+            .filter_map(|axis| Tag::from_str(axis.tag()).ok().map(|tag| (tag, axis.id())))
+            .collect::<Vec<_>>();
+        let ordered_axes = tagged_axes.iter().map(|(tag, _)| *tag).collect();
+        let axis_ids_by_tag = tagged_axes.into_iter().collect::<HashMap<_, _>>();
+        let mut points = HashMap::new();
+
+        for source in self.sources().iter().filter(|source| source.is_master()) {
+            let Some(layer) = glyph.layer_for_source(source.id()) else {
+                continue;
+            };
+            if !layers_are_compatible(default_layer, layer) {
+                continue;
+            }
+
+            let location = normalized_location(source.location(), self.axes());
+            if points
+                .insert(location, layer.interpolation_values().into_vec())
+                .is_some()
+            {
+                return Ok(None);
+            }
+        }
+
+        if points.is_empty() {
+            return Ok(None);
+        }
+
+        let model = VariationModel::new(
+            points
+                .keys()
+                .cloned()
+                .collect::<HashSet<NormalizedLocation>>(),
+            ordered_axes,
+        );
+        let Ok(model_deltas) = model.deltas::<f64, f64>(&points) else {
+            return Ok(None);
+        };
+
+        let regions = model_deltas
+            .iter()
+            .map(|(region, _)| InterpolationRegion {
+                supports: region
+                    .iter()
+                    .filter_map(|(tag, support)| {
+                        let axis_id = axis_ids_by_tag.get(tag)?;
+                        Some(AxisSupport {
+                            axis_id: axis_id.clone(),
+                            minimum: support.min.into_inner().into_inner(),
+                            peak: support.peak.into_inner().into_inner(),
+                            maximum: support.max.into_inner().into_inner(),
+                        })
+                    })
+                    .collect(),
+            })
+            .collect();
+        let deltas = model_deltas
+            .into_iter()
+            .map(|(_, values)| GlyphInterpolationValues::new(values))
+            .collect();
+
+        Ok(Some(GlyphInterpolation {
+            template: default_layer.clone(),
+            regions,
+            deltas,
+        }))
+    }
+}
+
+fn normalized_location(location: &Location, axes: &[Axis]) -> NormalizedLocation {
+    axes.iter()
+        .filter_map(|axis| {
+            let tag = Tag::from_str(axis.tag()).ok()?;
+            let value = location.get(&axis.id()).unwrap_or(axis.default());
+            Some((tag, NormalizedCoord::new(axis.normalize(value))))
+        })
+        .collect()
+}
+
+fn layers_are_compatible(template: &GlyphLayer, candidate: &GlyphLayer) -> bool {
+    if template.contours().len() != candidate.contours().len()
+        || template.anchors().len() != candidate.anchors().len()
+        || template.components().len() != candidate.components().len()
+    {
+        return false;
+    }
+
+    for (template, candidate) in template.contours_iter().zip(candidate.contours_iter()) {
+        if template.is_closed() != candidate.is_closed()
+            || template.points().len() != candidate.points().len()
+        {
+            return false;
+        }
+
+        if template
+            .points()
+            .iter()
+            .zip(candidate.points())
+            .any(|(template, candidate)| template.is_on_curve() != candidate.is_on_curve())
+        {
+            return false;
+        }
+    }
+
+    if template
+        .anchors_iter()
+        .zip(candidate.anchors_iter())
+        .any(|(template, candidate)| template.name() != candidate.name())
+    {
+        return false;
+    }
+
+    !template
+        .components_iter()
+        .zip(candidate.components_iter())
+        .any(|(template, candidate)| template.base_glyph_id() != candidate.base_glyph_id())
+}
+
+fn region_scalar(
+    region: &InterpolationRegion,
+    location: &Location,
+    axes: &[Axis],
+) -> CoreResult<f64> {
+    let mut scalar = 1.0;
+
+    for support in region.supports() {
+        if support.minimum > support.peak
+            || support.peak > support.maximum
+            || (support.minimum < 0.0 && support.maximum > 0.0)
+        {
+            continue;
+        }
+
+        let axis = axes
+            .iter()
+            .find(|axis| axis.id() == support.axis_id)
+            .ok_or_else(|| CoreError::AxisNotFound(support.axis_id.clone()))?;
+        let value = location.get(&axis.id()).unwrap_or(axis.default());
+        let normalized = axis.normalize(value);
+
+        if normalized == support.peak
+            || (support.minimum == 0.0 && support.peak == 0.0 && support.maximum == 0.0)
+        {
+            continue;
+        }
+
+        if normalized <= support.minimum || support.maximum <= normalized {
+            return Ok(0.0);
+        }
+
+        let edge = if normalized < support.peak {
+            support.minimum
+        } else {
+            support.maximum
+        };
+        scalar *= (normalized - edge) / (support.peak - edge);
+    }
+
+    Ok(scalar)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_support::sample_variable_font;
+    use crate::{GlyphInterpolationValues, Location};
+
+    #[test]
+    fn layer_values_roundtrip_without_changing_topology() {
+        let font = sample_variable_font();
+        let glyph = font.glyph_by_name("A").unwrap();
+        let layer = glyph
+            .layer_for_source(font.default_source_id().unwrap())
+            .unwrap();
+        let mut restored = layer.clone();
+
+        restored
+            .apply_interpolation_values(&GlyphInterpolationValues::from_layer(layer))
+            .unwrap();
+
+        assert_eq!(restored, *layer);
+    }
+
+    #[test]
+    fn applying_invalid_values_does_not_partially_mutate_a_layer() {
+        let font = sample_variable_font();
+        let layer = font
+            .glyph_by_name("A")
+            .unwrap()
+            .layer_for_source(font.default_source_id().unwrap())
+            .unwrap();
+        let mut restored = layer.clone();
+
+        let error = restored
+            .apply_interpolation_values(&GlyphInterpolationValues::new(vec![123.0]))
+            .unwrap_err();
+
+        assert!(matches!(error, crate::CoreError::MissingGlyphValue { .. }));
+        assert_eq!(restored, *layer);
+    }
+
+    #[test]
+    fn smooth_metadata_does_not_make_layers_incompatible() {
+        let font = sample_variable_font();
+        let glyph = font.glyph_by_name("A").unwrap();
+        let template = glyph
+            .layer_for_source(font.default_source_id().unwrap())
+            .unwrap();
+        let mut candidate = template.clone();
+        let point = candidate
+            .contours_iter_mut()
+            .next()
+            .unwrap()
+            .points_mut()
+            .first_mut()
+            .unwrap();
+        point.set_smooth(!point.is_smooth());
+
+        assert!(super::layers_are_compatible(template, &candidate));
+    }
+
+    #[test]
+    fn glyph_interpolation_resolves_intermediate_outline_and_advance() {
+        let font = sample_variable_font();
+        let glyph = font.glyph_by_name("A").unwrap();
+        let axis_id = font.axes()[0].id();
+        let mut location = Location::new();
+        location.set(axis_id, 600.0);
+
+        let layer = font
+            .glyph_interpolation(&glyph.id())
+            .unwrap()
+            .unwrap()
+            .resolve(&location, font.axes())
+            .unwrap();
+
+        assert_eq!(layer.width(), 700.0);
+        assert_eq!(layer.contours_iter().next().unwrap().points()[1].x(), 340.0);
+    }
+
+    #[test]
+    fn glyph_interpolation_rejects_missing_axis_definitions() {
+        let font = sample_variable_font();
+        let glyph = font.glyph_by_name("A").unwrap();
+        let interpolation = font.glyph_interpolation(&glyph.id()).unwrap().unwrap();
+
+        let error = interpolation.resolve(&Location::new(), &[]).unwrap_err();
+
+        assert!(matches!(error, crate::CoreError::AxisNotFound(_)));
+    }
+}

--- a/crates/shift-font/src/interpolation/values.rs
+++ b/crates/shift-font/src/interpolation/values.rs
@@ -1,0 +1,157 @@
+use crate::{CoreError, CoreResult, DecomposedTransform, GlyphLayer};
+
+/// Numeric glyph-layer values that participate in interpolation.
+///
+/// Values are ordered as advance width, contour point positions, anchor
+/// positions, and component transforms. The ordering is owned alongside
+/// [`GlyphLayer`] so persistence and transport adapters do not define domain
+/// interpolation semantics.
+#[derive(Clone, Debug, PartialEq)]
+pub struct GlyphInterpolationValues {
+    values: Vec<f64>,
+}
+
+impl GlyphInterpolationValues {
+    /// Wraps values already encoded in the canonical glyph interpolation order.
+    pub fn new(values: Vec<f64>) -> Self {
+        Self { values }
+    }
+
+    /// Returns the canonical interpolation values for an authored layer.
+    pub fn from_layer(layer: &GlyphLayer) -> Self {
+        let mut values = Vec::new();
+        values.push(layer.width());
+
+        for contour in layer.contours_iter() {
+            for point in contour.points() {
+                values.push(point.x());
+                values.push(point.y());
+            }
+        }
+
+        for anchor in layer.anchors_iter() {
+            values.push(anchor.x());
+            values.push(anchor.y());
+        }
+
+        for component in layer.components_iter() {
+            let transform = component.transform();
+            values.push(transform.translate_x);
+            values.push(transform.translate_y);
+            values.push(transform.rotation);
+            values.push(transform.scale_x);
+            values.push(transform.scale_y);
+            values.push(transform.skew_x);
+            values.push(transform.skew_y);
+            values.push(transform.t_center_x);
+            values.push(transform.t_center_y);
+        }
+
+        Self { values }
+    }
+
+    pub fn as_slice(&self) -> &[f64] {
+        &self.values
+    }
+
+    pub fn into_vec(self) -> Vec<f64> {
+        self.values
+    }
+}
+
+impl GlyphLayer {
+    /// Returns the numeric values that participate in glyph interpolation.
+    pub fn interpolation_values(&self) -> GlyphInterpolationValues {
+        GlyphInterpolationValues::from_layer(self)
+    }
+
+    /// Replaces every interpolating value without changing layer topology.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError::MissingGlyphValue`] or
+    /// [`CoreError::TrailingGlyphValues`] when `values` does not match this
+    /// layer's contour, anchor, and component structure. Shape mismatches are
+    /// rejected before any layer value changes.
+    pub fn apply_interpolation_values(
+        &mut self,
+        values: &GlyphInterpolationValues,
+    ) -> CoreResult<()> {
+        let expected = 1
+            + self
+                .contours_iter()
+                .map(|contour| contour.points().len() * 2)
+                .sum::<usize>()
+            + self.anchors().len() * 2
+            + self.components().len() * 9;
+        let actual = values.as_slice().len();
+        if actual < expected {
+            return Err(CoreError::MissingGlyphValue { index: actual });
+        }
+        if actual > expected {
+            return Err(CoreError::TrailingGlyphValues { expected, actual });
+        }
+
+        let mut cursor = ValueCursor::new(values.as_slice());
+        self.set_width(cursor.next()?);
+
+        for contour in self.contours_iter_mut() {
+            for point in contour.points_mut() {
+                point.set_position(cursor.next()?, cursor.next()?);
+            }
+        }
+
+        for anchor in self.anchors_iter_mut() {
+            anchor.set_position(cursor.next()?, cursor.next()?);
+        }
+
+        for component in self.components_iter_mut() {
+            component.set_transform(DecomposedTransform {
+                translate_x: cursor.next()?,
+                translate_y: cursor.next()?,
+                rotation: cursor.next()?,
+                scale_x: cursor.next()?,
+                scale_y: cursor.next()?,
+                skew_x: cursor.next()?,
+                skew_y: cursor.next()?,
+                t_center_x: cursor.next()?,
+                t_center_y: cursor.next()?,
+            });
+        }
+
+        cursor.finish()
+    }
+}
+
+struct ValueCursor<'a> {
+    values: &'a [f64],
+    index: usize,
+}
+
+impl<'a> ValueCursor<'a> {
+    fn new(values: &'a [f64]) -> Self {
+        Self { values, index: 0 }
+    }
+
+    fn next(&mut self) -> CoreResult<f64> {
+        let index = self.index;
+        let value = self
+            .values
+            .get(index)
+            .copied()
+            .ok_or(CoreError::MissingGlyphValue { index })?;
+        self.index += 1;
+        Ok(value)
+    }
+
+    fn finish(self) -> CoreResult<()> {
+        if self.index == self.values.len() {
+            return Ok(());
+        }
+
+        Err(CoreError::TrailingGlyphValues {
+            expected: self.index,
+            actual: self.values.len(),
+        })
+    }
+}

--- a/crates/shift-font/src/ir/axis.rs
+++ b/crates/shift-font/src/ir/axis.rs
@@ -625,6 +625,19 @@ impl Location {
             (value - axis.default()).abs() < f64::EPSILON
         })
     }
+
+    /// Returns whether two locations address the same position on `axes`.
+    ///
+    /// Missing coordinates use axis defaults, values within `1e-6` axis units
+    /// are equivalent, and coordinates outside `axes` do not participate. Use
+    /// [`PartialEq`] when exact stored-coordinate equality is required.
+    pub fn is_equivalent_to(&self, other: &Self, axes: &[Axis]) -> bool {
+        axes.iter().all(|axis| {
+            let left = self.get(&axis.id()).unwrap_or(axis.default());
+            let right = other.get(&axis.id()).unwrap_or(axis.default());
+            (left - right).abs() <= 1e-6
+        })
+    }
 }
 
 #[cfg(test)]
@@ -767,5 +780,22 @@ mod tests {
         assert_eq!(loc.get(&weight), Some(700.0));
         assert_eq!(loc.get(&width), Some(100.0));
         assert_eq!(loc.get(&slant), None);
+    }
+
+    #[test]
+    fn location_equivalence_uses_axis_defaults_and_tolerance() {
+        let axis = Axis::weight();
+        let implicit_default = Location::new();
+        let mut explicit_default = Location::new();
+        explicit_default.set(axis.id(), axis.default());
+        let mut near_default = Location::new();
+        near_default.set(axis.id(), axis.default() + 0.0000005);
+        let mut distinct = Location::new();
+        distinct.set(axis.id(), axis.default() + 0.001);
+
+        assert_ne!(implicit_default, explicit_default);
+        assert!(implicit_default.is_equivalent_to(&explicit_default, std::slice::from_ref(&axis)));
+        assert!(implicit_default.is_equivalent_to(&near_default, std::slice::from_ref(&axis)));
+        assert!(!implicit_default.is_equivalent_to(&distinct, std::slice::from_ref(&axis)));
     }
 }

--- a/crates/shift-font/src/ir/glyph.rs
+++ b/crates/shift-font/src/ir/glyph.rs
@@ -184,6 +184,10 @@ impl GlyphLayer {
         self.components.values()
     }
 
+    pub fn components_iter_mut(&mut self) -> impl Iterator<Item = &mut Component> {
+        self.components.values_mut()
+    }
+
     pub fn component(&self, id: ComponentId) -> Option<&Component> {
         self.components.get(&id)
     }
@@ -208,6 +212,10 @@ impl GlyphLayer {
 
     pub fn anchors_iter(&self) -> impl Iterator<Item = &Anchor> {
         self.anchors.iter()
+    }
+
+    pub fn anchors_iter_mut(&mut self) -> impl Iterator<Item = &mut Anchor> {
+        self.anchors.iter_mut()
     }
 
     pub fn anchor(&self, id: AnchorId) -> Option<&Anchor> {

--- a/crates/shift-font/src/lib.rs
+++ b/crates/shift-font/src/lib.rs
@@ -34,16 +34,20 @@ pub mod composite;
 pub mod curve;
 pub mod error;
 pub mod intents;
+pub mod interpolation;
 pub mod ir;
 pub mod layer_edit;
+pub mod projection;
 #[cfg(any(test, feature = "test-support"))]
 pub mod test_support;
 
 pub use changes::*;
 pub use error::{CoreError, CoreResult};
 pub use intents::*;
+pub use interpolation::*;
 pub use ir::*;
 pub use ir::{
     anchor, axis, boolean, component, contour, entity, features, font, glyph, glyph_name,
     guideline, kerning, lib_data, metrics, named_instance, point, segment, source, variation,
 };
+pub use projection::*;

--- a/crates/shift-font/src/projection.rs
+++ b/crates/shift-font/src/projection.rs
@@ -1,0 +1,294 @@
+//! Location-bound, read-only glyph resolution.
+
+use std::collections::HashMap;
+
+use crate::composite::{
+    preferred_layer_for_glyph, resolved_contours_for_layer, GlyphLayerProvider, ResolvedContour,
+};
+use crate::{CoreResult, Font, Glyph, GlyphId, GlyphLayer, Location, SourceId};
+
+/// Read-only font projection fixed to one internal authoring location.
+///
+/// The projection snapshots its location and memoizes derived layers for its
+/// own lifetime. It does not mutate authored font data or retain renderer,
+/// persistence, or compiler state.
+pub struct FontProjection<'a> {
+    font: &'a Font,
+    location: Location,
+    exact_source_id: Option<SourceId>,
+    layers: HashMap<GlyphId, Option<GlyphLayer>>,
+}
+
+/// Fully resolved glyph geometry at one internal authoring location.
+///
+/// Components are flattened into `contours`. An existing blank glyph has an
+/// empty contour collection and remains distinguishable from a missing glyph,
+/// which resolves to `None`.
+#[derive(Clone, Debug)]
+pub struct ResolvedGlyph {
+    glyph_id: GlyphId,
+    contours: Vec<ResolvedContour>,
+    x_advance: f64,
+}
+
+impl ResolvedGlyph {
+    pub fn glyph_id(&self) -> GlyphId {
+        self.glyph_id.clone()
+    }
+
+    pub fn contours(&self) -> &[ResolvedContour] {
+        &self.contours
+    }
+
+    pub fn x_advance(&self) -> f64 {
+        self.x_advance
+    }
+}
+
+impl Font {
+    /// Creates a read-only projection at an internal authoring location.
+    ///
+    /// Missing axis coordinates use axis defaults. External axis mappings must
+    /// be evaluated before constructing the projection.
+    pub fn projection(&self, location: &Location) -> FontProjection<'_> {
+        let exact_source_id = self
+            .sources()
+            .iter()
+            .filter(|source| source.is_master())
+            .find(|source| locations_equal(source.location(), location, self))
+            .map(|source| source.id());
+
+        FontProjection {
+            font: self,
+            location: location.clone(),
+            exact_source_id,
+            layers: HashMap::new(),
+        }
+    }
+}
+
+impl FontProjection<'_> {
+    pub fn location(&self) -> &Location {
+        &self.location
+    }
+
+    /// Resolves one glyph without exposing editable layer identities.
+    ///
+    /// Exact authored layers win, followed by compatible interpolation and the
+    /// default-source fallback. Components resolve recursively at this
+    /// projection's location and cyclic branches are skipped locally.
+    ///
+    /// # Errors
+    ///
+    /// Returns a glyph interpolation error when derived values do not match
+    /// their compatible structural template.
+    pub fn glyph(&mut self, glyph_id: &GlyphId) -> CoreResult<Option<ResolvedGlyph>> {
+        self.prepare_layer_tree(glyph_id)?;
+
+        let provider = ProjectionLayerProvider {
+            font: self.font,
+            layers: &self.layers,
+        };
+        let Some(layer) = provider.glyph_layer(glyph_id) else {
+            return Ok(None);
+        };
+
+        Ok(Some(ResolvedGlyph {
+            glyph_id: glyph_id.clone(),
+            contours: resolved_contours_for_layer(&provider, layer, glyph_id),
+            x_advance: layer.width(),
+        }))
+    }
+
+    /// Resolves existing glyphs in request order with shared component work.
+    ///
+    /// Missing glyph IDs are omitted. Duplicate existing IDs produce duplicate
+    /// ordered results while reusing this projection's resolved layers.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first interpolation error encountered while resolving a
+    /// requested glyph or one of its component branches.
+    pub fn glyphs(&mut self, glyph_ids: &[GlyphId]) -> CoreResult<Vec<ResolvedGlyph>> {
+        let mut glyphs = Vec::new();
+        for glyph_id in glyph_ids {
+            if let Some(glyph) = self.glyph(glyph_id)? {
+                glyphs.push(glyph);
+            }
+        }
+        Ok(glyphs)
+    }
+
+    fn prepare_layer_tree(&mut self, glyph_id: &GlyphId) -> CoreResult<()> {
+        self.resolve_layer(glyph_id)?;
+
+        let component_ids = match self.layers.get(glyph_id) {
+            Some(Some(layer)) => layer
+                .components_iter()
+                .map(|component| component.base_glyph_id())
+                .collect::<Vec<_>>(),
+            Some(None) | None => return Ok(()),
+        };
+
+        for component_id in component_ids {
+            if !self.layers.contains_key(&component_id) {
+                self.prepare_layer_tree(&component_id)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn resolve_layer(&mut self, glyph_id: &GlyphId) -> CoreResult<()> {
+        if self.layers.contains_key(glyph_id) {
+            return Ok(());
+        }
+
+        let Some(glyph) = self.font.glyph(glyph_id.clone()) else {
+            self.layers.insert(glyph_id.clone(), None);
+            return Ok(());
+        };
+
+        let layer = if let Some(source_id) = self.exact_source_id.clone() {
+            glyph.layer_for_source(source_id).cloned()
+        } else {
+            None
+        };
+        let layer = match layer {
+            Some(layer) => Some(layer),
+            None => match self.font.glyph_interpolation(glyph_id)? {
+                Some(interpolation) => {
+                    Some(interpolation.resolve(&self.location, self.font.axes())?)
+                }
+                None => fallback_layer(self.font, glyph).cloned(),
+            },
+        };
+        self.layers.insert(glyph_id.clone(), layer);
+        Ok(())
+    }
+}
+
+struct ProjectionLayerProvider<'a> {
+    font: &'a Font,
+    layers: &'a HashMap<GlyphId, Option<GlyphLayer>>,
+}
+
+impl GlyphLayerProvider for ProjectionLayerProvider<'_> {
+    fn glyph_layer(&self, glyph_id: &GlyphId) -> Option<&GlyphLayer> {
+        match self.layers.get(glyph_id) {
+            Some(Some(layer)) => Some(layer),
+            Some(None) | None => None,
+        }
+    }
+
+    fn glyph_name(&self, glyph_id: &GlyphId) -> Option<&str> {
+        self.font.glyph(glyph_id.clone()).map(Glyph::name)
+    }
+}
+
+fn fallback_layer<'a>(font: &Font, glyph: &'a Glyph) -> Option<&'a GlyphLayer> {
+    if let Some(layer) = font
+        .default_source_id()
+        .and_then(|source_id| glyph.layer_for_source(source_id))
+    {
+        return Some(layer);
+    }
+
+    preferred_layer_for_glyph(glyph)
+}
+
+fn locations_equal(left: &Location, right: &Location, font: &Font) -> bool {
+    font.axes().iter().all(|axis| {
+        let left = left.get(&axis.id()).unwrap_or(axis.default());
+        let right = right.get(&axis.id()).unwrap_or(axis.default());
+        (left - right).abs() <= 1e-6
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_support::sample_variable_font;
+    use crate::{
+        Component, Contour, Font, Glyph, GlyphId, GlyphLayer, LayerId, Location, PointType,
+        Transform,
+    };
+
+    #[test]
+    fn projection_interpolates_when_an_exact_source_has_no_glyph_layer() {
+        let font = sample_variable_font();
+        let glyph_id = font.glyph_by_name("A").unwrap().id();
+        let mut location = Location::new();
+        location.set(font.axes()[0].id(), 600.0);
+
+        let glyph = font
+            .projection(&location)
+            .glyph(&glyph_id)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(glyph.x_advance(), 700.0);
+        assert_eq!(glyph.contours()[0].points[1].x(), 340.0);
+    }
+
+    #[test]
+    fn projection_preserves_order_and_distinguishes_blank_from_missing() {
+        let mut font = Font::new();
+        let source_id = font.default_source_id().unwrap();
+        let blank_id = GlyphId::from_raw("blank");
+        let mut blank = Glyph::with_id(blank_id.clone(), "blank");
+        blank.set_layer(GlyphLayer::with_width(LayerId::new(), source_id, 420.0));
+        font.insert_glyph(blank).unwrap();
+
+        let glyphs = font
+            .projection(&Location::new())
+            .glyphs(&[
+                GlyphId::from_raw("missing"),
+                blank_id.clone(),
+                blank_id.clone(),
+            ])
+            .unwrap();
+
+        assert_eq!(glyphs.len(), 2);
+        assert_eq!(glyphs[0].glyph_id(), blank_id);
+        assert!(glyphs[0].contours().is_empty());
+        assert_eq!(glyphs[0].x_advance(), 420.0);
+    }
+
+    #[test]
+    fn projection_flattens_transformed_components() {
+        let mut font = Font::new();
+        let source_id = font.default_source_id().unwrap();
+        let base_id = GlyphId::from_raw("base");
+        let mut base = Glyph::with_id(base_id.clone(), "base");
+        let mut base_layer = GlyphLayer::with_width(LayerId::new(), source_id.clone(), 200.0);
+        let mut contour = Contour::new();
+        contour.add_point(0.0, 0.0, PointType::OnCurve, false);
+        contour.add_point(10.0, 10.0, PointType::OnCurve, false);
+        base_layer.add_contour(contour);
+        base.set_layer(base_layer);
+        font.insert_glyph(base).unwrap();
+
+        let root_id = GlyphId::from_raw("root");
+        let mut root = Glyph::with_id(root_id.clone(), "root");
+        let mut root_layer = GlyphLayer::with_width(LayerId::new(), source_id, 500.0);
+        root_layer.add_component(Component::with_matrix(
+            base_id,
+            "base",
+            &Transform::translate(50.0, 20.0),
+        ));
+        root.set_layer(root_layer);
+        font.insert_glyph(root).unwrap();
+
+        let glyph = font
+            .projection(&Location::new())
+            .glyph(&root_id)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(glyph.x_advance(), 500.0);
+        let first = &glyph.contours()[0].points[0];
+        let second = &glyph.contours()[0].points[1];
+        assert_eq!((first.x(), first.y()), (50.0, 20.0));
+        assert_eq!((second.x(), second.y()), (60.0, 30.0));
+    }
+}

--- a/crates/shift-font/src/projection.rs
+++ b/crates/shift-font/src/projection.rs
@@ -55,7 +55,7 @@ impl Font {
             .sources()
             .iter()
             .filter(|source| source.is_master())
-            .find(|source| locations_equal(source.location(), location, self))
+            .find(|source| source.location().is_equivalent_to(location, self.axes()))
             .map(|source| source.id());
 
         FontProjection {
@@ -195,14 +195,6 @@ fn fallback_layer<'a>(font: &Font, glyph: &'a Glyph) -> Option<&'a GlyphLayer> {
     }
 
     preferred_layer_for_glyph(glyph)
-}
-
-fn locations_equal(left: &Location, right: &Location, font: &Font) -> bool {
-    font.axes().iter().all(|axis| {
-        let left = left.get(&axis.id()).unwrap_or(axis.default());
-        let right = right.get(&axis.id()).unwrap_or(axis.default());
-        (left - right).abs() <= 1e-6
-    })
 }
 
 #[cfg(test)]

--- a/crates/shift-wire/Cargo.toml
+++ b/crates/shift-wire/Cargo.toml
@@ -15,7 +15,6 @@ napi = ["dep:napi", "dep:napi-derive"]
 [dependencies]
 shift-font = { workspace = true }
 
-fontdrasil = "0.4.0"
 napi = { version = "=3.8.6", optional = true, default-features = false, features = [
     "napi6",
 ] }

--- a/crates/shift-wire/src/bridges/napi/mod.rs
+++ b/crates/shift-wire/src/bridges/napi/mod.rs
@@ -7,7 +7,7 @@ use shift_font::{GlyphId, PointType as IrPointType};
 use crate::{
     AnchorData, Axis, AxisLabel, AxisMapping, AxisMappingPoint, AxisTent, ComponentData,
     ContourData, FontMetadata, FontMetrics, GlyphChangedEntities, GlyphLayerRecord,
-    GlyphLayerSnapshot, GlyphMaster, GlyphRecord, GlyphSnapshot, GlyphSnapshotRequest, GlyphState,
+    GlyphLayerSnapshot, GlyphRecord, GlyphSnapshot, GlyphSnapshotRequest, GlyphState,
     GlyphStructure, GlyphVariationData, Location, NamedInstance, PointData, PointType, Source,
 };
 
@@ -635,30 +635,6 @@ impl From<GlyphVariationData> for NapiGlyphVariationData {
                 .map(|region| region.into_iter().map(Into::into).collect())
                 .collect(),
             deltas: data.deltas.into_iter().map(Into::into).collect(),
-        }
-    }
-}
-
-#[napi(object)]
-pub struct NapiGlyphMaster {
-    #[napi(ts_type = "SourceId")]
-    pub source_id: String,
-    pub source_name: String,
-    pub is_default_source: bool,
-    pub location: NapiLocation,
-    pub structure: NapiGlyphStructure,
-    pub values: Float64Array,
-}
-
-impl From<GlyphMaster> for NapiGlyphMaster {
-    fn from(master: GlyphMaster) -> Self {
-        Self {
-            source_id: master.source_id,
-            source_name: master.source_name,
-            is_default_source: master.is_default_source,
-            location: master.location.into(),
-            structure: master.structure.into(),
-            values: master.values.into(),
         }
     }
 }

--- a/crates/shift-wire/src/interpolation.rs
+++ b/crates/shift-wire/src/interpolation.rs
@@ -1,338 +1,52 @@
-use std::collections::{HashMap, HashSet};
-use std::str::FromStr;
+//! Transport adapters for native glyph interpolation.
 
-use fontdrasil::coords::{NormalizedCoord, NormalizedLocation};
-use fontdrasil::types::Tag;
-use fontdrasil::variations::VariationModel;
-use shift_font::{Axis, Font, Glyph};
+use shift_font::{Axis, CoreError, CoreResult, GlyphInterpolation};
 
-use crate::{
-    values_from_layer, AxisTent, GlyphMaster, GlyphStructure, GlyphVariationData, Location,
-};
+use crate::{AxisTent, GlyphVariationData};
 
-#[derive(Debug, Clone)]
-pub struct SourceError {
-    pub source_index: usize,
-    pub source_id: String,
-    pub source_name: String,
-    pub message: String,
-}
-
-#[derive(Debug, Clone)]
-pub struct GlyphVariationBuild {
-    pub variation_data: Option<GlyphVariationData>,
-    pub source_errors: Vec<SourceError>,
-    pub missing_default_source: bool,
-    pub model_error: Option<String>,
-}
-
-impl GlyphVariationBuild {
-    fn data(variation_data: GlyphVariationData, source_errors: Vec<SourceError>) -> Self {
-        Self {
-            variation_data: Some(variation_data),
-            source_errors,
-            missing_default_source: false,
-            model_error: None,
-        }
-    }
-
-    fn missing_default() -> Self {
-        Self {
-            variation_data: None,
-            source_errors: Vec::new(),
-            missing_default_source: true,
-            model_error: None,
-        }
-    }
-
-    fn model_failed(source_errors: Vec<SourceError>, message: String) -> Self {
-        Self {
-            variation_data: None,
-            source_errors,
-            missing_default_source: false,
-            model_error: Some(message),
-        }
-    }
-}
-
-fn check_compatibility(a: &GlyphStructure, b: &GlyphStructure) -> Result<(), String> {
-    // Contour topology must match so point values line up by index.
-    if a.contours.len() != b.contours.len() {
-        return Err(format!(
-            "contour count mismatch: {} vs {}",
-            a.contours.len(),
-            b.contours.len()
-        ));
-    }
-
-    for (i, (ca, cb)) in a.contours.iter().zip(b.contours.iter()).enumerate() {
-        if ca.closed != cb.closed {
-            return Err(format!(
-                "contour {i} closed mismatch: {} vs {}",
-                ca.closed, cb.closed
-            ));
-        }
-
-        if ca.points.len() != cb.points.len() {
-            return Err(format!(
-                "contour {} point count mismatch: {} vs {}",
-                i,
-                ca.points.len(),
-                cb.points.len()
-            ));
-        }
-
-        for (j, (pa, pb)) in ca.points.iter().zip(cb.points.iter()).enumerate() {
-            if pa.point_type != pb.point_type {
-                return Err(format!("contour {i} point {j} type mismatch"));
-            }
-        }
-    }
-
-    // Anchors contribute x/y values, so names and order must agree.
-    if a.anchors.len() != b.anchors.len() {
-        return Err(format!(
-            "anchor count mismatch: {} vs {}",
-            a.anchors.len(),
-            b.anchors.len()
-        ));
-    }
-
-    for (i, (aa, ab)) in a.anchors.iter().zip(b.anchors.iter()).enumerate() {
-        if aa.name != ab.name {
-            return Err(format!("anchor {i} name mismatch"));
-        }
-    }
-
-    // Components contribute transform values, keyed structurally by base glyph id.
-    if a.components.len() != b.components.len() {
-        return Err(format!(
-            "component count mismatch: {} vs {}",
-            a.components.len(),
-            b.components.len()
-        ));
-    }
-
-    for (i, (ca, cb)) in a.components.iter().zip(b.components.iter()).enumerate() {
-        if ca.base_glyph_id != cb.base_glyph_id {
-            return Err(format!(
-                "component {i} base glyph mismatch: {} ({}) vs {} ({})",
-                ca.base_glyph_name, ca.base_glyph_id, cb.base_glyph_name, cb.base_glyph_id
-            ));
-        }
-    }
-
-    Ok(())
-}
-
-fn to_fd_wire_location(location: &Location, axes: &[Axis]) -> NormalizedLocation {
-    let mut result = NormalizedLocation::new();
-
-    for axis in axes {
-        let value = location
-            .values
-            .get(&axis.id())
-            .copied()
-            .unwrap_or(axis.default());
-        let normalized = axis.normalize(value);
-        let Ok(tag) = Tag::from_str(axis.tag()) else {
-            continue;
-        };
-
-        result.insert(tag, NormalizedCoord::new(normalized));
-    }
-
-    result
-}
-
-/// Build per-source masters for a single glyph.
+/// Projects native glyph interpolation into the renderer's variation DTO.
 ///
-/// Pure: no editing-session knowledge. Caller passes the `Glyph` it wants the
-/// masters from (could be the committed copy or an in-progress editing copy
-/// with the live session layer patched in by the bridge).
+/// Shift's authoring model identifies axes by stable identity. The renderer's
+/// existing interpolation DTO uses OpenType tags, so this adapter resolves the
+/// tag without rebuilding or evaluating the interpolation model.
 ///
-/// Returns `None` if the font isn't variable or no source has a non-empty layer
-/// for this glyph.
-pub fn build_masters(font: &Font, glyph: &Glyph) -> Option<Vec<GlyphMaster>> {
-    if !font.is_variable() {
-        return None;
-    }
-
-    let default_source_id = font.default_source_id();
-    let mut masters: Vec<GlyphMaster> = Vec::new();
-
-    for source in font.sources() {
-        let layer = match glyph.layer_for_source(source.id()) {
-            Some(layer)
-                if !layer.contours().is_empty()
-                    || !layer.anchors().is_empty()
-                    || !layer.components().is_empty() =>
-            {
-                layer
-            }
-            _ => continue,
-        };
-
-        let structure = GlyphStructure::from(layer);
-        let values = values_from_layer(layer);
-
-        masters.push(GlyphMaster {
-            source_id: source.id().to_string(),
-            source_name: source.name().to_string(),
-            is_default_source: default_source_id == Some(source.id()),
-            location: source.location().into(),
-            structure,
-            values,
-        });
-    }
-
-    if masters.is_empty() {
-        None
-    } else {
-        Some(masters)
-    }
-}
-
-pub fn build_glyph_variation_data(masters: &[GlyphMaster], axes: &[Axis]) -> GlyphVariationBuild {
-    let ordered_axes: Vec<Tag> = axes
-        .iter()
-        .filter_map(|a| Tag::from_str(a.tag()).ok())
-        .collect();
-
-    let Some(default_master) = masters.iter().find(|master| master.is_default_source) else {
-        return GlyphVariationBuild::missing_default();
-    };
-
-    let mut errors = Vec::new();
-    let mut points: HashMap<NormalizedLocation, Vec<f64>> = HashMap::new();
-    for (source_index, master) in masters.iter().enumerate() {
-        match check_compatibility(&master.structure, &default_master.structure) {
-            Ok(()) => {
-                let loc = to_fd_wire_location(&master.location, axes);
-                points.insert(loc, master.values.clone());
-            }
-            Err(message) => {
-                errors.push(SourceError {
-                    source_index,
-                    source_id: master.source_id.clone(),
-                    source_name: master.source_name.clone(),
-                    message,
-                });
-            }
-        }
-    }
-
-    let locations_set: HashSet<NormalizedLocation> = points.keys().cloned().collect();
-    let model = VariationModel::new(locations_set, ordered_axes);
-    let model_deltas = match model.deltas::<f64, f64>(&points) {
-        Ok(model_deltas) => model_deltas,
-        Err(err) => return GlyphVariationBuild::model_failed(errors, err.to_string()),
-    };
-
-    let regions: Vec<Vec<AxisTent>> = model_deltas
-        .iter()
-        .map(|(region, _)| {
-            region
-                .iter()
-                .map(|(tag, tent)| AxisTent {
-                    axis_tag: tag.to_string(),
-                    lower: tent.min.into_inner().into_inner(),
-                    peak: tent.peak.into_inner().into_inner(),
-                    upper: tent.max.into_inner().into_inner(),
-                })
-                .collect()
-        })
-        .collect();
-
-    let deltas: Vec<Vec<f64>> = model_deltas.into_iter().map(|(_, d)| d).collect();
-
-    GlyphVariationBuild::data(GlyphVariationData { regions, deltas }, errors)
-}
-
-pub fn get_glyph_variation_data(
-    masters: &[GlyphMaster],
+/// # Errors
+///
+/// Returns [`CoreError::AxisNotFound`] if an interpolation support references
+/// an axis outside `axes`.
+pub fn glyph_variation_data(
+    interpolation: &GlyphInterpolation,
     axes: &[Axis],
-) -> Option<GlyphVariationData> {
-    build_glyph_variation_data(masters, axes).variation_data
-}
+) -> CoreResult<GlyphVariationData> {
+    let regions = interpolation
+        .regions()
+        .iter()
+        .map(|region| {
+            region
+                .supports()
+                .iter()
+                .map(|support| {
+                    let axis_id = support.axis_id();
+                    let axis = axes
+                        .iter()
+                        .find(|axis| axis.id() == axis_id)
+                        .ok_or_else(|| CoreError::AxisNotFound(axis_id.clone()))?;
 
-#[cfg(test)]
-mod tests {
-    use std::collections::HashMap;
+                    Ok(AxisTent {
+                        axis_tag: axis.tag().to_string(),
+                        lower: support.minimum(),
+                        peak: support.peak(),
+                        upper: support.maximum(),
+                    })
+                })
+                .collect::<CoreResult<Vec<_>>>()
+        })
+        .collect::<CoreResult<Vec<_>>>()?;
+    let deltas = interpolation
+        .deltas()
+        .iter()
+        .map(|delta| delta.as_slice().to_vec())
+        .collect();
 
-    use crate::{ContourData, GlyphMaster, GlyphStructure, Location, PointData, PointType};
-
-    use super::build_glyph_variation_data;
-    use shift_font::{Axis, AxisId};
-
-    fn weight_axis_id() -> AxisId {
-        AxisId::from_raw("axis_weight")
-    }
-
-    fn structure_with_smooth(smooth: bool) -> GlyphStructure {
-        GlyphStructure {
-            contours: vec![ContourData {
-                id: "contour-1".to_string(),
-                closed: false,
-                points: vec![
-                    PointData {
-                        id: "point-1".to_string(),
-                        point_type: PointType::OnCurve,
-                        smooth,
-                    },
-                    PointData {
-                        id: "point-2".to_string(),
-                        point_type: PointType::OnCurve,
-                        smooth: false,
-                    },
-                ],
-            }],
-            anchors: Vec::new(),
-            components: Vec::new(),
-        }
-    }
-
-    fn master(
-        source_name: &str,
-        is_default_source: bool,
-        location_value: f64,
-        smooth: bool,
-        x_offset: f64,
-    ) -> GlyphMaster {
-        GlyphMaster {
-            source_id: source_name.to_string(),
-            source_name: source_name.to_string(),
-            is_default_source,
-            location: Location {
-                values: HashMap::from([(weight_axis_id(), location_value)]),
-            },
-            structure: structure_with_smooth(smooth),
-            values: vec![500.0, x_offset, 0.0, 100.0 + x_offset, 0.0],
-        }
-    }
-
-    #[test]
-    fn smooth_point_mismatch_does_not_make_masters_incompatible() {
-        let axes = vec![Axis::with_id(
-            weight_axis_id(),
-            "wght".to_string(),
-            "Weight".to_string(),
-            0.0,
-            0.0,
-            100.0,
-        )];
-        let masters = vec![
-            master("Regular", true, 0.0, false, 0.0),
-            master("Bold", false, 100.0, true, 20.0),
-        ];
-
-        let build = build_glyph_variation_data(&masters, &axes);
-
-        assert!(
-            build.source_errors.is_empty(),
-            "smooth-only mismatch should not skip sources: {:?}",
-            build.source_errors
-        );
-        assert!(build.variation_data.is_some());
-    }
+    Ok(GlyphVariationData { regions, deltas })
 }

--- a/crates/shift-wire/src/lib.rs
+++ b/crates/shift-wire/src/lib.rs
@@ -9,11 +9,10 @@ use serde::{Deserialize, Serialize};
 use shift_font::{
     Anchor as IrAnchor, AnchorId, Axis as IrAxis, AxisId, AxisKind as IrAxisKind, AxisLabelId,
     AxisMapping as IrAxisMapping, AxisMappingId, AxisRole as IrAxisRole, Component as IrComponent,
-    ComponentId, Contour as IrContour, ContourId, DecomposedTransform as IrTransform,
-    FontMetadata as IrFontMetadata, FontMetrics as IrFontMetrics, Glyph as IrGlyph, GlyphId,
-    GlyphLayer, GlyphName, GuidelineId, LayerId, Location as IrLocation,
-    NamedInstance as IrNamedInstance, NamedInstanceId, Point as IrPoint, PointId,
-    PointType as IrPointType, Source as IrSource, SourceId,
+    ComponentId, Contour as IrContour, ContourId, FontMetadata as IrFontMetadata,
+    FontMetrics as IrFontMetrics, Glyph as IrGlyph, GlyphId, GlyphLayer, GlyphName, GuidelineId,
+    LayerId, Location as IrLocation, NamedInstance as IrNamedInstance, NamedInstanceId,
+    Point as IrPoint, PointId, PointType as IrPointType, Source as IrSource, SourceId,
 };
 
 pub mod bridges;
@@ -565,49 +564,7 @@ pub struct GlyphVariationData {
     pub deltas: Vec<Vec<f64>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct GlyphMaster {
-    pub source_id: String,
-    pub source_name: String,
-    pub is_default_source: bool,
-    pub location: Location,
-    pub structure: GlyphStructure,
-    pub values: GlyphValues,
-}
-
 /// Flatten mutable numeric glyph state in the order described by `GlyphState::values`.
 pub fn values_from_layer(layer: &GlyphLayer) -> GlyphValues {
-    let mut values = Vec::new();
-    values.push(layer.width());
-
-    for contour in layer.contours_iter() {
-        for point in contour.points() {
-            values.push(point.x());
-            values.push(point.y());
-        }
-    }
-
-    for anchor in layer.anchors_iter() {
-        values.push(anchor.x());
-        values.push(anchor.y());
-    }
-
-    for component in layer.components_iter() {
-        push_transform_values(&mut values, component.transform());
-    }
-
-    values
-}
-
-fn push_transform_values(values: &mut Vec<f64>, transform: &IrTransform) {
-    values.push(transform.translate_x);
-    values.push(transform.translate_y);
-    values.push(transform.rotation);
-    values.push(transform.scale_x);
-    values.push(transform.scale_y);
-    values.push(transform.skew_x);
-    values.push(transform.skew_y);
-    values.push(transform.t_center_x);
-    values.push(transform.t_center_y);
+    layer.interpolation_values().into_vec()
 }

--- a/crates/shift-wire/src/state.rs
+++ b/crates/shift-wire/src/state.rs
@@ -5,8 +5,8 @@ use std::str::FromStr;
 use crate::{AnchorData, ComponentData, ContourData, GlyphStructure, GlyphValue};
 use shift_font::{
     Anchor as IrAnchor, AnchorId, Component as IrComponent, ComponentId, Contour as IrContour,
-    ContourId, CoreError, CoreResult, DecomposedTransform as IrTransform, GlyphId, GlyphLayer,
-    LayerId, PointId, PointType as IrPointType, SourceId,
+    ContourId, CoreError, CoreResult, DecomposedTransform as IrTransform, GlyphId,
+    GlyphInterpolationValues, GlyphLayer, LayerId, PointId, PointType as IrPointType, SourceId,
 };
 
 pub fn layer_from_state(
@@ -20,90 +20,20 @@ pub fn layer_from_state(
     Ok(layer)
 }
 
-pub fn apply_state_to_layer(
+fn apply_state_to_layer(
     layer: &mut GlyphLayer,
     structure: &GlyphStructure,
     values: &[GlyphValue],
 ) -> CoreResult<()> {
-    let mut cursor = GlyphValueCursor::new(values);
-    let width = cursor.read_x_advance()?;
-
     layer.clear_contours();
     layer.clear_anchors();
     layer.clear_components();
-    layer.set_width(width);
 
-    restore_contours(layer, &structure.contours, &mut cursor)?;
-    restore_anchors(layer, &structure.anchors, &mut cursor)?;
-    restore_components(layer, &structure.components, &mut cursor)?;
+    restore_contours(layer, &structure.contours)?;
+    restore_anchors(layer, &structure.anchors)?;
+    restore_components(layer, &structure.components)?;
 
-    cursor.finish()?;
-    Ok(())
-}
-
-#[derive(Debug, Clone, Copy)]
-struct PointPosition {
-    x: GlyphValue,
-    y: GlyphValue,
-}
-
-struct GlyphValueCursor<'a> {
-    values: &'a [GlyphValue],
-    index: usize,
-}
-
-impl<'a> GlyphValueCursor<'a> {
-    fn new(values: &'a [GlyphValue]) -> Self {
-        Self { values, index: 0 }
-    }
-
-    fn read_x_advance(&mut self) -> CoreResult<GlyphValue> {
-        self.next()
-    }
-
-    fn read_point(&mut self) -> CoreResult<PointPosition> {
-        Ok(PointPosition {
-            x: self.next()?,
-            y: self.next()?,
-        })
-    }
-
-    fn read_component_transform(&mut self) -> CoreResult<IrTransform> {
-        Ok(IrTransform {
-            translate_x: self.next()?,
-            translate_y: self.next()?,
-            rotation: self.next()?,
-            scale_x: self.next()?,
-            scale_y: self.next()?,
-            skew_x: self.next()?,
-            skew_y: self.next()?,
-            t_center_x: self.next()?,
-            t_center_y: self.next()?,
-        })
-    }
-
-    fn finish(self) -> CoreResult<()> {
-        if self.index == self.values.len() {
-            Ok(())
-        } else {
-            Err(CoreError::TrailingGlyphValues {
-                expected: self.index,
-                actual: self.values.len(),
-            })
-        }
-    }
-
-    fn next(&mut self) -> CoreResult<GlyphValue> {
-        let idx = self.index;
-        let value = self
-            .values
-            .get(idx)
-            .copied()
-            .ok_or(CoreError::MissingGlyphValue { index: idx })?;
-
-        self.index += 1;
-        Ok(value)
-    }
+    layer.apply_interpolation_values(&GlyphInterpolationValues::new(values.to_vec()))
 }
 
 fn parse_id<T>(value: &str, invalid: impl FnOnce(String) -> CoreError) -> CoreResult<T>
@@ -113,20 +43,15 @@ where
     value.parse().map_err(|_| invalid(value.to_string()))
 }
 
-fn restore_contours(
-    layer: &mut GlyphLayer,
-    contours: &[ContourData],
-    cursor: &mut GlyphValueCursor<'_>,
-) -> CoreResult<()> {
+fn restore_contours(layer: &mut GlyphLayer, contours: &[ContourData]) -> CoreResult<()> {
     for contour_data in contours {
         let contour_id: ContourId = parse_id(&contour_data.id, CoreError::InvalidContourId)?;
         let mut new_contour = IrContour::with_id(contour_id);
 
         for point in &contour_data.points {
             let point_id: PointId = parse_id(&point.id, CoreError::InvalidPointId)?;
-            let new_pos = cursor.read_point()?;
             let point_type = IrPointType::from(point.point_type);
-            new_contour.add_point_with_id(point_id, new_pos.x, new_pos.y, point_type, point.smooth);
+            new_contour.add_point_with_id(point_id, 0.0, 0.0, point_type, point.smooth);
         }
 
         if contour_data.closed {
@@ -139,15 +64,10 @@ fn restore_contours(
     Ok(())
 }
 
-fn restore_anchors(
-    layer: &mut GlyphLayer,
-    anchors: &[AnchorData],
-    cursor: &mut GlyphValueCursor<'_>,
-) -> CoreResult<()> {
+fn restore_anchors(layer: &mut GlyphLayer, anchors: &[AnchorData]) -> CoreResult<()> {
     for anchor_data in anchors {
         let anchor_id: AnchorId = parse_id(&anchor_data.id, CoreError::InvalidAnchorId)?;
-        let position = cursor.read_point()?;
-        let anchor = IrAnchor::with_id(anchor_id, anchor_data.name.clone(), position.x, position.y);
+        let anchor = IrAnchor::with_id(anchor_id, anchor_data.name.clone(), 0.0, 0.0);
 
         layer.add_anchor(anchor);
     }
@@ -155,11 +75,7 @@ fn restore_anchors(
     Ok(())
 }
 
-fn restore_components(
-    layer: &mut GlyphLayer,
-    components: &[ComponentData],
-    cursor: &mut GlyphValueCursor<'_>,
-) -> CoreResult<()> {
+fn restore_components(layer: &mut GlyphLayer, components: &[ComponentData]) -> CoreResult<()> {
     for component_data in components {
         let component_id: ComponentId =
             parse_id(&component_data.id, CoreError::InvalidComponentId)?;
@@ -167,12 +83,11 @@ fn restore_components(
             component_data.base_glyph_id.as_str(),
             CoreError::InvalidGlyphId,
         )?;
-        let transform = cursor.read_component_transform()?;
         let component = IrComponent::with_id(
             component_id,
             base_glyph_id,
             component_data.base_glyph_name.clone(),
-            transform,
+            IrTransform::identity(),
         );
 
         layer.add_component(component);

--- a/packages/types/src/bridge/generated.ts
+++ b/packages/types/src/bridge/generated.ts
@@ -392,15 +392,6 @@ export interface GlyphLayerSnapshot {
   state: GlyphState
 }
 
-export interface GlyphMaster {
-  sourceId: SourceId
-  sourceName: string
-  isDefaultSource: boolean
-  location: Location
-  structure: GlyphStructure
-  values: Float64Array
-}
-
 export interface GlyphRecord {
   id: GlyphId
   name: GlyphName

--- a/packages/types/src/bridge/index.ts
+++ b/packages/types/src/bridge/index.ts
@@ -39,7 +39,6 @@ export type {
   FontMetrics,
   GlyphChangedEntities,
   GlyphLayerRecord,
-  GlyphMaster,
   GlyphName,
   GlyphRecord,
   GlyphState,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -104,7 +104,6 @@ export type {
   GlyphChangedEntities,
   GlyphHandle,
   GlyphLayerRecord,
-  GlyphMaster,
   GlyphName,
   GlyphRecord,
   GlyphState,


### PR DESCRIPTION
## Summary

- move canonical glyph interpolation values, source compatibility, variation-model construction, and evaluation into `shift-font`
- add `FontProjection` and `ResolvedGlyph` as a location-bound read-only projection with exact-source, interpolation, sparse fallback, and recursive component semantics
- reduce `shift-wire` to adapting native interpolation into renderer DTOs, and remove the leaked `GlyphMaster` NAPI/TypeScript contract
- document the new ownership boundary in the canonical font and bridge docs

## Why

Issue #150 needs a lightweight batch preview built on a canonical Rust projection. Previously, interpolation semantics and flattened glyph values were partly owned by `shift-wire`, which made a preview resolver either duplicate that logic or turn a transport crate into a domain service.

This PR gives `shift-font` one native projection API that the preview bridge can consume in a follow-up. It intentionally does not add preview DTOs, workspace transport, TanStack Query integration, or grid UI.

## Resolution semantics

- an exact authored master layer wins
- otherwise compatible source layers interpolate at the internal authoring location
- unavailable interpolation falls back to the default/preferred authored layer
- components resolve recursively at the same location and cyclic branches are skipped locally
- existing blank glyphs remain present with empty contours and their advance; missing IDs are omitted
- external axis mappings must be applied before constructing a projection

## Validation

- pre-commit suite: Cargo check/fmt/Clippy/tests, Oxfmt, Oxlint, tsgo, dead-code checks, and Vitest
- `pnpm test`: all Turbo test tasks passed, including 503 desktop tests
- `pnpm typecheck`
- `cargo clippy --workspace --all-targets -- -D warnings`
- Rustdoc broken-link validation across the workspace
- documentation drift check reports only the repository's 15 pre-existing errors; the changed docs introduce none

Foundation for #150; does not close it.
