### PR TITLE
Load fvar metadata from binary fonts

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -650,7 +650,7 @@ These are allowed to jump around when energy is high, but they should not silent
 - [x] File → Open dialog (UFO, TTF, OTF)
 - [ ] Drag-and-drop font files
 - [ ] Recent files list
-- [ ] Variable font axis reading from binary
+- [x] Variable font axis reading from binary
 
 **Saving**
 

--- a/crates/shift-backends/docs/DOCS.md
+++ b/crates/shift-backends/docs/DOCS.md
@@ -35,6 +35,8 @@ src/
   glyphs/
     mod.rs         -- GlyphsReader re-export; fixture-based integration tests
     reader.rs      -- GlyphsReader: glyphs_reader::Font -> shift_font::Font (read-only)
+  binary/
+    reader.rs      -- TTF/OTF outlines, metrics, names, and fvar metadata -> shift_font::Font
   shift2fontir/
     source.rs      -- owned Shift FontView snapshot and fontir Source implementation
     axes.rs         -- Shift axis/mapping conversion and source normalization
@@ -64,6 +66,8 @@ src/
 **Point type mapping (read):** norad uses separate `Move`, `Line`, `Curve`, `OffCurve`, `QCurve` types. The IR collapses `Move`/`Line`/`Curve` into `OnCurve` and keeps `OffCurve` and `QCurve` distinct. On write, context (position in contour, open/closed, preceding point type) is used to reconstruct the correct norad variant.
 
 **Multi-layer support:** `UfoReader` iterates all norad layers. The `public.default` layer maps to the IR's default layer; other layers are added via `Font::add_layer`. Glyphs in non-default layers are merged into existing `Glyph` entries when the glyph already exists from another layer.
+
+**Binary variation metadata:** The TTF/OTF reader imports `fvar` axis definitions, hidden flags, and named instances into the Shift IR. Binary glyph geometry is still materialized only at the default variation location; recovering editable `gvar` sources is separate work.
 
 **Glyphs-format specifics:** `GlyphsReader` also extracts axes, sources, and per-master locations -- data that UFO does not natively represent. Kerning group membership is derived from per-glyph `right_kern`/`left_kern` fields and normalized to `public.kern1.*`/`public.kern2.*` conventions.
 

--- a/crates/shift-backends/src/binary/reader.rs
+++ b/crates/shift-backends/src/binary/reader.rs
@@ -1,9 +1,11 @@
 use crate::errors::{FormatBackendError, FormatBackendResult};
-use shift_font::{Contour, Font, Glyph, GlyphLayer, LayerId, MetricKind, PointType};
+use shift_font::{
+    Axis, Contour, Font, Glyph, GlyphLayer, LayerId, Location, MetricKind, NamedInstance, PointType,
+};
 use skrifa::{
     outline::{DrawSettings, OutlinePen},
     prelude::{LocationRef, Size},
-    raw::TableProvider,
+    raw::{ReadError, TableProvider},
     string::StringId,
     FontRef, MetadataProvider,
 };
@@ -196,6 +198,8 @@ fn font_from_skrifa(font: &FontRef<'_>) -> FormatBackendResult<Font> {
         ir_font.metadata_mut().style_name = Some(style_name);
     }
 
