### PR TITLE
Reuse native Turbo builds in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,6 @@ jobs:
             .turbo/cache
             crates/shift-bridge/*.node
           key: native-turbo-v1-${{ runner.os }}-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'crates/*/Cargo.toml', 'crates/*/build.rs', 'crates/*/src/**', 'crates/shift-bridge/package.json', 'crates/shift-bridge/*.d.ts', 'pnpm-lock.yaml', 'turbo.json') }}
-          save-always: true
 
       - name: Run unit tests
         run: pnpm test:unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,10 +122,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: shift-rust
-
       - name: Typecheck
         run: pnpm typecheck
 
@@ -164,16 +160,13 @@ jobs:
         with:
           shared-key: shift-rust
 
-      - name: Cache native module binary
-        id: native-cache
+      - name: Cache native Turbo build
         uses: actions/cache@v6
         with:
-          path: crates/shift-bridge/*.node
-          key: native-module-${{ runner.os }}-${{ hashFiles('crates/**', 'Cargo.lock') }}
-
-      - name: Build native module
-        if: steps.native-cache.outputs.cache-hit != 'true'
-        run: pnpm build:native
+          path: |
+            .turbo/cache
+            crates/shift-bridge/*.node
+          key: native-turbo-v1-${{ runner.os }}-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'crates/*/Cargo.toml', 'crates/*/build.rs', 'crates/*/src/**', 'crates/shift-bridge/package.json', 'crates/shift-bridge/*.d.ts', 'pnpm-lock.yaml', 'turbo.json') }}
 
       - name: Run unit tests
         run: pnpm test:unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,7 @@ jobs:
             .turbo/cache
             crates/shift-bridge/*.node
           key: native-turbo-v1-${{ runner.os }}-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'crates/*/Cargo.toml', 'crates/*/build.rs', 'crates/*/src/**', 'crates/shift-bridge/package.json', 'crates/shift-bridge/*.d.ts', 'pnpm-lock.yaml', 'turbo.json') }}
+          save-always: true
 
       - name: Run unit tests
         run: pnpm test:unit

--- a/turbo.json
+++ b/turbo.json
@@ -31,7 +31,7 @@
       "outputs": ["resources/**"]
     },
     "typecheck": {
-      "dependsOn": ["^build", "^generate:bridge-types", "generate:bridge-types"],
+      "dependsOn": ["^generate:bridge-types", "generate:bridge-types"],
       "outputs": []
     },
     "@shift/glyph-info#typecheck": {
@@ -40,7 +40,6 @@
     },
     "@shift/desktop#typecheck": {
       "dependsOn": [
-        "^build",
         "@shift/glyph-info#generate",
         "^generate:bridge-types",
         "generate:bridge-types"


### PR DESCRIPTION
## Summary

- stop TypeScript typechecking from building the Rust/N-API addon
- cache Turbo's native build record together with the `.node` artifact for unit tests
- let the unit-test graph build the addon once on a cache miss instead of running a separate build first

The previous native artifact cache restored the `.node` file, but Turbo had no cached task record and rebuilt it anyway.

## Testing

- `pnpm typecheck` — passed without a native build task
- `pnpm test:unit` — passed
- Turbo typecheck dry-run contains zero `shift-bridge#build` tasks
- cached `shift-bridge#build` restored a deleted `.node` output in 38 ms
- repository pre-commit hooks
