### PR TITLE
Add semantic CLI font authoring

### DIFF
--- a/crates/shift-cli/Cargo.toml
+++ b/crates/shift-cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "shift-cli"
 version = "0.1.0"
 edition = "2024"
-description = "Command-line tools for inspecting and compiling Shift source packages"
+description = "Command-line tools for authoring, inspecting, and compiling Shift source packages"
 readme = "README.md"
 
 [dependencies]

--- a/crates/shift-cli/README.md
+++ b/crates/shift-cli/README.md
@@ -1,8 +1,8 @@
 # shift-cli
 
-Command-line tools for `.shift` source packages.
+Command-line inspection, authoring, and compilation for `.shift` source packages.
 
-The crate builds the `shift-cli` binary. `inspect` opens a source package, summarizes the font model, and can emit stable JSON for scripts and CI. `compile` sends the canonical Shift model directly through fontir/fontc to produce a TrueType font.
+The crate builds the `shift-cli` binary. `inspect` opens a source package, summarizes the font model, and can emit stable JSON for scripts and CI. Resource commands apply semantic Shift intents and save only after the complete change validates. `compile` sends the canonical Shift model directly through fontir/fontc to produce a TrueType font.
 
 ## Usage
 
@@ -14,6 +14,12 @@ cargo run -p shift-cli -- inspect --view sources path/to/Family.shift
 cargo run -p shift-cli -- inspect --view layers path/to/Family.shift
 cargo run -p shift-cli -- inspect --json path/to/Family.shift
 cargo run -p shift-cli -- compile path/to/Family.shift --output path/to/Family.ttf
+
+cargo run -p shift-cli -- font create path/to/Lab.shift
+cargo run -p shift-cli -- axis add path/to/Lab.shift \
+  --id weight --tag wght --name Weight --min 100 --default 400 --max 900
+cargo run -p shift-cli -- source add path/to/Lab.shift \
+  --id black --name Black --location wght=900
 ```
 
 Human-readable output is quiet by default and uses plain text when stdout is redirected. Use `--json` when another tool needs the complete report.
@@ -26,6 +32,26 @@ Available views:
 - `sources`: design sources and locations
 - `glyphs`: glyph names, Unicode values, and layer counts
 - `layers`: glyph layer source bindings and geometry counts
+
+## Authoring
+
+Authoring commands operate on Shift domain objects rather than package JSON. The initial resource surface creates fonts, continuous axes, and master sources:
+
+```sh
+shift font create Lab.shift
+shift axis add Lab.shift --tag wght --name Weight --min 100 --default 400 --max 900
+shift source add Lab.shift --name Black --location wght=900
+```
+
+Entity IDs are minted automatically. Pass `--id` when a script or agent needs deterministic identity; the typed prefix is optional.
+
+Every mutation supports:
+
+- `--dry-run` to execute real domain validation without writing;
+- `--json` for a structured result; and
+- `--output Variant.shift` to leave the input untouched and write an independent package.
+
+In-place changes retain package identity. `--output` refuses to overwrite an existing destination and mints a new package identity. All mutations apply to a cloned font and write atomically only after the complete semantic change succeeds.
 
 ## Install
 
@@ -43,4 +69,6 @@ After pulling or merging `main`, rerun the same `cargo install` command to updat
 cargo test -p shift-cli
 cargo run -p shift-cli -- inspect --help
 cargo run -p shift-cli -- compile --help
+cargo run -p shift-cli -- axis add --help
+cargo run -p shift-cli -- source add --help
 ```

--- a/crates/shift-cli/README.md
+++ b/crates/shift-cli/README.md
@@ -17,9 +17,15 @@ cargo run -p shift-cli -- compile path/to/Family.shift --output path/to/Family.t
 
 cargo run -p shift-cli -- font create path/to/Lab.shift
 cargo run -p shift-cli -- axis add path/to/Lab.shift \
-  --id weight --tag wght --name Weight --min 100 --default 400 --max 900
+  --tag wght --name Weight --min 100 --default 400 --max 900
 cargo run -p shift-cli -- source add path/to/Lab.shift \
-  --id black --name Black --location wght=900
+  --name Black --location wght=900
+cargo run -p shift-cli -- glyph add path/to/Lab.shift A \
+  --unicode U+0041
+cargo run -p shift-cli -- layer add path/to/Lab.shift \
+  --glyph A --source Regular --input A-regular.json
+cargo run -p shift-cli -- layer copy path/to/Lab.shift \
+  --glyph A --from-source Regular --source Black
 ```
 
 Human-readable output is quiet by default and uses plain text when stdout is redirected. Use `--json` when another tool needs the complete report.
@@ -35,15 +41,39 @@ Available views:
 
 ## Authoring
 
-Authoring commands operate on Shift domain objects rather than package JSON. The initial resource surface creates fonts, continuous axes, and master sources:
+Authoring commands operate on Shift domain objects rather than package JSON. The resource surface creates font topology, glyph identity, and sparse authored layers:
 
 ```sh
 shift font create Lab.shift
 shift axis add Lab.shift --tag wght --name Weight --min 100 --default 400 --max 900
 shift source add Lab.shift --name Black --location wght=900
+shift glyph add Lab.shift A --unicode U+0041
+shift layer add Lab.shift --glyph A --source Regular --input A-regular.json
+shift layer copy Lab.shift --glyph A --from-source Regular --source Black
 ```
 
-Entity IDs are minted automatically. Pass `--id` when a script or agent needs deterministic identity; the typed prefix is optional.
+Shift mints every new entity ID. Human and agent workflows may read returned IDs and use them as selectors, but authoring commands never accept caller-chosen identity.
+
+`layer add` reads a semantic layer payload from a JSON file, or from stdin when `--input -` is used. Glyph and source membership stay in the command selectors instead of being duplicated inside the payload:
+
+```json
+{
+  "advance": 600,
+  "contours": [
+    {
+      "closed": true,
+      "points": [
+        { "x": 0, "y": 0 },
+        { "x": 300, "y": 700, "pointType": "onCurve" },
+        { "x": 600, "y": 0 }
+      ]
+    }
+  ],
+  "anchors": [{ "name": "top", "x": 300, "y": 700 }]
+}
+```
+
+Identity is not part of the layer payload. `pointType` defaults to `onCurve`; accepted values are `onCurve`, `offCurve`, and `qCurve`. A new layer payload currently authors contours and anchors. `layer copy` preserves complete authored layer content, including components, while minting fresh internal identities.
 
 Every mutation supports:
 
@@ -71,4 +101,7 @@ cargo run -p shift-cli -- inspect --help
 cargo run -p shift-cli -- compile --help
 cargo run -p shift-cli -- axis add --help
 cargo run -p shift-cli -- source add --help
+cargo run -p shift-cli -- glyph add --help
+cargo run -p shift-cli -- layer add --help
+cargo run -p shift-cli -- layer copy --help
 ```

