### PR TITLE
Preserve authored order across font imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,9 +23,9 @@ repos:
         language: system
         types_or: [javascript, jsx, ts, tsx, rust, css, json]
 
-      - id: no-console-log
-        name: no console.log in production code
-        entry: "bash -c 'for f in \"$@\"; do case \"$f\" in *.test.*|*/testing/*|*/e2e/*|scripts/*|*/scripts/*) continue;; esac; if grep -n \"^\\s*console\\.log\\b\" \"$f\" >/dev/null 2>&1; then echo \"$f has console.log:\"; grep -n \"^\\s*console\\.log\\b\" \"$f\"; exit 1; fi; done'"
+      - id: no-console-debug-output
+        name: no console debug output in production code
+        entry: "bash -c 'for f in \"$@\"; do case \"$f\" in *.test.*|*/testing/*|*/e2e/*|scripts/*|*/scripts/*) continue;; esac; if grep -En \"^[[:space:]]*console\\.(log|debug|table|group|groupCollapsed|groupEnd)\\b\" \"$f\" >/dev/null 2>&1; then echo \"$f has console debug output:\"; grep -En \"^[[:space:]]*console\\.(log|debug|table|group|groupCollapsed|groupEnd)\\b\" \"$f\"; exit 1; fi; done'"
         language: system
         types_or: [javascript, jsx, ts, tsx]
 

--- a/apps/desktop/src/main/menu/ApplicationMenu.ts
+++ b/apps/desktop/src/main/menu/ApplicationMenu.ts
@@ -73,7 +73,7 @@ export class ApplicationMenu {
         submenu: [
           ...this.#viewZoomItems(),
           { type: "separator" },
-          { label: "Developer", submenu: [{ role: "toggleDevTools" }] },
+          { label: "Developer", submenu: this.#developerItems() },
         ],
       },
       {
@@ -115,6 +115,13 @@ export class ApplicationMenu {
       this.#commandItem("ui.zoomOut"),
       this.#commandItem("ui.zoomReset"),
     ];
+  }
+
+  #developerItems(): MenuItemConstructorOptions[] {
+    const tools: MenuItemConstructorOptions[] = [{ role: "toggleDevTools" }];
+    if (app.isPackaged) return tools;
+
+    return [{ role: "reload" }, { role: "forceReload" }, { type: "separator" }, ...tools];
   }
 
   #fileItems(): MenuItemConstructorOptions[] {

--- a/crates/shift-backends/docs/DOCS.md
+++ b/crates/shift-backends/docs/DOCS.md
@@ -20,6 +20,8 @@ Font format backends that convert between on-disk font files and the `Font` IR u
 
 **Architecture Invariant:** TrueType export compiles an owned snapshot of the Shift `Font` IR directly through fontir/fontc. It must not serialize a temporary UFO or fall back to another authoring format. WHY: `.shift` is the canonical authoring source, and an intermediate format would discard or reinterpret Shift concepts before compilation.
 
