### PR TITLE
Add structured glyph compatibility diagnostics

### DIFF
--- a/crates/shift-font/docs/DOCS.md
+++ b/crates/shift-font/docs/DOCS.md
@@ -44,6 +44,7 @@ crates/shift-font/src/
 - `GlyphLayer` is authored editable data for one glyph at one source.
 - `InterpolationBasis` is coordinate-independent variation math for an ordered source set. It contains normalized supports and source coefficient rows, never glyph coordinates or metrics.
 - `GlyphInterpolation` combines a reusable basis with one glyph's compatible authored source values. Its default-source template owns topology.
+- `LayerCompatibility` records every hard structural difference between an interpolation reference layer and another source layer. `LayerDifference` retains ordered path, node, anchor, and component evidence for diagnostics.
 - `GlyphProjection` is a compact location-independent glyph payload: fallback shape, optional compatible interpolation, exact-source shapes for incompatible topology, and component identities.
 - `FontProjection` is a read-only, location-bound view that reuses resolved component layers across one or many glyph requests.
 - `ResolvedGlyph` is derived, flattened geometry plus x advance. An existing blank glyph resolves to an empty contour list; a missing glyph resolves to `None`.
@@ -71,6 +72,10 @@ Stable IDs are identity. Names and Unicode values are editable metadata.
 - Stay independent of TypeScript, NAPI, and bridge DTOs.
 
 `Font::glyph_interpolation(glyph_id)` builds compatible source values over an `InterpolationBasis`. The default source defines structural topology. The basis depends only on axes and ordered source locations, so the same mechanism can interpolate other numeric domains without copying glyph concepts into them.