+    load_variation_metadata(font, &mut ir_font)?;
+
     for (unicode, glyph_id) in char_map.mappings() {
         let outline = outlines.get(glyph_id).ok_or_else(|| {
             FormatBackendError::Binary(format!(
@@ -236,6 +240,78 @@ fn font_from_skrifa(font: &FontRef<'_>) -> FormatBackendResult<Font> {
     }
 
     Ok(ir_font)
+}
+
+fn load_variation_metadata(font: &FontRef<'_>, ir_font: &mut Font) -> FormatBackendResult<()> {
+    let fvar = match font.fvar() {
+        Ok(fvar) => fvar,
+        Err(ReadError::TableIsMissing(_)) => return Ok(()),
+        Err(error) => {
+            return Err(FormatBackendError::Binary(format!(
+                "failed to read fvar table: {error}"
+            )))
+        }
+    };
+    fvar.axes().map_err(|error| {
+        FormatBackendError::Binary(format!("failed to read fvar axes: {error}"))
+    })?;
+    let fvar_instances = fvar.instances().map_err(|error| {
+        FormatBackendError::Binary(format!("failed to read fvar instances: {error}"))
+    })?;
+    for index in 0..fvar.instance_count() as usize {
+        fvar_instances.get(index).map_err(|error| {
+            FormatBackendError::Binary(format!("failed to read fvar instance {index}: {error}"))
+        })?;
+    }
+
+    let mut axis_ids = Vec::with_capacity(fvar.axis_count() as usize);
+    let mut default_location = Location::new();
+    for source_axis in font.axes().iter() {
+        let tag = source_axis.tag().to_string();
+        let name = localized_string(font, source_axis.name_id()).unwrap_or_else(|| tag.clone());
+        let mut axis = Axis::new(
+            tag,
+            name,
+            source_axis.min_value() as f64,
+            source_axis.default_value() as f64,
+            source_axis.max_value() as f64,
+        );
+        axis.set_hidden(source_axis.is_hidden());
+        let axis_id = axis.id();
+        default_location.set(axis_id.clone(), axis.default());
+        ir_font.add_axis(axis)?;
+        axis_ids.push(axis_id);
+    }
+
+    let default_source_id = ir_font
+        .default_source_id()
+        .expect("new font should have a default source");
+    ir_font
+        .source_mut(default_source_id)
+        .expect("new font should contain its default source")
+        .set_location(default_location);
+
+    let instances = font
+        .named_instances()
+        .iter()
+        .enumerate()
+        .map(|(index, source_instance)| {
+            let name = localized_string(font, source_instance.subfamily_name_id())
+                .unwrap_or_else(|| format!("Instance {}", index + 1));
+            let postscript_name = source_instance
+                .postscript_name_id()
+                .and_then(|name_id| localized_string(font, name_id));
+            let mut location = Location::new();
+            for (axis_id, coordinate) in axis_ids.iter().zip(source_instance.user_coords()) {
+                location.set(axis_id.clone(), coordinate as f64);
+            }
+
+            NamedInstance::new(name, location, postscript_name)
+        })
+        .collect();
+    ir_font.set_named_instances(instances)?;
+
+    Ok(())
 }
 
 fn localized_string(font: &FontRef<'_>, id: StringId) -> Option<String> {

--- a/crates/shift-backends/tests/loading.rs
+++ b/crates/shift-backends/tests/loading.rs
@@ -24,6 +24,15 @@ fn mutatorsans_otf_path() -> PathBuf {
     fixtures_path().join("fonts/mutatorsans/MutatorSans.otf")
 }
 
+fn host_grotesk_variable_ttf_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("apps/desktop/src/renderer/src/assets/fonts/HostGrotesk-VariableFont_wght.ttf")
+}
+
 fn homenaje_glyphs_path() -> PathBuf {
     fixtures_path().join("fonts/Homenaje.glyphs")
 }
@@ -165,6 +174,37 @@ fn loads_binary_fonts_with_contours() {
         assert!(font.glyph_count() > 0);
         assert!(!main_layer(glyph_a).contours().is_empty());
     }
+}
+
+#[test]
+fn loads_binary_variable_axes_and_named_instances() {
+    let font = load_font(&host_grotesk_variable_ttf_path());
+
+    assert!(font.is_variable());
+    assert_eq!(font.axes().len(), 1);
+    let weight = &font.axes()[0];
+    assert_eq!(weight.tag(), "wght");
+    assert_eq!(weight.name(), "Weight");
+    assert_eq!(weight.minimum(), 300.0);
+    assert_eq!(weight.default(), 300.0);
+    assert_eq!(weight.maximum(), 800.0);
+    assert!(!weight.is_hidden());
+    assert_eq!(
+        font.default_source()
+            .expect("binary font should have a default source")
+            .location()
+            .get(&weight.id()),
+        Some(300.0)
+    );
+
+    assert_eq!(font.named_instances().len(), 6);
+    let regular = font
+        .named_instances()
+        .iter()
+        .find(|instance| instance.name() == "Regular")
+        .expect("Host Grotesk should contain a Regular instance");
+    assert_eq!(regular.location().get(&weight.id()), Some(400.0));
+    assert_eq!(regular.postscript_name(), Some("HostGrotesk-Regular"));
 }
 
 fn assert_cubic_point_runs(contour: &Contour, context: &str) {


### PR DESCRIPTION
## Summary

- load `fvar` axis tags, localized names, ranges, defaults, and hidden flags from TTF/OTF files
- load named-instance locations and optional PostScript names into the Shift font IR
- set the binary font's default source location from the imported axis defaults
- add regression coverage using the existing Host Grotesk variable TTF

`gvar` outline/source reconstruction remains separate work under #143.

Closes #48.

## Validation

- `cargo test -p shift-backends`
- `cargo clippy -p shift-backends --all-targets -- -D warnings`
- `cargo fmt --all --check`

The repository-wide documentation drift checker still reports 13 unrelated pre-existing errors. The global commit test hook also encountered an existing wall-clock performance test fluctuating around its one-second threshold; the focused `shift-font` performance tests passed when rerun, and the complete `shift-backends` suite passes.