+**Architecture Invariant:** Designspace source locations are imported as complete design-space locations. An omitted source dimension resolves to that axis's user-space default mapped into design space; default-source selection compares against that same completed mapped location and never silently substitutes the first source. A `layer` attribute only selects where a source's outlines live and does not make it ineligible to be the default. WHY: these are the reference designspaceLib semantics, and mixing user defaults with design coordinates corrupts interpolation bases.
+
 ## Codemap
 
 ```
@@ -66,6 +68,8 @@ src/
 **Glyphs-format specifics:** `GlyphsReader` also extracts axes, sources, and per-master locations -- data that UFO does not natively represent. Kerning group membership is derived from per-glyph `right_kern`/`left_kern` fields and normalized to `public.kern1.*`/`public.kern2.*` conventions.
 
 **Designspace mapping:** Per-axis `<map>` entries become independent `AxisMapping` values. Designspace 5.1+ `<mappings>` entries become the font's single cross-axis mapping group. Axis value labels use the standard Designspace 5.0 `<labels>` representation; imported labels receive newly minted Shift identity because Designspace has no equivalent stable label ID.
+
+**Designspace conformance references:** The [Designspace XML source definition](https://fonttools.readthedocs.io/en/latest/designspaceLib/xml.html#source-element) defines source locations in design-space coordinates. The reference [`SourceDescriptor.getFullDesignLocation`](https://fonttools.readthedocs.io/en/stable/designspaceLib/python.html#fontTools.designspaceLib.SourceDescriptor.getFullDesignLocation) completes omitted dimensions with mapped axis defaults, and [`DesignSpaceDocument.findDefault`](https://fonttools.readthedocs.io/en/stable/designspaceLib/python.html#fontTools.designspaceLib.DesignSpaceDocument.findDefault) selects the source at that complete mapped default. Instance import follows the corresponding complete-location precedence and the reference continuous/discrete axis mapping behavior. Keep importer behavior and fixtures aligned with those APIs when extending Designspace support.
 
 **Saving authoring sources:** `UfoWriter` builds a `norad::Font`, projects the default source's standard metrics, populates metadata/kerning/groups/guidelines/lib, and converts each glyph per layer. It writes the complete UFO to a sibling staging directory, syncs the tree, and atomically swaps it into place. `.shift` packages are written by `ShiftSourcePackage` through `FontLoader`.
 

--- a/crates/shift-backends/src/designspace/error.rs
+++ b/crates/shift-backends/src/designspace/error.rs
@@ -16,6 +16,9 @@ pub enum DesignspaceError {
     #[error("designspace has no sources")]
     NoSources,
 
+    #[error("designspace has no source at the mapped default location")]
+    MissingDefaultSource,
+
     #[error("layer '{layer}' not found in '{filename}'")]
     MissingLayer { layer: String, filename: String },
 
@@ -60,9 +63,6 @@ pub enum DesignspaceError {
 
     #[error("failed to parse designspace XML: {details}")]
     ParseDesignspaceXml { details: String },
-
-    #[error("axis '{axis}' has a non-invertible map: {details}")]
-    NonInvertibleAxisMap { axis: String, details: String },
 
     #[error(transparent)]
     Font(#[from] shift_font::CoreError),

--- a/crates/shift-backends/src/designspace/reader.rs
+++ b/crates/shift-backends/src/designspace/reader.rs
@@ -67,7 +67,8 @@ impl DesignspaceReader {
             return Err(DesignspaceError::NoSources);
         }
 
-        let default_idx = find_default_source_index(&doc);
+        let default_idx =
+            find_default_source_index(&doc).ok_or(DesignspaceError::MissingDefaultSource)?;
 
         // Load the default source first to establish the base font.
         let default_ds_source = &doc.sources[default_idx];
@@ -87,10 +88,8 @@ impl DesignspaceReader {
                     path: default_ufo_path.clone(),
                     details: source.to_string(),
                 })?;
-        let default_ufo_source_id = font
-            .default_source_id()
-            .ok_or(DesignspaceError::NoSources)?;
-        let default_ufo_source = font
+        let default_ufo_source_id = source_layer_id(&font, default_ds_source)?;
+        let default_ufo_metrics = font
             .default_source()
             .cloned()
             .ok_or(DesignspaceError::NoSources)?;
@@ -136,18 +135,26 @@ impl DesignspaceReader {
         font.set_named_instances(named_instances_from_designspace(&doc, font.axes())?)?;
 
         // Register the default source.
+        let mut source_names = HashSet::new();
         let default_location =
             location_from_dimensions(&default_ds_source.location, &doc, font.axes());
-        let default_name = source_name(default_ds_source, default_idx);
+        let default_name = source_name(
+            default_ds_source,
+            font.metadata().style_name.as_deref(),
+            &source_names,
+            default_idx,
+        );
+        source_names.insert(default_name.clone());
         let mut default_source = Source::with_filename(
             default_name,
             default_location,
             default_ds_source.filename.clone(),
         );
+        default_source.set_layer_name(default_ds_source.layer.clone());
         let metric_definitions = font.metric_definitions().to_vec();
         copy_source_metrics(
             &metric_definitions,
-            &default_ufo_source,
+            &default_ufo_metrics,
             &metric_definitions,
             &mut default_source,
         );
@@ -188,29 +195,24 @@ impl DesignspaceReader {
             };
 
             // Determine which layer from the source UFO to read.
-            let source_source_id = match &ds_source.layer {
-                Some(layer_name) => find_source_by_external_layer_name(source_font, layer_name)
-                    .ok_or_else(|| DesignspaceError::MissingLayer {
-                        layer: layer_name.clone(),
-                        filename: ds_source.filename.clone(),
-                    })?,
-                None => source_font
-                    .default_source_id()
-                    .ok_or(DesignspaceError::NoSources)?,
-            };
+            let source_source_id = source_layer_id(source_font, ds_source)?;
 
-            let name = source_name(ds_source, idx);
+            let name = source_name(
+                ds_source,
+                source_font.metadata().style_name.as_deref(),
+                &source_names,
+                idx,
+            );
+            source_names.insert(name.clone());
             let location = location_from_dimensions(&ds_source.location, &doc, font.axes());
             let mut source = Source::with_filename(name, location, ds_source.filename.clone());
             source.set_layer_name(ds_source.layer.clone());
-            let imported_source = source_font
-                .sources()
-                .iter()
-                .find(|source| source.id() == source_source_id)
+            let imported_metrics = source_font
+                .default_source()
                 .ok_or(DesignspaceError::NoSources)?;
             copy_source_metrics(
                 source_font.metric_definitions(),
-                imported_source,
+                imported_metrics,
                 font.metric_definitions(),
                 &mut source,
             );
@@ -297,9 +299,9 @@ fn external_location_from_dimensions(
             .iter()
             .find(|dimension| dimension.name == ds_axis.name)
         {
-            Some(dimension) => match (dimension.uservalue, dimension.xvalue) {
-                (Some(value), _) => value as f64,
-                (None, Some(value)) => unmap_axis_value(ds_axis, value as f64)?,
+            Some(dimension) => match (dimension.xvalue, dimension.uservalue) {
+                (Some(value), _) => unmap_axis_value(ds_axis, value as f64),
+                (None, Some(value)) => value as f64,
                 (None, None) => axis.default(),
             },
             None => axis.default(),
@@ -310,50 +312,53 @@ fn external_location_from_dimensions(
     Ok(location)
 }
 
-fn unmap_axis_value(axis: &norad::designspace::Axis, value: f64) -> DesignspaceResult<f64> {
+// Matches designspaceLib's continuous and discrete `map_backward` behavior.
+// Continuous flat segments choose the first user value; discrete maps only
+// replace exact authored values.
+// https://fonttools.readthedocs.io/en/stable/designspaceLib/python.html#fontTools.designspaceLib.AxisDescriptor.map_backward
+fn unmap_axis_value(axis: &norad::designspace::Axis, value: f64) -> f64 {
     let Some(map) = axis.map.as_ref().filter(|map| !map.is_empty()) else {
-        return Ok(value);
+        return value;
     };
+
+    if axis.values.is_some() {
+        return map
+            .iter()
+            .find(|point| point.output as f64 == value)
+            .map(|point| point.input as f64)
+            .unwrap_or(value);
+    }
+
     let mut points = map
         .iter()
-        .map(|point| (point.input as f64, point.output as f64))
+        .map(|point| (point.output as f64, point.input as f64))
         .collect::<Vec<_>>();
-    points.sort_by(|left, right| left.0.total_cmp(&right.0));
+    points.sort_by(|left, right| {
+        left.0
+            .total_cmp(&right.0)
+            .then_with(|| left.1.total_cmp(&right.1))
+    });
 
-    if points
-        .windows(2)
-        .any(|pair| pair[0].0 >= pair[1].0 || pair[0].1 >= pair[1].1)
-    {
-        return Err(DesignspaceError::NonInvertibleAxisMap {
-            axis: axis.name.clone(),
-            details: "input and output values must be strictly increasing".to_string(),
-        });
+    let (first_design, first_user) = points[0];
+    if value <= first_design {
+        return value + first_user - first_design;
     }
-    if let Some((input, _)) = points.iter().find(|(_, output)| *output == value) {
-        return Ok(*input);
+    for pair in points.windows(2) {
+        let (lower_design, lower_user) = pair[0];
+        let (upper_design, upper_user) = pair[1];
+        if lower_design <= value && value <= upper_design {
+            if lower_design == upper_design {
+                return lower_user;
+            }
+
+            return lower_user
+                + (upper_user - lower_user) * (value - lower_design)
+                    / (upper_design - lower_design);
+        }
     }
 
-    let first = points[0];
-    if value < first.1 {
-        return Ok(value + first.0 - first.1);
-    }
-    let last = points[points.len() - 1];
-    if value > last.1 {
-        return Ok(value + last.0 - last.1);
-    }
-
-    let Some(pair) = points
-        .windows(2)
-        .find(|pair| pair[0].1 < value && value < pair[1].1)
-    else {
-        return Err(DesignspaceError::NonInvertibleAxisMap {
-            axis: axis.name.clone(),
-            details: format!("cannot invert design value {value}"),
-        });
-    };
-    let lower = pair[0];
-    let upper = pair[1];
-    Ok(lower.0 + (upper.0 - lower.0) * (value - lower.1) / (upper.1 - lower.1))
+    let (last_design, last_user) = points[points.len() - 1];
+    value + last_user - last_design
 }
 
 fn axis_mappings_from_designspace(
@@ -517,8 +522,16 @@ fn load_axisless_designspace(
         font.metadata_mut().family_name = Some(family.clone());
     }
 
+    let mut source_names = HashSet::new();
+    let default_name = axisless_source_name(
+        default_source,
+        font.metadata().style_name.as_deref(),
+        &source_names,
+        0,
+    );
+    source_names.insert(default_name.clone());
     let mut new_default_source = Source::with_filename(
-        axisless_source_name(default_source, 0),
+        default_name,
         Location::new(),
         default_source.filename.clone(),
     );
@@ -569,7 +582,13 @@ fn load_axisless_designspace(
                 .ok_or(DesignspaceError::NoSources)?,
         };
 
-        let name = axisless_source_name(ds_source, idx);
+        let name = axisless_source_name(
+            ds_source,
+            source_font.metadata().style_name.as_deref(),
+            &source_names,
+            idx,
+        );
+        source_names.insert(name.clone());
         let mut source = Source::with_filename(name, Location::new(), ds_source.filename.clone());
         source.set_layer_name(ds_source.layer.clone());
         let imported_source = source_font
@@ -606,12 +625,20 @@ fn load_axisless_designspace(
     Ok(font)
 }
 
-fn axisless_source_name(source: &AxislessSource, index: usize) -> String {
-    source
-        .name
-        .clone()
-        .or_else(|| source.stylename.clone())
-        .unwrap_or_else(|| format!("Source {index}"))
+fn axisless_source_name(
+    source: &AxislessSource,
+    ufo_style_name: Option<&str>,
+    used_names: &HashSet<String>,
+    index: usize,
+) -> String {
+    imported_source_name(
+        source.name.as_deref(),
+        source.stylename.as_deref(),
+        ufo_style_name,
+        &source.filename,
+        used_names,
+        index,
+    )
 }
 
 fn parse_axisless_sources(xml: &str) -> DesignspaceResult<Vec<AxislessSource>> {
@@ -675,12 +702,65 @@ fn xml_attr(
     Ok(None)
 }
 
-fn source_name(source: &norad::designspace::Source, index: usize) -> String {
-    source
-        .name
-        .clone()
-        .or_else(|| source.stylename.clone())
-        .unwrap_or_else(|| format!("Source {index}"))
+fn source_name(
+    source: &norad::designspace::Source,
+    ufo_style_name: Option<&str>,
+    used_names: &HashSet<String>,
+    index: usize,
+) -> String {
+    imported_source_name(
+        source.name.as_deref(),
+        source.stylename.as_deref(),
+        ufo_style_name,
+        &source.filename,
+        used_names,
+        index,
+    )
+}
+
+fn imported_source_name(
+    designspace_name: Option<&str>,
+    designspace_style_name: Option<&str>,
+    ufo_style_name: Option<&str>,
+    filename: &str,
+    used_names: &HashSet<String>,
+    index: usize,
+) -> String {
+    // Source names and style names are optional in Designspace. The backing
+    // UFO is therefore the next authoritative naming source, followed by the
+    // required filename.
+    // https://fonttools.readthedocs.io/en/latest/designspaceLib/xml.html#source-element
+    let filename_stem = Path::new(filename)
+        .file_stem()
+        .and_then(|stem| stem.to_str());
+    for candidate in [
+        designspace_name,
+        designspace_style_name,
+        ufo_style_name,
+        filename_stem,
+    ]
+    .into_iter()
+    .flatten()
+    .filter(|candidate| !candidate.trim().is_empty())
+    {
+        if !used_names.contains(candidate) {
+            return candidate.to_string();
+        }
+    }
+
+    let base = format!("Source {index}");
+    if !used_names.contains(&base) {
+        return base;
+    }
+
+    let mut suffix = 2;
+    loop {
+        let candidate = format!("{base} {suffix}");
+        if !used_names.contains(&candidate) {
+            return candidate;
+        }
+        suffix += 1;
+    }
 }
 
 fn location_from_dimensions(
@@ -689,46 +769,118 @@ fn location_from_dimensions(
     axes: &[Axis],
 ) -> Location {
     let mut location = Location::new();
-    for dim in dimensions {
-        let value = dim.xvalue.unwrap_or(0.0) as f64;
-        if let Some(axis) = doc.axes.iter().find(|a| a.name == dim.name) {
-            if let Some(axis) = axes.iter().find(|candidate| candidate.tag() == axis.tag) {
-                location.set(axis.id(), value);
-            }
-        }
+    for ds_axis in &doc.axes {
+        let Some(axis) = axes.iter().find(|candidate| candidate.tag() == ds_axis.tag) else {
+            continue;
+        };
+
+        location.set(axis.id(), source_axis_design_value(dimensions, ds_axis));
     }
     location
 }
 
-fn find_default_source_index(doc: &DesignSpaceDocument) -> usize {
-    for (idx, source) in doc.sources.iter().enumerate() {
-        // Skip support layer sources.
-        if source.layer.is_some() {
-            continue;
-        }
+// Designspace source locations are partial design-space locations. Missing
+// dimensions resolve to the axis default after mapping from user space.
+// https://fonttools.readthedocs.io/en/stable/designspaceLib/python.html#fontTools.designspaceLib.SourceDescriptor.getFullDesignLocation
+fn source_axis_design_value(
+    dimensions: &[norad::designspace::Dimension],
+    axis: &norad::designspace::Axis,
+) -> f64 {
+    let dimension = dimensions
+        .iter()
+        .find(|dimension| dimension.name == axis.name);
 
-        let is_default = doc.axes.iter().all(|axis| {
-            source
-                .location
-                .iter()
-                .find(|d| d.name == axis.name)
-                .map(|d| {
-                    let val = d.xvalue.unwrap_or(0.0);
-                    (val - axis.default).abs() < 0.001
-                })
-                .unwrap_or(false)
-        });
-        if is_default {
-            return idx;
-        }
+    match dimension {
+        Some(dimension) => match (dimension.xvalue, dimension.uservalue) {
+            (Some(value), _) => value as f64,
+            (None, Some(value)) => map_axis_value(axis, value as f64),
+            (None, None) => map_axis_value(axis, axis.default as f64),
+        },
+        None => map_axis_value(axis, axis.default as f64),
     }
-    0
+}
+
+fn map_axis_value(axis: &norad::designspace::Axis, user_value: f64) -> f64 {
+    let Some(mapping) = axis.map.as_ref().filter(|mapping| !mapping.is_empty()) else {
+        return user_value;
+    };
+
+    if axis.values.is_some() {
+        return mapping
+            .iter()
+            .find(|point| point.input as f64 == user_value)
+            .map(|point| point.output as f64)
+            .unwrap_or(user_value);
+    }
+
+    let mut points = mapping
+        .iter()
+        .map(|point| (point.input as f64, point.output as f64))
+        .collect::<Vec<_>>();
+    points.sort_by(|left, right| left.0.total_cmp(&right.0));
+
+    if let Some((_, output)) = points.iter().find(|(input, _)| *input == user_value) {
+        return *output;
+    }
+
+    let first = points[0];
+    if user_value < first.0 {
+        return user_value + first.1 - first.0;
+    }
+    let last = points[points.len() - 1];
+    if user_value > last.0 {
+        return user_value + last.1 - last.0;
+    }
+
+    let Some(pair) = points
+        .windows(2)
+        .find(|pair| pair[0].0 < user_value && user_value < pair[1].0)
+    else {
+        return user_value;
+    };
+    let lower = pair[0];
+    let upper = pair[1];
+    lower.1 + (upper.1 - lower.1) * (user_value - lower.0) / (upper.0 - lower.0)
+}
+
+// This mirrors designspaceLib's findDefault semantics: compare complete
+// design-space locations to the mapped user-space defaults. Layer-backed
+// sources remain eligible because `layer` describes storage, not source role.
+// https://fonttools.readthedocs.io/en/stable/designspaceLib/python.html#fontTools.designspaceLib.DesignSpaceDocument.findDefault
+fn find_default_source_index(doc: &DesignSpaceDocument) -> Option<usize> {
+    doc.sources.iter().position(|source| {
+        doc.axes.iter().all(|axis| {
+            let source_value = source_axis_design_value(&source.location, axis);
+            let default_value = map_axis_value(axis, axis.default as f64);
+            design_values_equal(source_value, default_value)
+        })
+    })
+}
+
+fn design_values_equal(left: f64, right: f64) -> bool {
+    let scale = left.abs().max(right.abs()).max(1.0);
+    (left - right).abs() <= f64::from(f32::EPSILON) * scale * 4.0
+}
+
+fn source_layer_id(
+    font: &Font,
+    source: &norad::designspace::Source,
+) -> DesignspaceResult<SourceId> {
+    match &source.layer {
+        Some(layer_name) => find_source_by_external_layer_name(font, layer_name).ok_or_else(|| {
+            DesignspaceError::MissingLayer {
+                layer: layer_name.clone(),
+                filename: source.filename.clone(),
+            }
+        }),
+        None => font.default_source_id().ok_or(DesignspaceError::NoSources),
+    }
 }
 
 fn find_source_by_external_layer_name(font: &Font, name: &str) -> Option<SourceId> {
     font.sources()
         .iter()
-        .find(|source| source.name() == name)
+        .find(|source| !source.is_master() && source.name() == name)
         .map(Source::id)
 }
 
@@ -842,7 +994,7 @@ fn derive_axis_range(ds_axis: &norad::designspace::Axis) -> (f64, f64) {
 #[cfg(test)]
 mod axis_range_tests {
     use super::*;
-    use norad::designspace::Axis as DsAxis;
+    use norad::designspace::{Axis as DsAxis, AxisMapping as DsAxisMapping, Source as DsSource};
 
     fn axis(min: Option<f32>, max: Option<f32>, default: f32, values: Option<Vec<f32>>) -> DsAxis {
         DsAxis {
@@ -886,8 +1038,28 @@ mod axis_range_tests {
             },
         ]);
 
-        assert_eq!(unmap_axis_value(&axis, 260.0).unwrap(), 300.0);
-        assert_eq!(unmap_axis_value(&axis, 420.0).unwrap(), 400.0);
+        assert_eq!(unmap_axis_value(&axis, 260.0), 300.0);
+        assert_eq!(unmap_axis_value(&axis, 420.0), 400.0);
+    }
+
+    #[test]
+    fn discrete_axis_mapping_uses_exact_values_without_interpolation() {
+        let mut axis = axis(None, None, 0.0, Some(vec![0.0, 1.0]));
+        axis.map = Some(vec![
+            DsAxisMapping {
+                input: 0.0,
+                output: 0.0,
+            },
+            DsAxisMapping {
+                input: 1.0,
+                output: -11.0,
+            },
+        ]);
+
+        assert_eq!(map_axis_value(&axis, 1.0), -11.0);
+        assert_eq!(unmap_axis_value(&axis, -11.0), 1.0);
+        assert_eq!(map_axis_value(&axis, 0.5), 0.5);
+        assert_eq!(unmap_axis_value(&axis, -5.5), -5.5);
     }
 
     #[test]
@@ -938,6 +1110,28 @@ mod axis_range_tests {
     fn empty_values_list_collapses_to_default() {
         let a = axis(None, None, 0.0, Some(vec![]));
         assert_eq!(derive_axis_range(&a), (0.0, 0.0));
+    }
+
+    #[test]
+    fn absent_default_source_is_not_replaced_by_the_first_source() {
+        let weight = axis(Some(100.0), Some(900.0), 400.0, None);
+        let source = DsSource {
+            filename: "Bold.ufo".to_string(),
+            location: vec![norad::designspace::Dimension {
+                name: "test".to_string(),
+                xvalue: Some(900.0),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let document = DesignSpaceDocument {
+            format: 5.0,
+            axes: vec![weight],
+            sources: vec![source],
+            ..Default::default()
+        };
+
+        assert_eq!(find_default_source_index(&document), None);
     }
 
     #[test]

--- a/crates/shift-backends/tests/round_trip/designspace.rs
+++ b/crates/shift-backends/tests/round_trip/designspace.rs
@@ -1,6 +1,9 @@
 use std::path::{Path, PathBuf};
 
-use norad::designspace::{Axis as DsAxis, DesignSpaceDocument, Dimension, Source as DsSource};
+use norad::designspace::{
+    Axis as DsAxis, AxisMapping as DsAxisMapping, DesignSpaceDocument, Dimension,
+    Source as DsSource,
+};
 use shift_backends::font_loader::FontLoader;
 use shift_font::Font;
 
@@ -73,6 +76,14 @@ fn ds_source(style: &str, filename: &str, layer: Option<&str>, weight: f32) -> D
     }
 }
 
+fn unnamed_ds_source(filename: &str, weight: f32) -> DsSource {
+    DsSource {
+        filename: filename.to_string(),
+        location: vec![weight_dimension(weight)],
+        ..Default::default()
+    }
+}
+
 /// A designspace spread over two master UFOs, with an intermediate master
 /// declared as a layer of the bold UFO.
 fn multi_ufo_designspace(dir: &Path) -> PathBuf {
@@ -109,6 +120,88 @@ fn multi_ufo_designspace(dir: &Path) -> PathBuf {
     path
 }
 
+fn mapped_sparse_layer_default_designspace(dir: &Path) -> PathBuf {
+    let ufo_path = master_ufo(dir, "Mapped.ufo", "Display", 700.0, 750.0);
+    let mut ufo = norad::Font::load(&ufo_path).unwrap();
+    ufo.layers
+        .new_layer("Regular")
+        .unwrap()
+        .insert_glyph(triangle_glyph("A", 500.0, 650.0));
+    ufo.save(&ufo_path).unwrap();
+
+    let weight = DsAxis {
+        name: "Weight".to_string(),
+        tag: "wght".to_string(),
+        minimum: Some(100.0),
+        default: 400.0,
+        maximum: Some(900.0),
+        map: Some(vec![
+            DsAxisMapping {
+                input: 100.0,
+                output: 100.0,
+            },
+            DsAxisMapping {
+                input: 400.0,
+                output: 350.0,
+            },
+            DsAxisMapping {
+                input: 900.0,
+                output: 900.0,
+            },
+        ]),
+        ..Default::default()
+    };
+    let italic = DsAxis {
+        name: "Italic".to_string(),
+        tag: "ital".to_string(),
+        default: 0.0,
+        values: Some(vec![0.0, 1.0]),
+        ..Default::default()
+    };
+    let display = DsSource {
+        familyname: Some("Grouped".to_string()),
+        stylename: Some("Display".to_string()),
+        name: Some("Display".to_string()),
+        filename: "Mapped.ufo".to_string(),
+        location: vec![
+            Dimension {
+                name: "Weight".to_string(),
+                xvalue: Some(900.0),
+                ..Default::default()
+            },
+            Dimension {
+                name: "Italic".to_string(),
+                xvalue: Some(0.0),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+    let regular = DsSource {
+        familyname: Some("Grouped".to_string()),
+        stylename: Some("Regular".to_string()),
+        name: Some("Regular".to_string()),
+        filename: "Mapped.ufo".to_string(),
+        layer: Some("Regular".to_string()),
+        // Weight is already in design coordinates; Italic is omitted and
+        // therefore resolves to its mapped default.
+        location: vec![Dimension {
+            name: "Weight".to_string(),
+            xvalue: Some(350.0),
+            ..Default::default()
+        }],
+    };
+    let document = DesignSpaceDocument {
+        format: 5.0,
+        axes: vec![weight, italic],
+        sources: vec![display, regular],
+        ..Default::default()
+    };
+    let path = dir.join("Mapped.designspace");
+    document.save(&path).unwrap();
+    path
+}
+
 /// (name, filename, layer name, weight location) per source.
 type SourceShape = (String, Option<String>, Option<String>, Option<f64>);
 
@@ -138,6 +231,74 @@ fn layer_width(font: &Font, source_name: &str, glyph_name: &str) -> f64 {
         .layer_for_source(source.id())
         .unwrap_or_else(|| panic!("{glyph_name} should have a layer for {source_name}"))
         .width()
+}
+
+#[test]
+fn imports_the_complete_mapped_default_location_from_a_named_layer() {
+    let fixture_dir = tempfile::tempdir().unwrap();
+    let font = load_font(&mapped_sparse_layer_default_designspace(fixture_dir.path()));
+
+    let default = font
+        .default_source()
+        .expect("mapped designspace should have a default source");
+    let weight = font.axis_id_by_tag("wght").unwrap();
+    let italic = font.axis_id_by_tag("ital").unwrap();
+
+    assert_eq!(default.name(), "Regular");
+    assert_eq!(default.location().get(&weight), Some(350.0));
+    assert_eq!(default.location().get(&italic), Some(0.0));
+    assert_eq!(layer_width(&font, "Regular", "A"), 500.0);
+}
+
+#[test]
+fn imports_missing_source_names_from_ufo_metadata_and_filenames() {
+    let fixture_dir = tempfile::tempdir().unwrap();
+    master_ufo(fixture_dir.path(), "Grouped-Text.ufo", "Text", 400.0, 600.0);
+    master_ufo(
+        fixture_dir.path(),
+        "Grouped-Text-Alt.ufo",
+        "Text",
+        550.0,
+        675.0,
+    );
+    master_ufo(
+        fixture_dir.path(),
+        "Grouped-Display.ufo",
+        "Display",
+        700.0,
+        750.0,
+    );
+
+    let mut explicitly_named = unnamed_ds_source("Grouped-Display.ufo", 700.0);
+    explicitly_named.name = Some("Editorial".to_string());
+    let document = DesignSpaceDocument {
+        format: 5.0,
+        axes: vec![DsAxis {
+            name: "Weight".to_string(),
+            tag: "wght".to_string(),
+            minimum: Some(300.0),
+            default: 300.0,
+            maximum: Some(700.0),
+            ..Default::default()
+        }],
+        sources: vec![
+            unnamed_ds_source("Grouped-Text.ufo", 300.0),
+            unnamed_ds_source("Grouped-Text-Alt.ufo", 500.0),
+            explicitly_named,
+        ],
+        ..Default::default()
+    };
+    let path = fixture_dir.path().join("Unnamed.designspace");
+    document.save(&path).unwrap();
+
+    let font = load_font(&path);
+    let source_names = font
+        .sources()
+        .iter()
+        .map(|source| source.name())
+        .collect::<Vec<_>>();
+
+    assert_eq!(source_names, ["Text", "Grouped-Text-Alt", "Editorial"]);
 }
 
 #[test]

--- a/crates/shift-font/docs/DOCS.md
+++ b/crates/shift-font/docs/DOCS.md
@@ -6,6 +6,7 @@ First-class Rust font object model for Shift.
 
 - **Architecture Invariant:** `shift-font` owns Shift authoring concepts and semantic validation, never format/compiler DTOs.
 - **Architecture Invariant:** Stable IDs are identity. Names, tags, Unicode assignments, and coordinates remain editable authoring values.
+- **Architecture Invariant:** Ordered, identity-addressable authoring collections use `EntityList`. Its iteration, equality, and serialization preserve authored order; its private backing container is not part of the model contract.
 - **Architecture Invariant:** Named instances own complete external locations but no source or geometry. Sources own design-space locations.
 - **Architecture Invariant:** Mapping edits never rewrite external named-instance intent.
 - **Architecture Invariant:** Authored metadata and font metrics are independent. Metadata edits replace the complete metadata snapshot without rewriting metrics.
@@ -16,6 +17,7 @@ First-class Rust font object model for Shift.
 ```text
 crates/shift-font/src/
   ir/              -- font entities, IDs, axes, mappings, instances, glyph data