+
+`GlyphLayer::interpolation_compatibility_with(source)` is the source of truth for hard structural compatibility. The receiver is the interpolation reference. It compares paths, nodes, anchors, and components in authored order and never sorts them. OpenType requires corresponding outlines to have the same contour and point structure, and `gvar` addresses composite components by their ordered component index. Shift therefore treats component identity and order as structural. See the [OpenType Font Variations overview](https://learn.microsoft.com/en-us/typography/opentype/spec/otvaroverview), the [`gvar` composite processing rules](https://learn.microsoft.com/en-us/typography/opentype/spec/gvar#point-numbers-and-processing-for-composite-glyphs), and [fontTools interpolatability diagnostics](https://fonttools.readthedocs.io/en/latest/varLib/interpolatable.html).
+
+Coordinates, advance width, smooth flags, anchor positions, and component transforms are interpolated values, not structural compatibility. Matching anchor count, names, and order is currently a Shift-specific restriction because anchor positions share the ordered glyph interpolation vector; OpenType `gvar` and fontTools do not define source-anchor compatibility. Variable component scale or matrix transforms need a separate export diagnostic because `gvar` varies component placement rather than those transforms. Correspondence and quality warnings such as contour order, wrong start point, and kinks are separate from this hard structural result.
 
 `Font::glyph_projection(glyph_id)` preserves the preferred fallback, compatible interpolation, and incompatible authored source shapes without resolving a location. The fallback is normally the default-source layer and uses the glyph's preferred layer when the default source has no layer for that glyph. A renderer can retain this compact payload and combine its basis with current authored source signals. No arbitrary location result is persisted.
 

--- a/crates/shift-font/src/interpolation.rs
+++ b/crates/shift-font/src/interpolation.rs
@@ -9,9 +9,11 @@ use fontdrasil::variations::VariationModel;
 
 use crate::{Axis, AxisId, CoreError, CoreResult, Font, GlyphId, GlyphLayer, Location, SourceId};
 
+mod compatibility;
 mod metrics;
 mod values;
 
+pub use compatibility::{LayerCompatibility, LayerDifference};
 pub use metrics::{
     ResolvedSourceMetrics, SourceMetricField, SourceMetricInterpolation, SourceMetricValues,
 };
@@ -253,7 +255,10 @@ impl Font {
             let Some(layer) = glyph.layer_for_source(source.id()) else {
                 continue;
             };
-            if !layers_are_compatible(default_layer, layer) {
+            if !default_layer
+                .interpolation_compatibility_with(layer)
+                .is_compatible()
+            {
                 continue;
             }
 
@@ -356,46 +361,6 @@ fn normalized_location(location: &Location, axes: &[Axis]) -> NormalizedLocation
             Some((tag, NormalizedCoord::new(axis.normalize(value))))
         })
         .collect()
-}
-
-/// Returns whether two layers can share structure-ordered interpolation values.
-pub(crate) fn layers_are_compatible(template: &GlyphLayer, candidate: &GlyphLayer) -> bool {
-    if template.contours().len() != candidate.contours().len()
-        || template.anchors().len() != candidate.anchors().len()
-        || template.components().len() != candidate.components().len()
-    {
-        return false;
-    }
-
-    for (template, candidate) in template.contours_iter().zip(candidate.contours_iter()) {
-        if template.is_closed() != candidate.is_closed()
-            || template.points().len() != candidate.points().len()
-        {
-            return false;
-        }
-
-        if template
-            .points()
-            .iter()
-            .zip(candidate.points())
-            .any(|(template, candidate)| template.is_on_curve() != candidate.is_on_curve())
-        {
-            return false;
-        }
-    }
-
-    if template
-        .anchors_iter()
-        .zip(candidate.anchors_iter())
-        .any(|(template, candidate)| template.name() != candidate.name())
-    {
-        return false;
-    }
-
-    !template
-        .components_iter()
-        .zip(candidate.components_iter())
-        .any(|(template, candidate)| template.base_glyph_id() != candidate.base_glyph_id())
 }
 
 fn region_scalar(
@@ -520,7 +485,9 @@ mod tests {
             .unwrap();
         point.set_smooth(!point.is_smooth());
 
-        assert!(super::layers_are_compatible(template, &candidate));
+        assert!(template
+            .interpolation_compatibility_with(&candidate)
+            .is_compatible());
     }
 
     #[test]

--- a/crates/shift-font/src/interpolation/compatibility.rs
+++ b/crates/shift-font/src/interpolation/compatibility.rs
@@ -1,0 +1,423 @@
+//! Structural compatibility between ordered authored glyph layers.
+
+use crate::{GlyphId, GlyphLayer, PointType};
+
+/// One structural difference that prevents two glyph layers from sharing values.
+///
+/// Paths, nodes, anchors, and components are compared in authored order. This
+/// follows the positional correspondence required by outline interpolation and
+/// by OpenType `gvar`, where composite variation indices address components in
+/// glyph order.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum LayerDifference {
+    /// The layers contain different numbers of paths.
+    PathCount { reference: usize, source: usize },
+    /// The path at the given position is open in one layer and closed in the other.
+    PathClosed {
+        path: usize,
+        reference: bool,
+        source: bool,
+    },
+    /// Corresponding paths contain different numbers of nodes.
+    NodeCount {
+        path: usize,
+        reference: usize,
+        source: usize,
+    },
+    /// Corresponding nodes have different authored point kinds.
+    NodeKind {
+        path: usize,
+        node: usize,
+        reference: PointType,
+        source: PointType,
+    },
+    /// The layers contain different numbers of anchors.
+    ///
+    /// This is a Shift interpolation constraint, not an OpenType `gvar`
+    /// compatibility rule. Shift currently stores anchor positions in the
+    /// layer's ordered interpolation values.
+    AnchorCount { reference: usize, source: usize },
+    /// Corresponding anchors have different names or authored order.
+    ///
+    /// This is a Shift interpolation constraint, not an OpenType `gvar`
+    /// compatibility rule.
+    AnchorSequence {
+        reference: Vec<Option<String>>,
+        source: Vec<Option<String>>,
+    },
+    /// Component glyph identities differ by count, identity, or authored order.
+    ComponentSequence {
+        reference: Vec<GlyphId>,
+        source: Vec<GlyphId>,
+    },
+}
+
+/// Complete structural comparison of a source layer with a reference layer.
+///
+/// An empty difference list means that both layers can share Shift's canonical
+/// structure-ordered interpolation values. Coordinates, advance width, smooth
+/// flags, anchor positions, and component transforms are values rather than
+/// structural compatibility constraints.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[must_use]
+pub struct LayerCompatibility {
+    differences: Vec<LayerDifference>,
+}
+
+impl LayerCompatibility {
+    /// Returns whether the source can share the reference layer's structure.
+    pub fn is_compatible(&self) -> bool {
+        self.differences.is_empty()
+    }
+
+    /// Returns structural differences in deterministic authored order.
+    pub fn differences(&self) -> &[LayerDifference] {
+        &self.differences
+    }
+
+    /// Consumes the comparison and returns its structural differences.
+    pub fn into_differences(self) -> Vec<LayerDifference> {
+        self.differences
+    }
+}
+
+impl GlyphLayer {
+    /// Compares a source layer with this reference topology for interpolation.
+    ///
+    /// The comparison never sorts authored collections. Component identity at
+    /// a given position is significant because OpenType `gvar` addresses
+    /// composite components by their glyph order. When an enclosing path or
+    /// node count differs, nested differences are omitted to avoid cascading
+    /// diagnostics.
+    pub fn interpolation_compatibility_with(&self, source: &Self) -> LayerCompatibility {
+        let mut differences = Vec::new();
+
+        compare_paths(self, source, &mut differences);
+        compare_anchors(self, source, &mut differences);
+        compare_components(self, source, &mut differences);
+
+        LayerCompatibility { differences }
+    }
+}
+
+fn compare_paths(
+    reference: &GlyphLayer,
+    source: &GlyphLayer,
+    differences: &mut Vec<LayerDifference>,
+) {
+    if reference.contours().len() != source.contours().len() {
+        differences.push(LayerDifference::PathCount {
+            reference: reference.contours().len(),
+            source: source.contours().len(),
+        });
+        return;
+    }
+
+    for (path, (reference, source)) in reference
+        .contours_iter()
+        .zip(source.contours_iter())
+        .enumerate()
+    {
+        if reference.is_closed() != source.is_closed() {
+            differences.push(LayerDifference::PathClosed {
+                path,
+                reference: reference.is_closed(),
+                source: source.is_closed(),
+            });
+        }
+
+        if reference.points().len() != source.points().len() {
+            differences.push(LayerDifference::NodeCount {
+                path,
+                reference: reference.points().len(),
+                source: source.points().len(),
+            });
+            continue;
+        }
+
+        for (node, (reference, source)) in
+            reference.points().iter().zip(source.points()).enumerate()
+        {
+            if reference.point_type() == source.point_type() {
+                continue;
+            }
+
+            differences.push(LayerDifference::NodeKind {
+                path,
+                node,
+                reference: reference.point_type(),
+                source: source.point_type(),
+            });
+        }
+    }
+}
+
+fn compare_anchors(
+    reference: &GlyphLayer,
+    source: &GlyphLayer,
+    differences: &mut Vec<LayerDifference>,
+) {
+    if reference.anchors().len() != source.anchors().len() {
+        differences.push(LayerDifference::AnchorCount {
+            reference: reference.anchors().len(),
+            source: source.anchors().len(),
+        });
+        return;
+    }
+
+    let sequence_differs = reference
+        .anchors_iter()
+        .zip(source.anchors_iter())
+        .any(|(reference, source)| reference.name() != source.name());
+    if sequence_differs {
+        differences.push(LayerDifference::AnchorSequence {
+            reference: anchor_sequence(reference),
+            source: anchor_sequence(source),
+        });
+    }
+}
+
+fn anchor_sequence(layer: &GlyphLayer) -> Vec<Option<String>> {
+    layer
+        .anchors_iter()
+        .map(|anchor| anchor.name().map(ToOwned::to_owned))
+        .collect()
+}
+
+fn compare_components(
+    reference: &GlyphLayer,
+    source: &GlyphLayer,
+    differences: &mut Vec<LayerDifference>,
+) {
+    let sequence_differs = reference.components().len() != source.components().len()
+        || reference
+            .components_iter()
+            .zip(source.components_iter())
+            .any(|(reference, source)| reference.base_glyph_id() != source.base_glyph_id());
+    if sequence_differs {
+        differences.push(LayerDifference::ComponentSequence {
+            reference: component_sequence(reference),
+            source: component_sequence(source),
+        });
+    }
+}
+
+fn component_sequence(layer: &GlyphLayer) -> Vec<GlyphId> {
+    layer
+        .components_iter()
+        .map(|component| component.base_glyph_id())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Anchor, Component, Contour, LayerId, Point, SourceId};
+
+    fn layer() -> GlyphLayer {
+        let mut layer = GlyphLayer::with_width(
+            LayerId::from_raw("layer"),
+            SourceId::from_raw("source"),
+            600.0,
+        );
+        let mut contour = Contour::from_points(
+            vec![
+                Point::on_curve(0.0, 0.0),
+                Point::off_curve(50.0, 100.0),
+                Point::on_curve(100.0, 0.0),
+            ],
+            true,
+        );
+        contour.points_mut()[1].set_smooth(true);
+        layer.add_contour(contour);
+        layer.add_anchor(Anchor::new(Some("top".to_string()), 50.0, 100.0));
+        layer.add_component(Component::new(GlyphId::from_raw("C"), "C"));
+        layer.add_component(Component::new(GlyphId::from_raw("caron.cap"), "caron.cap"));
+        layer
+    }
+
+    #[test]
+    fn compatible_layers_may_change_interpolated_values_and_metadata() {
+        let reference = layer();
+        let mut source = reference.clone_with_fresh_ids(
+            LayerId::from_raw("source-layer"),
+            SourceId::from_raw("other-source"),
+        );
+        source.set_width(900.0);
+        source.contours_iter_mut().next().unwrap().points_mut()[0].set_position(200.0, 300.0);
+        source.contours_iter_mut().next().unwrap().points_mut()[1].set_smooth(false);
+        source
+            .anchors_iter_mut()
+            .next()
+            .unwrap()
+            .set_position(300.0, 400.0);
+        source
+            .components_iter_mut()
+            .next()
+            .unwrap()
+            .translate(50.0, 60.0);
+
+        assert!(reference
+            .interpolation_compatibility_with(&source)
+            .is_compatible());
+    }
+
+    #[test]
+    fn reports_each_hard_structural_difference() {
+        let reference = layer();
+
+        let mut path_count = reference.clone();
+        path_count.add_contour(Contour::new());
+        assert_eq!(
+            reference
+                .interpolation_compatibility_with(&path_count)
+                .differences(),
+            &[LayerDifference::PathCount {
+                reference: 1,
+                source: 2,
+            }]
+        );
+
+        let mut path_closed = reference.clone();
+        path_closed.contours_iter_mut().next().unwrap().open();
+        assert_eq!(
+            reference
+                .interpolation_compatibility_with(&path_closed)
+                .differences(),
+            &[LayerDifference::PathClosed {
+                path: 0,
+                reference: true,
+                source: false,
+            }]
+        );
+
+        let mut node_count = reference.clone();
+        node_count
+            .contours_iter_mut()
+            .next()
+            .unwrap()
+            .points_mut()
+            .pop();
+        assert_eq!(
+            reference
+                .interpolation_compatibility_with(&node_count)
+                .differences(),
+            &[LayerDifference::NodeCount {
+                path: 0,
+                reference: 3,
+                source: 2,
+            }]
+        );
+
+        let mut node_kind = reference.clone();
+        node_kind.contours_iter_mut().next().unwrap().points_mut()[0]
+            .set_point_type(PointType::QCurve);
+        assert_eq!(
+            reference
+                .interpolation_compatibility_with(&node_kind)
+                .differences(),
+            &[LayerDifference::NodeKind {
+                path: 0,
+                node: 0,
+                reference: PointType::OnCurve,
+                source: PointType::QCurve,
+            }]
+        );
+
+        let mut anchor_count = reference.clone();
+        anchor_count.clear_anchors();
+        assert_eq!(
+            reference
+                .interpolation_compatibility_with(&anchor_count)
+                .differences(),
+            &[LayerDifference::AnchorCount {
+                reference: 1,
+                source: 0,
+            }]
+        );
+
+        let mut anchor_sequence = reference.clone();
+        anchor_sequence
+            .anchors_iter_mut()
+            .next()
+            .unwrap()
+            .set_name(Some("bottom".to_string()));
+        assert_eq!(
+            reference
+                .interpolation_compatibility_with(&anchor_sequence)
+                .differences(),
+            &[LayerDifference::AnchorSequence {
+                reference: vec![Some("top".to_string())],
+                source: vec![Some("bottom".to_string())],
+            }]
+        );
+
+        let mut component_sequence = GlyphLayer::new(
+            LayerId::from_raw("components"),
+            SourceId::from_raw("other-source"),
+        );
+        component_sequence.add_contour(reference.contours_iter().next().unwrap().clone());
+        component_sequence.add_anchor(reference.anchors()[0].clone());
+        component_sequence
+            .add_component(Component::new(GlyphId::from_raw("caron.cap"), "caron.cap"));
+        component_sequence.add_component(Component::new(GlyphId::from_raw("C"), "C"));
+        assert_eq!(
+            reference
+                .interpolation_compatibility_with(&component_sequence)
+                .differences(),
+            &[LayerDifference::ComponentSequence {
+                reference: vec![GlyphId::from_raw("C"), GlyphId::from_raw("caron.cap")],
+                source: vec![GlyphId::from_raw("caron.cap"), GlyphId::from_raw("C")],
+            }]
+        );
+    }
+
+    #[test]
+    fn enclosing_count_differences_do_not_cascade() {
+        let reference = layer();
+        let mut source = reference.clone();
+        let contour = source.contours_iter_mut().next().unwrap();
+        contour.points_mut().pop();
+        contour.points_mut()[0].set_point_type(PointType::OffCurve);
+
+        assert_eq!(
+            reference
+                .interpolation_compatibility_with(&source)
+                .differences(),
+            &[LayerDifference::NodeCount {
+                path: 0,
+                reference: 3,
+                source: 2,
+            }]
+        );
+    }
+
+    #[test]
+    fn reports_independent_differences_together_in_domain_order() {
+        let reference = layer();
+        let source = GlyphLayer::new(
+            LayerId::from_raw("empty-layer"),
+            SourceId::from_raw("other-source"),
+        );
+
+        assert_eq!(
+            reference
+                .interpolation_compatibility_with(&source)
+                .into_differences(),
+            vec![
+                LayerDifference::PathCount {
+                    reference: 1,
+                    source: 0,
+                },
+                LayerDifference::AnchorCount {
+                    reference: 1,
+                    source: 0,
+                },
+                LayerDifference::ComponentSequence {
+                    reference: vec![GlyphId::from_raw("C"), GlyphId::from_raw("caron.cap"),],
+                    source: Vec::new(),
+                },
+            ]
+        );
+    }
+}

