### PR TITLE
Stabilize GPU route retention test geometry

### DIFF
--- a/apps/desktop/e2e/README.md
+++ b/apps/desktop/e2e/README.md
@@ -28,8 +28,8 @@ Build the native bridge first with `pnpm build:native` when its binary is absent
 | Project  | Fixture                   | Rendering                                         | CI policy                            |
 | -------- | ------------------------- | ------------------------------------------------- | ------------------------------------ |
 | `visual` | `fixtures/electronApp.ts` | Software rendering, DPR 1, `1200×600` page window | Required on pull requests and `main` |
-| `gpu`    | `fixtures/perfApp.ts`     | Hardware GPU and host device scale                | Required on pull requests and `main` |
-| `perf`   | `fixtures/perfApp.ts`     | Hardware GPU and host device scale                | Nightly and manual only              |
+| `gpu`    | `fixtures/perfApp.ts`     | Hardware GPU, host scale, stable content size     | Required on pull requests and `main` |
+| `perf`   | `fixtures/perfApp.ts`     | Hardware GPU, host scale, stable content size     | Nightly and manual only              |
 
 Visual tests default to MutatorSans. The GPU and performance fixture also defaults to MutatorSans, but accepts a real font or designspace through `SHIFT_E2E_FONT_PATH`:
 
@@ -56,6 +56,7 @@ A snapshot match alone does not prove GPU content exists. Rendering tests that c
 - Use locator-relative positions for canvas clicks.
 - For raw mouse drags, derive page coordinates from the target canvas's `boundingBox()`.
 - Keep interactions inside measured bounds; do not assume the host desktop is wider than the fixture window.
+- GPU fixtures must await workspace-window visibility, then apply the final owning `BrowserWindow` size and await the tested page's matching renderer content size; do not let a hidden-to-visible OS adjustment invalidate a baseline.
 - Wait for a route, visible surface, animation frame, or domain state instead of assuming startup completed after a fixed delay.
 - Do not force software rendering or a fixed DPR in GPU and performance tests.
 

--- a/apps/desktop/e2e/fixtures/perfApp.ts
+++ b/apps/desktop/e2e/fixtures/perfApp.ts
@@ -66,23 +66,43 @@ export const test = base.extend<PerfFixtures>({
         },
       });
 
-      await app.firstWindow();
+      const page = await app.firstWindow();
       const activeUserDataDir = await app.evaluate(({ app: electronApp }) =>
         electronApp.getPath("userData"),
       );
       if (fs.realpathSync(activeUserDataDir) !== fs.realpathSync(userDataDir)) {
         throw new Error(`Electron ignored isolated user data directory: ${activeUserDataDir}`);
       }
-      await app.evaluate(
-        async ({ BrowserWindow }, { w, h }) => {
-          const win = BrowserWindow.getAllWindows()[0];
-          if (win) {
-            win.unmaximize();
-            win.setSize(w, h);
-            win.center();
-          }
+
+      const browserWindow = await app.browserWindow(page);
+      const initialContentSize = await browserWindow.evaluate(
+        (win, { w, h }) => {
+          win.unmaximize();
+          win.setSize(w, h);
+          win.center();
+          const [width, height] = win.getContentSize();
+          return { width, height };
         },
         { w: WINDOW_WIDTH, h: WINDOW_HEIGHT },
+      );
+      await page.waitForFunction(
+        ({ width, height }) => window.innerWidth === width && window.innerHeight === height,
+        initialContentSize,
+      );
+      await page.waitForFunction(() => document.visibilityState === "visible");
+      const visibleContentSize = await browserWindow.evaluate(
+        (win, { w, h }) => {
+          win.setSize(w, h);
+          win.center();
+          const [width, height] = win.getContentSize();
+          return { width, height };
+        },
+        { w: WINDOW_WIDTH, h: WINDOW_HEIGHT },
+      );
+      await browserWindow.dispose();
+      await page.waitForFunction(
+        ({ width, height }) => window.innerWidth === width && window.innerHeight === height,
+        visibleContentSize,
       );
 
       await use(app);

--- a/apps/desktop/e2e/glyph-grid.spec.ts
+++ b/apps/desktop/e2e/glyph-grid.spec.ts
@@ -45,6 +45,11 @@ test.describe("Resident Glyph Grid", () => {
     }
 
     await expectCompleteResidency(glyphCanvas);
+    await expect
+      .poll(() =>
+        glyphCanvas.evaluate((canvas) => ({ width: canvas.width, height: canvas.height })),
+      )
+      .toEqual(initialSize);
 
     await scrollViewport.click({ position: { x: 50, y: 50 } });
     await page.waitForURL(/#\/editor\//);


### PR DESCRIPTION
## Summary

- bind the hardware-GPU fixture to the `BrowserWindow` that owns the tested page
- let the hidden window reach initial Grid readiness, wait for workspace-window visibility, then reapply its final size
- wait until the renderer reports the visible window's actual content dimensions before yielding the fixture
- verify the Grid canvas baseline remains stable immediately before navigation

## Regression

Post-merge PR #172 GPU job [91719413543](https://github.com/shift-editor/shift/actions/runs/30823598181/job/91719413543) failed both attempts of the editor-navigation test:

```text
initial Grid canvas    883 × 752
observed after route   828 × 629
```

The first PR #176 run moved the same assertion immediately before navigation. It still observed the exact `883 × 752` to `828 × 629` change, proving navigation was not the trigger.

`perfApp` sized the workspace while its `BrowserWindow` was hidden and yielded without waiting for the later `workspace.ready` visibility transition. On the macOS runner, showing the window applied another OS content-bound adjustment after the test had captured its baseline. This also explains the earlier extra-frame evidence without requiring an atlas or renderer change.

The fixture now:

1. sizes the owning hidden window so the Grid can reach first-frame readiness;
2. waits on `document.visibilityState` rather than a sleep;
3. reapplies the final size after the window becomes visible;
4. waits for `window.innerWidth`/`window.innerHeight` to equal the visible window's actual content size.

Product Grid code and atlas behavior are unchanged.

## Verification

- focused route-retention GPU test repeated 5 times — passed
- complete `e2e/glyph-grid.spec.ts` GPU suite — 7 passed
- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm format:check`
- commit hooks: formatting, lint, typecheck, dead-code, and Vitest passed