+    collection.rs  -- semantic ordered identity collections
   intents.rs       -- atomic authoring intents and semantic application
   changes.rs       -- replace-grade semantic change records
   layer_edit.rs    -- glyph-layer geometry mutations
@@ -28,6 +30,7 @@ crates/shift-font/src/
 ## Key Types
 
 - `Font` owns glyphs, sources, axes, axis mappings, named instances, metadata, and font-level data.
+- `EntityList` owns stable-ID lookup and authoring order for glyphs, contours, components, and future ordered entity collections.
 - `FontMetadata` is the complete authored naming and attribution snapshot replaced by `UpdateFontMetadata`.
 - `Axis` has stable identity, an external/internal role, a continuous or discrete kind, and optional external/user-space value labels.
 - `AxisLabel` has font-wide stable identity so UI rows and later instance recipes survive renames and reordering.

--- a/crates/shift-font/src/ir/collection.rs
+++ b/crates/shift-font/src/ir/collection.rs
@@ -1,0 +1,232 @@
+//! Semantic collections for Shift authoring entities.
+//!
+//! [`EntityList`] is for values that have stable identity and meaningful
+//! order. It deliberately differs from a map: iteration and equality both
+//! observe authoring order, and serialization emits an ordered sequence.
+//! Unordered dictionaries and derived lookup indices should remain behind
+//! their domain-specific types instead of using this collection.
+
+use std::hash::Hash;
+use std::sync::Arc;
+
+use indexmap::IndexMap;
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Supplies the stable identity owned by an authoring entity.
+pub trait Identified {
+    type Id: Clone + Eq + Hash;
+
+    fn id(&self) -> Self::Id;
+}
+
+impl<T> Identified for Arc<T>
+where
+    T: Identified,
+{
+    type Id = T::Id;
+
+    fn id(&self) -> Self::Id {
+        self.as_ref().id()
+    }
+}
+
+/// An identity-addressable sequence whose order is part of its value.
+///
+/// Lookup uses an entity's stable ID, while iteration, equality, and
+/// serialization preserve authoring order. Replacing an existing entity keeps
+/// its current position; removing one preserves the relative order of the
+/// remaining entities.
+#[derive(Clone, Debug)]
+pub struct EntityList<T>
+where
+    T: Identified,
+{
+    entries: IndexMap<T::Id, T>,
+}
+
+impl<T> EntityList<T>
+where
+    T: Identified,
+{
+    pub fn new() -> Self {
+        Self {
+            entries: IndexMap::new(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn contains(&self, id: &T::Id) -> bool {
+        self.entries.contains_key(id)
+    }
+
+    pub fn get(&self, id: &T::Id) -> Option<&T> {
+        self.entries.get(id)
+    }
+
+    pub fn get_mut(&mut self, id: &T::Id) -> Option<&mut T> {
+        self.entries.get_mut(id)
+    }
+
+    pub fn get_index(&self, index: usize) -> Option<(&T::Id, &T)> {
+        self.entries.get_index(index)
+    }
+
+    pub fn keys(&self) -> indexmap::map::Keys<'_, T::Id, T> {
+        self.entries.keys()
+    }
+
+    pub fn values(&self) -> indexmap::map::Values<'_, T::Id, T> {
+        self.entries.values()
+    }
+
+    pub fn values_mut(&mut self) -> indexmap::map::ValuesMut<'_, T::Id, T> {
+        self.entries.values_mut()
+    }
+
+    pub fn iter(&self) -> indexmap::map::Iter<'_, T::Id, T> {
+        self.entries.iter()
+    }
+
+    /// Inserts an entity at the end or replaces the entity with the same ID.
+    ///
+    /// Replacement preserves the existing position and returns the previous
+    /// value. A newly inserted entity returns `None`.
+    pub fn insert(&mut self, entity: T) -> Option<T> {
+        self.entries.insert(entity.id(), entity)
+    }
+
+    pub fn shift_remove(&mut self, id: &T::Id) -> Option<T> {
+        self.entries.shift_remove(id)
+    }
+
+    pub fn clear(&mut self) {
+        self.entries.clear();
+    }
+
+    /// Moves an entity to another position without changing its identity.
+    ///
+    /// Returns `false` when either index is outside the list.
+    pub fn move_index(&mut self, from: usize, to: usize) -> bool {
+        if from >= self.len() || to >= self.len() {
+            return false;
+        }
+
+        self.entries.move_index(from, to);
+        true
+    }
+}
+
+impl<T> Default for EntityList<T>
+where
+    T: Identified,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> PartialEq for EntityList<T>
+where
+    T: Identified + PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.entries.as_slice() == other.entries.as_slice()
+    }
+}
+
+impl<T> Eq for EntityList<T> where T: Identified + Eq {}
+
+impl<T> Serialize for EntityList<T>
+where
+    T: Identified + Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_seq(self.values())
+    }
+}
+
+impl<'de, T> Deserialize<'de> for EntityList<T>
+where
+    T: Identified + Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let entities = Vec::<T>::deserialize(deserializer)?;
+        let mut list = Self::new();
+
+        for entity in entities {
+            if list.insert(entity).is_some() {
+                return Err(D::Error::custom("duplicate entity identity"));
+            }
+        }
+
+        Ok(list)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    struct Item {
+        id: u32,
+        value: String,
+    }
+
+    impl Identified for Item {
+        type Id = u32;
+
+        fn id(&self) -> Self::Id {
+            self.id
+        }
+    }
+
+    fn item(id: u32, value: &'static str) -> Item {
+        Item {
+            id,
+            value: value.to_string(),
+        }
+    }
+
+    #[test]
+    fn equality_observes_entity_order() {
+        let mut first = EntityList::new();
+        first.insert(item(2, "second"));
+        first.insert(item(1, "first"));
+
+        let mut reordered = EntityList::new();
+        reordered.insert(item(1, "first"));
+        reordered.insert(item(2, "second"));
+
+        assert_ne!(first, reordered);
+    }
+
+    #[test]
+    fn replacement_preserves_position() {
+        let mut list = EntityList::new();
+        list.insert(item(2, "old"));
+        list.insert(item(1, "first"));
+
+        assert_eq!(list.insert(item(2, "new")), Some(item(2, "old")));
+        assert_eq!(
+            list.values()
+                .map(|item| item.value.as_str())
+                .collect::<Vec<_>>(),
+            vec!["new", "first"]
+        );
+    }
+}

