### PR TITLE
CI: adopt tsgo and run Playwright perf nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
 
+      - name: Cache Typecheck Turbo results
+        uses: actions/cache@v6
+        with:
+          path: .turbo/cache
+          key: typecheck-turbo-v1-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            typecheck-turbo-v1-${{ runner.os }}-
+
       - name: Typecheck
         run: pnpm typecheck
 
@@ -156,17 +164,19 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: shift-rust
-
       - name: Cache native Turbo build
+        id: native-turbo-cache
         uses: actions/cache@v6
         with:
           path: |
             .turbo/cache
             crates/shift-bridge/*.node
           key: native-turbo-v1-${{ runner.os }}-${{ hashFiles('Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', 'crates/*/Cargo.toml', 'crates/*/build.rs', 'crates/*/src/**', 'crates/shift-bridge/package.json', 'crates/shift-bridge/*.d.ts', 'pnpm-lock.yaml', 'turbo.json') }}
+
+      - uses: Swatinem/rust-cache@v2
+        if: steps.native-turbo-cache.outputs.cache-hit != 'true'
+        with:
+          shared-key: shift-rust
 
       - name: Run unit tests
         run: pnpm test:unit

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,6 +1,8 @@
 name: Perf
 
 on:
+  schedule:
+    - cron: "0 6 * * *"
   push:
     branches: [main]
     paths:
@@ -68,6 +70,7 @@ concurrency:
 jobs:
   engine-benchmarks:
     name: Engine Benchmarks
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -116,8 +119,17 @@ jobs:
       - name: Run engine benchmarks
         run: pnpm test:perf
 
-  playwright-perf:
-    name: Playwright GPU and Perf
+  playwright:
+    name: Playwright ${{ matrix.name }}
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: GPU
+            project: gpu
+          - name: Perf
+            project: perf
     runs-on: macos-latest
     permissions:
       contents: read
@@ -203,19 +215,19 @@ jobs:
       - name: Build E2E app
         run: pnpm --filter @shift/desktop build:e2e
 
-      - name: Run Playwright GPU and perf tests
-        run: pnpm --filter @shift/desktop exec playwright test --project=gpu --project=perf
+      - name: Run Playwright ${{ matrix.name }} tests
+        run: pnpm --filter @shift/desktop exec playwright test --project=${{ matrix.project }}
 
       - name: Upload Playwright failures
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-gpu-results
+          name: playwright-${{ matrix.project }}-results
           path: apps/desktop/e2e/test-results/
           retention-days: 7
 
       - name: Upload perf results
-        if: always()
+        if: ${{ always() && matrix.project == 'perf' }}
         uses: actions/upload-artifact@v7
         with:
           name: perf-results

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -10,7 +10,7 @@
     "package": "electron-forge package",
     "make": "electron-forge make",
     "publish": "electron-forge publish",
-    "typecheck": "tsc --noEmit -p tsconfig.build.json",
+    "typecheck": "tsgo --noEmit -p tsconfig.build.json",
     "lint": "oxlint --fix src/",
     "lint:check": "oxlint --deny-warnings src/",
     "test": "vitest run",

--- a/apps/desktop/src/renderer/env.d.ts
+++ b/apps/desktop/src/renderer/env.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="vite/client" />
 /// <reference types="@webgpu/types" />
 
 declare module "*.wgsl?raw" {

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "extends": "@electron-toolkit/tsconfig/tsconfig.json",
+  "files": ["src/renderer/src/types/svg.d.ts"],
   "include": [
     "src/renderer/env.d.ts",
     "src/renderer/**/*",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "node": ">=24.0.0 <25"
   },
   "devDependencies": {
+    "@typescript/native-preview": "7.0.0-dev.20260707.2",
     "knip": "^5.84.1",
     "oxfmt": "^0.49.0",
     "ts-morph": "^27.0.2",

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
     "@shift/types": "workspace:*",

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/glyph-codec/package.json
+++ b/packages/glyph-codec/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/glyph-info/package.json
+++ b/packages/glyph-info/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "generate": "git -C ../.. submodule update --init --recursive packages/glyph-info/vendor/GlyphsInfo && tsx scripts/generate.ts",

--- a/packages/glyph-state/package.json
+++ b/packages/glyph-state/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "generate:bridge-types": "node ../../scripts/generate-bridge-types.mjs",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsgo --noEmit"
   },
   "devDependencies": {
     "@shift/tsconfig": "workspace:*",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
 
   .:
     devDependencies:
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260707.2
+        version: 7.0.0-dev.20260707.2
       knip:
         specifier: ^5.84.1
         version: 5.84.1(@types/node@25.3.0)(typescript@5.9.3)
@@ -2476,6 +2479,53 @@ packages:
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-wny2pgKjGbiZtnOIHVa3tXC1UfDqxNEFzyPGmiqybedG8hipG2Nfp0l5UxbaKCjkLacUpH/W5bP2hBOMVhCOzg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-Afc7M5zOwo+GpfcYwz5Z8HMB2tPVsui7nNIqEuuFB73MPdVqNn/Wmpe4tP4MRri0AtJnJknoHBaTJ/VDAp/Jhw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-iITBa2WjjTI5N9t5l7Z4KoOSI+2zBlhbvFzsD/f8qX8QoKjz/Y4DPyBDgezYi8nkqjjksbgSOJ3/ykzhwrB9cg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-hJm/UOqZTr9FHmR7uNm8VGX4oKtfWk0Jem0zPeJFNC8ckGUfSBueyiEYMZB+XmRc1aG4x1E46y3CplP4CLHvGQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-du0dzi6y97Po5vDNdPJTyyijHCpaS22JLRnKZEJXBDaO9gCIymOv/5QQokFRuOlQm0bWl3i9PF4OVdGP6uAOQA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-SsAwfhyHJ1akgBc+99z4+hwdbHsdWaKB8EwCNIMA6JfSLMeUjffrYvxu+vfMyxVtOVOz7RrRXRoiDiu4a2sCtg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-DL4u27stv0fo71sVhOzHSwE+YMZsbBijVI+kg5dLDLilSH79WFTJ8RSQ46vJrCMt+Gjlv/JOZP1PuLJDfioYeQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-oUGp+Rep/hqMhPunyinsALUwSlzHINSxitifPiSaeqoKOKD2OlR9NE3TaPqwsl4NlGslsOSUXI1JotWQzpYCPg==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
 
   '@vitejs/plugin-react@4.6.0':
     resolution: {integrity: sha512-5Kgff+m8e2PB+9j51eGHEpn5kUzRKH2Ry0qGoe8ItJg7pqnkPrYPkDQZGgGmTa0EGarHrkjLvOdU3b1fzI8otQ==}
@@ -6896,6 +6946,37 @@ snapshots:
     dependencies:
       '@types/node': 25.3.0
     optional: true
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260707.2':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260707.2
 
   '@vitejs/plugin-react@4.6.0(supports-color@8.1.1)(vite@6.4.3(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.49.0)(tsx@4.21.0))':
     dependencies:


### PR DESCRIPTION
## Summary

- switch all workspace package typecheck scripts to the pinned TypeScript native preview (`tsgo`)
- load Vite client types while preserving the existing SVGR declaration precedence
- persist Typecheck Turbo results and avoid restoring the Rust cache when the native Turbo cache hits
- run Playwright GPU and Perf as separate parallel macOS jobs on nightly schedules and manual runs
- keep Engine Benchmarks on PR/main path-filtered runs and manual dispatches

## Typecheck timing

Uncached direct desktop config runs on this machine:

- `tsc --noEmit -p apps/desktop/tsconfig.build.json`: 16.10s
- `tsgo --noEmit -p apps/desktop/tsconfig.build.json`: 3.87s

That is approximately a 4.2x speedup.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm format:check`
- `pnpm test:unit`
- `actionlint .github/workflows/ci.yml .github/workflows/perf.yml`
- commit hooks, including strict dead-code checks and the full Vitest suite

All passed. The local Nix Node environment required adding its SQLite library directory to `LD_LIBRARY_PATH` for native bridge tests.