--- a/crates/shift-cli/src/authoring.rs
+++ b/crates/shift-cli/src/authoring.rs
@@ -1,0 +1,486 @@
+//! Semantic `.shift` authoring commands.
+//!
+//! CLI flags are translated into [`FontIntentSet`] values and applied to a
+//! cloned [`Font`]. The destination is written only after the complete intent
+//! set validates, so a failed command cannot partially mutate a package.
+
+use std::collections::{BTreeMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use miette::{IntoDiagnostic, Result, WrapErr, bail, miette};
+use serde::Serialize;
+use shift_font::{Axis, AxisId, Font, FontChange, FontIntent, FontIntentSet, Location, SourceId};
+use shift_source::ShiftSourcePackage;
+
+use crate::cli::{AddAxisArgs, AddSourceArgs, CreateFontArgs, MutationArgs};
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthoringReport {
+    pub valid: bool,
+    pub document: PathBuf,
+    pub output: PathBuf,
+    pub wrote: bool,
+    pub changes: Vec<AuthoringChange>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum AuthoringChange {
+    FontCreated {
+        package_id: Option<String>,
+    },
+    AxisCreated {
+        axis_id: String,
+        tag: String,
+        name: String,
+        minimum: f64,
+        default: f64,
+        maximum: f64,
+    },
+    SourceCreated {
+        source_id: String,
+        name: String,
+        location: BTreeMap<String, f64>,
+    },
+    NamedInstancesUpdated {
+        count: usize,
+    },
+}
+
+impl AuthoringReport {
+    pub fn render(&self) -> String {
+        let mut lines = vec![self.document.display().to_string(), String::new()];
+        for change in &self.changes {
+            match change {
+                AuthoringChange::FontCreated { package_id } => {
+                    let id = package_id.as_deref().unwrap_or("assigned when written");
+                    lines.push(format!("+ font    {id}"));
+                }
+                AuthoringChange::AxisCreated {
+                    axis_id,
+                    tag,
+                    name,
+                    minimum,
+                    default,
+                    maximum,
+                } => lines.push(format!(
+                    "+ axis    {name} ({tag})  {axis_id}  {minimum} · {default} · {maximum}"
+                )),
+                AuthoringChange::SourceCreated {
+                    source_id,
+                    name,
+                    location,
+                } => {
+                    let location = location
+                        .iter()
+                        .map(|(tag, value)| format!("{tag}={value}"))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    lines.push(format!("+ source  {name}  {source_id}  {location}"));
+                }
+                AuthoringChange::NamedInstancesUpdated { count } => {
+                    lines.push(format!("~ instances  {count} product locations completed"));
+                }
+            }
+        }
+        lines.push(String::new());
+        if self.wrote {
+            lines.push(format!("Saved {}", self.output.display()));
+        } else {
+            lines.push("Valid. No files written.".to_string());
+        }
+        lines.join("\n")
+    }
+}
+
+/// Creates a canonical `.shift` package with the model's default source.
+///
+/// A dry run validates the path and overwrite precondition without writing.
+///
+/// # Errors
+///
+/// Returns an error for a non-`.shift` path, an existing destination, or a
+/// package serialization or filesystem failure.
+pub fn create_font(args: CreateFontArgs) -> Result<AuthoringReport> {
+    validate_new_package_path(&args.path)?;
+
+    let package_id = if args.dry_run {
+        None
+    } else {
+        let package = ShiftSourcePackage::create_empty(&args.path)
+            .into_diagnostic()
+            .wrap_err("failed to create Shift font")?;
+        Some(package.package_id().to_string())
+    };
+
+    Ok(AuthoringReport {
+        valid: true,
+        document: args.path.clone(),
+        output: args.path,
+        wrote: !args.dry_run,
+        changes: vec![AuthoringChange::FontCreated { package_id }],
+    })
+}
+
+/// Adds one continuous axis through Shift's semantic intent path.
+///
+/// # Errors
+///
+/// Returns an error when the package cannot be loaded, the axis is invalid or
+/// conflicts with existing authoring data, or the destination cannot be saved.
+pub fn add_axis(args: AddAxisArgs) -> Result<AuthoringReport> {
+    let font = ShiftSourcePackage::load_font(&args.path)
+        .into_diagnostic()
+        .wrap_err("failed to load Shift font")?;
+    let axis_id = args.id.map_or_else(AxisId::new, AxisId::from_raw);
+    let axis = Axis::with_id(
+        axis_id,
+        args.tag,
+        args.name,
+        args.minimum,
+        args.default,
+        args.maximum,
+    );
+    let set = FontIntentSet {
+        intents: vec![FontIntent::CreateAxis { axis }],
+    };
+
+    apply_mutation(&args.path, &args.mutation, font, set, None)
+}
+
+/// Adds one master source after resolving axis tags to stable identities.
+///
+/// Omitted axes are completed with their design-space defaults before the
+/// source is created, so the written source location is explicit.
+///
+/// # Errors
+///
+/// Returns an error for malformed coordinates, unknown or repeated tags,
+/// non-finite values, invalid source authoring, or persistence failures.
+pub fn add_source(args: AddSourceArgs) -> Result<AuthoringReport> {
+    let font = ShiftSourcePackage::load_font(&args.path)
+        .into_diagnostic()
+        .wrap_err("failed to load Shift font")?;
+    let (location, rendered_location) = parse_location(&font, &args.location)?;
+    let source_id = args.id.map_or_else(SourceId::new, SourceId::from_raw);
+    let set = FontIntentSet {
+        intents: vec![FontIntent::CreateSource {
+            source_id,
+            name: args.name,
+            location,
+        }],
+    };
+
+    apply_mutation(
+        &args.path,
+        &args.mutation,
+        font,
+        set,
+        Some(rendered_location),
+    )
+}
+
+fn apply_mutation(
+    path: &Path,
+    options: &MutationArgs,
+    font: Font,
+    set: FontIntentSet,
+    source_location: Option<BTreeMap<String, f64>>,
+) -> Result<AuthoringReport> {
+    let destination = mutation_destination(path, options.output.as_deref())?;
+    let mut next = font.clone();
+    let outcome = next
+        .apply_intents(set)
+        .into_diagnostic()
+        .wrap_err("authoring change is invalid")?;
+    let changes = report_changes(outcome.changes.changes, source_location);
+
+    if !options.dry_run {
+        if options.output.is_some() {
+            ShiftSourcePackage::save_font_as(&destination, &next)
+                .into_diagnostic()
+                .wrap_err("failed to save independent Shift font")?;
+        } else {
+            ShiftSourcePackage::save_font(&destination, &next)
+                .into_diagnostic()
+                .wrap_err("failed to save Shift font")?;
+        }
+    }
+
+    Ok(AuthoringReport {
+        valid: true,
+        document: path.to_path_buf(),
+        output: destination,
+        wrote: !options.dry_run,
+        changes,
+    })
+}
+
+fn report_changes(
+    changes: Vec<FontChange>,
+    source_location: Option<BTreeMap<String, f64>>,
+) -> Vec<AuthoringChange> {
+    changes
+        .into_iter()
+        .filter_map(|change| match change {
+            FontChange::AxisCreated(change) => Some(AuthoringChange::AxisCreated {
+                axis_id: change.axis.id().to_string(),
+                tag: change.axis.tag().to_string(),
+                name: change.axis.name().to_string(),
+                minimum: change.axis.minimum(),
+                default: change.axis.default(),
+                maximum: change.axis.maximum(),
+            }),
+            FontChange::SourceCreated(change) => Some(AuthoringChange::SourceCreated {
+                source_id: change.source_id.to_string(),
+                name: change.name,
+                location: source_location.clone().unwrap_or_default(),
+            }),
+            FontChange::NamedInstancesUpdated(change) => {
+                Some(AuthoringChange::NamedInstancesUpdated {
+                    count: change.instances.len(),
+                })
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+fn parse_location(
+    font: &Font,
+    coordinates: &[String],
+) -> Result<(Location, BTreeMap<String, f64>)> {
+    let mut location = Location::new();
+    let mut rendered = BTreeMap::new();
+    for axis in font.axes() {
+        location.set(axis.id(), axis.default());
+        rendered.insert(axis.tag().to_string(), axis.default());
+    }
+
+    let mut seen = HashSet::new();
+    for coordinate in coordinates {
+        let Some((tag, value)) = coordinate.split_once('=') else {
+            return Err(miette!(
+                "invalid location {coordinate:?}; expected TAG=VALUE"
+            ));
+        };
+        let tag = tag.trim();
+        if tag.is_empty() || !seen.insert(tag.to_string()) {
+            bail!("axis tag {tag:?} is blank or repeated in the location");
+        }
+        let axis_id = font
+            .axis_id_by_tag(tag)
+            .ok_or_else(|| miette!("axis tag {tag:?} does not exist"))?;
+        let value = value
+            .trim()
+            .parse::<f64>()
+            .into_diagnostic()
+            .wrap_err_with(|| format!("invalid value for axis tag {tag:?}"))?;
+        if !value.is_finite() {
+            bail!("location value for axis tag {tag:?} must be finite");
+        }
+
+        location.set(axis_id, value);
+        rendered.insert(tag.to_string(), value);
+    }
+
+    Ok((location, rendered))
+}
+
+fn mutation_destination(path: &Path, output: Option<&Path>) -> Result<PathBuf> {
+    let Some(output) = output else {
+        return Ok(path.to_path_buf());
+    };
+    if output == path {
+        bail!("--output must differ from the input path");
+    }
+    validate_new_package_path(output)?;
+    Ok(output.to_path_buf())
+}
+
+fn validate_new_package_path(path: &Path) -> Result<()> {
+    if !ShiftSourcePackage::is_package_path(path) {
+        bail!("Shift font path must use the .shift extension");
+    }
+    if path.exists() {
+        bail!("refusing to overwrite existing path {}", path.display());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    fn mutation(dry_run: bool) -> MutationArgs {
+        MutationArgs {
+            output: None,
+            dry_run,
+            json: false,
+        }
+    }
+
+    fn create_package(path: &Path) {
+        create_font(CreateFontArgs {
+            path: path.to_path_buf(),
+            dry_run: false,
+            json: false,
+        })
+        .unwrap();
+    }
+
+    fn weight_axis(path: &Path, mutation: MutationArgs) -> AddAxisArgs {
+        AddAxisArgs {
+            path: path.to_path_buf(),
+            id: Some("weight".to_string()),
+            tag: "wght".to_string(),
+            name: "Weight".to_string(),
+            minimum: 100.0,
+            default: 400.0,
+            maximum: 900.0,
+            mutation,
+        }
+    }
+
+    #[test]
+    fn create_font_writes_a_new_package_and_refuses_to_overwrite_it() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("Lab.shift");
+
+        let report = create_font(CreateFontArgs {
+            path: path.clone(),
+            dry_run: false,
+            json: false,
+        })
+        .unwrap();
+
+        assert!(report.wrote);
+        assert_eq!(
+            ShiftSourcePackage::load_font(&path)
+                .unwrap()
+                .sources()
+                .len(),
+            1
+        );
+        assert!(
+            create_font(CreateFontArgs {
+                path,
+                dry_run: false,
+                json: false,
+            })
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn axis_dry_run_uses_real_validation_without_writing() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("Lab.shift");
+        create_package(&path);
+        let before = fs::read(&path).unwrap();
+
+        let report = add_axis(weight_axis(&path, mutation(true))).unwrap();
+
+        assert!(!report.wrote);
+        assert_eq!(fs::read(&path).unwrap(), before);
+        assert!(
+            ShiftSourcePackage::load_font(&path)
+                .unwrap()
+                .axes()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn axis_mutation_preserves_package_identity() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("Lab.shift");
+        create_package(&path);
+        let package_id = ShiftSourcePackage::open(&path)
+            .unwrap()
+            .package_id()
+            .clone();
+
+        add_axis(weight_axis(&path, mutation(false))).unwrap();
+
+        let package = ShiftSourcePackage::open(&path).unwrap();
+        let font = ShiftSourcePackage::load_font(&path).unwrap();
+        assert_eq!(package.package_id(), &package_id);
+        assert_eq!(font.axes()[0].tag(), "wght");
+    }
+
+    #[test]
+    fn invalid_axis_does_not_change_the_package() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("Lab.shift");
+        create_package(&path);
+        let before = fs::read(&path).unwrap();
+        let mut args = weight_axis(&path, mutation(false));
+        args.minimum = 500.0;
+        args.default = 400.0;
+
+        assert!(add_axis(args).is_err());
+        assert_eq!(fs::read(&path).unwrap(), before);
+    }
+
+    #[test]
+    fn output_writes_an_independent_package_without_changing_input() {
+        let temp = tempfile::tempdir().unwrap();
+        let input = temp.path().join("Lab.shift");
+        let output = temp.path().join("Variant.shift");
+        create_package(&input);
+        let before = fs::read(&input).unwrap();
+        let mut options = mutation(false);
+        options.output = Some(output.clone());
+
+        add_axis(weight_axis(&input, options)).unwrap();
+
+        assert_eq!(fs::read(&input).unwrap(), before);
+        assert!(
+            ShiftSourcePackage::load_font(&input)
+                .unwrap()
+                .axes()
+                .is_empty()
+        );
+        assert_eq!(
+            ShiftSourcePackage::load_font(&output).unwrap().axes().len(),
+            1
+        );
+        assert_ne!(
+            ShiftSourcePackage::open(&input).unwrap().package_id(),
+            ShiftSourcePackage::open(&output).unwrap().package_id()
+        );
+    }
+
+    #[test]
+    fn source_location_is_completed_with_axis_defaults() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("Lab.shift");
+        create_package(&path);
+        add_axis(weight_axis(&path, mutation(false))).unwrap();
+
+        add_source(AddSourceArgs {
+            path: path.clone(),
+            id: Some("black".to_string()),
+            name: "Black".to_string(),
+            location: vec!["wght=900".to_string()],
+            mutation: mutation(false),
+        })
+        .unwrap();
+
+        let font = ShiftSourcePackage::load_font(&path).unwrap();
+        let source = font
+            .sources()
+            .iter()
+            .find(|source| source.name() == "Black")
+            .unwrap();
+        assert_eq!(source.location().get(&font.axes()[0].id()), Some(900.0));
+    }
+}

--- a/crates/shift-cli/src/authoring.rs
+++ b/crates/shift-cli/src/authoring.rs
@@ -9,10 +9,14 @@ use std::path::{Path, PathBuf};
 
 use miette::{IntoDiagnostic, Result, WrapErr, bail, miette};
 use serde::Serialize;
-use shift_font::{Axis, AxisId, Font, FontChange, FontIntent, FontIntentSet, Location, SourceId};
+use shift_font::{Axis, Font, FontChange, FontIntent, FontIntentSet, Location, SourceId};
 use shift_source::ShiftSourcePackage;
 
 use crate::cli::{AddAxisArgs, AddSourceArgs, CreateFontArgs, MutationArgs};
+
+mod glyph;
+
+pub use glyph::{add_glyph, add_layer, copy_layer};
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -46,6 +50,21 @@ pub enum AuthoringChange {
         source_id: String,
         name: String,
         location: BTreeMap<String, f64>,
+    },
+    GlyphCreated {
+        glyph_id: String,
+        name: String,
+        unicodes: Vec<String>,
+    },
+    GlyphLayerCreated {
+        layer_id: String,
+        glyph_id: String,
+        source_id: String,
+        advance: f64,
+        contour_count: usize,
+        point_count: usize,
+        anchor_count: usize,
+        component_count: usize,
     },
     NamedInstancesUpdated {
         count: usize,
@@ -83,6 +102,31 @@ impl AuthoringReport {
                         .join(", ");
                     lines.push(format!("+ source  {name}  {source_id}  {location}"));
                 }
+                AuthoringChange::GlyphCreated {
+                    glyph_id,
+                    name,
+                    unicodes,
+                } => {
+                    let unicodes = unicodes.join(", ");
+                    let suffix = if unicodes.is_empty() {
+                        String::new()
+                    } else {
+                        format!("  {unicodes}")
+                    };
+                    lines.push(format!("+ glyph   {name}  {glyph_id}{suffix}"));
+                }
+                AuthoringChange::GlyphLayerCreated {
+                    layer_id,
+                    glyph_id,
+                    source_id,
+                    advance,
+                    contour_count,
+                    point_count,
+                    anchor_count,
+                    component_count,
+                } => lines.push(format!(
+                    "+ layer   {layer_id}  {glyph_id} @ {source_id}  advance {advance}; {contour_count} contours, {point_count} points, {anchor_count} anchors, {component_count} components"
+                )),
                 AuthoringChange::NamedInstancesUpdated { count } => {
                     lines.push(format!("~ instances  {count} product locations completed"));
                 }
@@ -137,9 +181,7 @@ pub fn add_axis(args: AddAxisArgs) -> Result<AuthoringReport> {
     let font = ShiftSourcePackage::load_font(&args.path)
         .into_diagnostic()
         .wrap_err("failed to load Shift font")?;
-    let axis_id = args.id.map_or_else(AxisId::new, AxisId::from_raw);
-    let axis = Axis::with_id(
-        axis_id,
+    let axis = Axis::new(
         args.tag,
         args.name,
         args.minimum,
@@ -150,7 +192,7 @@ pub fn add_axis(args: AddAxisArgs) -> Result<AuthoringReport> {
         intents: vec![FontIntent::CreateAxis { axis }],
     };
 
-    apply_mutation(&args.path, &args.mutation, font, set, None)
+    apply_mutation(&args.path, &args.mutation, font, set)
 }
 
 /// Adds one master source after resolving axis tags to stable identities.
@@ -166,8 +208,8 @@ pub fn add_source(args: AddSourceArgs) -> Result<AuthoringReport> {
     let font = ShiftSourcePackage::load_font(&args.path)
         .into_diagnostic()
         .wrap_err("failed to load Shift font")?;
-    let (location, rendered_location) = parse_location(&font, &args.location)?;
-    let source_id = args.id.map_or_else(SourceId::new, SourceId::from_raw);
+    let location = parse_location(&font, &args.location)?;
+    let source_id = SourceId::new();
     let set = FontIntentSet {
         intents: vec![FontIntent::CreateSource {
             source_id,
@@ -176,21 +218,14 @@ pub fn add_source(args: AddSourceArgs) -> Result<AuthoringReport> {
         }],
     };
 
-    apply_mutation(
-        &args.path,
-        &args.mutation,
-        font,
-        set,
-        Some(rendered_location),
-    )
+    apply_mutation(&args.path, &args.mutation, font, set)
 }
 
-fn apply_mutation(
+pub(super) fn apply_mutation(
     path: &Path,
     options: &MutationArgs,
     font: Font,
     set: FontIntentSet,
-    source_location: Option<BTreeMap<String, f64>>,
 ) -> Result<AuthoringReport> {
     let destination = mutation_destination(path, options.output.as_deref())?;
     let mut next = font.clone();
@@ -198,7 +233,7 @@ fn apply_mutation(
         .apply_intents(set)
         .into_diagnostic()
         .wrap_err("authoring change is invalid")?;
-    let changes = report_changes(outcome.changes.changes, source_location);
+    let changes = report_changes(&next, outcome.changes.changes);
 
     if !options.dry_run {
         if options.output.is_some() {
@@ -221,10 +256,7 @@ fn apply_mutation(
     })
 }
 
-fn report_changes(
-    changes: Vec<FontChange>,
-    source_location: Option<BTreeMap<String, f64>>,
-) -> Vec<AuthoringChange> {
+fn report_changes(font: &Font, changes: Vec<FontChange>) -> Vec<AuthoringChange> {
     changes
         .into_iter()
         .filter_map(|change| match change {
@@ -239,8 +271,45 @@ fn report_changes(
             FontChange::SourceCreated(change) => Some(AuthoringChange::SourceCreated {
                 source_id: change.source_id.to_string(),
                 name: change.name,
-                location: source_location.clone().unwrap_or_default(),
+                location: change
+                    .location
+                    .into_iter()
+                    .filter_map(|coordinate| {
+                        let tag = font
+                            .axes()
+                            .iter()
+                            .find(|axis| axis.id() == coordinate.axis_id)?
+                            .tag()
+                            .to_string();
+                        Some((tag, coordinate.value))
+                    })
+                    .collect(),
             }),
+            FontChange::GlyphCreated(change) => Some(AuthoringChange::GlyphCreated {
+                glyph_id: change.glyph_id.to_string(),
+                name: change.name.to_string(),
+                unicodes: change
+                    .unicodes
+                    .into_iter()
+                    .map(|unicode| format!("U+{unicode:04X}"))
+                    .collect(),
+            }),
+            FontChange::GlyphLayerCreated(change) => {
+                let layer = font.layer(change.layer_id.clone())?;
+                Some(AuthoringChange::GlyphLayerCreated {
+                    layer_id: change.layer_id.to_string(),
+                    glyph_id: change.glyph_id.to_string(),
+                    source_id: change.source_id.to_string(),
+                    advance: layer.width(),
+                    contour_count: layer.contours().len(),
+                    point_count: layer
+                        .contours_iter()
+                        .map(|contour| contour.points().len())
+                        .sum(),
+                    anchor_count: layer.anchors().len(),
+                    component_count: layer.components().len(),
+                })
+            }
             FontChange::NamedInstancesUpdated(change) => {
                 Some(AuthoringChange::NamedInstancesUpdated {
                     count: change.instances.len(),
@@ -251,15 +320,10 @@ fn report_changes(
         .collect()
 }
 
-fn parse_location(
-    font: &Font,
-    coordinates: &[String],
-) -> Result<(Location, BTreeMap<String, f64>)> {
+fn parse_location(font: &Font, coordinates: &[String]) -> Result<Location> {
     let mut location = Location::new();
-    let mut rendered = BTreeMap::new();
     for axis in font.axes() {
         location.set(axis.id(), axis.default());
-        rendered.insert(axis.tag().to_string(), axis.default());
     }
 
     let mut seen = HashSet::new();
@@ -286,10 +350,9 @@ fn parse_location(
         }
 
         location.set(axis_id, value);
-        rendered.insert(tag.to_string(), value);
     }
 
-    Ok((location, rendered))
+    Ok(location)
 }
 
 fn mutation_destination(path: &Path, output: Option<&Path>) -> Result<PathBuf> {
@@ -314,173 +377,4 @@ fn validate_new_package_path(path: &Path) -> Result<()> {
 }
 
 #[cfg(test)]
-mod tests {
-    use std::fs;
-
-    use super::*;
-
-    fn mutation(dry_run: bool) -> MutationArgs {
-        MutationArgs {
-            output: None,
-            dry_run,
-            json: false,
-        }
-    }
-
-    fn create_package(path: &Path) {
-        create_font(CreateFontArgs {
-            path: path.to_path_buf(),
-            dry_run: false,
-            json: false,
-        })
-        .unwrap();
-    }
-
-    fn weight_axis(path: &Path, mutation: MutationArgs) -> AddAxisArgs {
-        AddAxisArgs {
-            path: path.to_path_buf(),
-            id: Some("weight".to_string()),
-            tag: "wght".to_string(),
-            name: "Weight".to_string(),
-            minimum: 100.0,
-            default: 400.0,
-            maximum: 900.0,
-            mutation,
-        }
-    }
-
-    #[test]
-    fn create_font_writes_a_new_package_and_refuses_to_overwrite_it() {
-        let temp = tempfile::tempdir().unwrap();
-        let path = temp.path().join("Lab.shift");
-
-        let report = create_font(CreateFontArgs {
-            path: path.clone(),
-            dry_run: false,
-            json: false,
-        })
-        .unwrap();
-
-        assert!(report.wrote);
-        assert_eq!(
-            ShiftSourcePackage::load_font(&path)
-                .unwrap()
-                .sources()
-                .len(),
-            1
-        );
-        assert!(
-            create_font(CreateFontArgs {
-                path,
-                dry_run: false,
-                json: false,
-            })
-            .is_err()
-        );
-    }
-
-    #[test]
-    fn axis_dry_run_uses_real_validation_without_writing() {
-        let temp = tempfile::tempdir().unwrap();
-        let path = temp.path().join("Lab.shift");
-        create_package(&path);
-        let before = fs::read(&path).unwrap();
-
-        let report = add_axis(weight_axis(&path, mutation(true))).unwrap();
-
-        assert!(!report.wrote);
-        assert_eq!(fs::read(&path).unwrap(), before);
-        assert!(
-            ShiftSourcePackage::load_font(&path)
-                .unwrap()
-                .axes()
-                .is_empty()
-        );
-    }
-
-    #[test]
-    fn axis_mutation_preserves_package_identity() {
-        let temp = tempfile::tempdir().unwrap();
-        let path = temp.path().join("Lab.shift");
-        create_package(&path);
-        let package_id = ShiftSourcePackage::open(&path)
-            .unwrap()
-            .package_id()
-            .clone();
-
-        add_axis(weight_axis(&path, mutation(false))).unwrap();
-
-        let package = ShiftSourcePackage::open(&path).unwrap();
-        let font = ShiftSourcePackage::load_font(&path).unwrap();
-        assert_eq!(package.package_id(), &package_id);
-        assert_eq!(font.axes()[0].tag(), "wght");
-    }
-
-    #[test]
-    fn invalid_axis_does_not_change_the_package() {
-        let temp = tempfile::tempdir().unwrap();
-        let path = temp.path().join("Lab.shift");
-        create_package(&path);
-        let before = fs::read(&path).unwrap();
-        let mut args = weight_axis(&path, mutation(false));
-        args.minimum = 500.0;
-        args.default = 400.0;
-
-        assert!(add_axis(args).is_err());
-        assert_eq!(fs::read(&path).unwrap(), before);
-    }
-
-    #[test]
-    fn output_writes_an_independent_package_without_changing_input() {
-        let temp = tempfile::tempdir().unwrap();
-        let input = temp.path().join("Lab.shift");
-        let output = temp.path().join("Variant.shift");
-        create_package(&input);
-        let before = fs::read(&input).unwrap();
-        let mut options = mutation(false);
-        options.output = Some(output.clone());
-
-        add_axis(weight_axis(&input, options)).unwrap();
-
-        assert_eq!(fs::read(&input).unwrap(), before);
-        assert!(
-            ShiftSourcePackage::load_font(&input)
-                .unwrap()
-                .axes()
-                .is_empty()
-        );
-        assert_eq!(
-            ShiftSourcePackage::load_font(&output).unwrap().axes().len(),
-            1
-        );
-        assert_ne!(
-            ShiftSourcePackage::open(&input).unwrap().package_id(),
-            ShiftSourcePackage::open(&output).unwrap().package_id()
-        );
-    }
-
-    #[test]
-    fn source_location_is_completed_with_axis_defaults() {
-        let temp = tempfile::tempdir().unwrap();
-        let path = temp.path().join("Lab.shift");
-        create_package(&path);
-        add_axis(weight_axis(&path, mutation(false))).unwrap();
-
-        add_source(AddSourceArgs {
-            path: path.clone(),
-            id: Some("black".to_string()),
-            name: "Black".to_string(),
-            location: vec!["wght=900".to_string()],
-            mutation: mutation(false),
-        })
-        .unwrap();
-
-        let font = ShiftSourcePackage::load_font(&path).unwrap();
-        let source = font
-            .sources()
-            .iter()
-            .find(|source| source.name() == "Black")
-            .unwrap();
-        assert_eq!(source.location().get(&font.axes()[0].id()), Some(900.0));
-    }
-}
+mod tests;

--- a/crates/shift-cli/src/authoring/glyph.rs
+++ b/crates/shift-cli/src/authoring/glyph.rs
@@ -1,0 +1,300 @@
+//! Glyph identity and sparse authored-layer commands.
+//!
+//! The command path and selectors establish layer membership. A layer JSON
+//! payload owns only authored values: advance, contours, points, and anchors.
+//! Every payload is lowered to a single [`FontIntentSet`], preserving the same
+//! validation and all-or-nothing behavior as interactive authoring.
+
+use std::collections::HashSet;
+use std::io::{self, Read};
+use std::path::Path;
+
+use miette::{IntoDiagnostic, Result, WrapErr, bail, miette};
+use serde::Deserialize;
+use shift_font::{
+    AnchorId, AnchorSeed, ContourId, Font, FontIntent, FontIntentSet, GlyphId, LayerId, PointId,
+    PointSeed, PointType, SourceId,
+};
+use shift_source::ShiftSourcePackage;
+
+use crate::cli::{AddGlyphArgs, AddLayerArgs, CopyLayerArgs};
+
+use super::{AuthoringReport, apply_mutation};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct LayerInput {
+    advance: f64,
+    #[serde(default)]
+    contours: Vec<ContourInput>,
+    #[serde(default)]
+    anchors: Vec<AnchorInput>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ContourInput {
+    closed: bool,
+    points: Vec<PointInput>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct PointInput {
+    x: f64,
+    y: f64,
+    #[serde(default)]
+    point_type: PointType,
+    #[serde(default)]
+    smooth: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct AnchorInput {
+    name: Option<String>,
+    x: f64,
+    y: f64,
+}
+
+/// Adds glyph identity and Unicode assignments without implicitly creating geometry.
+///
+/// Unicode arguments use `U+XXXX` notation and preserve their command order.
+/// Authored layers remain explicit, separate mutations.
+///
+/// # Errors
+///
+/// Returns an error when a Unicode value is malformed, the glyph conflicts
+/// with existing identity, the package cannot be loaded, or saving fails.
+pub fn add_glyph(args: AddGlyphArgs) -> Result<AuthoringReport> {
+    let font = load_font(&args.path)?;
+    let unicodes = parse_unicodes(&args.unicode)?;
+    let set = FontIntentSet {
+        intents: vec![FontIntent::CreateGlyph {
+            glyph_id: None,
+            name: args.name,
+            unicodes,
+        }],
+    };
+
+    apply_mutation(&args.path, &args.mutation, font, set)
+}
+
+/// Adds one sparse authored layer from a semantic JSON payload.
+///
+/// Glyph and source selectors accept a unique authored name or a full stable
+/// id. The payload is read completely before mutation; `-` reads stdin. Shift
+/// mints every layer, contour, point, and anchor identity.
+///
+/// # Errors
+///
+/// Returns an error for unreadable or invalid JSON, unsupported payload
+/// fields, non-finite values, unresolved selectors, invalid authoring, or
+/// persistence failures.
+pub fn add_layer(args: AddLayerArgs) -> Result<AuthoringReport> {
+    let font = load_font(&args.path)?;
+    let glyph_id = resolve_glyph_id(&font, &args.glyph)?;
+    let source_id = resolve_source_id(&font, &args.source)?;
+    let layer_id = LayerId::new();
+    let input = read_layer_input(&args.input)?;
+    let set = layer_intents(layer_id, glyph_id, source_id, input)?;
+
+    apply_mutation(&args.path, &args.mutation, font, set)
+}
+
+/// Copies one glyph layer to another source with fresh internal identities.
+///
+/// The copied layer retains advance, contours, components, anchors, guidelines,
+/// and library data while receiving a new layer id, contour ids, point ids, and
+/// other internal identities.
+///
+/// # Errors
+///
+/// Returns an error when selectors cannot be resolved, the origin layer is
+/// absent, the destination already owns a layer for the glyph, or saving fails.
+pub fn copy_layer(args: CopyLayerArgs) -> Result<AuthoringReport> {
+    let font = load_font(&args.path)?;
+    let glyph_id = resolve_glyph_id(&font, &args.glyph)?;
+    let from_source_id = resolve_source_id(&font, &args.from_source)?;
+    let source_id = resolve_source_id(&font, &args.source)?;
+    let from_layer_id = font
+        .layer_id_for_glyph_source(glyph_id.clone(), from_source_id.clone())
+        .ok_or_else(|| {
+            miette!(
+                "glyph {:?} has no authored layer at source {:?}",
+                args.glyph,
+                args.from_source
+            )
+        })?;
+    let layer_id = LayerId::new();
+    let set = FontIntentSet {
+        intents: vec![FontIntent::CloneGlyphLayer {
+            layer_id,
+            glyph_id,
+            source_id,
+            from_layer_id,
+        }],
+    };
+
+    apply_mutation(&args.path, &args.mutation, font, set)
+}
+
+fn load_font(path: &Path) -> Result<Font> {
+    ShiftSourcePackage::load_font(path)
+        .into_diagnostic()
+        .wrap_err("failed to load Shift font")
+}
+
+fn parse_unicodes(values: &[String]) -> Result<Vec<u32>> {
+    let mut seen = HashSet::new();
+    let mut unicodes = Vec::with_capacity(values.len());
+
+    for value in values {
+        let digits = value
+            .strip_prefix("U+")
+            .or_else(|| value.strip_prefix("u+"))
+            .ok_or_else(|| miette!("invalid Unicode {value:?}; expected U+XXXX"))?;
+        if digits.is_empty() {
+            bail!("invalid Unicode {value:?}; expected hexadecimal digits after U+");
+        }
+        let scalar = u32::from_str_radix(digits, 16)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("invalid Unicode {value:?}"))?;
+        if char::from_u32(scalar).is_none() {
+            bail!("Unicode {value:?} is not a scalar value");
+        }
+        if !seen.insert(scalar) {
+            bail!("Unicode {value:?} is repeated");
+        }
+
+        unicodes.push(scalar);
+    }
+
+    Ok(unicodes)
+}
+
+fn read_layer_input(path: &Path) -> Result<LayerInput> {
+    let mut json = String::new();
+    if path == Path::new("-") {
+        io::stdin()
+            .read_to_string(&mut json)
+            .into_diagnostic()
+            .wrap_err("failed to read layer payload from stdin")?;
+    } else {
+        json = std::fs::read_to_string(path)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to read layer payload from {}", path.display()))?;
+    }
+
+    serde_json::from_str(&json)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("invalid layer payload from {}", path.display()))
+}
+
+fn layer_intents(
+    layer_id: LayerId,
+    glyph_id: GlyphId,
+    source_id: SourceId,
+    input: LayerInput,
+) -> Result<FontIntentSet> {
+    require_finite(input.advance, "layer advance")?;
+    let mut intents = vec![
+        FontIntent::CreateGlyphLayer {
+            layer_id: layer_id.clone(),
+            glyph_id,
+            source_id,
+        },
+        FontIntent::SetXAdvance {
+            layer_id: layer_id.clone(),
+            width: input.advance,
+        },
+    ];
+    for contour in input.contours {
+        let contour_id = ContourId::new();
+        let mut points = Vec::with_capacity(contour.points.len());
+
+        for point in contour.points {
+            require_finite(point.x, "point x")?;
+            require_finite(point.y, "point y")?;
+            points.push(PointSeed {
+                id: PointId::new(),
+                x: point.x,
+                y: point.y,
+                point_type: point.point_type,
+                smooth: point.smooth,
+            });
+        }
+
+        intents.push(FontIntent::AddContour {
+            layer_id: layer_id.clone(),
+            contour_id: contour_id.clone(),
+            closed: contour.closed,
+        });
+        if !points.is_empty() {
+            intents.push(FontIntent::AddPoints {
+                layer_id: layer_id.clone(),
+                contour_id: Some(contour_id),
+                before: None,
+                points,
+            });
+        }
+    }
+
+    let mut anchors = Vec::with_capacity(input.anchors.len());
+    for anchor in input.anchors {
+        require_finite(anchor.x, "anchor x")?;
+        require_finite(anchor.y, "anchor y")?;
+        anchors.push(AnchorSeed {
+            id: AnchorId::new(),
+            name: anchor.name,
+            x: anchor.x,
+            y: anchor.y,
+        });
+    }
+    if !anchors.is_empty() {
+        intents.push(FontIntent::AddAnchors { layer_id, anchors });
+    }
+
+    Ok(FontIntentSet { intents })
+}
+
+fn resolve_glyph_id(font: &Font, selector: &str) -> Result<GlyphId> {
+    if let Ok(glyph_id) = selector.parse::<GlyphId>()
+        && font.glyph(glyph_id.clone()).is_some()
+    {
+        return Ok(glyph_id);
+    }
+    if let Some(glyph_id) = font.glyph_id_by_name(selector) {
+        return Ok(glyph_id);
+    }
+
+    Err(miette!(
+        "glyph {selector:?} does not exist; use its name or full glyph_ id"
+    ))
+}
+
+fn resolve_source_id(font: &Font, selector: &str) -> Result<SourceId> {
+    if let Ok(source_id) = selector.parse::<SourceId>()
+        && font.sources().iter().any(|source| source.id() == source_id)
+    {
+        return Ok(source_id);
+    }
+    if let Some(source) = font
+        .sources()
+        .iter()
+        .find(|source| source.name() == selector)
+    {
+        return Ok(source.id());
+    }
+
+    Err(miette!(
+        "source {selector:?} does not exist; use its name or full source_ id"
+    ))
+}
+
+fn require_finite(value: f64, label: &str) -> Result<()> {
+    if !value.is_finite() {
+        bail!("{label} must be finite");
+    }
+    Ok(())
+}

--- a/crates/shift-cli/src/authoring/tests.rs
+++ b/crates/shift-cli/src/authoring/tests.rs
@@ -1,0 +1,171 @@
+use std::fs;
+use std::path::Path;
+
+use shift_source::ShiftSourcePackage;
+
+use crate::cli::{AddAxisArgs, AddSourceArgs, CreateFontArgs, MutationArgs};
+
+use super::{add_axis, add_source, create_font};
+
+fn mutation(dry_run: bool) -> MutationArgs {
+    MutationArgs {
+        output: None,
+        dry_run,
+        json: false,
+    }
+}
+
+fn create_package(path: &Path) {
+    create_font(CreateFontArgs {
+        path: path.to_path_buf(),
+        dry_run: false,
+        json: false,
+    })
+    .unwrap();
+}
+
+fn weight_axis(path: &Path, mutation: MutationArgs) -> AddAxisArgs {
+    AddAxisArgs {
+        path: path.to_path_buf(),
+        tag: "wght".to_string(),
+        name: "Weight".to_string(),
+        minimum: 100.0,
+        default: 400.0,
+        maximum: 900.0,
+        mutation,
+    }
+}
+
+#[test]
+fn create_font_writes_a_new_package_and_refuses_to_overwrite_it() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("Lab.shift");
+
+    let report = create_font(CreateFontArgs {
+        path: path.clone(),
+        dry_run: false,
+        json: false,
+    })
+    .unwrap();
+
+    assert!(report.wrote);
+    assert_eq!(
+        ShiftSourcePackage::load_font(&path)
+            .unwrap()
+            .sources()
+            .len(),
+        1
+    );
+    assert!(
+        create_font(CreateFontArgs {
+            path,
+            dry_run: false,
+            json: false,
+        })
+        .is_err()
+    );
+}
+
+#[test]
+fn axis_dry_run_uses_real_validation_without_writing() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("Lab.shift");
+    create_package(&path);
+    let before = fs::read(&path).unwrap();
+
+    let report = add_axis(weight_axis(&path, mutation(true))).unwrap();
+
+    assert!(!report.wrote);
+    assert_eq!(fs::read(&path).unwrap(), before);
+    assert!(
+        ShiftSourcePackage::load_font(&path)
+            .unwrap()
+            .axes()
+            .is_empty()
+    );
+}
+
+#[test]
+fn axis_mutation_preserves_package_identity() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("Lab.shift");
+    create_package(&path);
+    let package_id = ShiftSourcePackage::open(&path)
+        .unwrap()
+        .package_id()
+        .clone();
+
+    add_axis(weight_axis(&path, mutation(false))).unwrap();
+
+    let package = ShiftSourcePackage::open(&path).unwrap();
+    let font = ShiftSourcePackage::load_font(&path).unwrap();
+    assert_eq!(package.package_id(), &package_id);
+    assert_eq!(font.axes()[0].tag(), "wght");
+}
+
+#[test]
+fn invalid_axis_does_not_change_the_package() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("Lab.shift");
+    create_package(&path);
+    let before = fs::read(&path).unwrap();
+    let mut args = weight_axis(&path, mutation(false));
+    args.minimum = 500.0;
+    args.default = 400.0;
+
+    assert!(add_axis(args).is_err());
+    assert_eq!(fs::read(&path).unwrap(), before);
+}
+
+#[test]
+fn output_writes_an_independent_package_without_changing_input() {
+    let temp = tempfile::tempdir().unwrap();
+    let input = temp.path().join("Lab.shift");
+    let output = temp.path().join("Variant.shift");
+    create_package(&input);
+    let before = fs::read(&input).unwrap();
+    let mut options = mutation(false);
+    options.output = Some(output.clone());
+
+    add_axis(weight_axis(&input, options)).unwrap();
+
+    assert_eq!(fs::read(&input).unwrap(), before);
+    assert!(
+        ShiftSourcePackage::load_font(&input)
+            .unwrap()
+            .axes()
+            .is_empty()
+    );
+    assert_eq!(
+        ShiftSourcePackage::load_font(&output).unwrap().axes().len(),
+        1
+    );
+    assert_ne!(
+        ShiftSourcePackage::open(&input).unwrap().package_id(),
+        ShiftSourcePackage::open(&output).unwrap().package_id()
+    );
+}
+
+#[test]
+fn source_location_is_completed_with_axis_defaults() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("Lab.shift");
+    create_package(&path);
+    add_axis(weight_axis(&path, mutation(false))).unwrap();
+
+    add_source(AddSourceArgs {
+        path: path.clone(),
+        name: "Black".to_string(),
+        location: vec!["wght=900".to_string()],
+        mutation: mutation(false),
+    })
+    .unwrap();
+
+    let font = ShiftSourcePackage::load_font(&path).unwrap();
+    let source = font
+        .sources()
+        .iter()
+        .find(|source| source.name() == "Black")
+        .unwrap();
+    assert_eq!(source.location().get(&font.axes()[0].id()), Some(900.0));
+}

--- a/crates/shift-cli/src/cli.rs
+++ b/crates/shift-cli/src/cli.rs
@@ -53,6 +53,18 @@ pub enum Command {
         #[command(subcommand)]
         command: SourceCommand,
     },
+
+    /// Author glyph identities.
+    Glyph {
+        #[command(subcommand)]
+        command: GlyphCommand,
+    },
+
+    /// Author sparse glyph layers.
+    Layer {
+        #[command(subcommand)]
+        command: LayerCommand,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -71,6 +83,21 @@ pub enum AxisCommand {
 pub enum SourceCommand {
     /// Add a master source at a design-space location.
     Add(AddSourceArgs),
+}
+
+#[derive(Debug, Subcommand)]
+pub enum GlyphCommand {
+    /// Add glyph identity and Unicode assignments without creating layers.
+    Add(AddGlyphArgs),
+}
+
+#[derive(Debug, Subcommand)]
+pub enum LayerCommand {
+    /// Add one authored layer from a semantic JSON payload.
+    Add(AddLayerArgs),
+
+    /// Copy one glyph's authored layer to another source with fresh internal ids.
+    Copy(CopyLayerArgs),
 }
 
 #[derive(Debug, Args)]
@@ -93,10 +120,6 @@ pub struct AddAxisArgs {
     /// Path to the canonical .shift source package.
     #[arg(value_hint = ValueHint::FilePath)]
     pub path: PathBuf,
-
-    /// Caller-minted stable identity; the axis_ prefix is optional.
-    #[arg(long)]
-    pub id: Option<String>,
 
     /// Four-character OpenType axis tag.
     #[arg(long)]
@@ -128,10 +151,6 @@ pub struct AddSourceArgs {
     #[arg(value_hint = ValueHint::FilePath)]
     pub path: PathBuf,
 
-    /// Caller-minted stable identity; the source_ prefix is optional.
-    #[arg(long)]
-    pub id: Option<String>,
-
     /// Human-readable source name.
     #[arg(long)]
     pub name: String,
@@ -139,6 +158,67 @@ pub struct AddSourceArgs {
     /// Design-space coordinate as TAG=VALUE; repeat or comma-separate values.
     #[arg(long, value_name = "TAG=VALUE", value_delimiter = ',')]
     pub location: Vec<String>,
+
+    #[command(flatten)]
+    pub mutation: MutationArgs,
+}
+
+#[derive(Debug, Args)]
+pub struct AddGlyphArgs {
+    /// Path to the canonical .shift source package.
+    #[arg(value_hint = ValueHint::FilePath)]
+    pub path: PathBuf,
+
+    /// Glyph name, such as A or a.alt.
+    pub name: String,
+
+    /// Unicode scalar in U+XXXX form; repeat or comma-separate values.
+    #[arg(long, value_name = "U+XXXX", value_delimiter = ',')]
+    pub unicode: Vec<String>,
+
+    #[command(flatten)]
+    pub mutation: MutationArgs,
+}
+
+#[derive(Debug, Args)]
+pub struct AddLayerArgs {
+    /// Path to the canonical .shift source package.
+    #[arg(value_hint = ValueHint::FilePath)]
+    pub path: PathBuf,
+
+    /// Glyph name or full stable glyph id.
+    #[arg(long)]
+    pub glyph: String,
+
+    /// Source name or full stable source id.
+    #[arg(long)]
+    pub source: String,
+
+    /// JSON layer payload path, or - to read it from stdin.
+    #[arg(long, value_hint = ValueHint::FilePath)]
+    pub input: PathBuf,
+
+    #[command(flatten)]
+    pub mutation: MutationArgs,
+}
+
+#[derive(Debug, Args)]
+pub struct CopyLayerArgs {
+    /// Path to the canonical .shift source package.
+    #[arg(value_hint = ValueHint::FilePath)]
+    pub path: PathBuf,
+
+    /// Glyph name or full stable glyph id.
+    #[arg(long)]
+    pub glyph: String,
+
+    /// Source owning the layer to copy, by name or full stable id.
+    #[arg(long = "from-source")]
+    pub from_source: String,
+
+    /// Destination source, by name or full stable id.
+    #[arg(long)]
+    pub source: String,
 
     #[command(flatten)]
     pub mutation: MutationArgs,

--- a/crates/shift-cli/src/cli.rs
+++ b/crates/shift-cli/src/cli.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use anstyle::{AnsiColor, Effects};
 use clap::builder::styling::Styles;
-use clap::{ColorChoice, Parser, Subcommand, ValueHint};
+use clap::{Args, ColorChoice, Parser, Subcommand, ValueHint};
 
 use crate::inspect::InspectView;
 
@@ -35,6 +35,128 @@ pub enum Command {
 
     /// Compile a .shift source package to a TrueType font.
     Compile(CompileArgs),
+
+    /// Create a Shift font document.
+    Font {
+        #[command(subcommand)]
+        command: FontCommand,
+    },
+
+    /// Author variable-font axes.
+    Axis {
+        #[command(subcommand)]
+        command: AxisCommand,
+    },
+
+    /// Author master sources.
+    Source {
+        #[command(subcommand)]
+        command: SourceCommand,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum FontCommand {
+    /// Create a new .shift document with its default Regular source.
+    Create(CreateFontArgs),
+}
+
+#[derive(Debug, Subcommand)]
+pub enum AxisCommand {
+    /// Add a continuous axis.
+    Add(AddAxisArgs),
+}
+
+#[derive(Debug, Subcommand)]
+pub enum SourceCommand {
+    /// Add a master source at a design-space location.
+    Add(AddSourceArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct CreateFontArgs {
+    /// Path for the new canonical .shift source package.
+    #[arg(value_hint = ValueHint::FilePath)]
+    pub path: PathBuf,
+
+    /// Validate and describe the creation without writing.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Emit a structured result for scripts and agents.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct AddAxisArgs {
+    /// Path to the canonical .shift source package.
+    #[arg(value_hint = ValueHint::FilePath)]
+    pub path: PathBuf,
+
+    /// Caller-minted stable identity; the axis_ prefix is optional.
+    #[arg(long)]
+    pub id: Option<String>,
+
+    /// Four-character OpenType axis tag.
+    #[arg(long)]
+    pub tag: String,
+
+    /// Human-readable axis name.
+    #[arg(long)]
+    pub name: String,
+
+    /// Minimum external/design value.
+    #[arg(long = "min")]
+    pub minimum: f64,
+
+    /// Default external/design value.
+    #[arg(long)]
+    pub default: f64,
+
+    /// Maximum external/design value.
+    #[arg(long = "max")]
+    pub maximum: f64,
+
+    #[command(flatten)]
+    pub mutation: MutationArgs,
+}
+
+#[derive(Debug, Args)]
+pub struct AddSourceArgs {
+    /// Path to the canonical .shift source package.
+    #[arg(value_hint = ValueHint::FilePath)]
+    pub path: PathBuf,
+
+    /// Caller-minted stable identity; the source_ prefix is optional.
+    #[arg(long)]
+    pub id: Option<String>,
+
+    /// Human-readable source name.
+    #[arg(long)]
+    pub name: String,
+
+    /// Design-space coordinate as TAG=VALUE; repeat or comma-separate values.
+    #[arg(long, value_name = "TAG=VALUE", value_delimiter = ',')]
+    pub location: Vec<String>,
+
+    #[command(flatten)]
+    pub mutation: MutationArgs,
+}
+
+#[derive(Debug, Args)]
+pub struct MutationArgs {
+    /// Write a new independent package instead of modifying the input.
+    #[arg(long, value_hint = ValueHint::FilePath)]
+    pub output: Option<PathBuf>,
+
+    /// Validate and describe the mutation without writing.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Emit a structured result for scripts and agents.
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Debug, Parser)]

--- a/crates/shift-cli/src/main.rs
+++ b/crates/shift-cli/src/main.rs
@@ -1,10 +1,12 @@
+mod authoring;
 mod cli;
 mod inspect;
 
 use std::io::{self, IsTerminal, Write};
 
+use authoring::{AuthoringReport, add_axis, add_source, create_font};
 use clap::Parser;
-use cli::{Cli, Command, CompileArgs};
+use cli::{AxisCommand, Cli, Command, CompileArgs, FontCommand, SourceCommand};
 use inspect::{InspectReport, RenderMode};
 use miette::IntoDiagnostic;
 use shift_backends::{ExportFormat, FontExportRequest, FontExportResult, FontExporter};
@@ -17,7 +19,63 @@ fn main() -> miette::Result<()> {
             let result = compile(args)?;
             write_stdout(&result.path.display().to_string())
         }
+        Command::Font { command } => match command {
+            FontCommand::Create(args) => {
+                let json = args.json;
+                write_authoring_result(create_font(args), json)
+            }
+        },
+        Command::Axis { command } => match command {
+            AxisCommand::Add(args) => {
+                let json = args.mutation.json;
+                write_authoring_result(add_axis(args), json)
+            }
+        },
+        Command::Source { command } => match command {
+            SourceCommand::Add(args) => {
+                let json = args.mutation.json;
+                write_authoring_result(add_source(args), json)
+            }
+        },
     }
+}
+
+fn write_authoring_result(
+    result: miette::Result<AuthoringReport>,
+    json: bool,
+) -> miette::Result<()> {
+    match result {
+        Ok(report) => write_authoring_report(report, json),
+        Err(error) if json => {
+            let mut messages = vec![error.to_string()];
+            let error_ref: &(dyn std::error::Error + Send + Sync + 'static) = error.as_ref();
+            let mut source = error_ref.source();
+            while let Some(cause) = source {
+                messages.push(cause.to_string());
+                source = cause.source();
+            }
+            let output = serde_json::to_string_pretty(&serde_json::json!({
+                "valid": false,
+                "error": {
+                    "summary": messages[0],
+                    "causes": &messages[1..],
+                }
+            }))
+            .into_diagnostic()?;
+            write_stdout(&output)?;
+            Err(error)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn write_authoring_report(report: AuthoringReport, json: bool) -> miette::Result<()> {
+    let output = if json {
+        serde_json::to_string_pretty(&report).into_diagnostic()?
+    } else {
+        report.render()
+    };
+    write_stdout(&output)
 }
 
 fn compile(args: CompileArgs) -> miette::Result<FontExportResult> {

--- a/crates/shift-cli/src/main.rs
+++ b/crates/shift-cli/src/main.rs
@@ -4,9 +4,13 @@ mod inspect;
 
 use std::io::{self, IsTerminal, Write};
 
-use authoring::{AuthoringReport, add_axis, add_source, create_font};
+use authoring::{
+    AuthoringReport, add_axis, add_glyph, add_layer, add_source, copy_layer, create_font,
+};
 use clap::Parser;
-use cli::{AxisCommand, Cli, Command, CompileArgs, FontCommand, SourceCommand};
+use cli::{
+    AxisCommand, Cli, Command, CompileArgs, FontCommand, GlyphCommand, LayerCommand, SourceCommand,
+};
 use inspect::{InspectReport, RenderMode};
 use miette::IntoDiagnostic;
 use shift_backends::{ExportFormat, FontExportRequest, FontExportResult, FontExporter};
@@ -35,6 +39,22 @@ fn main() -> miette::Result<()> {
             SourceCommand::Add(args) => {
                 let json = args.mutation.json;
                 write_authoring_result(add_source(args), json)
+            }
+        },
+        Command::Glyph { command } => match command {
+            GlyphCommand::Add(args) => {
+                let json = args.mutation.json;
+                write_authoring_result(add_glyph(args), json)
+            }
+        },
+        Command::Layer { command } => match command {
+            LayerCommand::Add(args) => {
+                let json = args.mutation.json;
+                write_authoring_result(add_layer(args), json)
+            }
+            LayerCommand::Copy(args) => {
+                let json = args.mutation.json;
+                write_authoring_result(copy_layer(args), json)
             }
         },
     }

--- a/crates/shift-cli/tests/authoring_cli.rs
+++ b/crates/shift-cli/tests/authoring_cli.rs
@@ -1,0 +1,151 @@
+use std::process::{Command, Output};
+
+use serde_json::Value;
+use shift_source::ShiftSourcePackage;
+
+fn shift(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_shift-cli"))
+        .args(args)
+        .output()
+        .expect("shift CLI should run")
+}
+
+#[test]
+fn authors_axis_and_source_through_the_cli() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("Lab.shift");
+    let path = path.to_str().unwrap();
+
+    let created = shift(&["font", "create", path, "--json"]);
+    assert!(created.status.success(), "{:?}", created.stderr);
+
+    let axis = shift(&[
+        "axis",
+        "add",
+        path,
+        "--id",
+        "weight",
+        "--tag",
+        "wght",
+        "--name",
+        "Weight",
+        "--min",
+        "100",
+        "--default",
+        "400",
+        "--max",
+        "900",
+        "--json",
+    ]);
+    assert!(axis.status.success(), "{:?}", axis.stderr);
+    let report: Value = serde_json::from_slice(&axis.stdout).unwrap();
+    assert_eq!(report["valid"], true);
+    assert_eq!(report["wrote"], true);
+    assert_eq!(report["changes"][0]["kind"], "axisCreated");
+    assert_eq!(report["changes"][0]["axisId"], "axis_weight");
+
+    let source = shift(&[
+        "source",
+        "add",
+        path,
+        "--id",
+        "black",
+        "--name",
+        "Black",
+        "--location",
+        "wght=900",
+        "--json",
+    ]);
+    assert!(source.status.success(), "{:?}", source.stderr);
+
+    let font = ShiftSourcePackage::load_font(path).unwrap();
+    assert_eq!(font.axes()[0].tag(), "wght");
+    assert_eq!(font.sources().len(), 2);
+    assert_eq!(font.sources()[1].name(), "Black");
+    assert_eq!(
+        font.sources()[1].location().get(&font.axes()[0].id()),
+        Some(900.0)
+    );
+}
+
+#[test]
+fn dry_run_reports_a_valid_change_without_writing() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("Lab.shift");
+    let path = path.to_str().unwrap();
+    assert!(shift(&["font", "create", path]).status.success());
+
+    let output = shift(&[
+        "axis",
+        "add",
+        path,
+        "--tag",
+        "wght",
+        "--name",
+        "Weight",
+        "--min",
+        "100",
+        "--default",
+        "400",
+        "--max",
+        "900",
+        "--dry-run",
+        "--json",
+    ]);
+
+    assert!(output.status.success(), "{:?}", output.stderr);
+    let report: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(report["valid"], true);
+    assert_eq!(report["wrote"], false);
+    assert!(
+        ShiftSourcePackage::load_font(path)
+            .unwrap()
+            .axes()
+            .is_empty()
+    );
+}
+
+#[test]
+fn invalid_mutation_exits_nonzero_and_keeps_the_input_unchanged() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("Lab.shift");
+    let path_string = path.to_str().unwrap();
+    assert!(shift(&["font", "create", path_string]).status.success());
+    let before = std::fs::read(&path).unwrap();
+
+    let output = shift(&[
+        "axis",
+        "add",
+        path_string,
+        "--tag",
+        "wght",
+        "--name",
+        "Weight",
+        "--min",
+        "500",
+        "--default",
+        "400",
+        "--max",
+        "900",
+        "--json",
+    ]);
+
+    assert!(!output.status.success());
+    let report: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(report["valid"], false);
+    assert_eq!(report["error"]["summary"], "authoring change is invalid");
+    assert!(
+        report["error"]["causes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|cause| cause
+                .as_str()
+                .unwrap()
+                .contains("expected minimum <= default <= maximum"))
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("expected minimum <= default <= maximum")
+    );
+    assert_eq!(std::fs::read(path).unwrap(), before);
+}

--- a/crates/shift-cli/tests/authoring_cli.rs
+++ b/crates/shift-cli/tests/authoring_cli.rs
@@ -23,8 +23,6 @@ fn authors_axis_and_source_through_the_cli() {
         "axis",
         "add",
         path,
-        "--id",
-        "weight",
         "--tag",
         "wght",
         "--name",
@@ -42,14 +40,17 @@ fn authors_axis_and_source_through_the_cli() {
     assert_eq!(report["valid"], true);
     assert_eq!(report["wrote"], true);
     assert_eq!(report["changes"][0]["kind"], "axisCreated");
-    assert_eq!(report["changes"][0]["axisId"], "axis_weight");
+    assert!(
+        report["changes"][0]["axisId"]
+            .as_str()
+            .unwrap()
+            .starts_with("axis_")
+    );
 
     let source = shift(&[
         "source",
         "add",
         path,
-        "--id",
-        "black",
         "--name",
         "Black",
         "--location",

--- a/crates/shift-cli/tests/glyph_authoring_cli.rs
+++ b/crates/shift-cli/tests/glyph_authoring_cli.rs
@@ -1,0 +1,344 @@
+use std::io::Write;
+use std::process::{Command, Output, Stdio};
+
+use serde_json::Value;
+use shift_font::test_support::sample_font;
+use shift_source::ShiftSourcePackage;
+
+fn shift(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_shift-cli"))
+        .args(args)
+        .output()
+        .expect("shift CLI should run")
+}
+
+fn shift_with_stdin(args: &[&str], input: &str) -> Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_shift-cli"))
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("shift CLI should run");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+    child.wait_with_output().unwrap()
+}
+
+#[test]
+fn authors_glyph_geometry_and_copies_a_layer_through_the_cli() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("Lab.shift");
+    let input = temp.path().join("A-regular.json");
+    let path_string = path.to_str().unwrap();
+    std::fs::write(
+        &input,
+        r#"{
+          "advance": 600,
+          "contours": [{
+            "closed": true,
+            "points": [
+              {"x": 0, "y": 0},
+              {"x": 300, "y": 700},
+              {"x": 600, "y": 0}
+            ]
+          }],
+          "anchors": [{"name": "top", "x": 300, "y": 700}]
+        }"#,
+    )
+    .unwrap();
+
+    assert!(shift(&["font", "create", path_string]).status.success());
+    assert!(
+        shift(&[
+            "axis",
+            "add",
+            path_string,
+            "--tag",
+            "wght",
+            "--name",
+            "Weight",
+            "--min",
+            "100",
+            "--default",
+            "400",
+            "--max",
+            "900",
+        ])
+        .status
+        .success()
+    );
+    assert!(
+        shift(&[
+            "source",
+            "add",
+            path_string,
+            "--name",
+            "Black",
+            "--location",
+            "wght=900",
+        ])
+        .status
+        .success()
+    );
+    let glyph = shift(&[
+        "glyph",
+        "add",
+        path_string,
+        "A",
+        "--unicode",
+        "U+0041",
+        "--json",
+    ]);
+    assert!(glyph.status.success(), "{:?}", glyph.stderr);
+    let report: Value = serde_json::from_slice(&glyph.stdout).unwrap();
+    assert!(
+        report["changes"][0]["glyphId"]
+            .as_str()
+            .unwrap()
+            .starts_with("glyph_")
+    );
+    assert_eq!(report["changes"][0]["unicodes"][0], "U+0041");
+
+    let added = shift(&[
+        "layer",
+        "add",
+        path_string,
+        "--glyph",
+        "A",
+        "--source",
+        "Regular",
+        "--input",
+        input.to_str().unwrap(),
+        "--json",
+    ]);
+    assert!(added.status.success(), "{:?}", added.stderr);
+    let report: Value = serde_json::from_slice(&added.stdout).unwrap();
+    assert_eq!(report["changes"][0]["kind"], "glyphLayerCreated");
+    assert_eq!(report["changes"][0]["pointCount"], 3);
+
+    let copied = shift(&[
+        "layer",
+        "copy",
+        path_string,
+        "--glyph",
+        "A",
+        "--from-source",
+        "Regular",
+        "--source",
+        "Black",
+    ]);
+    assert!(copied.status.success(), "{:?}", copied.stderr);
+
+    let font = ShiftSourcePackage::load_font(path_string).unwrap();
+    let glyph = font.glyph_by_name("A").unwrap();
+    assert_eq!(glyph.unicodes(), &[0x41]);
+    assert_eq!(glyph.layers().len(), 2);
+    let regular_source = font
+        .sources()
+        .iter()
+        .find(|source| source.name() == "Regular")
+        .unwrap();
+    let black_source = font
+        .sources()
+        .iter()
+        .find(|source| source.name() == "Black")
+        .unwrap();
+    let regular = glyph.layer_for_source(regular_source.id()).unwrap();
+    let black = glyph.layer_for_source(black_source.id()).unwrap();
+    assert_eq!(regular.width(), 600.0);
+    assert_eq!(black.width(), 600.0);
+    assert_eq!(regular.contours_iter().next().unwrap().points().len(), 3);
+    assert_ne!(
+        regular.contours_iter().next().unwrap().id(),
+        black.contours_iter().next().unwrap().id()
+    );
+    assert_eq!(regular.anchors()[0].name(), Some("top"));
+}
+
+#[test]
+fn reads_a_layer_payload_from_stdin() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("Lab.shift");
+    let path_string = path.to_str().unwrap();
+    assert!(shift(&["font", "create", path_string]).status.success());
+    assert!(
+        shift(&["glyph", "add", path_string, "space", "--unicode", "U+0020"])
+            .status
+            .success()
+    );
+
+    let output = shift_with_stdin(
+        &[
+            "layer",
+            "add",
+            path_string,
+            "--glyph",
+            "space",
+            "--source",
+            "Regular",
+            "--input",
+            "-",
+        ],
+        r#"{"advance": 250}"#,
+    );
+
+    assert!(output.status.success(), "{:?}", output.stderr);
+    let font = ShiftSourcePackage::load_font(path_string).unwrap();
+    let layer = font
+        .glyph_by_name("space")
+        .unwrap()
+        .layer_for_source(font.default_source_id().unwrap())
+        .unwrap();
+    assert_eq!(layer.width(), 250.0);
+    assert!(layer.contours().is_empty());
+}
+
+#[test]
+fn invalid_unicode_is_structured_and_does_not_create_a_glyph() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("Lab.shift");
+    let path_string = path.to_str().unwrap();
+    assert!(shift(&["font", "create", path_string]).status.success());
+    let before = std::fs::read(&path).unwrap();
+
+    let output = shift(&[
+        "glyph",
+        "add",
+        path_string,
+        "broken",
+        "--unicode",
+        "U+D800",
+        "--json",
+    ]);
+
+    assert!(!output.status.success());
+    let report: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(report["valid"], false);
+    assert!(
+        report["error"]["summary"]
+            .as_str()
+            .unwrap()
+            .contains("not a scalar value")
+    );
+    assert_eq!(std::fs::read(path).unwrap(), before);
+}
+
+#[test]
+fn payload_identity_is_rejected_without_creating_a_partial_layer() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("Lab.shift");
+    let path_string = path.to_str().unwrap();
+    assert!(shift(&["font", "create", path_string]).status.success());
+    assert!(shift(&["glyph", "add", path_string, "A"]).status.success());
+    let before = std::fs::read(&path).unwrap();
+
+    let output = shift_with_stdin(
+        &[
+            "layer",
+            "add",
+            path_string,
+            "--glyph",
+            "A",
+            "--source",
+            "Regular",
+            "--input",
+            "-",
+            "--json",
+        ],
+        r#"{
+          "advance": 600,
+          "contours": [{
+            "id": "caller-owned",
+            "closed": true,
+            "points": [
+              {"x": 0, "y": 0},
+              {"x": 100, "y": 100}
+            ]
+          }]
+        }"#,
+    );
+
+    assert!(!output.status.success());
+    let report: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(
+        report["error"]["summary"]
+            .as_str()
+            .unwrap()
+            .contains("invalid layer payload")
+    );
+    assert_eq!(std::fs::read(&path).unwrap(), before);
+    assert!(
+        ShiftSourcePackage::load_font(path_string)
+            .unwrap()
+            .glyph_by_name("A")
+            .unwrap()
+            .layers()
+            .is_empty()
+    );
+}
+
+#[test]
+fn copying_a_layer_preserves_components_with_fresh_identity() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("Lab.shift");
+    let path_string = path.to_str().unwrap();
+    ShiftSourcePackage::save_font(&path, &sample_font()).unwrap();
+    assert!(
+        shift(&[
+            "source",
+            "add",
+            path_string,
+            "--name",
+            "Light",
+            "--location",
+            "wght=100,wdth=75",
+        ])
+        .status
+        .success()
+    );
+
+    let output = shift(&[
+        "layer",
+        "copy",
+        path_string,
+        "--glyph",
+        "A",
+        "--from-source",
+        "Regular",
+        "--source",
+        "Light",
+    ]);
+
+    assert!(output.status.success(), "{:?}", output.stderr);
+    let font = ShiftSourcePackage::load_font(path_string).unwrap();
+    let glyph = font.glyph_by_name("A").unwrap();
+    let regular_source = font
+        .sources()
+        .iter()
+        .find(|source| source.name() == "Regular")
+        .unwrap();
+    let light_source = font
+        .sources()
+        .iter()
+        .find(|source| source.name() == "Light")
+        .unwrap();
+    let regular = glyph.layer_for_source(regular_source.id()).unwrap();
+    let light = glyph.layer_for_source(light_source.id()).unwrap();
+    assert_eq!(regular.components().len(), 2);
+    assert_eq!(light.components().len(), regular.components().len());
+    for (light_component, regular_component) in
+        light.components_iter().zip(regular.components_iter())
+    {
+        assert_eq!(
+            light_component.base_glyph_id(),
+            regular_component.base_glyph_id()
+        );
+        assert_eq!(light_component.transform(), regular_component.transform());
+        assert_ne!(light_component.id(), regular_component.id());
+    }
+}

--- a/crates/shift-font/docs/DOCS.md
+++ b/crates/shift-font/docs/DOCS.md
@@ -6,6 +6,7 @@ First-class Rust font object model for Shift.
 
 - **Architecture Invariant:** `shift-font` owns Shift authoring concepts and semantic validation, never format/compiler DTOs.
 - **Architecture Invariant:** Stable IDs are identity. Names, tags, Unicode assignments, and coordinates remain editable authoring values.
+- **Architecture Invariant:** Glyph-structure IDs are font-wide within their entity type. Contours, points, components, anchors, and glyph-layer guidelines are never addressed by a layer-qualified identity.
 - **Architecture Invariant:** Ordered, identity-addressable authoring collections use `EntityList`. Its iteration, equality, and serialization preserve authored order; its private backing container is not part of the model contract.
 - **Architecture Invariant:** Named instances own complete external locations but no source or geometry. Sources own design-space locations.
 - **Architecture Invariant:** Mapping edits never rewrite external named-instance intent.
@@ -55,6 +56,7 @@ Stable IDs are identity. Names and Unicode values are editable metadata.
 - `GlyphId` identifies a glyph.
 - `SourceId` identifies a source.
 - `LayerId` identifies a glyph layer: the authored data for one glyph at one source.
+- `ContourId`, `PointId`, `ComponentId`, `AnchorId`, and glyph-layer `GuidelineId` identify one authored node anywhere in the font; authoring operations mint them rather than accepting user-chosen values.
 - `AxisMappingId` identifies a font-owned mapping independently of its editable name.
 - `AxisLabelId` identifies an axis value label independently of its editable name or position.
 - `NamedInstanceId` identifies an explicit product preset independently of its editable name and location.

--- a/crates/shift-font/src/error.rs
+++ b/crates/shift-font/src/error.rs
@@ -1,6 +1,6 @@
 use crate::{
-    AnchorId, AxisId, AxisLabelId, AxisMappingId, ContourId, GlyphId, GlyphName, LayerId, MetricId,
-    MetricKind, NamedInstanceId, PointId, SourceId,
+    AnchorId, AxisId, AxisLabelId, AxisMappingId, ComponentId, ContourId, GlyphId, GlyphName,
+    GuidelineId, LayerId, MetricId, MetricKind, NamedInstanceId, PointId, SourceId,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -16,6 +16,12 @@ pub enum CoreError {
 
     #[error("anchor id {0} already exists")]
     DuplicateAnchorId(AnchorId),
+
+    #[error("component id {0} already exists")]
+    DuplicateComponentId(ComponentId),
+
+    #[error("guideline id {0} already exists")]
+    DuplicateGuidelineId(GuidelineId),
 
     #[error("invalid contour id {0}")]
     InvalidContourId(String),

--- a/crates/shift-font/src/intents.rs
+++ b/crates/shift-font/src/intents.rs
@@ -16,9 +16,9 @@ use crate::ir::{
 };
 use crate::layer_edit::BulkNodePositionUpdates;
 use crate::source::source_locations_equal;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
-/// A point to create, with its caller-minted id.
+/// A point to create, with stable identity minted by a trusted caller.
 #[derive(Clone, Debug)]
 pub struct PointSeed {
     pub id: PointId,
@@ -28,7 +28,7 @@ pub struct PointSeed {
     pub smooth: bool,
 }
 
-/// An anchor to create, with its caller-minted id.
+/// An anchor to create, with stable identity minted by a trusted caller.
 #[derive(Clone, Debug)]
 pub struct AnchorSeed {
     pub id: AnchorId,
@@ -802,75 +802,85 @@ impl Font {
                 before,
                 points,
             } => {
-                let layer = self.layer_mut_or_err(layer_id)?;
-
+                let mut point_ids = HashSet::new();
                 for seed in points {
-                    if layer.has_point(seed.id.clone()) {
+                    if self.has_point_id(&seed.id) || !point_ids.insert(seed.id.clone()) {
                         return Err(CoreError::DuplicatePointId(seed.id.clone()));
                     }
                 }
 
-                let contour_id = match (contour_id, before) {
-                    (Some(contour_id), _) => contour_id.clone(),
-                    (None, Some(before_id)) => layer.contour_of_point(before_id.clone())?,
-                    (None, None) => {
-                        return Err(CoreError::InvalidContourId(
-                            "addPoints requires a contour or a before anchor".to_string(),
-                        ));
+                let change = {
+                    let layer = self.layer_mut_or_err(layer_id)?;
+                    let contour_id = match (contour_id, before) {
+                        (Some(contour_id), _) => contour_id.clone(),
+                        (None, Some(before_id)) => layer.contour_of_point(before_id.clone())?,
+                        (None, None) => {
+                            return Err(CoreError::InvalidContourId(
+                                "addPoints requires a contour or a before anchor".to_string(),
+                            ));
+                        }
+                    };
+
+                    let contour = layer
+                        .contour_mut(contour_id.clone())
+                        .ok_or(CoreError::ContourNotFound(contour_id))?;
+
+                    let insert_at = match before {
+                        Some(before_id) => Some(
+                            contour
+                                .points()
+                                .iter()
+                                .position(|point| point.id() == *before_id)
+                                .ok_or(CoreError::PointNotFound(before_id.clone()))?,
+                        ),
+                        None => None,
+                    };
+
+                    let mut ids = Vec::with_capacity(points.len());
+                    for (offset, seed) in points.iter().enumerate() {
+                        let point = crate::ir::Point::new(
+                            seed.id.clone(),
+                            seed.x,
+                            seed.y,
+                            seed.point_type,
+                            seed.smooth,
+                        );
+
+                        match insert_at {
+                            Some(index) => contour.insert_point(index + offset, point),
+                            None => contour.push_point(point),
+                        }
+                        ids.push(seed.id.clone());
                     }
+
+                    FontChange::points_added(layer_id.clone(), contour, ids)
                 };
 
-                let contour = layer
-                    .contour_mut(contour_id.clone())
-                    .ok_or(CoreError::ContourNotFound(contour_id))?;
-
-                let insert_at = match before {
-                    Some(before_id) => Some(
-                        contour
-                            .points()
-                            .iter()
-                            .position(|point| point.id() == *before_id)
-                            .ok_or(CoreError::PointNotFound(before_id.clone()))?,
-                    ),
-                    None => None,
-                };
-
-                let mut ids = Vec::with_capacity(points.len());
-                for (offset, seed) in points.iter().enumerate() {
-                    let point = crate::ir::Point::new(
-                        seed.id.clone(),
-                        seed.x,
-                        seed.y,
-                        seed.point_type,
-                        seed.smooth,
-                    );
-
-                    match insert_at {
-                        Some(index) => contour.insert_point(index + offset, point),
-                        None => contour.push_point(point),
-                    }
-                    ids.push(seed.id.clone());
-                }
-
-                Ok(FontChange::points_added(layer_id.clone(), contour, ids))
+                self.record_point_ids(points.iter().map(|seed| seed.id.clone()));
+                Ok(change)
             }
             FontIntent::AddContour {
                 layer_id,
                 contour_id,
                 closed,
             } => {
-                let layer = self.layer_mut_or_err(layer_id)?;
-                if layer.contour(contour_id.clone()).is_some() {
+                if self.has_contour_id(contour_id) {
                     return Err(CoreError::DuplicateContourId(contour_id.clone()));
                 }
 
-                let mut contour = Contour::with_id(contour_id.clone());
-                if *closed {
-                    contour.close();
-                }
+                let change = {
+                    let layer = self.layer_mut_or_err(layer_id)?;
+                    let mut contour = Contour::with_id(contour_id.clone());
+                    if *closed {
+                        contour.close();
+                    }
 
-                layer.add_contour(contour.clone());
-                Ok(FontChange::contour_added(layer_id.clone(), &contour))
+                    layer.add_contour(contour.clone());
+                    FontChange::contour_added(layer_id.clone(), &contour)
+                };
+
+                self.record_contour_id(contour_id.clone());
+                Ok(change)
             }
             FontIntent::SetContourClosed {
                 layer_id,
@@ -945,30 +955,39 @@ impl Font {
                 layer_id,
                 point_ids,
             } => {
-                let layer = self.layer_mut_or_err(layer_id)?;
-                layer.remove_points(point_ids)?;
+                let change = {
+                    let layer = self.layer_mut_or_err(layer_id)?;
+                    layer.remove_points(point_ids)?;
+                    FontChange::layer_geometry_replaced(layer)
+                };
 
-                Ok(FontChange::layer_geometry_replaced(layer))
+                self.forget_point_ids(point_ids);
+                Ok(change)
             }
             FontIntent::AddAnchors { layer_id, anchors } => {
-                let layer = self.layer_mut_or_err(layer_id)?;
-
+                let mut anchor_ids = HashSet::new();
                 for seed in anchors {
-                    if layer.has_anchor(seed.id.clone()) {
+                    if self.has_anchor_id(&seed.id) || !anchor_ids.insert(seed.id.clone()) {
                         return Err(CoreError::DuplicateAnchorId(seed.id.clone()));
                     }
                 }
 
-                for seed in anchors {
-                    layer.add_anchor(Anchor::with_id(
-                        seed.id.clone(),
-                        seed.name.clone(),
-                        seed.x,
-                        seed.y,
-                    ));
-                }
+                let change = {
+                    let layer = self.layer_mut_or_err(layer_id)?;
+                    for seed in anchors {
+                        layer.add_anchor(Anchor::with_id(
+                            seed.id.clone(),
+                            seed.name.clone(),
+                            seed.x,
+                            seed.y,
+                        ));
+                    }
 
-                Ok(FontChange::layer_geometry_replaced(layer))
+                    FontChange::layer_geometry_replaced(layer)
+                };
+
+                self.record_anchor_ids(anchors.iter().map(|seed| seed.id.clone()));
+                Ok(change)
             }
             FontIntent::MoveAnchors {
                 layer_id,
@@ -1011,10 +1030,14 @@ impl Font {
                 layer_id,
                 anchor_ids,
             } => {
-                let layer = self.layer_mut_or_err(layer_id)?;
-                layer.remove_anchors(anchor_ids)?;
+                let change = {
+                    let layer = self.layer_mut_or_err(layer_id)?;
+                    layer.remove_anchors(anchor_ids)?;
+                    FontChange::layer_geometry_replaced(layer)
+                };
 
-                Ok(FontChange::layer_geometry_replaced(layer))
+                self.forget_anchor_ids(anchor_ids);
+                Ok(change)
             }
             FontIntent::ReverseContour {
                 layer_id,
@@ -1067,10 +1090,18 @@ impl Font {
                 contour_id_b,
                 operation,
             } => {
-                let layer = self.layer_mut_or_err(layer_id)?;
-                layer.apply_boolean_op(contour_id_a.clone(), contour_id_b.clone(), *operation)?;
+                let change = {
+                    let layer = self.layer_mut_or_err(layer_id)?;
+                    layer.apply_boolean_op(
+                        contour_id_a.clone(),
+                        contour_id_b.clone(),
+                        *operation,
+                    )?;
+                    FontChange::layer_geometry_replaced(layer)
+                };
 
-                Ok(FontChange::layer_geometry_replaced(layer))
+                self.rebuild_structure_index()?;
+                Ok(change)
             }
             FontIntent::CreateGlyph { .. }
             | FontIntent::UpdateGlyph { .. }
@@ -1160,6 +1191,45 @@ mod tests {
             result,
             Err(CoreError::DuplicateSourceLocation { .. })
         ));
+    }
+
+    #[test]
+    fn intent_set_rejects_contour_identity_used_by_another_layer() {
+        let mut font = Font::new();
+        let default_source_id = font.default_source_id().unwrap();
+        let contour_id = ContourId::from_raw("shared");
+        let glyph_id = GlyphId::new();
+        let mut contour = Contour::with_id(contour_id.clone());
+        contour.add_point(0.0, 0.0, PointType::OnCurve, false);
+        let mut layer = GlyphLayer::new(LayerId::new(), default_source_id);
+        layer.add_contour(contour);
+        let mut glyph = Glyph::with_id(glyph_id.clone(), "A");
+        glyph.set_layer(layer);
+        font.insert_glyph(glyph).unwrap();
+
+        let source_id = font.add_source(Source::new("Other".to_string(), Location::new()));
+        let layer_id = LayerId::new();
+        let mut candidate = font.clone();
+        let result = candidate.apply_intents(FontIntentSet {
+            intents: vec![
+                FontIntent::CreateGlyphLayer {
+                    layer_id: layer_id.clone(),
+                    glyph_id,
+                    source_id,
+                },
+                FontIntent::AddContour {
+                    layer_id,
+                    contour_id: contour_id.clone(),
+                    closed: true,
+                },
+            ],
+        });
+
+        assert!(matches!(
+            result,
+            Err(CoreError::DuplicateContourId(id)) if id == contour_id
+        ));
+        assert_eq!(font.glyphs().next().unwrap().layers().len(), 1);
     }
 
     #[test]

--- a/crates/shift-font/src/ir/font.rs
+++ b/crates/shift-font/src/ir/font.rs
@@ -1,7 +1,10 @@
 use crate::axis::{Axis, AxisMapping, Location};
 use crate::binary_data::BinaryData;
 use crate::collection::EntityList;
-use crate::entity::{AxisId, GlyphId, LayerId, MetricId, SourceId};
+use crate::entity::{
+    AnchorId, AxisId, ComponentId, ContourId, GlyphId, GuidelineId, LayerId, MetricId, PointId,
+    SourceId,
+};
 use crate::error::{CoreError, CoreResult};
 use crate::features::FeatureData;
 use crate::glyph::{Glyph, GlyphLayer};
@@ -123,6 +126,11 @@ struct FontIndex {
     layer_owner: HashMap<LayerId, GlyphId>,
     layer_by_glyph_source: HashMap<(GlyphId, SourceId), LayerId>,
     glyphs_by_unicode: HashMap<u32, Vec<GlyphId>>,
+    contour_ids: HashSet<ContourId>,
+    point_ids: HashSet<PointId>,
+    component_ids: HashSet<ComponentId>,
+    anchor_ids: HashSet<AnchorId>,
+    guideline_ids: HashSet<GuidelineId>,
 }
 
 impl FontIndex {
@@ -130,49 +138,8 @@ impl FontIndex {
         let mut index = Self::default();
 
         for (glyph_id, glyph) in glyphs.iter() {
-            if *glyph_id != glyph.id() {
-                return Err(CoreError::MismatchedGlyphId {
-                    key: glyph_id.clone(),
-                    glyph_id: glyph.id(),
-                });
-            }
-
-            if index
-                .glyph_by_name
-                .insert(glyph.glyph_name().clone(), glyph_id.clone())
-                .is_some()
-            {
-                return Err(CoreError::DuplicateGlyphName(glyph.glyph_name().clone()));
-            }
-
-            for unicode in glyph.unicodes() {
-                index
-                    .glyphs_by_unicode
-                    .entry(*unicode)
-                    .or_default()
-                    .push(glyph_id.clone());
-            }
-
-            for layer in glyph.layers().values().map(Arc::as_ref) {
-                if index
-                    .layer_owner
-                    .insert(layer.id(), glyph_id.clone())
-                    .is_some()
-                {
-                    return Err(CoreError::DuplicateLayerId(layer.id()));
-                }
-
-                if index
-                    .layer_by_glyph_source
-                    .insert((glyph_id.clone(), layer.source_id()), layer.id())
-                    .is_some()
-                {
-                    return Err(CoreError::DuplicateGlyphLayer {
-                        glyph_id: glyph_id.clone(),
-                        source_id: layer.source_id(),
-                    });
-                }
-            }
+            index.validate_glyph_insert(glyph_id.clone(), glyph)?;
+            index.insert_glyph(glyph_id.clone(), glyph);
         }
 
         Ok(index)
@@ -191,6 +158,12 @@ impl FontIndex {
         }
 
         let mut local_sources = HashSet::new();
+        let mut local_contours = HashSet::new();
+        let mut local_points = HashSet::new();
+        let mut local_components = HashSet::new();
+        let mut local_anchors = HashSet::new();
+        let mut local_guidelines = HashSet::new();
+
         for layer in glyph.layers().values().map(Arc::as_ref) {
             if self.layer_owner.contains_key(&layer.id()) {
                 return Err(CoreError::DuplicateLayerId(layer.id()));
@@ -206,9 +179,140 @@ impl FontIndex {
                     source_id: layer.source_id(),
                 });
             }
+
+            for contour in layer.contours_iter() {
+                if self.contour_ids.contains(&contour.id()) || !local_contours.insert(contour.id())
+                {
+                    return Err(CoreError::DuplicateContourId(contour.id()));
+                }
+
+                for point in contour.points() {
+                    if self.point_ids.contains(&point.id()) || !local_points.insert(point.id()) {
+                        return Err(CoreError::DuplicatePointId(point.id()));
+                    }
+                }
+            }
+
+            for component in layer.components_iter() {
+                if self.component_ids.contains(&component.id())
+                    || !local_components.insert(component.id())
+                {
+                    return Err(CoreError::DuplicateComponentId(component.id()));
+                }
+            }
+
+            for anchor in layer.anchors_iter() {
+                if self.anchor_ids.contains(&anchor.id()) || !local_anchors.insert(anchor.id()) {
+                    return Err(CoreError::DuplicateAnchorId(anchor.id()));
+                }
+            }
+
+            for guideline in layer.guidelines() {
+                if self.guideline_ids.contains(&guideline.id())
+                    || !local_guidelines.insert(guideline.id())
+                {
+                    return Err(CoreError::DuplicateGuidelineId(guideline.id()));
+                }
+            }
         }
 
         Ok(())
+    }
+
+    fn validate_layer_insert(&self, glyph_id: &GlyphId, layer: &GlyphLayer) -> CoreResult<()> {
+        if self.layer_owner.contains_key(&layer.id()) {
+            return Err(CoreError::DuplicateLayerId(layer.id()));
+        }
+
+        if self
+            .layer_by_glyph_source
+            .contains_key(&(glyph_id.clone(), layer.source_id()))
+        {
+            return Err(CoreError::DuplicateGlyphLayer {
+                glyph_id: glyph_id.clone(),
+                source_id: layer.source_id(),
+            });
+        }
+
+        let mut contour_ids = HashSet::new();
+        let mut point_ids = HashSet::new();
+        let mut component_ids = HashSet::new();
+        let mut anchor_ids = HashSet::new();
+        let mut guideline_ids = HashSet::new();
+
+        for contour in layer.contours_iter() {
+            if self.contour_ids.contains(&contour.id()) || !contour_ids.insert(contour.id()) {
+                return Err(CoreError::DuplicateContourId(contour.id()));
+            }
+
+            for point in contour.points() {
+                if self.point_ids.contains(&point.id()) || !point_ids.insert(point.id()) {
+                    return Err(CoreError::DuplicatePointId(point.id()));
+                }
+            }
+        }
+
+        for component in layer.components_iter() {
+            if self.component_ids.contains(&component.id()) || !component_ids.insert(component.id())
+            {
+                return Err(CoreError::DuplicateComponentId(component.id()));
+            }
+        }
+
+        for anchor in layer.anchors_iter() {
+            if self.anchor_ids.contains(&anchor.id()) || !anchor_ids.insert(anchor.id()) {
+                return Err(CoreError::DuplicateAnchorId(anchor.id()));
+            }
+        }
+
+        for guideline in layer.guidelines() {
+            if self.guideline_ids.contains(&guideline.id()) || !guideline_ids.insert(guideline.id())
+            {
+                return Err(CoreError::DuplicateGuidelineId(guideline.id()));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn insert_layer(&mut self, glyph_id: GlyphId, layer: &GlyphLayer) {
+        self.layer_owner.insert(layer.id(), glyph_id.clone());
+        self.layer_by_glyph_source
+            .insert((glyph_id, layer.source_id()), layer.id());
+
+        for contour in layer.contours_iter() {
+            self.contour_ids.insert(contour.id());
+            self.point_ids
+                .extend(contour.points().iter().map(|point| point.id()));
+        }
+        self.component_ids
+            .extend(layer.components_iter().map(|component| component.id()));
+        self.anchor_ids
+            .extend(layer.anchors_iter().map(|anchor| anchor.id()));
+        self.guideline_ids
+            .extend(layer.guidelines().iter().map(Guideline::id));
+    }
+
+    fn remove_layer(&mut self, glyph_id: GlyphId, layer: &GlyphLayer) {
+        self.layer_owner.remove(&layer.id());
+        self.layer_by_glyph_source
+            .remove(&(glyph_id, layer.source_id()));
+
+        for contour in layer.contours_iter() {
+            self.contour_ids.remove(&contour.id());
+            for point in contour.points() {
+                self.point_ids.remove(&point.id());
+            }
+        }
+        for component in layer.components_iter() {
+            self.component_ids.remove(&component.id());
+        }
+        for anchor in layer.anchors_iter() {
+            self.anchor_ids.remove(&anchor.id());
+        }
+        for guideline in layer.guidelines() {
+            self.guideline_ids.remove(&guideline.id());
+        }
     }
 
     fn insert_glyph(&mut self, glyph_id: GlyphId, glyph: &Glyph) {
@@ -223,9 +327,7 @@ impl FontIndex {
         }
 
         for layer in glyph.layers().values().map(Arc::as_ref) {
-            self.layer_owner.insert(layer.id(), glyph_id.clone());
-            self.layer_by_glyph_source
-                .insert((glyph_id.clone(), layer.source_id()), layer.id());
+            self.insert_layer(glyph_id.clone(), layer);
         }
     }
 
@@ -242,9 +344,7 @@ impl FontIndex {
         }
 
         for layer in glyph.layers().values().map(Arc::as_ref) {
-            self.layer_owner.remove(&layer.id());
-            self.layer_by_glyph_source
-                .remove(&(glyph_id.clone(), layer.source_id()));
+            self.remove_layer(glyph_id.clone(), layer);
         }
     }
 }
@@ -856,6 +956,63 @@ impl Font {
         Ok(glyph_id)
     }
 
+    /// Returns whether a contour identity is already in use anywhere in the font.
+    pub(crate) fn has_contour_id(&self, contour_id: &ContourId) -> bool {
+        self.index().contour_ids.contains(contour_id)
+    }
+
+    /// Returns whether a point identity is already in use anywhere in the font.
+    pub(crate) fn has_point_id(&self, point_id: &PointId) -> bool {
+        self.index().point_ids.contains(point_id)
+    }
+
+    /// Returns whether an anchor identity is already in use anywhere in the font.
+    pub(crate) fn has_anchor_id(&self, anchor_id: &AnchorId) -> bool {
+        self.index().anchor_ids.contains(anchor_id)
+    }
+
+    /// Records a contour minted by an in-place layer edit.
+    pub(crate) fn record_contour_id(&mut self, contour_id: ContourId) {
+        self.state_mut().index.contour_ids.insert(contour_id);
+    }
+
+    /// Records points minted by an in-place layer edit.
+    pub(crate) fn record_point_ids(&mut self, point_ids: impl IntoIterator<Item = PointId>) {
+        self.state_mut().index.point_ids.extend(point_ids);
+    }
+
+    /// Records anchors minted by an in-place layer edit.
+    pub(crate) fn record_anchor_ids(&mut self, anchor_ids: impl IntoIterator<Item = AnchorId>) {
+        self.state_mut().index.anchor_ids.extend(anchor_ids);
+    }
+
+    /// Forgets point identities removed by an in-place layer edit.
+    pub(crate) fn forget_point_ids(&mut self, point_ids: &[PointId]) {
+        for point_id in point_ids {
+            self.state_mut().index.point_ids.remove(point_id);
+        }
+    }
+
+    /// Forgets anchor identities removed by an in-place layer edit.
+    pub(crate) fn forget_anchor_ids(&mut self, anchor_ids: &[AnchorId]) {
+        for anchor_id in anchor_ids {
+            self.state_mut().index.anchor_ids.remove(anchor_id);
+        }
+    }
+
+    /// Rebuilds identity indexes after a structural operation mints nodes internally.
+    ///
+    /// # Errors
+    ///
+    /// Returns a duplicate-identity error when the resulting font structure
+    /// violates font-wide stable identity.
+    pub(crate) fn rebuild_structure_index(&mut self) -> CoreResult<()> {
+        let mut state = (*self.state).clone();
+        state.rebuild_index()?;
+        self.state = Arc::new(state);
+        Ok(())
+    }
+
     pub fn remove_glyph(&mut self, glyph_id: GlyphId) -> Option<Glyph> {
         let state = self.state_mut();
         let glyph = state
@@ -933,15 +1090,19 @@ impl Font {
             return Err(CoreError::SourceNotFound(layer.source_id()));
         }
 
-        let mut state = (*self.state).clone();
+        if self.glyph(glyph_id.clone()).is_none() {
+            return Err(CoreError::GlyphNotFound(glyph_id));
+        }
+        self.index().validate_layer_insert(&glyph_id, &layer)?;
+
+        let state = self.state_mut();
         let glyph = state
             .data
             .glyphs
             .get_mut(&glyph_id)
-            .ok_or(CoreError::GlyphNotFound(glyph_id))?;
-        Arc::make_mut(glyph).set_layer(layer);
-        state.rebuild_index()?;
-        self.state = Arc::new(state);
+            .expect("glyph existence was checked before mutation");
+        Arc::make_mut(glyph).set_layer(layer.clone());
+        state.index.insert_layer(glyph_id, &layer);
         Ok(())
     }
 
@@ -949,17 +1110,16 @@ impl Font {
         let glyph_id = self
             .glyph_id_by_layer(layer_id.clone())
             .ok_or(CoreError::LayerNotFound(layer_id.clone()))?;
-        let mut state = (*self.state).clone();
+        let state = self.state_mut();
         let glyph = state
             .data
             .glyphs
             .get_mut(&glyph_id)
-            .ok_or(CoreError::GlyphNotFound(glyph_id))?;
+            .ok_or(CoreError::GlyphNotFound(glyph_id.clone()))?;
         let layer = Arc::make_mut(glyph)
             .remove_layer(layer_id.clone())
             .ok_or(CoreError::LayerNotFound(layer_id))?;
-        state.rebuild_index()?;
-        self.state = Arc::new(state);
+        state.index.remove_layer(glyph_id, &layer);
         Ok(layer)
     }
 
@@ -1254,6 +1414,34 @@ mod tests {
         }
 
         font
+    }
+
+    #[test]
+    fn glyph_insert_rejects_contour_identity_used_by_another_layer() {
+        let mut font = Font::new();
+        let source_id = font.default_source_id().unwrap();
+        let contour_id = ContourId::from_raw("shared");
+
+        let mut first_contour = Contour::with_id(contour_id.clone());
+        first_contour.add_point(0.0, 0.0, PointType::OnCurve, false);
+        let mut first_layer = GlyphLayer::new(LayerId::new(), source_id.clone());
+        first_layer.add_contour(first_contour);
+        let mut first_glyph = Glyph::new("A");
+        first_glyph.set_layer(first_layer);
+        font.insert_glyph(first_glyph).unwrap();
+
+        let mut second_contour = Contour::with_id(contour_id.clone());
+        second_contour.add_point(100.0, 100.0, PointType::OnCurve, false);
+        let mut second_layer = GlyphLayer::new(LayerId::new(), source_id);
+        second_layer.add_contour(second_contour);
+        let mut second_glyph = Glyph::new("B");
+        second_glyph.set_layer(second_layer);
+
+        assert!(matches!(
+            font.insert_glyph(second_glyph),
+            Err(CoreError::DuplicateContourId(id)) if id == contour_id
+        ));
+        assert_eq!(font.glyph_count(), 1);
     }
 
     fn print_perf_mark(operation: &str, mark: PerfFontMark, elapsed: Duration) {


### PR DESCRIPTION
## Summary

- add semantic `font create`, `axis add`, and `source add` commands
- add glyph identity and sparse layer authoring through `glyph add`, `layer add`, and `layer copy`
- validate mutations against a cloned font and save only complete, valid results
- support stable JSON reports, dry runs, alternate output packages, stdin layer payloads, and name-or-ID selectors
- mint every creation identity inside Shift; callers consume returned IDs but cannot choose persistence identity
- preserve ordered contours/components when cloning layers while minting fresh internal identities
- reject font-wide duplicate glyph-structure identities before a malformed package reaches workspace persistence

## Scope

Layer payloads author advance, contours, points, and anchors. Existing components are preserved by `layer copy`, but creating new component references remains intentionally unsupported until `shift-font` has a semantic component-creation intent.

Identity is deliberately absent from creation flags and layer JSON. Human and agent workflows select existing entities by unique name or returned ID; creation primitives own all new axis, source, glyph, layer, contour, point, and anchor IDs.

The commands are intended both for human automation and for agents to build small `.shift` examples, fixtures, and interpolation investigations. Examples remain ordinary `.shift` packages rather than a special CLI example command.

## Validation

- `cargo test -p shift-cli` (17 unit tests and 8 compiled CLI process tests)
- `cargo test -p shift-font` (162 unit tests, including font-wide identity and large-font index coverage)
- `cargo clippy -p shift-font -p shift-cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- full pre-commit Rust workspace checks
- generated and inspected `/Users/kostyafarber/Downloads/ShiftVariationLab.shift` with five glyphs and 14 layers, including sparse and incompatible interpolation cases
- confirmed the earlier duplicate-ID package now fails during package loading instead of at the SQLite boundary