--- a/crates/shift-font/src/ir/component.rs
+++ b/crates/shift-font/src/ir/component.rs
@@ -1,3 +1,4 @@
+use crate::collection::Identified;
 use crate::entity::{ComponentId, GlyphId};
 use crate::GlyphName;
 use serde::{Deserialize, Serialize};
@@ -8,6 +9,14 @@ pub struct Component {
     base_glyph_id: GlyphId,
     base_glyph_name: GlyphName,
     transform: DecomposedTransform,
+}
+
+impl Identified for Component {
+    type Id = ComponentId;
+
+    fn id(&self) -> Self::Id {
+        Component::id(self)
+    }
 }
 
 /// Raw 2D affine transformation matrix (6 values).

--- a/crates/shift-font/src/ir/contour.rs
+++ b/crates/shift-font/src/ir/contour.rs
@@ -1,3 +1,4 @@
+use crate::collection::Identified;
 use crate::entity::{ContourId, PointId};
 use crate::point::{Point, PointType};
 use crate::segment::CurveSegmentIter;
@@ -9,6 +10,14 @@ pub struct Contour {
     id: ContourId,
     points: Vec<Point>,
     closed: bool,
+}
+
+impl Identified for Contour {
+    type Id = ContourId;
+
+    fn id(&self) -> Self::Id {
+        Contour::id(self)
+    }
 }
 
 impl Default for Contour {

--- a/crates/shift-font/src/ir/font.rs
+++ b/crates/shift-font/src/ir/font.rs
@@ -1,5 +1,6 @@
 use crate::axis::{Axis, AxisMapping, Location};
 use crate::binary_data::BinaryData;
+use crate::collection::EntityList;
 use crate::entity::{AxisId, GlyphId, LayerId, MetricId, SourceId};
 use crate::error::{CoreError, CoreResult};
 use crate::features::FeatureData;
@@ -12,7 +13,6 @@ use crate::named_instance::{validate_named_instances, NamedInstance};
 use crate::source::source_locations_equal;
 use crate::source::Source;
 use crate::{AxisLabelId, GlyphName, NamedInstanceId};
-use indexmap::IndexMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -104,7 +104,7 @@ struct FontData {
     sources: Vec<Source>,
     #[serde(default)]
     default_source_id: Option<SourceId>,
-    glyphs: IndexMap<GlyphId, Arc<Glyph>>,
+    glyphs: EntityList<Arc<Glyph>>,
     kerning: KerningData,
     features: FeatureData,
     guidelines: Vec<Guideline>,
@@ -126,10 +126,10 @@ struct FontIndex {
 }
 
 impl FontIndex {
-    fn from_glyphs(glyphs: &IndexMap<GlyphId, Arc<Glyph>>) -> CoreResult<Self> {
+    fn from_glyphs(glyphs: &EntityList<Arc<Glyph>>) -> CoreResult<Self> {
         let mut index = Self::default();
 
-        for (glyph_id, glyph) in glyphs {
+        for (glyph_id, glyph) in glyphs.iter() {
             if *glyph_id != glyph.id() {
                 return Err(CoreError::MismatchedGlyphId {
                     key: glyph_id.clone(),
@@ -308,7 +308,7 @@ impl Default for Font {
                     named_instances: Vec::new(),
                     sources: vec![default_source],
                     default_source_id: Some(default_source_id),
-                    glyphs: IndexMap::new(),
+                    glyphs: EntityList::new(),
                     kerning: KerningData::new(),
                     features: FeatureData::new(),
                     guidelines: Vec::new(),
@@ -341,7 +341,7 @@ impl Font {
                     named_instances: Vec::new(),
                     sources: Vec::new(),
                     default_source_id: None,
-                    glyphs: IndexMap::new(),
+                    glyphs: EntityList::new(),
                     kerning: KerningData::new(),
                     features: FeatureData::new(),
                     guidelines: Vec::new(),
@@ -844,7 +844,7 @@ impl Font {
 
     pub fn insert_glyph(&mut self, glyph: Glyph) -> CoreResult<GlyphId> {
         let glyph_id = glyph.id();
-        if self.data().glyphs.contains_key(&glyph_id) {
+        if self.data().glyphs.contains(&glyph_id) {
             return Err(CoreError::DuplicateGlyphId(glyph_id));
         }
         self.index()
@@ -852,7 +852,7 @@ impl Font {
 
         let state = self.state_mut();
         state.index.insert_glyph(glyph_id.clone(), &glyph);
-        state.data.glyphs.insert(glyph_id.clone(), Arc::new(glyph));
+        state.data.glyphs.insert(Arc::new(glyph));
         Ok(glyph_id)
     }
 
@@ -1657,8 +1657,8 @@ mod tests {
         let mut glyph = Glyph::new("A");
         glyph.set_layer(GlyphLayer::new(LayerId::new(), source_id.clone()));
         glyph.set_layer(GlyphLayer::new(LayerId::new(), source_id.clone()));
-        let mut glyphs = IndexMap::new();
-        glyphs.insert(glyph.id(), Arc::new(glyph));
+        let mut glyphs = EntityList::new();
+        glyphs.insert(Arc::new(glyph));
 
         let error = FontIndex::from_glyphs(&glyphs).unwrap_err();
 

--- a/crates/shift-font/src/ir/glyph.rs
+++ b/crates/shift-font/src/ir/glyph.rs
@@ -1,4 +1,5 @@
 use crate::anchor::Anchor;
+use crate::collection::{EntityList, Identified};
 use crate::component::Component;
 use crate::contour::Contour;
 use crate::entity::{
@@ -8,7 +9,6 @@ use crate::guideline::Guideline;
 use crate::lib_data::LibData;
 use crate::point::Point;
 use crate::GlyphName;
-use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -22,14 +22,22 @@ pub struct Glyph {
     lib: LibData,
 }
 
+impl Identified for Glyph {
+    type Id = GlyphId;
+
+    fn id(&self) -> Self::Id {
+        Glyph::id(self)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GlyphLayer {
     id: LayerId,
     source_id: SourceId,
     width: f64,
     height: Option<f64>,
-    contours: IndexMap<ContourId, Contour>,
-    components: IndexMap<ComponentId, Component>,
+    contours: EntityList<Contour>,
+    components: EntityList<Component>,
     anchors: Vec<Anchor>,
     guidelines: Vec<Guideline>,
     lib: LibData,
@@ -42,8 +50,8 @@ impl GlyphLayer {
             source_id,
             width: 0.0,
             height: None,
-            contours: IndexMap::new(),
-            components: IndexMap::new(),
+            contours: EntityList::new(),
+            components: EntityList::new(),
             anchors: Vec::new(),
             guidelines: Vec::new(),
             lib: LibData::new(),
@@ -142,7 +150,7 @@ impl GlyphLayer {
         self.height = height;
     }
 
-    pub fn contours(&self) -> &IndexMap<ContourId, Contour> {
+    pub fn contours(&self) -> &EntityList<Contour> {
         &self.contours
     }
 
@@ -164,7 +172,7 @@ impl GlyphLayer {
 
     pub fn add_contour(&mut self, contour: Contour) -> ContourId {
         let id = contour.id();
-        self.contours.insert(id.clone(), contour);
+        self.contours.insert(contour);
         id
     }
 
@@ -176,7 +184,7 @@ impl GlyphLayer {
         self.contours.clear();
     }
 
-    pub fn components(&self) -> &IndexMap<ComponentId, Component> {
+    pub fn components(&self) -> &EntityList<Component> {
         &self.components
     }
 
@@ -194,7 +202,7 @@ impl GlyphLayer {
 
     pub fn add_component(&mut self, component: Component) -> ComponentId {
         let id = component.id();
-        self.components.insert(id.clone(), component);
+        self.components.insert(component);
         id
     }
 

--- a/crates/shift-font/src/ir/mod.rs
+++ b/crates/shift-font/src/ir/mod.rs
@@ -2,6 +2,7 @@ pub mod anchor;
 pub mod axis;
 pub mod binary_data;
 pub mod boolean;
+pub mod collection;
 pub mod component;
 pub mod contour;
 pub mod entity;

--- a/crates/shift-font/src/lib.rs
+++ b/crates/shift-font/src/lib.rs
@@ -47,7 +47,8 @@ pub use intents::*;
 pub use interpolation::*;
 pub use ir::*;
 pub use ir::{
-    anchor, axis, boolean, component, contour, entity, features, font, glyph, glyph_name,
-    guideline, kerning, lib_data, metrics, named_instance, point, segment, source, variation,
+    anchor, axis, boolean, collection, component, contour, entity, features, font, glyph,
+    glyph_name, guideline, kerning, lib_data, metrics, named_instance, point, segment, source,
+    variation,
 };
 pub use projection::*;

--- a/crates/shift-font/src/test_support.rs
+++ b/crates/shift-font/src/test_support.rs
@@ -13,6 +13,9 @@ use std::collections::HashMap;
 ///
 /// Checklist when adding a new `FontData` field: populate it here with a
 /// non-default, distinguishable value before relying on equality round-trips.
+/// Ordered collections need multiple entries whose identity sort order differs
+/// from their authored order so deterministic serializers cannot reorder them
+/// unnoticed.
 pub fn sample_font() -> Font {
     let mut font = Font::empty();
     font.metadata_mut().family_name = Some("Dogfood Sans".to_string());
@@ -259,8 +262,8 @@ pub fn sample_font() -> Font {
         700.0,
     ));
     regular_layer.add_component(Component::with_id(
-        ComponentId::from_raw("acute_component"),
-        acute_id,
+        ComponentId::from_raw("z_first"),
+        acute_id.clone(),
         "acute",
         DecomposedTransform {
             translate_x: 10.0,
@@ -272,6 +275,16 @@ pub fn sample_font() -> Font {
             skew_y: -1.5,
             t_center_x: 50.0,
             t_center_y: 75.0,
+        },
+    ));
+    regular_layer.add_component(Component::with_id(
+        ComponentId::from_raw("a_second"),
+        acute_id,
+        "acute",
+        DecomposedTransform {
+            translate_x: 120.0,
+            translate_y: 240.0,
+            ..DecomposedTransform::identity()
         },
     ));
     regular_layer.add_guideline(Guideline::with_id(

--- a/crates/shift-source/docs/DOCS.md
+++ b/crates/shift-source/docs/DOCS.md
@@ -8,6 +8,7 @@ Source-package crate for Shift's user-authored `.shift` format.
 - **Architecture Invariant:** Every `.shift` manifest carries a stable `packageId`. Filesystem moves and byte-for-byte copies preserve it; Save As mints a new one.
 - **Architecture Invariant:** This crate owns the stable source schema DTOs and converts to/from `shift_font::Font`. It does not expose serde for private `shift-font` storage structs as the file contract.
 - **Architecture Invariant:** Serialization is tree-first: `font_to_tree` emits `Vec<(path, bytes)>`; `write_tree_atomic` is the zip container layer. A future loose-directory container can reuse the same tree schema.
+- **Architecture Invariant:** Deterministic serialization must preserve domain order. Ordered entities are encoded as JSON arrays containing their stable IDs; sorted JSON objects are reserved for dictionaries whose order has no authoring meaning.
 - **Architecture Invariant:** `.shift` is separate from the app-managed SQLite working store. SQLite import/export wiring belongs in `shift-workspace`, not here.
 
 ## Codemap
@@ -60,12 +61,14 @@ and `FontLoader`:
 - `instances.json` stores explicit named product presets. Every location is a
   complete `axisId -> external value` map; instances do not reference sources
   and do not store Designspace or compiler fields.
-- `font.json` stores global UPM and ordered, stable-ID metric definitions.
+- `font.json` stores global UPM, ordered stable-ID metric definitions, and the glyph order for the independently stored glyph files.
 - `sources.json` stores source locations as `axisId -> design-space value`, plus values and overshoots keyed by `metricId` and optional source technical metrics.
 - Each glyph file is `glyphs/<glyphId>.json`; glyph layers are keyed by
   `sourceId`.
-- Components store `baseGlyphId` as the canonical reference and
-  `baseGlyphName` as a label cache.
+- Components are an ordered array containing stable component identity,
+  `baseGlyphId` as the canonical reference, and `baseGlyphName` as a label
+  cache. Component order participates in rendering and interpolation
+  compatibility.
 - Load rejects non-finite metrics/coordinates/transforms/location values,
   invalid axis ranges, mismatched glyph file IDs, dangling source/layer/axis
   references, and component base caches that do not match the referenced glyph.

--- a/crates/shift-source/src/package.rs
+++ b/crates/shift-source/src/package.rs
@@ -10,11 +10,11 @@ use std::{
 use serde::{Deserialize, Serialize};
 use shift_font::{
     Anchor, Axis, AxisId, AxisKind, AxisLabel, AxisLabelId, AxisLabelRange, AxisMapping,
-    AxisMappingId, AxisMappingPoint, AxisRole, Component, ComponentId, Contour,
-    DecomposedTransform, FeatureData, Font, FontMetadata, FontMetrics, Glyph, GlyphLayer,
-    GlyphName, Guideline, KerningData, KerningPair, KerningSide, LibData, LibValue, Location,
-    MetricDefinition, MetricId, MetricKind, MetricValue, NamedInstance, NamedInstanceId, Point,
-    PointType, Source, SourceId, SourceRole,
+    AxisMappingId, AxisMappingPoint, AxisRole, Component, Contour, DecomposedTransform,
+    FeatureData, Font, FontMetadata, FontMetrics, Glyph, GlyphLayer, GlyphName, Guideline,
+    KerningData, KerningPair, KerningSide, LibData, LibValue, Location, MetricDefinition, MetricId,
+    MetricKind, MetricValue, NamedInstance, NamedInstanceId, Point, PointType, Source, SourceId,
+    SourceRole,
 };
 use zip::{CompressionMethod, ZipArchive, ZipWriter, result::ZipError, write::SimpleFileOptions};
 
@@ -134,6 +134,9 @@ pub enum SourcePackageError {
 
     #[error("glyph file path {path} does not match glyph id {id}")]
     MismatchedGlyphFileId { path: String, id: String },
+
+    #[error("invalid glyph order: {0}")]
+    InvalidGlyphOrder(String),
 
     #[error("invalid unicode scalar value: {0}")]
     InvalidUnicode(String),
@@ -282,6 +285,7 @@ struct ManifestDoc {
 struct FontDoc {
     metadata: MetadataDoc,
     metrics: MetricsDoc,
+    glyph_order: Vec<String>,
     #[serde(default)]
     guidelines: Vec<GuidelineDoc>,
 }
@@ -478,7 +482,7 @@ struct LayerDoc {
     advance: f64,
     height: Option<f64>,
     contours: Vec<ContourDoc>,
-    components: BTreeMap<String, ComponentDoc>,
+    components: Vec<ComponentDoc>,
     anchors: Vec<AnchorDoc>,
     #[serde(default)]
     guidelines: Vec<GuidelineDoc>,
@@ -516,6 +520,7 @@ struct PointDoc {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ComponentDoc {
+    id: String,
     base_glyph_id: String,
     base_glyph_name: String,
     transform: TransformDoc,
@@ -666,6 +671,7 @@ pub fn font_to_tree(
     let font_doc = FontDoc {
         metadata: MetadataDoc::from(font.metadata()),
         metrics: MetricsDoc::try_from(font)?,
+        glyph_order: font.glyphs().map(|glyph| glyph.id().to_string()).collect(),
         guidelines: font
             .guidelines()
             .iter()
@@ -873,8 +879,27 @@ pub fn tree_to_font(tree: PackageTree) -> Result<Font, SourcePackageError> {
         })
         .collect::<Result<Vec<_>, SourcePackageError>>()?;
     let glyph_names_by_id = glyph_doc_names_by_id(&glyph_docs)?;
+    let mut glyph_docs_by_id = glyph_docs
+        .into_iter()
+        .map(|(path, glyph_doc)| (glyph_doc.id.clone(), (path, glyph_doc)))
+        .collect::<HashMap<_, _>>();
+    let mut ordered_glyph_docs = Vec::with_capacity(font_doc.glyph_order.len());
 
-    for (_, glyph_doc) in glyph_docs {
+    for glyph_id in font_doc.glyph_order {
+        let Some(glyph_doc) = glyph_docs_by_id.remove(&glyph_id) else {
+            return Err(SourcePackageError::InvalidGlyphOrder(format!(
+                "{glyph_id} is missing or listed more than once"
+            )));
+        };
+        ordered_glyph_docs.push(glyph_doc);
+    }
+    if let Some(glyph_id) = glyph_docs_by_id.keys().next() {
+        return Err(SourcePackageError::InvalidGlyphOrder(format!(
+            "{glyph_id} is not listed"
+        )));
+    }
+
+    for (_, glyph_doc) in ordered_glyph_docs {
         validate_glyph_component_references(&glyph_doc, &glyph_names_by_id)?;
         let mut glyph = Glyph::try_from(glyph_doc)?;
         if let Some(module_doc) = &mut lib_module_doc {
@@ -1115,7 +1140,7 @@ fn validate_glyph_component_references(
     names_by_id: &HashMap<String, GlyphName>,
 ) -> Result<(), SourcePackageError> {
     for layer_doc in glyph_doc.layers.values() {
-        for component_doc in layer_doc.components.values() {
+        for component_doc in &layer_doc.components {
             glyph_name_from_ref(
                 component_doc.base_glyph_id.clone(),
                 component_doc.base_glyph_name.clone(),
@@ -2361,12 +2386,9 @@ impl LayerDoc {
                 .map(ContourDoc::try_from)
                 .collect::<Result<Vec<_>, _>>()?,
             components: layer
-                .components()
-                .iter()
-                .map(|(id, component)| {
-                    ComponentDoc::from_component(font, component).map(|doc| (id.to_string(), doc))
-                })
-                .collect::<Result<BTreeMap<_, _>, _>>()?,
+                .components_iter()
+                .map(|component| ComponentDoc::from_component(font, component))
+                .collect::<Result<Vec<_>, _>>()?,
             anchors: layer
                 .anchors_iter()
                 .map(AnchorDoc::try_from)
@@ -2394,10 +2416,8 @@ impl LayerDoc {
             layer.add_contour(Contour::try_from(contour_doc)?);
         }
 
-        for (component_id, component_doc) in self.components {
-            layer.add_component(
-                component_doc.into_component(parse_id("component", &component_id)?)?,
-            );
+        for component_doc in self.components {
+            layer.add_component(component_doc.into_component()?);
         }
 
         for anchor_doc in self.anchors {
@@ -2490,17 +2510,18 @@ impl ComponentDoc {
         })?;
 
         Ok(Self {
+            id: component.id().to_string(),
             base_glyph_id: base_glyph_id.to_string(),
             base_glyph_name: base_glyph.name().to_string(),
             transform: TransformDoc::try_from(*component.transform())?,
         })
     }
 
-    fn into_component(self, id: ComponentId) -> Result<Component, SourcePackageError> {
+    fn into_component(self) -> Result<Component, SourcePackageError> {
         let base_glyph_name = GlyphName::new(self.base_glyph_name.clone())
             .map_err(|_| SourcePackageError::InvalidGlyphName(self.base_glyph_name.clone()))?;
         Ok(Component::with_id(
-            id,
+            parse_id("component", &self.id)?,
             parse_id("glyph", &self.base_glyph_id)?,
             base_glyph_name,
             DecomposedTransform::try_from(self.transform)?,

--- a/crates/shift-source/tests/package_test.rs
+++ b/crates/shift-source/tests/package_test.rs
@@ -247,7 +247,8 @@ fn parses_minimal_handwritten_tree() {
       { "id": "metric_baseline", "kind": "baseline", "name": "Baseline" },
       { "id": "metric_descender", "kind": "descender", "name": "Descender" }
     ]
-  }
+  },
+  "glyphOrder": []
 }
 "#
             .to_vec(),


### PR DESCRIPTION
## Summary

- add an identity-addressable ordered collection for authored font entities
- persist glyph order and component identity/order in `.shift` packages
- align Designspace default-source, mapped-location, layer, and source-name resolution with designspaceLib semantics
- expose reload/force-reload in the development Electron menu
- reject console debug output in production files during pre-commit validation

## Why

Hash-map-backed glyph and component collections made iteration and serialization order accidental. The Designspace reader also treated source zero or incomplete raw coordinates as defaults. Together these could reorder authored structures, produce anonymous `Source N` masters, or build interpolation bases against the wrong source.

This intentionally updates the unshipped `.shift` schema without a compatibility migration.

## Validation

- `cargo test -p shift-font -p shift-source -p shift-backends`
- `cargo clippy -p shift-font -p shift-source -p shift-backends --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS='-D rustdoc::broken_intra_doc_links' cargo doc -p shift-font -p shift-source -p shift-backends --no-deps --document-private-items`
- `pnpm lint:check`
- `pnpm typecheck`
- `pnpm format:check`
