### PR TITLE
Update GitHub Actions and warm perf caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,11 @@ jobs:
       rust: ${{ steps.filter.outputs.rust }}
       typescript: ${{ steps.filter.outputs.typescript }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -63,19 +63,18 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
-          cache: pnpm
 
       - name: Cache node_modules
         id: modules-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             node_modules
@@ -100,19 +99,18 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
-          cache: pnpm
 
       - name: Cache node_modules
         id: modules-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             node_modules
@@ -139,19 +137,18 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
-          cache: pnpm
 
       - name: Cache node_modules
         id: modules-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             node_modules
@@ -169,7 +166,7 @@ jobs:
 
       - name: Cache native module binary
         id: native-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: crates/shift-bridge/*.node
           key: native-module-${{ runner.os }}-${{ hashFiles('crates/**', 'Cargo.lock') }}
@@ -189,19 +186,18 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
-          cache: pnpm
 
       - name: Cache node_modules
         id: modules-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             node_modules
@@ -227,7 +223,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
@@ -245,7 +241,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
@@ -272,16 +268,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
 
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
-          cache: pnpm
 
       - name: Install toolchain
         run: rustup show
@@ -293,7 +288,7 @@ jobs:
 
       - name: Cache node_modules
         id: modules-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             node_modules
@@ -321,16 +316,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
 
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
-          cache: pnpm
 
       - name: Install toolchain
         run: rustup show
@@ -341,7 +335,7 @@ jobs:
 
       - name: Cache node_modules
         id: modules-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             node_modules
@@ -355,7 +349,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('apps/desktop/node_modules/@playwright/test/package.json') }}
@@ -366,7 +360,7 @@ jobs:
 
       - name: Cache native module binary
         id: native-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: crates/shift-bridge/*.node
           key: native-module-${{ runner.os }}-${{ hashFiles('crates/**', 'Cargo.lock') }}
@@ -382,7 +376,7 @@ jobs:
 
       - name: Upload snapshots on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-results
           path: apps/desktop/e2e/test-results/

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -72,15 +72,14 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
-          cache: pnpm
 
       - name: Install toolchain
         run: rustup show
@@ -91,7 +90,7 @@ jobs:
 
       - name: Cache node_modules
         id: modules-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             node_modules
@@ -105,7 +104,7 @@ jobs:
 
       - name: Cache native module binary
         id: native-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: crates/shift-bridge/*.node
           key: native-module-${{ runner.os }}-${{ hashFiles('crates/**', 'Cargo.lock') }}
@@ -123,16 +122,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
           submodules: true
 
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
-          cache: pnpm
 
       - name: Install toolchain
         run: rustup show
@@ -141,9 +139,9 @@ jobs:
         with:
           shared-key: shift-rust-macos
 
-      - name: Cache node_modules
+      - name: Restore node_modules
         id: modules-cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v6
         with:
           path: |
             node_modules
@@ -155,9 +153,20 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
 
-      - name: Cache Playwright browsers
+      - name: Save node_modules
+        if: steps.modules-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: |
+            node_modules
+            apps/*/node_modules
+            packages/*/node_modules
+            crates/*/node_modules
+          key: ${{ steps.modules-cache.outputs.cache-primary-key }}
+
+      - name: Restore Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v6
         with:
           path: ~/Library/Caches/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('apps/desktop/node_modules/@playwright/test/package.json') }}
@@ -166,9 +175,16 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm --filter @shift/desktop exec playwright install
 
-      - name: Cache native module binary
+      - name: Save Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ~/Library/Caches/ms-playwright
+          key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
+
+      - name: Restore native module binary
         id: native-cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v6
         with:
           path: crates/shift-bridge/*.node
           key: native-module-${{ runner.os }}-${{ hashFiles('crates/**', 'Cargo.lock') }}
@@ -176,6 +192,13 @@ jobs:
       - name: Build native module
         if: steps.native-cache.outputs.cache-hit != 'true'
         run: pnpm build:native
+
+      - name: Save native module binary
+        if: steps.native-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: crates/shift-bridge/*.node
+          key: ${{ steps.native-cache.outputs.cache-primary-key }}
 
       - name: Build E2E app
         run: pnpm --filter @shift/desktop build:e2e
@@ -185,7 +208,7 @@ jobs:
 
       - name: Upload Playwright failures
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-gpu-results
           path: apps/desktop/e2e/test-results/
@@ -193,7 +216,7 @@ jobs:
 
       - name: Upload perf results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: perf-results
           path: apps/desktop/e2e/perf-results/

--- a/.github/workflows/pr-clean-caches.yml
+++ b/.github/workflows/pr-clean-caches.yml
@@ -8,28 +8,24 @@ permissions: {}
 
 jobs:
   cleanup:
-    name: Clean Branch Caches
+    name: Clean PR Caches
     runs-on: ubuntu-latest
     permissions:
       actions: write
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Delete caches for closed PR branch
+      - name: Delete caches for closed PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: ${{ github.head_ref }}
+          PR_REF: refs/pull/${{ github.event.pull_request.number }}/merge
         run: |
-          echo "Cleaning caches for branch: $BRANCH"
-          CACHE_KEYS=$(gh cache list --ref "refs/heads/$BRANCH" --json key --jq '.[].key')
-          if [ -z "$CACHE_KEYS" ]; then
-            echo "No caches found for branch $BRANCH"
+          echo "Cleaning caches for $PR_REF"
+          CACHES=$(gh cache list --repo "$GITHUB_REPOSITORY" --ref "$PR_REF" --limit 100 --json id,key --jq '.[] | [.id, .key] | @tsv')
+          if [ -z "$CACHES" ]; then
+            echo "No caches found for $PR_REF"
             exit 0
           fi
-          for key in $CACHE_KEYS; do
-            echo "Deleting cache: $key"
-            gh cache delete "$key" || true
-          done
+          while IFS=$'\t' read -r id key; do
+            echo "Deleting cache: $key ($id)"
+            gh cache delete "$id" --repo "$GITHUB_REPOSITORY"
+          done <<< "$CACHES"
           echo "Done."


### PR DESCRIPTION
## Summary

- upgrade GitHub, pnpm, and path-filter actions to their Node 24 releases
- remove the redundant `setup-node` pnpm-store cache while retaining the existing `node_modules` cache
- save macOS node modules, Playwright browsers, and native binaries immediately after they are produced so failing GPU tests do not prevent cache warming
- clean closed-PR caches using their actual `refs/pull/<number>/merge` scope and remove the unnecessary checkout

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/ci.yml .github/workflows/perf.yml .github/workflows/pr-clean-caches.yml`
- `pnpm format:files --check .github/workflows/ci.yml .github/workflows/perf.yml .github/workflows/pr-clean-caches.yml`
- dry-ran the cleanup lookup against merged PR #163; it correctly found and parsed seven pull-ref caches without deleting them