--- a/crates/shift-font/src/projection.rs
+++ b/crates/shift-font/src/projection.rs
@@ -5,7 +5,6 @@ use std::collections::HashMap;
 use crate::composite::{
     preferred_layer_for_glyph, resolved_contours_for_layer, GlyphLayerProvider, ResolvedContour,
 };
-use crate::interpolation::layers_are_compatible;
 use crate::{
     Axis, CoreResult, Font, Glyph, GlyphId, GlyphInterpolation, GlyphLayer, Location, Source,
     SourceId,
@@ -187,7 +186,7 @@ impl Font {
 
                 let represented_by_interpolation =
                     interpolation.as_ref().is_some_and(|interpolation| {
-                        layers_are_compatible(interpolation.template(), layer)
+                        interpolation.basis().source_ids().contains(&source.id())
                     });
                 if represented_by_interpolation {
                     return None;
@@ -392,24 +391,30 @@ mod tests {
     }
 
     #[test]
-    fn glyph_projection_preserves_incompatible_exact_source_shapes() {
+    fn glyph_projection_preserves_reordered_components_as_an_exact_source_shape() {
         let mut font = sample_variable_font();
         let glyph_id = font.glyph_by_name("A").unwrap().id();
+        let reference_source_id = font.default_source_id().unwrap();
         let bold_source = font
             .sources()
             .iter()
             .find(|source| source.name() == "Bold")
             .unwrap()
             .clone();
+        let reference_layer_id = font
+            .layer_id_for_glyph_source(glyph_id.clone(), reference_source_id)
+            .unwrap();
         let bold_layer_id = font
             .layer_id_for_glyph_source(glyph_id.clone(), bold_source.id())
             .unwrap();
-        font.layer_mut(bold_layer_id)
-            .unwrap()
-            .contours_iter_mut()
-            .next()
-            .unwrap()
-            .add_point(600.0, 100.0, PointType::OnCurve, false);
+        let c_id = GlyphId::from_raw("C");
+        let caron_id = GlyphId::from_raw("caron.cap");
+        let reference_layer = font.layer_mut(reference_layer_id).unwrap();
+        reference_layer.add_component(Component::new(c_id.clone(), "C"));
+        reference_layer.add_component(Component::new(caron_id.clone(), "caron.cap"));
+        let bold_layer = font.layer_mut(bold_layer_id).unwrap();
+        bold_layer.add_component(Component::new(caron_id.clone(), "caron.cap"));
+        bold_layer.add_component(Component::new(c_id.clone(), "C"));
 
         let projection = font.glyph_projection(&glyph_id).unwrap().unwrap();
         let bold = projection
@@ -422,10 +427,18 @@ mod tests {
             .unwrap();
 
         assert_eq!(projection.exact_source_shapes().len(), 1);
-        assert_eq!(bold.contours_iter().next().unwrap().points().len(), 4);
         assert_eq!(
-            interpolated.contours_iter().next().unwrap().points().len(),
-            3
+            bold.components_iter()
+                .map(|component| component.base_glyph_id())
+                .collect::<Vec<_>>(),
+            vec![caron_id.clone(), c_id.clone()]
+        );
+        assert_eq!(
+            interpolated
+                .components_iter()
+                .map(|component| component.base_glyph_id())
+                .collect::<Vec<_>>(),
+            vec![c_id, caron_id]
         );
     }
 


### PR DESCRIPTION
## What changed

- replace the lossy layer-compatibility boolean with `GlyphLayer::interpolation_compatibility_with`
- return a typed `LayerCompatibility` containing ordered `LayerDifference` evidence for path, node, anchor, and component mismatches
- preserve authored component sequence and add a Fraunces-shaped regression for `C → caron.cap` versus `caron.cap → C`
- avoid a second projection topology scan by checking membership in the interpolation basis
- document the OpenType/fontTools basis for the rules and the Shift-specific anchor constraint

## Why

The previous predicate could exclude a source but discarded the reason. That made interpolation failures difficult to explain and left the planned Variation Inspector and CLI without one canonical diagnostic API. Component order is structurally significant: OpenType `gvar` addresses composite components by ordered index.

The compatible hot path remains allocation-free; sequence evidence is cloned only after a mismatch is detected.

## Validation

- `cargo test --workspace`
- `cargo clippy -p shift-font --all-targets --all-features -- -D warnings`
- `cargo rustdoc -p shift-font -- -D rustdoc::broken_intra_doc_links`
- `cargo fmt --all -- --check`
- commit hooks, including Cargo check/tests and Clippy

`python3 scripts/context-drift-check.py` still reports 15 existing unrelated missing/stale documentation errors outside this diff.
