### PR TITLE
Add retained random-access font sources

### DIFF
--- a/crates/shift-backends/docs/DOCS.md
+++ b/crates/shift-backends/docs/DOCS.md
@@ -4,11 +4,11 @@ Font format backends that convert between on-disk font files and the `Font` IR u
 
 ## Architecture Invariants
 
-**Architecture Invariant:** All backends convert to/from `shift-font` values, never exposing format-specific types (norad, glyphs-reader) to callers. Eager readers return `Font`; bounded foreign imports return a glyph-free `Font` header plus batches of owned `Glyph` values. WHY: The rest of the editor operates on one authored model while large imports avoid constructing the complete model at once.
+**Architecture Invariant:** Backends never expose format-specific types (`norad`, `glyphs-reader`) to callers. Authored conversion returns `shift-font` values; retained source reading returns source-neutral `FontDirectory` and `DisplayGlyph` values without constructing authored objects. WHY: editing needs one authored model, while read-only directory and selected-glyph access must not manufacture Shift identity or eagerly convert a complete source.
 
 **Architecture Invariant:** `FontReader` and `FontWriter` require `Send + Sync`. WHY: Backends are stored in `FontLoader` which lives inside the editor's shared state; they must be safe to use from multiple threads.
 
-**Architecture Invariant:** Eager reader/writer backends are stateless unit structs. A `FontImport` owns the foreign bytes, GLIF directory records, or one upstream-parsed Glyphs source model plus its current cursor; it never owns a complete geometry-resident Shift `Font`. WHY: ordinary conversion stays pure, while bounded Shift conversion retains only format state needed to produce the next batch.
+**Architecture Invariant:** Eager reader/writer backends are stateless unit structs. `BinaryFont`, `GlifFont`, and `GlyphsFont` retain bytes, GLIF path indexes, or one upstream-parsed Glyphs source. A `FontImport` is an exhaustive bounded conversion cursor over that retained source and never owns a complete geometry-resident Shift `Font`. Binary sources intentionally expose no `FontImporter` capability. WHY: read-only access stays source-native and cheap, while explicit conversion remains bounded and uses original source semantics rather than display geometry.
 
 **Architecture Invariant:** `UfoWriter` stages a complete UFO beside the destination and swaps it into place only after the staged tree is durable. WHY: a failed save must preserve the previous source rather than leave a partial directory.
 
@@ -22,13 +22,17 @@ Font format backends that convert between on-disk font files and the `Font` IR u
 
 **Architecture Invariant:** TTF/OTF, UFO, Designspace, and Glyphs streaming imports convert glyphs in bounded Rayon batches and preserve input order when publishing each batch. Eager readers drain those same canonical streams rather than maintaining a second conversion path. UFO and Designspace share `GlifGlyphStream`; Glyphs parses its source model once, publishes stable glyph identities, then releases owned Shift batches through `GlyphsGlyphStream`. SQLite remains outside this crate and is written by one workspace-owned sink. WHY: one conversion path prevents eager/streaming semantic drift, while concurrent SQLite authors would add contention and weaken transaction ownership.
 
-**Architecture Invariant:** Compiled-font streaming enumerates `maxp` glyph IDs, not only `cmap` mappings. Unencoded glyphs receive their `post`/CFF name or a synthesized `gidN` name, and all Unicode mappings for a glyph share one authored glyph identity. WHY: `cmap` is character lookup, not the complete glyph directory.
+**Architecture Invariant:** Compiled-font streaming and random access enumerate `maxp` glyph IDs, not only `cmap` mappings. Unencoded glyphs receive their `post`/CFF name or a synthesized `gidN` name. `GlyphIndex` is the dense handle-local GID and is never converted to a Shift `GlyphId` for display; authored IDs are minted only if the legacy conversion stream is explicitly invoked. WHY: `cmap` is character lookup, not the complete glyph directory, and read-only display has no authored identity.
 
 **Architecture Invariant:** Compiled-font contour and point identities are deterministic positions within one glyph's emitted outline: `contour_b{glyph-id-hex}_{contour-index-hex}` and `point_b{glyph-id-hex}_{point-index-hex}`. Counters are monotonic from zero; dropping an explicit closing endpoint does not reuse its consumed point index. WHY: compiled fonts have stable glyph/outline order but no Shift identities, and random IDs make equivalent re-imports differ while injecting incompressible entropy into canonical payloads.
 
 **Architecture Invariant:** TrueType quadratic segments remain one `OffCurve` control plus one `QCurve` endpoint in the authored layer. Closing qcurve endpoints transfer their type to the wrapped start point. CFF cubic segments remain cubic. The bridge may project a qcurve endpoint as on-curve because clients infer the quadratic from its single control; canonical storage and source export retain the distinction. WHY: lifting every TrueType quadratic to cubic adds a point and derived coordinates to every segment, inflating canonical documents without adding information.
 
-**Architecture Invariant:** Designspace source locations are imported as complete design-space locations. An omitted source dimension resolves to that axis's user-space default mapped into design space; default-source selection compares against that same completed mapped location and never silently substitutes the first source. A `layer` attribute only selects where a source's outlines live and does not make it ineligible to be the default. Each source's standard metrics are translated from that UFO's metric identities into the Designspace header definitions. WHY: mixing user defaults with design coordinates corrupts interpolation bases, while looking up one UFO's metrics with another UFO's random IDs silently drops non-default master metrics.
+**Architecture Invariant:** Designspace source locations are imported as complete design-space locations. An omitted source dimension resolves to that axis's user-space default mapped into design space; default-source selection compares against that same completed mapped location and never silently substitutes the first source. A `layer` attribute only selects where a source's outlines live and does not make it ineligible to be the default. Each source's standard metrics are translated from that UFO's metric identities into the Designspace header definitions. Random access accepts external coordinates, applies independent and cross-axis mappings, then interpolates source geometry in design space. WHY: mixing user defaults with design coordinates corrupts interpolation bases, while looking up one UFO's metrics with another UFO's random IDs silently drops non-default master metrics.
+
+**Architecture Invariant:** `DisplayGlyph` is a validated flat arena containing only one selected root and its component closure. Geometry, contour, component, point, anchor, and guide ranges form complete non-overlapping partitions; all geometry is reachable from root index zero. Coordinates use y-up design-space font units. Native TrueType points retain local point indexes and implied quadratic points are explicit unindexed on-curve values. WHY: drawing and passive inspection need one coherent source-independent value without recursive duplication, hidden I/O, or synthetic Shift IDs.
+
+**Architecture Invariant:** Retained handles represent immutable source generations. Binary/Glyphs source stamps and GLIF manifests/selected paths are checked before reads; the first mismatch permanently returns the structured source-changed error from that handle. WHY: mixing directory data and geometry from different on-disk generations would produce incoherent display and conversion results.
 
 ## Codemap
 
@@ -36,7 +40,16 @@ Font format backends that convert between on-disk font files and the `Font` IR u
 src/
   lib.rs           -- re-exports FontReader, FontWriter, FontBackend, FontImport, and sub-modules
   import.rs        -- glyph-free foreign header, bounded cursor, and shared GLIF stream
-  traits.rs        -- FontReader, FontWriter, FontBackend trait definitions
+  font_source/
+    mod.rs          -- RandomAccessFont/FontImporter capability split and FontSource dispatch value
+    types.rs        -- source-local indexes, directories, locations, and validated DisplayGlyph arenas
+    geometry.rs     -- shared contour normalization, component-graph assembly, and exact bounds
+    binary.rs       -- retained TTF/OTF bytes, GID access, glyf/gvar/CFF resolution
+    glif.rs         -- retained UFO/Designspace manifests, paths, interpolation, and conversion cursor
+    glyphs.rs       -- retained parsed Glyphs source, mappings, interpolation, and conversion cursor
+    interpolation.rs -- source-location variation weights
+    error.rs        -- structured source-read failures
+  traits.rs        -- authored FontReader, FontWriter, FontBackend trait definitions
   ufo/
     mod.rs         -- UfoBackend convenience struct combining reader+writer; round-trip tests
     import.rs      -- UFO source discovery configured into the shared GLIF stream
@@ -63,6 +76,12 @@ src/
 
 ## Key Types
 
+- `RandomAccessFont` -- borrowed directory plus one-glyph-at-location resolution; implemented by all retained foreign handles
+- `FontImporter` -- optional authored-conversion capability implemented by GLIF and Glyphs handles, but not binary handles
+- `FontSource` -- dispatched `Binary`, `Glif`, or `Glyphs` retained handle returned by `FontLoader::open_source`
+- `FontDirectory` / `GlyphIndex` / `VariationLocation` -- source-local immutable directory and validated external-coordinate addressing
+- `DisplayGlyph` -- validated root/component closure in flat indexed arenas with exact bounds, metrics, anchors, guides, and point provenance
+- `BinaryFont` / `GlifFont` / `GlyphsFont` -- concrete retained source generations
 - `FontImport` -- top-level authored header, an immediately publishable stable-ID/name directory, and layer-aware `next_batch(limit)`, with no glyphs stored in the header
 - `GlyphDirectoryEntry` -- cheap foreign glyph ID and name used before geometry batches are parsed
 - `ImportBatchLimit` -- simultaneous glyph and authored-layer limits; multi-source projects cannot turn a glyph-count bound into an unbounded layer batch
@@ -79,13 +98,13 @@ src/
 
 ## How it works
 
-**Loading a font:** `FontLoader::read_font` retains the eager API but the TTF/OTF, UFO, Designspace, and Glyphs readers implement it by draining their bounded streams. `FontLoader::stream_font` dispatches those sources to the same importers. It first returns complete top-level metadata and a cheap glyph/source directory, then materializes at most the requested batch of `Glyph` values. UFO and Designspace both feed shared GLIF work records into `GlifGlyphStream`; Designspace only adds stable multi-source discovery. Glyphs syntax is parsed once by `glyphs-reader`; `GlyphsGlyphStream` preassigns every glyph identity so component references resolve before their bases are converted. Rayon converts geometry records in parallel; indexed collection preserves glyph order. The workspace writes and releases each Shift batch before requesting another.
+**Loading a font:** `FontLoader::open_source` dispatches TTF/OTF, UFO/Designspace, and Glyphs/Glyphspackage into retained random-access handles. Opening constructs a complete cheap directory but no authored `Font`, glyph, layer, contour, point identity, or workspace. `read_glyph` resolves only the requested root plus component closure at a validated external location. `FontLoader::read_font` retains the eager compatibility API, while `FontLoader::stream_font` dispatches explicit authored conversion. It first returns complete top-level metadata and a cheap glyph/source directory, then materializes at most the requested batch of `Glyph` values. UFO and Designspace both feed shared GLIF work records into `GlifGlyphStream`; Designspace only adds stable multi-source discovery. Glyphs syntax is parsed once by `glyphs-reader`; `GlyphsGlyphStream` preassigns every glyph identity so component references resolve before their bases are converted. Rayon converts geometry records in parallel; indexed collection preserves glyph order. The workspace writes and releases each Shift batch before requesting another.
 
 **Point type mapping (read):** norad uses separate `Move`, `Line`, `Curve`, `OffCurve`, `QCurve` types. The IR collapses `Move`/`Line`/`Curve` into `OnCurve` and keeps `OffCurve` and `QCurve` distinct. On write, context (position in contour, open/closed, preceding point type) is used to reconstruct the correct norad variant.
 
 **Multi-layer support:** `UfoReader` publishes `public.default` first, then preserves the relative authored order of every other entry in `layercontents.plist`. The default layer maps to the IR's default layer; other layers are represented by layer sources. Glyphs in non-default layers are merged into existing `Glyph` entries when the glyph already exists from another layer.
 
-**Binary variation metadata:** The TTF/OTF reader imports `fvar` axis definitions, hidden flags, and named instances into the Shift IR. The bounded path enumerates every `maxp` glyph ID, groups all `cmap` values by glyph, deterministically derives contour/point identities from emitted positions, and preserves TrueType quadratics instead of expanding them to cubic control pairs. Binary glyph geometry is still materialized only at the default variation location; recovering editable `gvar` sources is separate work.
+**Binary variation metadata:** The retained TTF/OTF handle exposes `fvar` axes in external/user coordinates and resolves selected glyphs at arbitrary valid locations. TrueType resolution applies `gvar` tuple scalars and IUP deltas, preserves native point indexes, inserts explicit implied quadratic points, and retains composite transforms as indexed geometry references. CFF outlines preserve cubic geometry with unindexed native provenance. The authored compatibility importer still materializes binary geometry only at the default location; recovering editable `gvar` masters remains separate work.
 
 **Glyphs-format specifics:** `GlyphsReader` also extracts axes, sources, and per-master locations -- data that UFO does not natively represent. Kerning group membership is derived from per-glyph `right_kern`/`left_kern` fields and normalized to `public.kern1.*`/`public.kern2.*` conventions. The upstream parser currently materializes its complete normalized Glyphs source model before the bounded cursor begins; batching bounds Shift glyph conversion and persistence, not source-syntax parsing.
 
@@ -138,11 +157,16 @@ src/
 cargo test -p shift-backends
 
 # Specific tests
+cargo test -p shift-backends font_source --lib
 cargo test -p shift-backends round_trip_ufo
 cargo test -p shift-backends writer_preserves_fractional_coordinates_and_skips_empty_contours
 cargo test -p shift-backends loads_homenaje_glyphs_file
 cargo test -p shift-backends loads_glyphs_package
 cargo test -p shift-backends --test export
+
+# Manual release profile: open/directory, selected default/non-default,
+# complete sequential/parallel binary resolution, and peak RSS
+cargo run -p shift-backends --release --example profile_font_source -- <font.ttf> [glyph-name]
 ```
 
 ## Related

--- a/crates/shift-backends/examples/profile_font_source.rs
+++ b/crates/shift-backends/examples/profile_font_source.rs
@@ -1,0 +1,178 @@
+use std::hint::black_box;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use rayon::prelude::*;
+use shift_backends::{
+    BinaryFont, DisplayGlyph, RandomAccessFont, VariationAxisKind, VariationCoordinate,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    if cfg!(debug_assertions) {
+        return Err("run this profiler with --release".into());
+    }
+    let mut arguments = std::env::args().skip(1);
+    let path = arguments
+        .next()
+        .ok_or("usage: profile_font_source <font.ttf|font.otf> [glyph-name] [iterations]")?;
+    let requested_glyph = arguments.next();
+    let iterations = arguments
+        .next()
+        .map(|value| value.parse::<usize>())
+        .transpose()?
+        .unwrap_or(200)
+        .max(1);
+
+    let open_started = Instant::now();
+    let font = BinaryFont::open(Path::new(&path))?;
+    let open_and_directory = open_started.elapsed();
+    let directory = font.directory();
+    let selected = requested_glyph
+        .as_deref()
+        .and_then(|name| directory.glyphs.iter().find(|glyph| glyph.name == name))
+        .or_else(|| directory.glyphs.get(directory.glyphs.len() / 2))
+        .ok_or("font directory is empty")?;
+    let selected_index = selected.index;
+    let selected_name = selected.name.clone();
+    let default_location = directory.default_location().clone();
+    let non_default_location = directory.axes.first().map(|axis| {
+        let value = match &axis.kind {
+            VariationAxisKind::Continuous { maximum, .. } => *maximum,
+            VariationAxisKind::Discrete { values, .. } => values[values.len() - 1],
+        };
+        directory.location(&[VariationCoordinate {
+            axis: axis.index,
+            value,
+        }])
+    });
+    let glyphs = directory
+        .glyphs
+        .iter()
+        .map(|glyph| glyph.index)
+        .collect::<Vec<_>>();
+
+    black_box(font.read_glyph(selected_index, &default_location)?);
+    let default_samples = sample(iterations, || {
+        font.read_glyph(selected_index, &default_location)
+    })?;
+    let non_default_samples = non_default_location
+        .transpose()?
+        .map(|location| sample(iterations, || font.read_glyph(selected_index, &location)))
+        .transpose()?;
+
+    let sequential_started = Instant::now();
+    let sequential = glyphs
+        .iter()
+        .map(|glyph| font.read_glyph(*glyph, &default_location).map(summarize))
+        .collect::<Result<Vec<_>, _>>()?;
+    let sequential_elapsed = sequential_started.elapsed();
+    let sequential_checksum = checksum(&sequential);
+
+    let parallel_started = Instant::now();
+    let parallel = glyphs
+        .par_iter()
+        .map(|glyph| font.read_glyph(*glyph, &default_location).map(summarize))
+        .collect::<Result<Vec<_>, _>>()?;
+    let parallel_elapsed = parallel_started.elapsed();
+    let parallel_checksum = checksum(&parallel);
+    if sequential_checksum != parallel_checksum {
+        return Err("sequential and parallel resolution checksums disagree".into());
+    }
+
+    println!("source: {path}");
+    println!(
+        "directory: {} glyphs, {} axes, {:.3} ms open + directory",
+        glyphs.len(),
+        directory.axes.len(),
+        millis(open_and_directory)
+    );
+    print_samples(
+        &format!("selected default ({selected_name}, {selected_index:?})"),
+        &default_samples,
+    );
+    if let Some(samples) = non_default_samples {
+        print_samples("selected non-default", &samples);
+    }
+    println!(
+        "complete sequential: {:.3} ms ({:.1} glyphs/ms)",
+        millis(sequential_elapsed),
+        glyphs.len() as f64 / millis(sequential_elapsed)
+    );
+    println!(
+        "complete parallel:   {:.3} ms ({:.1} glyphs/ms, {} Rayon threads)",
+        millis(parallel_elapsed),
+        glyphs.len() as f64 / millis(parallel_elapsed),
+        rayon::current_num_threads()
+    );
+    println!("resolution checksum: {sequential_checksum}");
+    if let Some(mebibytes) = peak_rss_mebibytes() {
+        println!("peak RSS: {mebibytes:.1} MiB");
+    }
+    Ok(())
+}
+
+fn sample(
+    iterations: usize,
+    mut read: impl FnMut() -> Result<DisplayGlyph, shift_backends::FontReadError>,
+) -> Result<Vec<Duration>, shift_backends::FontReadError> {
+    let mut samples = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let started = Instant::now();
+        black_box(read()?);
+        samples.push(started.elapsed());
+    }
+    samples.sort_unstable();
+    Ok(samples)
+}
+
+fn print_samples(label: &str, samples: &[Duration]) {
+    let median = samples[samples.len() / 2];
+    let p95_index = (samples.len() * 95).div_ceil(100).saturating_sub(1);
+    let p95 = samples[p95_index];
+    println!(
+        "{label}: {:.3} ms p50, {:.3} ms p95 ({} reads)",
+        millis(median),
+        millis(p95),
+        samples.len()
+    );
+}
+
+fn summarize(glyph: DisplayGlyph) -> (usize, usize, usize, i64) {
+    (
+        glyph.geometries.len(),
+        glyph.components.len(),
+        glyph.points.len(),
+        glyph.metrics.x_advance.round() as i64,
+    )
+}
+
+fn checksum(summaries: &[(usize, usize, usize, i64)]) -> i64 {
+    summaries
+        .iter()
+        .map(|(geometries, components, points, advance)| {
+            *geometries as i64 * 31 + *components as i64 * 37 + *points as i64 * 41 + *advance
+        })
+        .sum()
+}
+
+fn millis(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000.0
+}
+
+#[cfg(unix)]
+fn peak_rss_mebibytes() -> Option<f64> {
+    let mut usage = std::mem::MaybeUninit::<libc::rusage>::uninit();
+    if unsafe { libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) } != 0 {
+        return None;
+    }
+    let rss = unsafe { usage.assume_init() }.ru_maxrss as f64;
+    #[cfg(target_os = "macos")]
+    return Some(rss / 1_048_576.0);
+    #[cfg(not(target_os = "macos"))]
+    Some(rss / 1_024.0)
+}
+
+#[cfg(not(unix))]
+fn peak_rss_mebibytes() -> Option<f64> {
+    None
+}

--- a/crates/shift-backends/src/binary/reader.rs
+++ b/crates/shift-backends/src/binary/reader.rs
@@ -1,7 +1,8 @@
-use std::sync::Arc;
+use std::{path::Path, sync::Arc};
 
 use crate::{
     errors::{FormatBackendError, FormatBackendResult},
+    font_source::{BinaryFont, RandomAccessFont},
     import::{collect_streamed_font, GlyphDirectoryEntry, GlyphStream, ImportBatchLimit},
 };
 use rayon::prelude::*;
@@ -259,61 +260,43 @@ struct BinaryGlyphRecord {
 }
 
 pub(crate) struct BinaryGlyphStream {
-    bytes: Arc<[u8]>,
+    font: Arc<BinaryFont>,
     source_id: SourceId,
     glyphs: Vec<BinaryGlyphRecord>,
     next_glyph: usize,
 }
 
 pub(crate) fn stream_font_file(path: &str) -> FormatBackendResult<(Font, BinaryGlyphStream)> {
-    let bytes: Arc<[u8]> = std::fs::read(path)
-        .map_err(|error| FormatBackendError::Binary(format!("failed to read '{path}': {error}")))?
-        .into();
-    let font = FontRef::new(bytes.as_ref()).map_err(|error| {
-        FormatBackendError::Binary(format!("failed to parse '{path}': {error}"))
-    })?;
-    font.hmtx().map_err(|error| {
-        FormatBackendError::Binary(format!("failed to read hmtx table: {error}"))
+    let retained = Arc::new(
+        BinaryFont::open(Path::new(path))
+            .map_err(|error| FormatBackendError::Binary(error.to_string()))?,
+    );
+    let font = FontRef::new(retained.bytes()).map_err(|error| {
+        FormatBackendError::Binary(format!("failed to parse retained font '{path}': {error}"))
     })?;
     let header = font_header_from_skrifa(&font)?;
     let source_id = header.default_source_id().ok_or_else(|| {
         FormatBackendError::Binary("binary font header is missing its default source".into())
     })?;
-    let glyph_count = font
-        .maxp()
-        .map_err(|error| FormatBackendError::Binary(format!("failed to read maxp table: {error}")))?
-        .num_glyphs() as usize;
-    let mut unicodes = vec![Vec::new(); glyph_count];
-    for (unicode, glyph_id) in font.charmap().mappings() {
-        if let Some(values) = unicodes.get_mut(glyph_id.to_u32() as usize) {
-            values.push(unicode);
-        }
-    }
-    let names = font.glyph_names();
-    let glyphs = unicodes
-        .into_iter()
-        .enumerate()
-        .map(|(index, unicodes)| {
-            let raw_id = GlyphId::new(index as u32);
-            let name = names
-                .get(raw_id)
-                .map(|name| name.to_string())
-                .unwrap_or_else(|| format!("gid{index}"));
-            BinaryGlyphRecord {
-                raw_id,
-                // Compiled fonts carry stable glyph order but no Shift IDs, so
-                // deterministic GID-derived identities make re-import repeatable.
-                shift_id: ShiftGlyphId::from_raw(format!("binary{index}")),
-                name: GlyphName::from(name),
-                unicodes,
-            }
+    let glyphs = retained
+        .directory()
+        .glyphs
+        .iter()
+        .map(|glyph| BinaryGlyphRecord {
+            raw_id: GlyphId::new(glyph.index.to_u32()),
+            // Compiled fonts carry stable glyph order but no Shift IDs, so
+            // deterministic GID-derived identities make re-import repeatable.
+            // These identities are minted only when authored import begins.
+            shift_id: ShiftGlyphId::from_raw(format!("binary{}", glyph.index.to_u32())),
+            name: GlyphName::from(glyph.name.clone()),
+            unicodes: glyph.unicodes.to_vec(),
         })
         .collect();
 
     Ok((
         header,
         BinaryGlyphStream {
-            bytes,
+            font: retained,
             source_id,
             glyphs,
             next_glyph: 0,
@@ -346,8 +329,8 @@ impl GlyphStream for BinaryGlyphStream {
             .next_glyph
             .saturating_add(batch_glyphs)
             .min(self.glyphs.len());
-        let font = FontRef::new(self.bytes.as_ref()).map_err(|error| {
-            FormatBackendError::Binary(format!("failed to reopen resident font: {error}"))
+        let font = FontRef::new(self.font.bytes()).map_err(|error| {
+            FormatBackendError::Binary(format!("failed to reopen retained font: {error}"))
         })?;
         let hmtx = font.hmtx().map_err(|error| {
             FormatBackendError::Binary(format!("failed to read hmtx table: {error}"))

--- a/crates/shift-backends/src/designspace/import.rs
+++ b/crates/shift-backends/src/designspace/import.rs
@@ -2,6 +2,7 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fs,
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use norad::designspace::DesignSpaceDocument;
@@ -41,10 +42,20 @@ struct DesignspaceSourceMaterial {
 }
 
 pub(crate) fn stream_font(path: &str) -> FormatBackendResult<(Font, GlifGlyphStream)> {
-    stream_designspace(Path::new(path)).map_err(FormatBackendError::from)
+    stream_designspace(Path::new(path), None).map_err(FormatBackendError::from)
 }
 
-fn stream_designspace(designspace_path: &Path) -> DesignspaceResult<(Font, GlifGlyphStream)> {
+pub(crate) fn stream_retained(
+    path: &Path,
+    glyph_paths: Arc<[BTreeMap<String, PathBuf>]>,
+) -> FormatBackendResult<(Font, GlifGlyphStream)> {
+    stream_designspace(path, Some(&glyph_paths)).map_err(FormatBackendError::from)
+}
+
+fn stream_designspace(
+    designspace_path: &Path,
+    retained_glyph_paths: Option<&[BTreeMap<String, PathBuf>]>,
+) -> DesignspaceResult<(Font, GlifGlyphStream)> {
     let designspace_dir =
         designspace_path
             .parent()
@@ -70,6 +81,12 @@ fn stream_designspace(designspace_path: &Path) -> DesignspaceResult<(Font, GlifG
     };
     if document.sources.is_empty() {
         return Err(DesignspaceError::NoSources);
+    }
+    if retained_glyph_paths.is_some_and(|paths| paths.len() != document.sources.len()) {
+        return Err(DesignspaceError::LoadDesignspace {
+            path: designspace_path.to_path_buf(),
+            details: "retained source path count does not match Designspace sources".into(),
+        });
     }
     let default_index =
         find_default_source_index(&document).ok_or(DesignspaceError::MissingDefaultSource)?;
@@ -125,12 +142,15 @@ fn stream_designspace(designspace_path: &Path) -> DesignspaceResult<(Font, GlifG
                 )
             };
             let glyphs =
-                read_glyph_paths(&ufo_path, descriptor.layer.as_deref()).map_err(|error| {
-                    DesignspaceError::LoadUfo {
-                        path: ufo_path,
-                        source: Box::new(error),
-                    }
-                })?;
+                match retained_glyph_paths {
+                    Some(paths) => paths[index].clone(),
+                    None => read_glyph_paths(&ufo_path, descriptor.layer.as_deref()).map_err(
+                        |error| DesignspaceError::LoadUfo {
+                            path: ufo_path,
+                            source: Box::new(error),
+                        },
+                    )?,
+                };
             Ok(DesignspaceSourceMaterial {
                 index,
                 style_name,

--- a/crates/shift-backends/src/designspace/mod.rs
+++ b/crates/shift-backends/src/designspace/mod.rs
@@ -5,8 +5,12 @@ mod reader;
 mod writer;
 
 pub use error::DesignspaceError;
-pub(crate) use import::stream_font;
+pub(crate) use import::{stream_font, stream_retained};
 pub use reader::DesignspaceReader;
+pub(crate) use reader::{
+    axis_mappings_from_designspace, derive_axis_range, find_default_source_index, map_axis_value,
+    source_axis_design_value,
+};
 pub use writer::DesignspaceWriter;
 
 #[cfg(test)]

--- a/crates/shift-backends/src/designspace/reader.rs
+++ b/crates/shift-backends/src/designspace/reader.rs
@@ -157,7 +157,7 @@ fn unmap_axis_value(axis: &norad::designspace::Axis, value: f64) -> f64 {
     value + last_user - last_design
 }
 
-pub(super) fn axis_mappings_from_designspace(
+pub(crate) fn axis_mappings_from_designspace(
     doc: &DesignSpaceDocument,
     axes: &[Axis],
 ) -> DesignspaceResult<Vec<AxisMapping>> {
@@ -424,7 +424,7 @@ pub(super) fn location_from_dimensions(
 // Designspace source locations are partial design-space locations. Missing
 // dimensions resolve to the axis default after mapping from user space.
 // https://fonttools.readthedocs.io/en/stable/designspaceLib/python.html#fontTools.designspaceLib.SourceDescriptor.getFullDesignLocation
-fn source_axis_design_value(
+pub(crate) fn source_axis_design_value(
     dimensions: &[norad::designspace::Dimension],
     axis: &norad::designspace::Axis,
 ) -> f64 {
@@ -442,7 +442,7 @@ fn source_axis_design_value(
     }
 }
 
-fn map_axis_value(axis: &norad::designspace::Axis, user_value: f64) -> f64 {
+pub(crate) fn map_axis_value(axis: &norad::designspace::Axis, user_value: f64) -> f64 {
     let Some(mapping) = axis.map.as_ref().filter(|mapping| !mapping.is_empty()) else {
         return user_value;
     };
@@ -489,7 +489,7 @@ fn map_axis_value(axis: &norad::designspace::Axis, user_value: f64) -> f64 {
 // design-space locations to the mapped user-space defaults. Layer-backed
 // sources remain eligible because `layer` describes storage, not source role.
 // https://fonttools.readthedocs.io/en/stable/designspaceLib/python.html#fontTools.designspaceLib.DesignSpaceDocument.findDefault
-pub(super) fn find_default_source_index(doc: &DesignSpaceDocument) -> Option<usize> {
+pub(crate) fn find_default_source_index(doc: &DesignSpaceDocument) -> Option<usize> {
     doc.sources.iter().position(|source| {
         doc.axes.iter().all(|axis| {
             let source_value = source_axis_design_value(&source.location, axis);
@@ -513,7 +513,7 @@ fn design_values_equal(left: f64, right: f64) -> bool {
 /// - **One-sided** (only min OR max specified): the missing side falls back
 ///   to `default`. Common with slant axes (`min=-15, default=0, max=0`).
 /// - **Degenerate** (no min/max/values): all three collapse to default.
-pub(super) fn derive_axis_range(ds_axis: &norad::designspace::Axis) -> (f64, f64) {
+pub(crate) fn derive_axis_range(ds_axis: &norad::designspace::Axis) -> (f64, f64) {
     let values_range = || {
         ds_axis
             .values

--- a/crates/shift-backends/src/font_loader.rs
+++ b/crates/shift-backends/src/font_loader.rs
@@ -6,6 +6,7 @@ use shift_source::ShiftSourcePackage;
 
 use crate::designspace::{DesignspaceReader, DesignspaceWriter};
 use crate::errors::{BackendError, BackendResult, FormatBackendError, FormatBackendResult};
+use crate::font_source::{BinaryFont, FontReadError, FontSource, GlifFont, GlyphsFont};
 use crate::format::FontFormat;
 use crate::glyphs::GlyphsReader;
 use crate::import::{FontImport, GlyphStream};
@@ -156,6 +157,29 @@ impl FontLoader {
         self.adaptors.keys().collect()
     }
 
+    /// Opens a retained random-access source without constructing an authored Font.
+    pub fn open_source(&self, path: &Path) -> Result<FontSource, FontReadError> {
+        let extension = path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .ok_or_else(|| FontReadError::UnsupportedFormat {
+                path: path.to_path_buf(),
+            })?;
+        let format =
+            format_from_extension(extension).map_err(|_| FontReadError::UnsupportedFormat {
+                path: path.to_path_buf(),
+            })?;
+
+        match format {
+            FontFormat::Ttf | FontFormat::Otf => BinaryFont::open(path).map(FontSource::Binary),
+            FontFormat::Ufo | FontFormat::Designspace => GlifFont::open(path).map(FontSource::Glif),
+            FontFormat::Glyphs => GlyphsFont::open(path).map(FontSource::Glyphs),
+            FontFormat::Shift => Err(FontReadError::UnsupportedFormat {
+                path: path.to_path_buf(),
+            }),
+        }
+    }
+
     pub fn stream_font(&self, path: &str) -> BackendResult<FontImport> {
         let resolved = resolve(path)?;
         let adaptor = self
@@ -227,8 +251,57 @@ impl FontLoader {
 
 #[cfg(test)]
 mod tests {
-    use super::format_from_extension;
+    use std::path::PathBuf;
+
+    use super::{format_from_extension, FontLoader};
+    use crate::font_source::FontSource;
     use crate::format::FontFormat;
+    use crate::ImportBatchLimit;
+
+    fn fixture(name: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("fixtures/fonts")
+            .join(name)
+    }
+
+    #[test]
+    fn retained_source_dispatch_preserves_import_capabilities() {
+        let loader = FontLoader::new();
+        let binary = loader
+            .open_source(&fixture("mutatorsans/MutatorSans.ttf"))
+            .unwrap();
+        let glif = loader
+            .open_source(&fixture("mutatorsans/MutatorSansLightCondensed.ufo"))
+            .unwrap();
+        let glyphs = loader.open_source(&fixture("Homenaje.glyphs")).unwrap();
+
+        assert!(matches!(&binary, FontSource::Binary(_)));
+        assert!(binary.importer().is_none());
+        assert!(matches!(&glif, FontSource::Glif(_)));
+        let mut glif_import = glif.importer().unwrap().begin_import().unwrap();
+        assert!(glif_import.glyph_count() > 0);
+        assert_eq!(
+            glif_import
+                .next_batch(ImportBatchLimit::new(1, 1))
+                .unwrap()
+                .len(),
+            1
+        );
+        assert!(matches!(&glyphs, FontSource::Glyphs(_)));
+        let mut glyphs_import = glyphs.importer().unwrap().begin_import().unwrap();
+        assert!(glyphs_import.glyph_count() > 0);
+        assert_eq!(
+            glyphs_import
+                .next_batch(ImportBatchLimit::new(1, 1))
+                .unwrap()
+                .len(),
+            1
+        );
+    }
 
     #[test]
     fn supports_glyphs_extensions() {

--- a/crates/shift-backends/src/font_source/binary.rs
+++ b/crates/shift-backends/src/font_source/binary.rs
@@ -1,0 +1,1023 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use skrifa::outline::{DrawSettings, OutlinePen};
+use skrifa::prelude::{LocationRef, Size};
+use skrifa::raw::tables::glyf::Glyf;
+use skrifa::raw::tables::glyf::{
+    Anchor as GlyfAnchor, CompositeGlyphFlags, Glyph as GlyfGlyph, PointFlags,
+};
+use skrifa::raw::tables::gvar::Gvar;
+use skrifa::raw::tables::loca::Loca;
+use skrifa::raw::types::{GlyphId, Point as RawPoint};
+use skrifa::raw::{ReadError, TableProvider};
+use skrifa::string::StringId;
+use skrifa::{FontRef, MetadataProvider};
+
+use crate::font_source::geometry::{
+    build_display_glyph, normalize_contour, ContourPoint, SourceComponent, SourceContour,
+    SourceGeometry,
+};
+use crate::font_source::{
+    AffineTransform, AxisIndex, DirectoryGlyph, DisplayGlyph, FontDirectory, FontReadError,
+    GlyphIndex, GlyphMetrics, GlyphPoint, GlyphPointKind, PointProvenance, RandomAccessFont,
+    TrueTypePointIndex, VariationAxis, VariationAxisKind, VariationLocation,
+};
+use crate::FontFormat;
+
+#[derive(Clone, Copy)]
+struct SourceStamp {
+    length: u64,
+    modified: Option<SystemTime>,
+}
+
+impl SourceStamp {
+    fn read(path: &Path) -> Result<Self, FontReadError> {
+        let metadata = std::fs::metadata(path).map_err(|source| FontReadError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        Ok(Self {
+            length: metadata.len(),
+            modified: metadata.modified().ok(),
+        })
+    }
+
+    fn matches(self, path: &Path) -> bool {
+        let Ok(metadata) = std::fs::metadata(path) else {
+            return false;
+        };
+        metadata.len() == self.length && metadata.modified().ok() == self.modified
+    }
+}
+
+/// Retained bytes and indexes for one binary TTF, OTF, or variable font.
+pub struct BinaryFont {
+    path: PathBuf,
+    stamp: SourceStamp,
+    changed: AtomicBool,
+    bytes: Arc<[u8]>,
+    directory: FontDirectory,
+}
+
+impl BinaryFont {
+    pub fn open(path: &Path) -> Result<Self, FontReadError> {
+        let stamp = SourceStamp::read(path)?;
+        let bytes: Arc<[u8]> = std::fs::read(path)
+            .map_err(|source| FontReadError::Io {
+                path: path.to_path_buf(),
+                source,
+            })?
+            .into();
+        let font = FontRef::new(bytes.as_ref())
+            .map_err(|error| malformed(path, format!("failed to parse font: {error}")))?;
+        let directory = binary_directory(path, &font)?;
+        Ok(Self {
+            path: path.to_path_buf(),
+            stamp,
+            changed: AtomicBool::new(false),
+            bytes,
+            directory,
+        })
+    }
+
+    pub(crate) fn bytes(&self) -> &Arc<[u8]> {
+        &self.bytes
+    }
+
+    fn verify_source(&self) -> Result<(), FontReadError> {
+        if self.changed.load(Ordering::Acquire) || !self.stamp.matches(&self.path) {
+            self.changed.store(true, Ordering::Release);
+            return Err(FontReadError::SourceChanged {
+                path: self.path.clone(),
+            });
+        }
+        Ok(())
+    }
+
+    fn skrifa_location(
+        &self,
+        font: &FontRef<'_>,
+        location: &VariationLocation,
+    ) -> Result<skrifa::instance::Location, FontReadError> {
+        if location.coordinates().len() != self.directory.axes.len() {
+            return Err(FontReadError::InvalidDisplayGlyph {
+                details: format!(
+                    "location has {} coordinates for {} axes",
+                    location.coordinates().len(),
+                    self.directory.axes.len()
+                ),
+            });
+        }
+        for (axis, value) in self.directory.axes.iter().zip(location.coordinates()) {
+            axis.kind.validate_for_read(axis.index, *value)?;
+        }
+        Ok(font.axes().location(
+            self.directory
+                .axes
+                .iter()
+                .zip(location.coordinates())
+                .map(|(axis, value)| (axis.tag.as_str(), *value as f32)),
+        ))
+    }
+}
+
+impl RandomAccessFont for BinaryFont {
+    fn directory(&self) -> &FontDirectory {
+        &self.directory
+    }
+
+    fn read_glyph(
+        &self,
+        glyph: GlyphIndex,
+        location: &VariationLocation,
+    ) -> Result<DisplayGlyph, FontReadError> {
+        self.verify_source()?;
+        let Some(_) = self.directory.glyphs.get(glyph.to_usize()) else {
+            return Err(FontReadError::GlyphOutOfRange {
+                glyph,
+                glyph_count: self.directory.glyphs.len() as u32,
+            });
+        };
+        let font = FontRef::new(self.bytes.as_ref()).map_err(|error| {
+            malformed(
+                &self.path,
+                format!("failed to reopen retained font: {error}"),
+            )
+        })?;
+        let skrifa_location = self.skrifa_location(&font, location)?;
+        let raw_glyph = GlyphId::new(glyph.to_u32());
+        let glyph_metrics =
+            font.glyph_metrics(Size::unscaled(), LocationRef::from(&skrifa_location));
+        let x_advance = glyph_metrics.advance_width(raw_glyph).ok_or_else(|| {
+            malformed(
+                &self.path,
+                format!("missing advance width for glyph {raw_glyph}"),
+            )
+        })? as f64;
+
+        let geometries = match (font.loca(None), font.glyf()) {
+            (Ok(loca), Ok(glyf)) => {
+                let gvar = match font.gvar() {
+                    Ok(gvar) => Some(gvar),
+                    Err(ReadError::TableIsMissing(_)) => None,
+                    Err(error) => {
+                        return Err(malformed(
+                            &self.path,
+                            format!("failed to read gvar table: {error}"),
+                        ))
+                    }
+                };
+                GlyfResolver::new(&self.path, loca, glyf, gvar, skrifa_location.coords())
+                    .resolve(glyph)?
+            }
+            _ => vec![cff_geometry(
+                &self.path,
+                &font,
+                raw_glyph,
+                &skrifa_location,
+                glyph,
+            )?],
+        };
+
+        build_display_glyph(
+            glyph,
+            location.clone(),
+            geometries,
+            GlyphMetrics {
+                x_advance,
+                y_advance: None,
+            },
+        )
+    }
+}
+
+fn binary_directory(path: &Path, font: &FontRef<'_>) -> Result<FontDirectory, FontReadError> {
+    font.hmtx()
+        .map_err(|error| malformed(path, format!("failed to read hmtx table: {error}")))?;
+    let glyph_count = font
+        .maxp()
+        .map_err(|error| malformed(path, format!("failed to read maxp table: {error}")))?
+        .num_glyphs() as usize;
+    let mut unicodes = vec![Vec::new(); glyph_count];
+    for (unicode, glyph_id) in font.charmap().mappings() {
+        if let Some(values) = unicodes.get_mut(glyph_id.to_u32() as usize) {
+            values.push(unicode);
+        }
+    }
+    let names = font.glyph_names();
+    let glyphs = unicodes
+        .into_iter()
+        .enumerate()
+        .map(|(index, unicodes)| {
+            let raw_id = GlyphId::new(index as u32);
+            DirectoryGlyph {
+                index: GlyphIndex::new(index as u32),
+                name: names
+                    .get(raw_id)
+                    .map(|name| name.to_string())
+                    .unwrap_or_else(|| format!("gid{index}")),
+                unicodes: unicodes.into_boxed_slice(),
+            }
+        })
+        .collect();
+    let axes = font
+        .axes()
+        .iter()
+        .enumerate()
+        .map(|(index, axis)| VariationAxis {
+            index: AxisIndex::new(index as u32),
+            tag: axis.tag().to_string(),
+            name: localized_string(font, axis.name_id()).unwrap_or_else(|| axis.tag().to_string()),
+            hidden: axis.is_hidden(),
+            kind: VariationAxisKind::Continuous {
+                minimum: axis.min_value() as f64,
+                default: axis.default_value() as f64,
+                maximum: axis.max_value() as f64,
+            },
+        })
+        .collect();
+    let metrics = font.metrics(Size::unscaled(), LocationRef::default());
+    FontDirectory::new(
+        format_for_path(path)?,
+        localized_string(font, StringId::FAMILY_NAME),
+        localized_string(font, StringId::SUBFAMILY_NAME),
+        metrics.units_per_em as f64,
+        glyphs,
+        axes,
+    )
+}
+
+struct ResolvedGlyfGeometry {
+    source: SourceGeometry,
+    attachment_points: Vec<(f64, f64)>,
+}
+
+struct GlyfResolver<'a> {
+    path: &'a Path,
+    loca: Loca<'a>,
+    glyf: Glyf<'a>,
+    gvar: Option<Gvar<'a>>,
+    coordinates: &'a [skrifa::instance::NormalizedCoord],
+    indices: HashMap<GlyphIndex, usize>,
+    states: Vec<u8>,
+    geometries: Vec<Option<ResolvedGlyfGeometry>>,
+}
+
+impl<'a> GlyfResolver<'a> {
+    fn new(
+        path: &'a Path,
+        loca: Loca<'a>,
+        glyf: Glyf<'a>,
+        gvar: Option<Gvar<'a>>,
+        coordinates: &'a [skrifa::instance::NormalizedCoord],
+    ) -> Self {
+        Self {
+            path,
+            loca,
+            glyf,
+            gvar,
+            coordinates,
+            indices: HashMap::new(),
+            states: Vec::new(),
+            geometries: Vec::new(),
+        }
+    }
+
+    fn resolve(mut self, root: GlyphIndex) -> Result<Vec<SourceGeometry>, FontReadError> {
+        self.resolve_geometry(root)?;
+        self.geometries
+            .into_iter()
+            .map(|geometry| {
+                geometry.map(|geometry| geometry.source).ok_or_else(|| {
+                    FontReadError::InvalidDisplayGlyph {
+                        details: "binary geometry resolution left an empty slot".into(),
+                    }
+                })
+            })
+            .collect()
+    }
+
+    fn resolve_geometry(&mut self, glyph: GlyphIndex) -> Result<usize, FontReadError> {
+        if let Some(index) = self.indices.get(&glyph).copied() {
+            return match self.states[index] {
+                1 => Err(FontReadError::ComponentCycle { glyph }),
+                2 => Ok(index),
+                _ => Err(FontReadError::InvalidDisplayGlyph {
+                    details: "binary geometry has an invalid resolution state".into(),
+                }),
+            };
+        }
+
+        let index = self.geometries.len();
+        self.indices.insert(glyph, index);
+        self.states.push(1);
+        self.geometries.push(None);
+        let raw_id = GlyphId::new(glyph.to_u32());
+        let raw = self.loca.get_glyf(raw_id, &self.glyf).map_err(|error| {
+            malformed(self.path, format!("failed to read glyph {raw_id}: {error}"))
+        })?;
+        let geometry = match raw {
+            None => ResolvedGlyfGeometry {
+                source: empty_geometry(glyph),
+                attachment_points: Vec::new(),
+            },
+            Some(GlyfGlyph::Simple(simple)) => self.resolve_simple(glyph, raw_id, &simple)?,
+            Some(GlyfGlyph::Composite(composite)) => {
+                let components = composite.components().collect::<Vec<_>>();
+                let deltas = self.composite_deltas(raw_id, components.len())?;
+                let mut source = empty_geometry(glyph);
+                let mut attachment_points: Vec<(f64, f64)> = Vec::new();
+
+                for (component_index, component) in components.into_iter().enumerate() {
+                    let child_glyph = GlyphIndex::new(component.glyph.to_u32());
+                    let child_index = self.resolve_geometry(child_glyph)?;
+                    let child = self.geometries[child_index].as_ref().ok_or_else(|| {
+                        FontReadError::InvalidDisplayGlyph {
+                            details: "resolved component geometry is unavailable".into(),
+                        }
+                    })?;
+                    let mut transform = component_transform(&component);
+                    match component.anchor {
+                        GlyfAnchor::Offset { x, y } => {
+                            let mut x = f64::from(x);
+                            let mut y = f64::from(y);
+                            if component
+                                .flags
+                                .contains(CompositeGlyphFlags::SCALED_COMPONENT_OFFSET)
+                                && !component
+                                    .flags
+                                    .contains(CompositeGlyphFlags::UNSCALED_COMPONENT_OFFSET)
+                            {
+                                x *= approximate_hypot(transform.xx, transform.yx);
+                                y *= approximate_hypot(transform.yy, transform.xy);
+                            }
+                            let delta = deltas.get(component_index).copied().unwrap_or_default();
+                            transform.dx = x + delta.0;
+                            transform.dy = y + delta.1;
+                        }
+                        GlyfAnchor::Point { base, component } => {
+                            let base =
+                                attachment_points
+                                    .get(base as usize)
+                                    .copied()
+                                    .ok_or_else(|| {
+                                        malformed(
+                                    self.path,
+                                    format!("invalid base anchor point {base} in glyph {raw_id}"),
+                                )
+                                    })?;
+                            let component_point = child
+                                .attachment_points
+                                .get(component as usize)
+                                .copied()
+                                .ok_or_else(|| {
+                                    malformed(
+                                        self.path,
+                                        format!(
+                                            "invalid component anchor point {component} in glyph {raw_id}"
+                                        ),
+                                    )
+                                })?;
+                            let component_point =
+                                transform.transform_point(component_point.0, component_point.1);
+                            transform.dx = base.0 - component_point.0;
+                            transform.dy = base.1 - component_point.1;
+                        }
+                    }
+                    attachment_points.extend(
+                        child
+                            .attachment_points
+                            .iter()
+                            .map(|point| transform.transform_point(point.0, point.1)),
+                    );
+                    source.components.push(SourceComponent {
+                        glyph: child_glyph,
+                        transform,
+                    });
+                }
+                ResolvedGlyfGeometry {
+                    source,
+                    attachment_points,
+                }
+            }
+        };
+        self.geometries[index] = Some(geometry);
+        self.states[index] = 2;
+        Ok(index)
+    }
+
+    fn resolve_simple(
+        &self,
+        glyph: GlyphIndex,
+        raw_id: GlyphId,
+        simple: &skrifa::raw::tables::glyf::SimpleGlyph<'_>,
+    ) -> Result<ResolvedGlyfGeometry, FontReadError> {
+        let point_count = simple.num_points();
+        let mut raw_points = vec![RawPoint::<i32>::default(); point_count];
+        let mut flags = vec![PointFlags::default(); point_count];
+        simple
+            .read_points_fast(&mut raw_points, &mut flags)
+            .map_err(|error| {
+                malformed(
+                    self.path,
+                    format!("failed to read points for glyph {raw_id}: {error}"),
+                )
+            })?;
+        let contour_ends = simple
+            .end_pts_of_contours()
+            .iter()
+            .map(|end| end.get())
+            .collect::<Vec<_>>();
+        let deltas = self.simple_deltas(raw_id, &raw_points, &contour_ends)?;
+        let resolved_points = raw_points
+            .iter()
+            .zip(deltas)
+            .map(|(point, delta)| (f64::from(point.x) + delta.0, f64::from(point.y) + delta.1))
+            .collect::<Vec<_>>();
+        let mut contours = Vec::with_capacity(contour_ends.len());
+        let mut start = 0;
+        for end in contour_ends {
+            let end = end as usize;
+            if end < start || end >= resolved_points.len() {
+                return Err(malformed(
+                    self.path,
+                    format!("invalid contour endpoint {end} in glyph {raw_id}"),
+                ));
+            }
+            contours.push(normalize_glyf_contour(
+                &resolved_points[start..=end],
+                &flags[start..=end],
+                start,
+            )?);
+            start = end + 1;
+        }
+        Ok(ResolvedGlyfGeometry {
+            source: SourceGeometry {
+                glyph,
+                contours,
+                components: Vec::new(),
+                anchors: Vec::new(),
+                guides: Vec::new(),
+            },
+            attachment_points: resolved_points,
+        })
+    }
+
+    fn simple_deltas(
+        &self,
+        glyph: GlyphId,
+        points: &[RawPoint<i32>],
+        contours: &[u16],
+    ) -> Result<Vec<(f64, f64)>, FontReadError> {
+        let mut total = vec![(0.0, 0.0); points.len()];
+        let Some(gvar) = &self.gvar else {
+            return Ok(total);
+        };
+        let Some(variation) = gvar.glyph_variation_data(glyph).map_err(|error| {
+            malformed(
+                self.path,
+                format!("failed to read variation data for glyph {glyph}: {error}"),
+            )
+        })?
+        else {
+            return Ok(total);
+        };
+
+        for (tuple, scalar) in variation.active_tuples_at(self.coordinates) {
+            let scalar = scalar.to_f64();
+            let mut tuple_deltas = vec![None; points.len()];
+            for delta in tuple.deltas() {
+                let index = delta.position as usize;
+                if index < tuple_deltas.len() {
+                    tuple_deltas[index] = Some((
+                        f64::from(delta.x_delta) * scalar,
+                        f64::from(delta.y_delta) * scalar,
+                    ));
+                }
+            }
+            infer_tuple_deltas(points, contours, &mut tuple_deltas)?;
+            for (total, delta) in total.iter_mut().zip(tuple_deltas) {
+                let delta = delta.unwrap_or_default();
+                total.0 += delta.0;
+                total.1 += delta.1;
+            }
+        }
+        Ok(total)
+    }
+
+    fn composite_deltas(
+        &self,
+        glyph: GlyphId,
+        component_count: usize,
+    ) -> Result<Vec<(f64, f64)>, FontReadError> {
+        let mut total = vec![(0.0, 0.0); component_count];
+        let Some(gvar) = &self.gvar else {
+            return Ok(total);
+        };
+        let Some(variation) = gvar.glyph_variation_data(glyph).map_err(|error| {
+            malformed(
+                self.path,
+                format!("failed to read variation data for glyph {glyph}: {error}"),
+            )
+        })?
+        else {
+            return Ok(total);
+        };
+        for (tuple, scalar) in variation.active_tuples_at(self.coordinates) {
+            let scalar = scalar.to_f64();
+            for delta in tuple.deltas() {
+                if let Some(total) = total.get_mut(delta.position as usize) {
+                    total.0 += f64::from(delta.x_delta) * scalar;
+                    total.1 += f64::from(delta.y_delta) * scalar;
+                }
+            }
+        }
+        Ok(total)
+    }
+}
+
+fn infer_tuple_deltas(
+    points: &[RawPoint<i32>],
+    contour_ends: &[u16],
+    deltas: &mut [Option<(f64, f64)>],
+) -> Result<(), FontReadError> {
+    let mut start = 0;
+    for end in contour_ends {
+        let end = *end as usize;
+        if end < start || end >= points.len() || end >= deltas.len() {
+            return Err(FontReadError::InvalidDisplayGlyph {
+                details: "variation contour endpoints are invalid".into(),
+            });
+        }
+        let references = (start..=end)
+            .filter(|index| deltas[*index].is_some())
+            .collect::<Vec<_>>();
+        match references.as_slice() {
+            [] => {}
+            [reference] => {
+                let delta = deltas[*reference].expect("reference has a delta");
+                for value in &mut deltas[start..=end] {
+                    *value = Some(delta);
+                }
+            }
+            _ => {
+                for position in 0..references.len() {
+                    let first = references[position];
+                    let second = references[(position + 1) % references.len()];
+                    let mut index = if first == end { start } else { first + 1 };
+                    while index != second {
+                        let x = interpolate_delta_coordinate(
+                            points[index].x,
+                            points[first].x,
+                            points[second].x,
+                            deltas[first].expect("reference has a delta").0,
+                            deltas[second].expect("reference has a delta").0,
+                        );
+                        let y = interpolate_delta_coordinate(
+                            points[index].y,
+                            points[first].y,
+                            points[second].y,
+                            deltas[first].expect("reference has a delta").1,
+                            deltas[second].expect("reference has a delta").1,
+                        );
+                        deltas[index] = Some((x, y));
+                        index = if index == end { start } else { index + 1 };
+                    }
+                }
+            }
+        }
+        start = end + 1;
+    }
+    Ok(())
+}
+
+fn interpolate_delta_coordinate(
+    point: i32,
+    first: i32,
+    second: i32,
+    first_delta: f64,
+    second_delta: f64,
+) -> f64 {
+    let (first, first_delta, second, second_delta) = if first <= second {
+        (first, first_delta, second, second_delta)
+    } else {
+        (second, second_delta, first, first_delta)
+    };
+    if first == second {
+        return if first_delta == second_delta {
+            first_delta
+        } else {
+            0.0
+        };
+    }
+    if point <= first {
+        return first_delta;
+    }
+    if point >= second {
+        return second_delta;
+    }
+    first_delta
+        + (second_delta - first_delta) * f64::from(point - first) / f64::from(second - first)
+}
+
+fn normalize_glyf_contour(
+    points: &[(f64, f64)],
+    flags: &[PointFlags],
+    source_start: usize,
+) -> Result<SourceContour, FontReadError> {
+    if points.is_empty() || points.len() != flags.len() {
+        return Err(FontReadError::InvalidDisplayGlyph {
+            details: "TrueType contour points and flags disagree".into(),
+        });
+    }
+    let points = points
+        .iter()
+        .zip(flags)
+        .enumerate()
+        .map(|(index, (point, flags))| {
+            let kind = if flags.is_on_curve() {
+                GlyphPointKind::OnCurve
+            } else if flags.is_off_curve_cubic() {
+                GlyphPointKind::CubicControl
+            } else {
+                GlyphPointKind::QuadraticControl
+            };
+            native_glyf_point(*point, kind, source_start + index)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    normalize_contour(points, true)
+}
+
+fn native_glyf_point(
+    point: (f64, f64),
+    kind: GlyphPointKind,
+    index: usize,
+) -> Result<ContourPoint, FontReadError> {
+    let index = u32::try_from(index).map_err(|_| FontReadError::InvalidDisplayGlyph {
+        details: "TrueType point index exceeds u32".into(),
+    })?;
+    Ok(ContourPoint {
+        x: point.0,
+        y: point.1,
+        kind,
+        smooth: false,
+        provenance: PointProvenance::Native {
+            ttf_point_index: Some(TrueTypePointIndex::new(index)),
+        },
+    })
+}
+
+fn component_transform(component: &skrifa::raw::tables::glyf::Component) -> AffineTransform {
+    AffineTransform {
+        xx: f64::from(component.transform.xx.to_f32()),
+        xy: f64::from(component.transform.yx.to_f32()),
+        yx: f64::from(component.transform.xy.to_f32()),
+        yy: f64::from(component.transform.yy.to_f32()),
+        dx: 0.0,
+        dy: 0.0,
+    }
+}
+
+fn approximate_hypot(a: f64, b: f64) -> f64 {
+    let a = a.abs();
+    let b = b.abs();
+    if a > b {
+        a + 0.375 * b
+    } else {
+        b + 0.375 * a
+    }
+}
+
+#[derive(Default)]
+struct CffPen {
+    contours: Vec<SourceContour>,
+    current: Vec<GlyphPoint>,
+}
+
+impl CffPen {
+    fn finish_contour(&mut self, closed: bool) {
+        if self.current.is_empty() {
+            return;
+        }
+        if closed && self.current.len() > 1 {
+            let first = &self.current[0];
+            let last = self.current.last().expect("current contour is non-empty");
+            if last.kind == GlyphPointKind::OnCurve && last.x == first.x && last.y == first.y {
+                self.current.pop();
+            }
+        }
+        self.contours.push(SourceContour {
+            points: std::mem::take(&mut self.current),
+            closed,
+        });
+    }
+
+    fn push(&mut self, x: f32, y: f32, kind: GlyphPointKind) {
+        self.current.push(GlyphPoint {
+            x: f64::from(x),
+            y: f64::from(y),
+            kind,
+            smooth: false,
+            provenance: PointProvenance::Native {
+                ttf_point_index: None,
+            },
+        });
+    }
+}
+
+impl OutlinePen for CffPen {
+    fn move_to(&mut self, x: f32, y: f32) {
+        self.finish_contour(false);
+        self.push(x, y, GlyphPointKind::OnCurve);
+    }
+
+    fn line_to(&mut self, x: f32, y: f32) {
+        self.push(x, y, GlyphPointKind::OnCurve);
+    }
+
+    fn quad_to(&mut self, cx0: f32, cy0: f32, x: f32, y: f32) {
+        self.push(cx0, cy0, GlyphPointKind::QuadraticControl);
+        self.push(x, y, GlyphPointKind::OnCurve);
+    }
+
+    fn curve_to(&mut self, cx0: f32, cy0: f32, cx1: f32, cy1: f32, x: f32, y: f32) {
+        self.push(cx0, cy0, GlyphPointKind::CubicControl);
+        self.push(cx1, cy1, GlyphPointKind::CubicControl);
+        self.push(x, y, GlyphPointKind::OnCurve);
+    }
+
+    fn close(&mut self) {
+        self.finish_contour(true);
+    }
+}
+
+fn cff_geometry(
+    path: &Path,
+    font: &FontRef<'_>,
+    raw_glyph: GlyphId,
+    location: &skrifa::instance::Location,
+    glyph: GlyphIndex,
+) -> Result<SourceGeometry, FontReadError> {
+    let mut pen = CffPen::default();
+    if let Some(outline) = font.outline_glyphs().get(raw_glyph) {
+        outline
+            .draw(
+                DrawSettings::unhinted(Size::unscaled(), LocationRef::from(location)),
+                &mut pen,
+            )
+            .map_err(|error| {
+                malformed(
+                    path,
+                    format!("failed to draw CFF glyph {raw_glyph}: {error}"),
+                )
+            })?;
+    }
+    pen.finish_contour(false);
+    Ok(SourceGeometry {
+        glyph,
+        contours: pen.contours,
+        components: Vec::new(),
+        anchors: Vec::new(),
+        guides: Vec::new(),
+    })
+}
+
+fn empty_geometry(glyph: GlyphIndex) -> SourceGeometry {
+    SourceGeometry {
+        glyph,
+        contours: Vec::new(),
+        components: Vec::new(),
+        anchors: Vec::new(),
+        guides: Vec::new(),
+    }
+}
+
+fn localized_string(font: &FontRef<'_>, id: StringId) -> Option<String> {
+    font.localized_strings(id)
+        .english_or_first()
+        .map(|string| string.to_string())
+        .filter(|string| !string.is_empty())
+}
+
+fn format_for_path(path: &Path) -> Result<FontFormat, FontReadError> {
+    match path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("ttf") => Ok(FontFormat::Ttf),
+        Some("otf") => Ok(FontFormat::Otf),
+        _ => Err(FontReadError::UnsupportedFormat {
+            path: path.to_path_buf(),
+        }),
+    }
+}
+
+fn malformed(path: &Path, details: String) -> FontReadError {
+    FontReadError::MalformedSource {
+        format: format_for_path(path).unwrap_or(FontFormat::Ttf),
+        path: path.to_path_buf(),
+        details,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    fn repository_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .to_path_buf()
+    }
+
+    fn fixture(name: &str) -> PathBuf {
+        repository_root()
+            .join("fixtures/fonts/mutatorsans")
+            .join(name)
+    }
+
+    #[test]
+    fn binary_directory_uses_gid_indexes_without_shift_identity() {
+        let font = BinaryFont::open(&fixture("MutatorSans.ttf")).unwrap();
+        assert!(!font.directory().glyphs.is_empty());
+        assert_eq!(font.directory().glyphs[0].index, GlyphIndex::new(0));
+        assert!(font.directory().units_per_em > 0.0);
+    }
+
+    #[test]
+    fn binary_glyph_preserves_native_true_type_point_indexes() {
+        let font = BinaryFont::open(&fixture("MutatorSans.ttf")).unwrap();
+        let glyph = font
+            .directory()
+            .glyphs
+            .iter()
+            .find(|glyph| glyph.name == "S")
+            .expect("fixture should contain S");
+        let display = font
+            .read_glyph(glyph.index, font.directory().default_location())
+            .unwrap();
+
+        assert_eq!(display.glyph, glyph.index);
+        assert!(!display.points.is_empty());
+        assert!(display.points.iter().all(|point| matches!(
+            point.provenance,
+            PointProvenance::Native {
+                ttf_point_index: Some(_)
+            } | PointProvenance::Implied
+        )));
+        assert!(display.bounds.is_some());
+    }
+
+    #[test]
+    fn binary_variable_glyph_changes_at_a_non_default_location() {
+        let font =
+            BinaryFont::open(&repository_root().join(
+                "apps/desktop/src/renderer/src/assets/fonts/HostGrotesk-VariableFont_wght.ttf",
+            ))
+            .unwrap();
+        let glyph = font
+            .directory()
+            .glyphs
+            .iter()
+            .find(|glyph| glyph.name == "A")
+            .expect("fixture should contain A");
+        let default = font
+            .read_glyph(glyph.index, font.directory().default_location())
+            .unwrap();
+        let axis = &font.directory().axes[0];
+        let maximum = match axis.kind {
+            VariationAxisKind::Continuous { maximum, .. } => maximum,
+            VariationAxisKind::Discrete { .. } => panic!("fixture axis should be continuous"),
+        };
+        let location = font
+            .directory()
+            .location(&[crate::font_source::VariationCoordinate {
+                axis: axis.index,
+                value: maximum,
+            }])
+            .unwrap();
+        let changed = font.read_glyph(glyph.index, &location).unwrap();
+        let font_ref = FontRef::new(font.bytes()).unwrap();
+        let skrifa_location = font.skrifa_location(&font_ref, &location).unwrap();
+        let flattened = cff_geometry(
+            Path::new("HostGrotesk-VariableFont_wght.ttf"),
+            &font_ref,
+            GlyphId::new(glyph.index.to_u32()),
+            &skrifa_location,
+            glyph.index,
+        )
+        .unwrap();
+        let trusted =
+            build_display_glyph(glyph.index, location, vec![flattened], changed.metrics).unwrap();
+
+        assert_ne!(default.points, changed.points);
+        assert_eq!(changed.bounds, trusted.bounds);
+    }
+
+    #[test]
+    fn binary_composite_retains_a_shared_indexed_geometry_graph() {
+        let font = BinaryFont::open(&fixture("MutatorSans.ttf")).unwrap();
+        let glyph = font
+            .directory()
+            .glyphs
+            .iter()
+            .find(|glyph| glyph.name == "Aacute")
+            .expect("fixture should contain Aacute");
+        let display = font
+            .read_glyph(glyph.index, font.directory().default_location())
+            .unwrap();
+
+        assert!(display.geometries.len() > 1);
+        assert!(!display.components.is_empty());
+        assert!(display
+            .components
+            .iter()
+            .all(|component| component.geometry.to_usize() < display.geometries.len()));
+    }
+
+    #[test]
+    fn binary_composite_bounds_match_skrifa_flattened_resolution() {
+        let path = fixture("MutatorSans.ttf");
+        let font = BinaryFont::open(&path).unwrap();
+        let glyph = font
+            .directory()
+            .glyphs
+            .iter()
+            .find(|glyph| glyph.name == "Aacute")
+            .expect("fixture should contain Aacute");
+        let location = font.directory().default_location();
+        let display = font.read_glyph(glyph.index, location).unwrap();
+        let font_ref = FontRef::new(font.bytes()).unwrap();
+        let skrifa_location = font.skrifa_location(&font_ref, location).unwrap();
+        let flattened = cff_geometry(
+            &path,
+            &font_ref,
+            GlyphId::new(glyph.index.to_u32()),
+            &skrifa_location,
+            glyph.index,
+        )
+        .unwrap();
+        let trusted = build_display_glyph(
+            glyph.index,
+            location.clone(),
+            vec![flattened],
+            display.metrics,
+        )
+        .unwrap();
+
+        assert_eq!(display.bounds, trusted.bounds);
+    }
+
+    #[test]
+    fn binary_empty_glyph_is_explicit_geometry_without_bounds() {
+        let font = BinaryFont::open(&fixture("MutatorSans.ttf")).unwrap();
+        let glyph = font
+            .directory()
+            .glyphs
+            .iter()
+            .find(|glyph| glyph.name == "space")
+            .expect("fixture should contain space");
+        let display = font
+            .read_glyph(glyph.index, font.directory().default_location())
+            .unwrap();
+
+        assert_eq!(display.geometries.len(), 1);
+        assert!(display.contours.is_empty());
+        assert!(display.components.is_empty());
+        assert!(display.bounds.is_none());
+        assert!(display.metrics.x_advance > 0.0);
+    }
+
+    #[test]
+    fn binary_cff_glyph_uses_unindexed_native_points() {
+        let font = BinaryFont::open(&fixture("MutatorSans.otf")).unwrap();
+        let glyph = font
+            .directory()
+            .glyphs
+            .iter()
+            .find(|glyph| glyph.name == "S")
+            .expect("fixture should contain S");
+        let display = font
+            .read_glyph(glyph.index, font.directory().default_location())
+            .unwrap();
+
+        assert!(!display.points.is_empty());
+        assert!(display.points.iter().all(|point| matches!(
+            point.provenance,
+            PointProvenance::Native {
+                ttf_point_index: None
+            }
+        )));
+    }
+}

--- a/crates/shift-backends/src/font_source/error.rs
+++ b/crates/shift-backends/src/font_source/error.rs
@@ -1,0 +1,59 @@
+use std::path::PathBuf;
+
+use crate::font_source::{AxisIndex, GlyphIndex};
+use crate::FontFormat;
+
+#[derive(Debug, thiserror::Error)]
+pub enum FontReadError {
+    #[error("unsupported font source format: {path}")]
+    UnsupportedFormat { path: PathBuf },
+
+    #[error("failed to read font source '{path}': {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("malformed {} font source '{}': {details}", format.name(), path.display())]
+    MalformedSource {
+        format: FontFormat,
+        path: PathBuf,
+        details: String,
+    },
+
+    #[error("font source changed after it was opened: {path}")]
+    SourceChanged { path: PathBuf },
+
+    #[error("glyph index {glyph:?} is outside directory length {glyph_count}")]
+    GlyphOutOfRange { glyph: GlyphIndex, glyph_count: u32 },
+
+    #[error("variation axis {axis:?} does not exist")]
+    UnknownAxis { axis: AxisIndex },
+
+    #[error("variation axis {axis:?} was specified more than once")]
+    DuplicateAxis { axis: AxisIndex },
+
+    #[error("variation coordinate {value} for axis {axis:?} is not finite")]
+    NonFiniteCoordinate { axis: AxisIndex, value: f64 },
+
+    #[error("variation coordinate {value} for axis {axis:?} is outside [{minimum}, {maximum}]")]
+    CoordinateOutOfRange {
+        axis: AxisIndex,
+        value: f64,
+        minimum: f64,
+        maximum: f64,
+    },
+
+    #[error("variation coordinate {value} is not declared for discrete axis {axis:?}")]
+    CoordinateNotAllowed { axis: AxisIndex, value: f64 },
+
+    #[error("glyph {glyph:?} references missing component glyph {base:?}")]
+    MissingComponent { glyph: GlyphIndex, base: GlyphIndex },
+
+    #[error("glyph {glyph:?} has a cyclic component reference")]
+    ComponentCycle { glyph: GlyphIndex },
+
+    #[error("invalid display glyph: {details}")]
+    InvalidDisplayGlyph { details: String },
+}

--- a/crates/shift-backends/src/font_source/geometry.rs
+++ b/crates/shift-backends/src/font_source/geometry.rs
@@ -1,0 +1,544 @@
+use std::collections::HashMap;
+
+use kurbo::{CubicBez, Line, Point, QuadBez, Shape};
+
+use crate::font_source::{
+    AffineTransform, AnchorRange, ComponentInstance, ComponentRange, ContourRange, DisplayGlyph,
+    FontReadError, GeometryIndex, GlyphAnchor, GlyphBounds, GlyphContour, GlyphGeometry,
+    GlyphGuide, GlyphIndex, GlyphMetrics, GlyphPoint, GlyphPointKind, GuideRange, PointProvenance,
+    PointRange, VariationLocation,
+};
+
+#[derive(Clone, Debug)]
+pub(crate) struct ContourPoint {
+    pub(crate) x: f64,
+    pub(crate) y: f64,
+    pub(crate) kind: GlyphPointKind,
+    pub(crate) smooth: bool,
+    pub(crate) provenance: PointProvenance,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct SourceContour {
+    pub(crate) points: Vec<GlyphPoint>,
+    pub(crate) closed: bool,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct SourceComponent {
+    pub(crate) glyph: GlyphIndex,
+    pub(crate) transform: AffineTransform,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct SourceGeometry {
+    pub(crate) glyph: GlyphIndex,
+    pub(crate) contours: Vec<SourceContour>,
+    pub(crate) components: Vec<SourceComponent>,
+    pub(crate) anchors: Vec<GlyphAnchor>,
+    pub(crate) guides: Vec<GlyphGuide>,
+}
+
+pub(crate) fn normalize_contour(
+    points: Vec<ContourPoint>,
+    closed: bool,
+) -> Result<SourceContour, FontReadError> {
+    if points.is_empty() {
+        return Err(invalid_segment("contour has no points"));
+    }
+    let points = points
+        .into_iter()
+        .map(|point| GlyphPoint {
+            x: point.x,
+            y: point.y,
+            kind: point.kind,
+            smooth: point.smooth,
+            provenance: point.provenance,
+        })
+        .collect::<Vec<_>>();
+    let first_on = points
+        .iter()
+        .position(|point| point.kind == GlyphPointKind::OnCurve);
+    let (start, indexes, all_off_curve) = match (closed, first_on) {
+        (false, Some(0)) => (
+            points[0].clone(),
+            (1..points.len()).collect::<Vec<_>>(),
+            false,
+        ),
+        (false, _) => return Err(invalid_segment("open contour does not begin on-curve")),
+        (true, Some(start)) => (
+            points[start].clone(),
+            (1..points.len())
+                .map(|offset| (start + offset) % points.len())
+                .collect(),
+            false,
+        ),
+        (true, None) => {
+            if points
+                .iter()
+                .any(|point| point.kind != GlyphPointKind::QuadraticControl)
+            {
+                return Err(invalid_segment(
+                    "closed contour without an endpoint contains non-quadratic controls",
+                ));
+            }
+            (
+                implied_point(points.last().expect("contour is non-empty"), &points[0]),
+                (0..points.len()).collect(),
+                true,
+            )
+        }
+    };
+
+    let mut normalized = Vec::with_capacity(points.len() * 2);
+    normalized.push(start);
+    for (position, index) in indexes.iter().copied().enumerate() {
+        let point = &points[index];
+        normalized.push(point.clone());
+        let next = if index + 1 < points.len() {
+            Some(index + 1)
+        } else if closed {
+            Some(0)
+        } else {
+            None
+        };
+        let closes_all_off_curve = all_off_curve && position + 1 == indexes.len();
+        if point.kind == GlyphPointKind::QuadraticControl
+            && !closes_all_off_curve
+            && next.is_some_and(|next| points[next].kind == GlyphPointKind::QuadraticControl)
+        {
+            normalized.push(implied_point(
+                point,
+                &points[next.expect("next was checked")],
+            ));
+        }
+    }
+    validate_contour_points(&normalized, closed)?;
+    Ok(SourceContour {
+        points: normalized,
+        closed,
+    })
+}
+
+fn implied_point(first: &GlyphPoint, second: &GlyphPoint) -> GlyphPoint {
+    GlyphPoint {
+        x: (first.x + second.x) * 0.5,
+        y: (first.y + second.y) * 0.5,
+        kind: GlyphPointKind::OnCurve,
+        smooth: false,
+        provenance: PointProvenance::Implied,
+    }
+}
+
+fn validate_contour_points(points: &[GlyphPoint], closed: bool) -> Result<(), FontReadError> {
+    if points[0].kind != GlyphPointKind::OnCurve {
+        return Err(invalid_segment(
+            "normalized contour does not begin on-curve",
+        ));
+    }
+    let limit = if closed {
+        points.len() + 1
+    } else {
+        points.len()
+    };
+    let mut cursor = 1;
+    while cursor < limit {
+        match points[cursor % points.len()].kind {
+            GlyphPointKind::OnCurve => cursor += 1,
+            GlyphPointKind::QuadraticControl => {
+                if cursor + 1 >= limit
+                    || points[(cursor + 1) % points.len()].kind != GlyphPointKind::OnCurve
+                {
+                    return Err(invalid_segment(
+                        "quadratic control is not followed by an endpoint",
+                    ));
+                }
+                cursor += 2;
+            }
+            GlyphPointKind::CubicControl => {
+                if cursor + 2 >= limit
+                    || points[(cursor + 1) % points.len()].kind != GlyphPointKind::CubicControl
+                    || points[(cursor + 2) % points.len()].kind != GlyphPointKind::OnCurve
+                {
+                    return Err(invalid_segment("invalid cubic point sequence"));
+                }
+                cursor += 3;
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn build_display_glyph(
+    root: GlyphIndex,
+    location: VariationLocation,
+    geometries: Vec<SourceGeometry>,
+    metrics: GlyphMetrics,
+) -> Result<DisplayGlyph, FontReadError> {
+    let geometry_indices = geometries
+        .iter()
+        .enumerate()
+        .map(|(index, geometry)| {
+            let index = u32::try_from(index).map_err(|_| FontReadError::InvalidDisplayGlyph {
+                details: "geometry count exceeds u32".into(),
+            })?;
+            Ok((geometry.glyph, GeometryIndex::new(index)))
+        })
+        .collect::<Result<HashMap<_, _>, FontReadError>>()?;
+    if geometry_indices.len() != geometries.len() {
+        return Err(FontReadError::InvalidDisplayGlyph {
+            details: "resolved geometries contain duplicate glyph indexes".into(),
+        });
+    }
+    let root_geometry =
+        geometry_indices
+            .get(&root)
+            .copied()
+            .ok_or_else(|| FontReadError::InvalidDisplayGlyph {
+                details: "resolved geometries omit the requested root".into(),
+            })?;
+
+    let bounds = glyph_bounds(root_geometry, &geometries, &geometry_indices)?;
+    let mut glyph_geometries = Vec::with_capacity(geometries.len());
+    let mut contours = Vec::new();
+    let mut components = Vec::new();
+    let mut points = Vec::new();
+    let mut anchors = Vec::new();
+    let mut guides = Vec::new();
+
+    for geometry in geometries {
+        let contour_start = contours.len();
+        for contour in geometry.contours {
+            let point_start = points.len();
+            let point_count = contour.points.len();
+            points.extend(contour.points);
+            contours.push(GlyphContour {
+                points: PointRange::new(point_start, point_count)?,
+                closed: contour.closed,
+            });
+        }
+
+        let component_start = components.len();
+        for component in geometry.components {
+            let geometry = geometry_indices.get(&component.glyph).copied().ok_or(
+                FontReadError::MissingComponent {
+                    glyph: geometry.glyph,
+                    base: component.glyph,
+                },
+            )?;
+            components.push(ComponentInstance {
+                geometry,
+                transform: component.transform,
+            });
+        }
+
+        let anchor_start = anchors.len();
+        let anchor_count = geometry.anchors.len();
+        anchors.extend(geometry.anchors);
+        let guide_start = guides.len();
+        let guide_count = geometry.guides.len();
+        guides.extend(geometry.guides);
+        glyph_geometries.push(GlyphGeometry {
+            glyph: geometry.glyph,
+            contours: ContourRange::new(contour_start, contours.len() - contour_start)?,
+            components: ComponentRange::new(component_start, components.len() - component_start)?,
+            anchors: AnchorRange::new(anchor_start, anchor_count)?,
+            guides: GuideRange::new(guide_start, guide_count)?,
+        });
+    }
+
+    let glyph = DisplayGlyph {
+        glyph: root,
+        location,
+        root_geometry,
+        geometries: glyph_geometries.into_boxed_slice(),
+        contours: contours.into_boxed_slice(),
+        components: components.into_boxed_slice(),
+        points: points.into_boxed_slice(),
+        anchors: anchors.into_boxed_slice(),
+        guides: guides.into_boxed_slice(),
+        metrics,
+        bounds,
+    };
+    glyph.validate()?;
+    Ok(glyph)
+}
+
+fn glyph_bounds(
+    root: GeometryIndex,
+    geometries: &[SourceGeometry],
+    indices: &HashMap<GlyphIndex, GeometryIndex>,
+) -> Result<Option<GlyphBounds>, FontReadError> {
+    let mut bounds = None;
+    let mut visiting = Vec::new();
+    append_geometry_bounds(
+        root,
+        AffineTransform::identity(),
+        geometries,
+        indices,
+        &mut visiting,
+        &mut bounds,
+    )?;
+    Ok(bounds)
+}
+
+fn append_geometry_bounds(
+    geometry_index: GeometryIndex,
+    transform: AffineTransform,
+    geometries: &[SourceGeometry],
+    indices: &HashMap<GlyphIndex, GeometryIndex>,
+    visiting: &mut Vec<GeometryIndex>,
+    bounds: &mut Option<GlyphBounds>,
+) -> Result<(), FontReadError> {
+    if visiting.contains(&geometry_index) {
+        return Err(FontReadError::ComponentCycle {
+            glyph: geometries[geometry_index.to_usize()].glyph,
+        });
+    }
+    visiting.push(geometry_index);
+    let geometry = &geometries[geometry_index.to_usize()];
+    for contour in &geometry.contours {
+        append_contour_bounds(contour, transform, bounds)?;
+    }
+    for component in &geometry.components {
+        let child =
+            indices
+                .get(&component.glyph)
+                .copied()
+                .ok_or(FontReadError::MissingComponent {
+                    glyph: geometry.glyph,
+                    base: component.glyph,
+                })?;
+        append_geometry_bounds(
+            child,
+            transform.compose(component.transform),
+            geometries,
+            indices,
+            visiting,
+            bounds,
+        )?;
+    }
+    visiting.pop();
+    Ok(())
+}
+
+fn append_contour_bounds(
+    contour: &SourceContour,
+    transform: AffineTransform,
+    bounds: &mut Option<GlyphBounds>,
+) -> Result<(), FontReadError> {
+    let point_count = contour.points.len();
+    if point_count < 2 {
+        return Ok(());
+    }
+    if contour.points[0].kind != GlyphPointKind::OnCurve {
+        return Err(FontReadError::InvalidDisplayGlyph {
+            details: "normalized contour does not begin on-curve".into(),
+        });
+    }
+
+    let limit = if contour.closed {
+        point_count + 1
+    } else {
+        point_count
+    };
+    let mut start = transformed_point(&contour.points[0], transform);
+    let mut cursor = 1;
+    while cursor < limit {
+        let point = &contour.points[cursor % point_count];
+        match point.kind {
+            GlyphPointKind::OnCurve => {
+                let end = transformed_point(point, transform);
+                include_rect(bounds, Line::new(start, end).bounding_box());
+                start = end;
+                cursor += 1;
+            }
+            GlyphPointKind::QuadraticControl => {
+                if cursor + 1 >= limit {
+                    return Err(invalid_segment("quadratic control has no endpoint"));
+                }
+                let end_point = &contour.points[(cursor + 1) % point_count];
+                if end_point.kind != GlyphPointKind::OnCurve {
+                    return Err(invalid_segment(
+                        "quadratic control is not followed by an endpoint",
+                    ));
+                }
+                let control = transformed_point(point, transform);
+                let end = transformed_point(end_point, transform);
+                include_rect(bounds, QuadBez::new(start, control, end).bounding_box());
+                start = end;
+                cursor += 2;
+            }
+            GlyphPointKind::CubicControl => {
+                if cursor + 2 >= limit {
+                    return Err(invalid_segment("cubic controls have no endpoint"));
+                }
+                let second = &contour.points[(cursor + 1) % point_count];
+                let end_point = &contour.points[(cursor + 2) % point_count];
+                if second.kind != GlyphPointKind::CubicControl
+                    || end_point.kind != GlyphPointKind::OnCurve
+                {
+                    return Err(invalid_segment("invalid cubic point sequence"));
+                }
+                let control_0 = transformed_point(point, transform);
+                let control_1 = transformed_point(second, transform);
+                let end = transformed_point(end_point, transform);
+                include_rect(
+                    bounds,
+                    CubicBez::new(start, control_0, control_1, end).bounding_box(),
+                );
+                start = end;
+                cursor += 3;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn transformed_point(point: &GlyphPoint, transform: AffineTransform) -> Point {
+    let (x, y) = transform.transform_point(point.x, point.y);
+    Point::new(x, y)
+}
+
+fn include_rect(bounds: &mut Option<GlyphBounds>, rect: kurbo::Rect) {
+    match bounds {
+        Some(bounds) => {
+            bounds.min_x = bounds.min_x.min(rect.x0);
+            bounds.min_y = bounds.min_y.min(rect.y0);
+            bounds.max_x = bounds.max_x.max(rect.x1);
+            bounds.max_y = bounds.max_y.max(rect.y1);
+        }
+        None => {
+            *bounds = Some(GlyphBounds {
+                min_x: rect.x0,
+                min_y: rect.y0,
+                max_x: rect.x1,
+                max_y: rect.y1,
+            });
+        }
+    }
+}
+
+fn invalid_segment(details: &str) -> FontReadError {
+    FontReadError::InvalidDisplayGlyph {
+        details: details.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn quadratic(x: f64, y: f64) -> ContourPoint {
+        ContourPoint {
+            x,
+            y,
+            kind: GlyphPointKind::QuadraticControl,
+            smooth: false,
+            provenance: PointProvenance::Native {
+                ttf_point_index: None,
+            },
+        }
+    }
+
+    fn native(x: f64, y: f64, kind: GlyphPointKind) -> GlyphPoint {
+        GlyphPoint {
+            x,
+            y,
+            kind,
+            smooth: false,
+            provenance: PointProvenance::Native {
+                ttf_point_index: None,
+            },
+        }
+    }
+
+    #[test]
+    fn all_off_curve_contour_does_not_duplicate_the_closing_implied_point() {
+        let contour = normalize_contour(
+            vec![
+                quadratic(0.0, 0.0),
+                quadratic(100.0, 0.0),
+                quadratic(100.0, 100.0),
+            ],
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(contour.points.len(), 6);
+        assert!(matches!(
+            contour.points[0].provenance,
+            PointProvenance::Implied
+        ));
+        assert!(matches!(
+            contour.points.last().unwrap().provenance,
+            PointProvenance::Native { .. }
+        ));
+        assert_eq!(contour.points[0].x, 50.0);
+        assert_eq!(contour.points[0].y, 50.0);
+    }
+
+    #[test]
+    fn component_bounds_apply_the_instance_transform_to_tight_curve_bounds() {
+        let root = GlyphIndex::new(0);
+        let child = GlyphIndex::new(1);
+        let glyph = build_display_glyph(
+            root,
+            VariationLocation::default(),
+            vec![
+                SourceGeometry {
+                    glyph: root,
+                    contours: Vec::new(),
+                    components: vec![SourceComponent {
+                        glyph: child,
+                        transform: AffineTransform {
+                            xx: 2.0,
+                            yy: 3.0,
+                            dx: 10.0,
+                            dy: 20.0,
+                            ..AffineTransform::identity()
+                        },
+                    }],
+                    anchors: Vec::new(),
+                    guides: Vec::new(),
+                },
+                SourceGeometry {
+                    glyph: child,
+                    contours: vec![SourceContour {
+                        points: vec![
+                            native(0.0, 0.0, GlyphPointKind::OnCurve),
+                            native(50.0, 100.0, GlyphPointKind::QuadraticControl),
+                            native(100.0, 0.0, GlyphPointKind::OnCurve),
+                        ],
+                        closed: false,
+                    }],
+                    components: Vec::new(),
+                    anchors: Vec::new(),
+                    guides: Vec::new(),
+                },
+            ],
+            GlyphMetrics {
+                x_advance: 100.0,
+                y_advance: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            glyph.bounds,
+            Some(GlyphBounds {
+                min_x: 10.0,
+                min_y: 20.0,
+                max_x: 210.0,
+                max_y: 170.0,
+            })
+        );
+
+        let mut invalid = glyph;
+        invalid.geometries[0].contours.start = 1;
+        assert!(matches!(
+            invalid.validate(),
+            Err(FontReadError::InvalidDisplayGlyph { .. })
+        ));
+    }
+}

--- a/crates/shift-backends/src/font_source/glif.rs
+++ b/crates/shift-backends/src/font_source/glif.rs
@@ -1,0 +1,1147 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use norad::designspace::DesignSpaceDocument;
+use norad::{DataRequest, Font as NoradFont, Line, PointType};
+use shift_font::{
+    Axis as ShiftAxis, AxisId, AxisMapping as ShiftAxisMapping, Location as ShiftLocation,
+};
+
+use crate::designspace::{
+    axis_mappings_from_designspace, derive_axis_range, find_default_source_index, map_axis_value,
+    source_axis_design_value,
+};
+use crate::font_source::geometry::{
+    build_display_glyph, normalize_contour, ContourPoint, SourceComponent, SourceContour,
+    SourceGeometry,
+};
+use crate::font_source::interpolation::{interpolation_weights, InterpolationAxis};
+use crate::font_source::{
+    AffineTransform, AxisIndex, DirectoryGlyph, DisplayGlyph, FontDirectory, FontImporter,
+    FontReadError, GlyphAnchor, GlyphGuide, GlyphIndex, GlyphMetrics, GlyphPointKind,
+    PointProvenance, RandomAccessFont, VariationAxis, VariationAxisKind, VariationLocation,
+};
+use crate::{BackendError, BackendResult, FontFormat, FontImport};
+
+#[derive(Clone, Copy)]
+struct FileStamp {
+    length: u64,
+    modified: Option<SystemTime>,
+}
+
+impl FileStamp {
+    fn read(path: &Path) -> Result<Self, FontReadError> {
+        let metadata = std::fs::metadata(path).map_err(|source| FontReadError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        Ok(Self {
+            length: metadata.len(),
+            modified: metadata.modified().ok(),
+        })
+    }
+
+    fn matches(self, path: &Path) -> bool {
+        let Ok(metadata) = std::fs::metadata(path) else {
+            return false;
+        };
+        metadata.len() == self.length && metadata.modified().ok() == self.modified
+    }
+}
+
+struct GlifSource {
+    location: Vec<f64>,
+    glyph_paths: Box<[Option<PathBuf>]>,
+    glyph_stamps: HashMap<PathBuf, FileStamp>,
+    manifest_stamps: HashMap<PathBuf, FileStamp>,
+}
+
+enum GlifImport {
+    Ufo(Arc<[crate::ufo::UfoLayerDirectory]>),
+    Designspace(Arc<[BTreeMap<String, PathBuf>]>),
+}
+
+/// Retained UFO or Designspace GLIF paths and source-location indexes.
+pub struct GlifFont {
+    path: PathBuf,
+    format: FontFormat,
+    changed: AtomicBool,
+    directory: FontDirectory,
+    glyphs_by_name: HashMap<String, GlyphIndex>,
+    sources: Vec<GlifSource>,
+    default_source: usize,
+    mapped_axes: Vec<ShiftAxis>,
+    axis_mappings: Vec<ShiftAxisMapping>,
+    interpolation_axes: Vec<InterpolationAxis>,
+    import: GlifImport,
+}
+
+impl GlifFont {
+    pub fn open(path: &Path) -> Result<Self, FontReadError> {
+        match path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .map(str::to_ascii_lowercase)
+            .as_deref()
+        {
+            Some("ufo") => Self::open_ufo(path),
+            Some("designspace") => Self::open_designspace(path),
+            _ => Err(FontReadError::UnsupportedFormat {
+                path: path.to_path_buf(),
+            }),
+        }
+    }
+
+    fn open_ufo(path: &Path) -> Result<Self, FontReadError> {
+        let header = load_norad_header(path)?;
+        let layers: Arc<[crate::ufo::UfoLayerDirectory]> = Arc::from(
+            crate::ufo::read_ufo_layer_directories(path)
+                .map_err(|error| malformed(FontFormat::Ufo, path, error.to_string()))?,
+        );
+        let paths = &layers[0].glyphs;
+        let mut names = Vec::new();
+        let mut seen_names = HashSet::new();
+        for name in layers.iter().flat_map(|layer| layer.glyphs.keys()) {
+            if seen_names.insert(name.clone()) {
+                names.push(name.clone());
+            }
+        }
+        let (directory, glyphs_by_name) = directory(
+            FontFormat::Ufo,
+            header.font_info.family_name.clone(),
+            header.font_info.style_name.clone(),
+            header
+                .font_info
+                .units_per_em
+                .map(|value| *value)
+                .unwrap_or(1_000.0),
+            names,
+            Vec::new(),
+        )?;
+        let manifests = layers
+            .iter()
+            .flat_map(|layer| ufo_manifest_paths(path, &layer.glyphs))
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let mut source = indexed_source(&directory, Vec::new(), paths, &manifests)?;
+        for glyph_path in layers.iter().flat_map(|layer| layer.glyphs.values()) {
+            source
+                .glyph_stamps
+                .insert(glyph_path.clone(), FileStamp::read(glyph_path)?);
+        }
+        Ok(Self {
+            path: path.to_path_buf(),
+            format: FontFormat::Ufo,
+            changed: AtomicBool::new(false),
+            directory,
+            glyphs_by_name,
+            sources: vec![source],
+            default_source: 0,
+            mapped_axes: Vec::new(),
+            axis_mappings: Vec::new(),
+            interpolation_axes: Vec::new(),
+            import: GlifImport::Ufo(layers),
+        })
+    }
+
+    fn open_designspace(path: &Path) -> Result<Self, FontReadError> {
+        let document = DesignSpaceDocument::load(path).map_err(|error| {
+            malformed(
+                FontFormat::Designspace,
+                path,
+                format!("failed to parse Designspace: {error}"),
+            )
+        })?;
+        if document.sources.is_empty() {
+            return Err(malformed(
+                FontFormat::Designspace,
+                path,
+                "Designspace has no sources".into(),
+            ));
+        }
+        let default_source = find_default_source_index(&document).ok_or_else(|| {
+            malformed(
+                FontFormat::Designspace,
+                path,
+                "Designspace has no source at the mapped default location".into(),
+            )
+        })?;
+        let directory_path = path.parent().ok_or_else(|| {
+            malformed(
+                FontFormat::Designspace,
+                path,
+                "Designspace path has no parent directory".into(),
+            )
+        })?;
+        let default_descriptor = &document.sources[default_source];
+        let default_ufo = directory_path.join(&default_descriptor.filename);
+        let header = load_norad_header(&default_ufo)?;
+        let mut source_paths = Vec::with_capacity(document.sources.len());
+        let mut names = Vec::new();
+        let mut seen_names = HashSet::new();
+        for descriptor in &document.sources {
+            let ufo = directory_path.join(&descriptor.filename);
+            let paths = crate::ufo::read_glyph_paths(&ufo, descriptor.layer.as_deref())
+                .map_err(|error| malformed(FontFormat::Designspace, path, error.to_string()))?;
+            for name in paths.keys() {
+                if seen_names.insert(name.clone()) {
+                    names.push(name.clone());
+                }
+            }
+            source_paths.push(paths);
+        }
+        names.sort();
+
+        let axes = document
+            .axes
+            .iter()
+            .enumerate()
+            .map(|(index, axis)| {
+                let kind = if let Some(values) = &axis.values {
+                    let mut values = values
+                        .iter()
+                        .map(|value| f64::from(*value))
+                        .collect::<Vec<_>>();
+                    values.sort_by(f64::total_cmp);
+                    values.dedup();
+                    VariationAxisKind::Discrete {
+                        values: values.into_boxed_slice(),
+                        default: f64::from(axis.default),
+                    }
+                } else {
+                    let (minimum, maximum) = derive_axis_range(axis);
+                    VariationAxisKind::Continuous {
+                        minimum,
+                        default: f64::from(axis.default),
+                        maximum,
+                    }
+                };
+                VariationAxis {
+                    index: AxisIndex::new(index as u32),
+                    tag: axis.tag.clone(),
+                    name: axis.name.clone(),
+                    hidden: axis.hidden,
+                    kind,
+                }
+            })
+            .collect::<Vec<_>>();
+        let mapped_axes = document
+            .axes
+            .iter()
+            .map(|axis| {
+                let mut mapped = if let Some(values) = &axis.values {
+                    let mut values = values
+                        .iter()
+                        .map(|value| f64::from(*value))
+                        .collect::<Vec<_>>();
+                    values.sort_by(f64::total_cmp);
+                    values.dedup();
+                    ShiftAxis::discrete_with_id(
+                        AxisId::new(),
+                        axis.tag.clone(),
+                        axis.name.clone(),
+                        values,
+                        f64::from(axis.default),
+                    )
+                } else {
+                    let (minimum, maximum) = derive_axis_range(axis);
+                    ShiftAxis::new(
+                        axis.tag.clone(),
+                        axis.name.clone(),
+                        minimum,
+                        f64::from(axis.default),
+                        maximum,
+                    )
+                };
+                mapped.set_hidden(axis.hidden);
+                mapped
+                    .validate()
+                    .map_err(|error| malformed(FontFormat::Designspace, path, error.to_string()))?;
+                Ok(mapped)
+            })
+            .collect::<Result<Vec<_>, FontReadError>>()?;
+        let axis_mappings = axis_mappings_from_designspace(&document, &mapped_axes)
+            .map_err(|error| malformed(FontFormat::Designspace, path, error.to_string()))?;
+        let interpolation_axes = document
+            .axes
+            .iter()
+            .map(|axis| {
+                let (user_minimum, user_maximum) = derive_axis_range(axis);
+                let default = map_axis_value(axis, f64::from(axis.default));
+                let mut design_values = vec![
+                    map_axis_value(axis, user_minimum),
+                    default,
+                    map_axis_value(axis, user_maximum),
+                ];
+                if let Some(mapping) = &axis.map {
+                    design_values.extend(mapping.iter().map(|point| f64::from(point.output)));
+                }
+                InterpolationAxis {
+                    tag: axis.tag.clone(),
+                    minimum: design_values.iter().copied().fold(default, f64::min),
+                    default,
+                    maximum: design_values.iter().copied().fold(default, f64::max),
+                }
+            })
+            .collect::<Vec<_>>();
+        let family_name = default_descriptor
+            .familyname
+            .clone()
+            .or_else(|| header.font_info.family_name.clone());
+        let (directory, glyphs_by_name) = directory(
+            FontFormat::Designspace,
+            family_name,
+            header.font_info.style_name.clone(),
+            header
+                .font_info
+                .units_per_em
+                .map(|value| *value)
+                .unwrap_or(1_000.0),
+            names,
+            axes,
+        )?;
+        let import_paths = Arc::from(source_paths.clone());
+        let sources = document
+            .sources
+            .iter()
+            .zip(source_paths)
+            .enumerate()
+            .map(|(source_index, (descriptor, paths))| {
+                let location = document
+                    .axes
+                    .iter()
+                    .map(|axis| source_axis_design_value(&descriptor.location, axis))
+                    .collect();
+                let ufo = directory_path.join(&descriptor.filename);
+                let mut manifests = ufo_manifest_paths(&ufo, &paths);
+                if source_index == 0 {
+                    manifests.push(path.to_path_buf());
+                }
+                indexed_source(&directory, location, &paths, &manifests)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            path: path.to_path_buf(),
+            format: FontFormat::Designspace,
+            changed: AtomicBool::new(false),
+            directory,
+            glyphs_by_name,
+            sources,
+            default_source,
+            mapped_axes,
+            axis_mappings,
+            interpolation_axes,
+            import: GlifImport::Designspace(import_paths),
+        })
+    }
+
+    fn verify_path(&self, source: usize, path: &Path) -> Result<(), FontReadError> {
+        let unchanged = self.sources[source]
+            .glyph_stamps
+            .get(path)
+            .is_some_and(|stamp| stamp.matches(path));
+        if self.changed.load(Ordering::Acquire) || !unchanged {
+            self.changed.store(true, Ordering::Release);
+            return Err(FontReadError::SourceChanged {
+                path: path.to_path_buf(),
+            });
+        }
+        Ok(())
+    }
+
+    fn verify_manifests(&self) -> Result<(), FontReadError> {
+        for source in &self.sources {
+            for (path, stamp) in &source.manifest_stamps {
+                if self.changed.load(Ordering::Acquire) || !stamp.matches(path) {
+                    self.changed.store(true, Ordering::Release);
+                    return Err(FontReadError::SourceChanged { path: path.clone() });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn verify_all(&self) -> Result<(), FontReadError> {
+        self.verify_manifests()?;
+        for (source_index, source) in self.sources.iter().enumerate() {
+            for path in source.glyph_stamps.keys() {
+                self.verify_path(source_index, path)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn design_location(&self, location: &VariationLocation) -> Result<Vec<f64>, FontReadError> {
+        if location.coordinates().len() != self.directory.axes.len() {
+            return Err(FontReadError::InvalidDisplayGlyph {
+                details: format!(
+                    "location has {} coordinates for {} axes",
+                    location.coordinates().len(),
+                    self.directory.axes.len()
+                ),
+            });
+        }
+        for (axis, value) in self.directory.axes.iter().zip(location.coordinates()) {
+            axis.kind.validate_for_read(axis.index, *value)?;
+        }
+        let mut external = ShiftLocation::new();
+        for (axis, value) in self.mapped_axes.iter().zip(location.coordinates()) {
+            external.set(axis.id(), *value);
+        }
+        let mapped =
+            shift_font::variation::map_location(&external, &self.mapped_axes, &self.axis_mappings)
+                .map_err(|error| malformed(self.format, &self.path, error.to_string()))?;
+        Ok(self
+            .mapped_axes
+            .iter()
+            .map(|axis| mapped.get(&axis.id()).unwrap_or(axis.default()))
+            .collect())
+    }
+}
+
+impl RandomAccessFont for GlifFont {
+    fn directory(&self) -> &FontDirectory {
+        &self.directory
+    }
+
+    fn read_glyph(
+        &self,
+        glyph: GlyphIndex,
+        location: &VariationLocation,
+    ) -> Result<DisplayGlyph, FontReadError> {
+        self.verify_manifests()?;
+        if glyph.to_usize() >= self.directory.glyphs.len() {
+            return Err(FontReadError::GlyphOutOfRange {
+                glyph,
+                glyph_count: self.directory.glyphs.len() as u32,
+            });
+        }
+        let design_location = self.design_location(location)?;
+        let mut resolver = GlifResolver {
+            font: self,
+            location: &design_location,
+            indices: HashMap::new(),
+            states: Vec::new(),
+            geometries: Vec::new(),
+            root_metrics: None,
+        };
+        resolver.resolve_geometry(glyph)?;
+        self.verify_manifests()?;
+        let metrics = resolver
+            .root_metrics
+            .ok_or_else(|| FontReadError::InvalidDisplayGlyph {
+                details: "resolved GLIF glyph has no metrics".into(),
+            })?;
+        build_display_glyph(glyph, location.clone(), resolver.geometries, metrics)
+    }
+}
+
+impl FontImporter for GlifFont {
+    fn begin_import(&self) -> BackendResult<FontImport> {
+        self.verify_all().map_err(|error| {
+            BackendError::load(
+                self.format,
+                self.path.clone(),
+                format_error(self.format, error.to_string()),
+            )
+        })?;
+        let (header, stream): (_, Box<dyn crate::import::GlyphStream>) = match &self.import {
+            GlifImport::Ufo(layers) => {
+                let (header, stream) = crate::ufo::stream_retained(&self.path, layers.clone())
+                    .map_err(|source| BackendError::load(self.format, self.path.clone(), source))?;
+                (header, Box::new(stream))
+            }
+            GlifImport::Designspace(glyph_paths) => {
+                let (header, stream) =
+                    crate::designspace::stream_retained(&self.path, glyph_paths.clone()).map_err(
+                        |source| BackendError::load(self.format, self.path.clone(), source),
+                    )?;
+                (header, Box::new(stream))
+            }
+        };
+        Ok(FontImport::new(
+            header,
+            stream,
+            self.format,
+            self.path.clone(),
+        ))
+    }
+}
+
+#[derive(Clone)]
+struct ResolvedLayer {
+    geometry: SourceGeometry,
+    metrics: GlyphMetrics,
+}
+
+struct GlifResolver<'a> {
+    font: &'a GlifFont,
+    location: &'a [f64],
+    indices: HashMap<GlyphIndex, usize>,
+    states: Vec<u8>,
+    geometries: Vec<SourceGeometry>,
+    root_metrics: Option<GlyphMetrics>,
+}
+
+impl GlifResolver<'_> {
+    fn resolve_geometry(&mut self, glyph: GlyphIndex) -> Result<usize, FontReadError> {
+        if let Some(index) = self.indices.get(&glyph).copied() {
+            return match self.states[index] {
+                1 => Err(FontReadError::ComponentCycle { glyph }),
+                2 => Ok(index),
+                _ => Err(FontReadError::InvalidDisplayGlyph {
+                    details: "GLIF geometry has an invalid resolution state".into(),
+                }),
+            };
+        }
+        let layer = resolve_glif_layer(self.font, glyph, self.location)?;
+        let index = self.geometries.len();
+        self.indices.insert(glyph, index);
+        self.states.push(1);
+        self.geometries.push(empty_geometry(glyph));
+        if index == 0 {
+            self.root_metrics = Some(layer.metrics);
+        }
+        for component in &layer.geometry.components {
+            self.resolve_geometry(component.glyph)?;
+        }
+        self.geometries[index] = layer.geometry;
+        self.states[index] = 2;
+        Ok(index)
+    }
+}
+
+fn resolve_glif_layer(
+    font: &GlifFont,
+    glyph: GlyphIndex,
+    location: &[f64],
+) -> Result<ResolvedLayer, FontReadError> {
+    let mut layers = Vec::new();
+    for (source_index, source) in font.sources.iter().enumerate() {
+        let Some(path) = source
+            .glyph_paths
+            .get(glyph.to_usize())
+            .and_then(Option::as_ref)
+        else {
+            continue;
+        };
+        font.verify_path(source_index, path)?;
+        let parsed = norad::Glyph::load(path).map_err(|error| {
+            malformed(
+                font.format,
+                &font.path,
+                format!("failed to read glyph {}: {error}", path.display()),
+            )
+        })?;
+        font.verify_path(source_index, path)?;
+        layers.push((source_index, convert_norad_layer(font, glyph, &parsed)?));
+    }
+    if layers.is_empty() {
+        return Ok(ResolvedLayer {
+            geometry: empty_geometry(glyph),
+            metrics: GlyphMetrics {
+                x_advance: 0.0,
+                y_advance: None,
+            },
+        });
+    }
+    if let Some((_, layer)) = layers
+        .iter()
+        .find(|(source, _)| font.sources[*source].location == location)
+    {
+        return Ok(layer.clone());
+    }
+    let reference_position = layers
+        .iter()
+        .position(|(source, _)| *source == font.default_source)
+        .unwrap_or(0);
+    let reference = layers[reference_position].1.clone();
+    let compatible = layers
+        .into_iter()
+        .filter(|(_, layer)| layer_compatible(&reference, layer))
+        .collect::<Vec<_>>();
+    let source_locations = compatible
+        .iter()
+        .map(|(source, _)| font.sources[*source].location.clone())
+        .collect::<Vec<_>>();
+    let Some(weights) =
+        interpolation_weights(&source_locations, &font.interpolation_axes, location)
+    else {
+        return Ok(reference);
+    };
+    interpolate_layers(&reference, &compatible, &weights)
+}
+
+fn convert_norad_layer(
+    font: &GlifFont,
+    glyph: GlyphIndex,
+    source: &norad::Glyph,
+) -> Result<ResolvedLayer, FontReadError> {
+    let mut components = Vec::with_capacity(source.components.len());
+    for component in &source.components {
+        let name = component.base.to_string();
+        let base = font.glyphs_by_name.get(&name).copied().ok_or_else(|| {
+            malformed(
+                font.format,
+                &font.path,
+                format!("component base glyph {name:?} does not exist"),
+            )
+        })?;
+        components.push(SourceComponent {
+            glyph: base,
+            transform: AffineTransform {
+                xx: component.transform.x_scale,
+                xy: component.transform.xy_scale,
+                yx: component.transform.yx_scale,
+                yy: component.transform.y_scale,
+                dx: component.transform.x_offset,
+                dy: component.transform.y_offset,
+            },
+        });
+    }
+    Ok(ResolvedLayer {
+        geometry: SourceGeometry {
+            glyph,
+            contours: source
+                .contours
+                .iter()
+                .filter(|contour| !contour.points.is_empty())
+                .map(normalize_glif_contour)
+                .collect::<Result<Vec<_>, _>>()?,
+            components,
+            anchors: source
+                .anchors
+                .iter()
+                .map(|anchor| GlyphAnchor {
+                    name: anchor.name.as_ref().map(ToString::to_string),
+                    x: anchor.x,
+                    y: anchor.y,
+                })
+                .collect(),
+            guides: source.guidelines.iter().map(convert_guide).collect(),
+        },
+        metrics: GlyphMetrics {
+            x_advance: source.width,
+            y_advance: Some(source.height),
+        },
+    })
+}
+
+fn layer_compatible(reference: &ResolvedLayer, candidate: &ResolvedLayer) -> bool {
+    reference.geometry.contours.len() == candidate.geometry.contours.len()
+        && reference
+            .geometry
+            .contours
+            .iter()
+            .zip(&candidate.geometry.contours)
+            .all(|(left, right)| {
+                left.closed == right.closed
+                    && left.points.len() == right.points.len()
+                    && left
+                        .points
+                        .iter()
+                        .zip(&right.points)
+                        .all(|(left, right)| left.kind == right.kind)
+            })
+        && reference.geometry.components.len() == candidate.geometry.components.len()
+        && reference
+            .geometry
+            .components
+            .iter()
+            .zip(&candidate.geometry.components)
+            .all(|(left, right)| left.glyph == right.glyph)
+        && reference.geometry.anchors.len() == candidate.geometry.anchors.len()
+        && reference
+            .geometry
+            .anchors
+            .iter()
+            .zip(&candidate.geometry.anchors)
+            .all(|(left, right)| left.name == right.name)
+        && reference.geometry.guides.len() == candidate.geometry.guides.len()
+        && reference
+            .geometry
+            .guides
+            .iter()
+            .zip(&candidate.geometry.guides)
+            .all(guides_compatible)
+}
+
+fn interpolate_layers(
+    reference: &ResolvedLayer,
+    sources: &[(usize, ResolvedLayer)],
+    weights: &[f64],
+) -> Result<ResolvedLayer, FontReadError> {
+    if sources.len() != weights.len() {
+        return Err(FontReadError::InvalidDisplayGlyph {
+            details: "interpolation source and weight counts disagree".into(),
+        });
+    }
+    let mut result = reference.clone();
+    for (contour_index, contour) in result.geometry.contours.iter_mut().enumerate() {
+        for (point_index, point) in contour.points.iter_mut().enumerate() {
+            point.x = weighted(sources, weights, |source| {
+                source.geometry.contours[contour_index].points[point_index].x
+            });
+            point.y = weighted(sources, weights, |source| {
+                source.geometry.contours[contour_index].points[point_index].y
+            });
+        }
+    }
+    for (component_index, component) in result.geometry.components.iter_mut().enumerate() {
+        component.transform.xx = weighted(sources, weights, |source| {
+            source.geometry.components[component_index].transform.xx
+        });
+        component.transform.xy = weighted(sources, weights, |source| {
+            source.geometry.components[component_index].transform.xy
+        });
+        component.transform.yx = weighted(sources, weights, |source| {
+            source.geometry.components[component_index].transform.yx
+        });
+        component.transform.yy = weighted(sources, weights, |source| {
+            source.geometry.components[component_index].transform.yy
+        });
+        component.transform.dx = weighted(sources, weights, |source| {
+            source.geometry.components[component_index].transform.dx
+        });
+        component.transform.dy = weighted(sources, weights, |source| {
+            source.geometry.components[component_index].transform.dy
+        });
+    }
+    for (anchor_index, anchor) in result.geometry.anchors.iter_mut().enumerate() {
+        anchor.x = weighted(sources, weights, |source| {
+            source.geometry.anchors[anchor_index].x
+        });
+        anchor.y = weighted(sources, weights, |source| {
+            source.geometry.anchors[anchor_index].y
+        });
+    }
+    for (guide_index, guide) in result.geometry.guides.iter_mut().enumerate() {
+        match guide {
+            GlyphGuide::Horizontal { y, .. } => {
+                *y = weighted(sources, weights, |source| {
+                    match &source.geometry.guides[guide_index] {
+                        GlyphGuide::Horizontal { y, .. } => *y,
+                        _ => unreachable!("compatible guide kind changed"),
+                    }
+                });
+            }
+            GlyphGuide::Vertical { x, .. } => {
+                *x = weighted(sources, weights, |source| {
+                    match &source.geometry.guides[guide_index] {
+                        GlyphGuide::Vertical { x, .. } => *x,
+                        _ => unreachable!("compatible guide kind changed"),
+                    }
+                });
+            }
+            GlyphGuide::Angled { x, y, degrees, .. } => {
+                *x = weighted(sources, weights, |source| {
+                    match &source.geometry.guides[guide_index] {
+                        GlyphGuide::Angled { x, .. } => *x,
+                        _ => unreachable!("compatible guide kind changed"),
+                    }
+                });
+                *y = weighted(sources, weights, |source| {
+                    match &source.geometry.guides[guide_index] {
+                        GlyphGuide::Angled { y, .. } => *y,
+                        _ => unreachable!("compatible guide kind changed"),
+                    }
+                });
+                *degrees = weighted(sources, weights, |source| {
+                    match &source.geometry.guides[guide_index] {
+                        GlyphGuide::Angled { degrees, .. } => *degrees,
+                        _ => unreachable!("compatible guide kind changed"),
+                    }
+                });
+            }
+        }
+    }
+    result.metrics.x_advance = weighted(sources, weights, |source| source.metrics.x_advance);
+    result.metrics.y_advance = if sources
+        .iter()
+        .all(|(_, source)| source.metrics.y_advance.is_some())
+    {
+        Some(weighted(sources, weights, |source| {
+            source.metrics.y_advance.unwrap_or_default()
+        }))
+    } else {
+        None
+    };
+    Ok(result)
+}
+
+fn weighted(
+    sources: &[(usize, ResolvedLayer)],
+    weights: &[f64],
+    value: impl Fn(&ResolvedLayer) -> f64,
+) -> f64 {
+    sources
+        .iter()
+        .zip(weights)
+        .map(|((_, source), weight)| value(source) * weight)
+        .sum()
+}
+
+fn normalize_glif_contour(contour: &norad::Contour) -> Result<SourceContour, FontReadError> {
+    let closed = contour.is_closed();
+    let points = contour
+        .points
+        .iter()
+        .enumerate()
+        .map(|(index, point)| {
+            Ok(ContourPoint {
+                x: point.x,
+                y: point.y,
+                kind: glif_point_kind(&contour.points, index, closed)?,
+                smooth: point.smooth,
+                provenance: PointProvenance::Native {
+                    ttf_point_index: None,
+                },
+            })
+        })
+        .collect::<Result<Vec<_>, FontReadError>>()?;
+    normalize_contour(points, closed)
+}
+
+fn glif_point_kind(
+    points: &[norad::ContourPoint],
+    index: usize,
+    closed: bool,
+) -> Result<GlyphPointKind, FontReadError> {
+    if points[index].typ != PointType::OffCurve {
+        return Ok(GlyphPointKind::OnCurve);
+    }
+    let mut next = next_contour_index(index, points.len(), closed);
+    for _ in 0..points.len() {
+        let Some(next_index) = next else {
+            break;
+        };
+        match points[next_index].typ {
+            PointType::OffCurve => next = next_contour_index(next_index, points.len(), closed),
+            PointType::QCurve => return Ok(GlyphPointKind::QuadraticControl),
+            PointType::Curve => return Ok(GlyphPointKind::CubicControl),
+            PointType::Move | PointType::Line => {
+                return Err(FontReadError::InvalidDisplayGlyph {
+                    details: "off-curve GLIF point is followed by a line endpoint".into(),
+                })
+            }
+        }
+    }
+    if closed {
+        return Ok(GlyphPointKind::QuadraticControl);
+    }
+    Err(FontReadError::InvalidDisplayGlyph {
+        details: "open GLIF contour ends with an off-curve point".into(),
+    })
+}
+
+fn next_contour_index(index: usize, count: usize, closed: bool) -> Option<usize> {
+    if index + 1 < count {
+        Some(index + 1)
+    } else if closed {
+        Some(0)
+    } else {
+        None
+    }
+}
+
+fn convert_guide(guide: &norad::Guideline) -> GlyphGuide {
+    match guide.line {
+        Line::Horizontal(y) => GlyphGuide::Horizontal {
+            y,
+            name: guide.name.as_ref().map(ToString::to_string),
+            color: guide.color.as_ref().map(|color| color.to_rgba_string()),
+        },
+        Line::Vertical(x) => GlyphGuide::Vertical {
+            x,
+            name: guide.name.as_ref().map(ToString::to_string),
+            color: guide.color.as_ref().map(|color| color.to_rgba_string()),
+        },
+        Line::Angle { x, y, degrees } => GlyphGuide::Angled {
+            x,
+            y,
+            degrees,
+            name: guide.name.as_ref().map(ToString::to_string),
+            color: guide.color.as_ref().map(|color| color.to_rgba_string()),
+        },
+    }
+}
+
+fn guides_compatible((left, right): (&GlyphGuide, &GlyphGuide)) -> bool {
+    match (left, right) {
+        (
+            GlyphGuide::Horizontal {
+                name: left_name,
+                color: left_color,
+                ..
+            },
+            GlyphGuide::Horizontal {
+                name: right_name,
+                color: right_color,
+                ..
+            },
+        )
+        | (
+            GlyphGuide::Vertical {
+                name: left_name,
+                color: left_color,
+                ..
+            },
+            GlyphGuide::Vertical {
+                name: right_name,
+                color: right_color,
+                ..
+            },
+        )
+        | (
+            GlyphGuide::Angled {
+                name: left_name,
+                color: left_color,
+                ..
+            },
+            GlyphGuide::Angled {
+                name: right_name,
+                color: right_color,
+                ..
+            },
+        ) => left_name == right_name && left_color == right_color,
+        _ => false,
+    }
+}
+
+fn empty_geometry(glyph: GlyphIndex) -> SourceGeometry {
+    SourceGeometry {
+        glyph,
+        contours: Vec::new(),
+        components: Vec::new(),
+        anchors: Vec::new(),
+        guides: Vec::new(),
+    }
+}
+
+fn ufo_manifest_paths(ufo: &Path, glyphs: &BTreeMap<String, PathBuf>) -> Vec<PathBuf> {
+    let mut paths = HashSet::new();
+    paths.insert(ufo.to_path_buf());
+    for name in [
+        "metainfo.plist",
+        "fontinfo.plist",
+        "lib.plist",
+        "groups.plist",
+        "kerning.plist",
+        "features.fea",
+        "layercontents.plist",
+    ] {
+        let path = ufo.join(name);
+        if path.exists() {
+            paths.insert(path);
+        }
+    }
+    for glyph in glyphs.values() {
+        if let Some(layer) = glyph.parent() {
+            paths.insert(layer.to_path_buf());
+            paths.insert(layer.join("contents.plist"));
+            let layer_info = layer.join("layerinfo.plist");
+            if layer_info.exists() {
+                paths.insert(layer_info);
+            }
+        }
+    }
+    let mut paths = paths.into_iter().collect::<Vec<_>>();
+    paths.sort();
+    paths
+}
+
+fn indexed_source(
+    directory: &FontDirectory,
+    location: Vec<f64>,
+    paths: &BTreeMap<String, PathBuf>,
+    manifests: &[PathBuf],
+) -> Result<GlifSource, FontReadError> {
+    let glyph_paths = directory
+        .glyphs
+        .iter()
+        .map(|glyph| paths.get(&glyph.name).cloned())
+        .collect::<Vec<_>>();
+    let glyph_stamps = glyph_paths
+        .iter()
+        .flatten()
+        .map(|path| Ok((path.clone(), FileStamp::read(path)?)))
+        .collect::<Result<HashMap<_, _>, FontReadError>>()?;
+    let manifest_stamps = manifests
+        .iter()
+        .map(|path| Ok((path.clone(), FileStamp::read(path)?)))
+        .collect::<Result<HashMap<_, _>, FontReadError>>()?;
+    Ok(GlifSource {
+        location,
+        glyph_paths: glyph_paths.into_boxed_slice(),
+        glyph_stamps,
+        manifest_stamps,
+    })
+}
+
+fn directory(
+    format: FontFormat,
+    family_name: Option<String>,
+    style_name: Option<String>,
+    units_per_em: f64,
+    names: Vec<String>,
+    axes: Vec<VariationAxis>,
+) -> Result<(FontDirectory, HashMap<String, GlyphIndex>), FontReadError> {
+    let glyphs = names
+        .into_iter()
+        .enumerate()
+        .map(|(index, name)| DirectoryGlyph {
+            index: GlyphIndex::new(index as u32),
+            name,
+            unicodes: Box::new([]),
+        })
+        .collect();
+    let directory =
+        FontDirectory::new(format, family_name, style_name, units_per_em, glyphs, axes)?;
+    let glyphs_by_name = directory
+        .glyphs
+        .iter()
+        .map(|glyph| (glyph.name.clone(), glyph.index))
+        .collect();
+    Ok((directory, glyphs_by_name))
+}
+
+fn load_norad_header(path: &Path) -> Result<NoradFont, FontReadError> {
+    NoradFont::load_requested_data(path, DataRequest::all().layers(false))
+        .map_err(|error| malformed(FontFormat::Ufo, path, error.to_string()))
+}
+
+fn format_error(format: FontFormat, details: String) -> crate::FormatBackendError {
+    match format {
+        FontFormat::Ufo => crate::FormatBackendError::Ufo(details),
+        FontFormat::Designspace => crate::FormatBackendError::Designspace(
+            crate::designspace::DesignspaceError::LoadDesignspace {
+                path: PathBuf::new(),
+                details,
+            },
+        ),
+        _ => unreachable!("GLIF format must be UFO or Designspace"),
+    }
+}
+
+fn malformed(format: FontFormat, path: &Path, details: String) -> FontReadError {
+    FontReadError::MalformedSource {
+        format,
+        path: path.to_path_buf(),
+        details,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+    use crate::font_source::VariationCoordinate;
+
+    fn fixture(path: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("fixtures/fonts")
+            .join(path)
+    }
+
+    #[test]
+    fn ufo_directory_and_selected_glyph_need_no_shift_identity() {
+        let font = GlifFont::open(&fixture("mutatorsans/MutatorSansLightCondensed.ufo")).unwrap();
+        let glyph = font
+            .directory()
+            .glyphs
+            .iter()
+            .find(|glyph| glyph.name == "S")
+            .expect("fixture should contain S");
+        let display = font
+            .read_glyph(glyph.index, font.directory().default_location())
+            .unwrap();
+
+        assert_eq!(display.glyph, glyph.index);
+        assert!(!display.points.is_empty());
+        assert!(display.points.iter().all(|point| matches!(
+            point.provenance,
+            PointProvenance::Native {
+                ttf_point_index: None
+            } | PointProvenance::Implied
+        )));
+    }
+
+    #[test]
+    fn ufo_manifest_changes_poison_the_open_generation() {
+        let temporary = tempfile::tempdir().unwrap();
+        let copied = temporary.path().join("Changed.ufo");
+        copy_directory(
+            &fixture("mutatorsans/MutatorSansLightCondensed.ufo"),
+            &copied,
+        );
+        let font = GlifFont::open(&copied).unwrap();
+        let glyph = font.directory().glyphs[0].index;
+        let manifest = copied.join("glyphs/contents.plist");
+        let original = fs::read(&manifest).unwrap();
+        let mut changed = original.clone();
+        changed.extend_from_slice(b"\n");
+        fs::write(&manifest, changed).unwrap();
+
+        assert!(matches!(
+            font.read_glyph(glyph, font.directory().default_location()),
+            Err(FontReadError::SourceChanged { .. })
+        ));
+        fs::write(&manifest, original).unwrap();
+        assert!(matches!(
+            font.read_glyph(glyph, font.directory().default_location()),
+            Err(FontReadError::SourceChanged { .. })
+        ));
+    }
+
+    #[test]
+    fn designspace_selected_glyph_changes_at_a_non_default_location() {
+        let font =
+            GlifFont::open(&fixture("mutatorsans-variable/MutatorSans.designspace")).unwrap();
+        let glyph = font
+            .directory()
+            .glyphs
+            .iter()
+            .find(|glyph| glyph.name == "S")
+            .expect("fixture should contain S");
+        let default = font
+            .read_glyph(glyph.index, font.directory().default_location())
+            .unwrap();
+        let axis = &font.directory().axes[0];
+        let maximum = match axis.kind {
+            VariationAxisKind::Continuous { maximum, .. } => maximum,
+            VariationAxisKind::Discrete { .. } => panic!("fixture axis should be continuous"),
+        };
+        let location = font
+            .directory()
+            .location(&[VariationCoordinate {
+                axis: axis.index,
+                value: maximum,
+            }])
+            .unwrap();
+        let changed = font.read_glyph(glyph.index, &location).unwrap();
+
+        assert_ne!(default.points, changed.points);
+    }
+
+    fn copy_directory(source: &Path, target: &Path) {
+        fs::create_dir_all(target).unwrap();
+        for entry in fs::read_dir(source).unwrap() {
+            let entry = entry.unwrap();
+            let destination = target.join(entry.file_name());
+            if entry.file_type().unwrap().is_dir() {
+                copy_directory(&entry.path(), &destination);
+            } else {
+                fs::copy(entry.path(), destination).unwrap();
+            }
+        }
+    }
+}

--- a/crates/shift-backends/src/font_source/glyphs.rs
+++ b/crates/shift-backends/src/font_source/glyphs.rs
@@ -1,0 +1,769 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use glyphs_reader::{Font as ParsedGlyphsFont, Glyph as ParsedGlyph, Layer, Node, NodeType, Shape};
+
+use crate::font_source::geometry::{
+    build_display_glyph, normalize_contour, ContourPoint, SourceComponent, SourceContour,
+    SourceGeometry,
+};
+use crate::font_source::interpolation::{interpolation_weights, InterpolationAxis};
+use crate::font_source::{
+    AffineTransform, AxisIndex, DirectoryGlyph, DisplayGlyph, FontDirectory, FontImporter,
+    FontReadError, GlyphAnchor, GlyphIndex, GlyphMetrics, GlyphPointKind, PointProvenance,
+    RandomAccessFont, VariationAxis, VariationAxisKind, VariationLocation,
+};
+use crate::{BackendError, BackendResult, FontFormat, FontImport};
+
+#[derive(Clone, Copy)]
+struct SourceStamp {
+    length: u64,
+    modified: Option<SystemTime>,
+}
+
+impl SourceStamp {
+    fn read(path: &Path) -> Result<Self, FontReadError> {
+        let metadata = std::fs::metadata(path).map_err(|source| FontReadError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        Ok(Self {
+            length: metadata.len(),
+            modified: metadata.modified().ok(),
+        })
+    }
+
+    fn matches(self, path: &Path) -> bool {
+        let Ok(metadata) = std::fs::metadata(path) else {
+            return false;
+        };
+        metadata.len() == self.length && metadata.modified().ok() == self.modified
+    }
+}
+
+#[derive(Clone)]
+struct GlyphsAxisMapping {
+    user_to_design: Box<[(f64, f64)]>,
+}
+
+impl GlyphsAxisMapping {
+    fn map(&self, user: f64) -> f64 {
+        piecewise_map(&self.user_to_design, user)
+    }
+
+    fn unmap(&self, design: f64) -> f64 {
+        let mut design_to_user = self
+            .user_to_design
+            .iter()
+            .map(|(user, design)| (*design, *user))
+            .collect::<Vec<_>>();
+        design_to_user.sort_by(|left, right| left.0.total_cmp(&right.0));
+        design_to_user.dedup_by(|left, right| left.0 == right.0);
+        piecewise_map(&design_to_user, design)
+    }
+
+    fn user_values(&self) -> impl Iterator<Item = f64> + '_ {
+        self.user_to_design.iter().map(|(user, _)| *user)
+    }
+}
+
+/// One retained parsed Glyphs or Glyphspackage source.
+pub struct GlyphsFont {
+    path: PathBuf,
+    stamp: SourceStamp,
+    changed: AtomicBool,
+    source: Arc<ParsedGlyphsFont>,
+    directory: FontDirectory,
+    glyphs_by_name: HashMap<String, GlyphIndex>,
+    master_locations: Vec<Vec<f64>>,
+    axis_mappings: Vec<GlyphsAxisMapping>,
+    interpolation_axes: Vec<InterpolationAxis>,
+}
+
+impl GlyphsFont {
+    pub fn open(path: &Path) -> Result<Self, FontReadError> {
+        let stamp = SourceStamp::read(path)?;
+        let source = Arc::new(
+            ParsedGlyphsFont::load(path)
+                .map_err(|error| malformed(path, format!("failed to parse source: {error}")))?,
+        );
+        let default_master = source.masters.get(source.default_master_idx);
+        let mut axes = Vec::with_capacity(source.axes.len());
+        let mut axis_mappings = Vec::with_capacity(source.axes.len());
+        let mut interpolation_axes = Vec::with_capacity(source.axes.len());
+        for (index, axis) in source.axes.iter().enumerate() {
+            let design_values = source
+                .masters
+                .iter()
+                .filter_map(|master| master.axes_values.get(index))
+                .map(|value| value.into_inner())
+                .collect::<Vec<_>>();
+            let design_default = default_master
+                .and_then(|master| master.axes_values.get(index))
+                .map(|value| value.into_inner())
+                .or_else(|| design_values.first().copied())
+                .unwrap_or(0.0);
+            let design_minimum = design_values.iter().copied().fold(design_default, f64::min);
+            let design_maximum = design_values.iter().copied().fold(design_default, f64::max);
+            let mut mapping = source
+                .axis_mappings
+                .get(&axis.name)
+                .map(|mapping| {
+                    mapping
+                        .iter()
+                        .map(|(user, design)| (user.into_inner(), design.into_inner()))
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_else(|| {
+                    design_values
+                        .iter()
+                        .copied()
+                        .map(|value| (value, value))
+                        .collect()
+                });
+            if mapping.is_empty() {
+                mapping.push((design_default, design_default));
+            }
+            mapping.sort_by(|left, right| left.0.total_cmp(&right.0));
+            mapping.dedup_by(|left, right| left.0 == right.0);
+            let mapping = GlyphsAxisMapping {
+                user_to_design: mapping.into_boxed_slice(),
+            };
+            let user_default = mapping.unmap(design_default);
+            let user_minimum = mapping.user_values().fold(user_default, f64::min);
+            let user_maximum = mapping.user_values().fold(user_default, f64::max);
+            axes.push(VariationAxis {
+                index: AxisIndex::new(index as u32),
+                tag: axis.tag.clone(),
+                name: axis.name.clone(),
+                hidden: axis.hidden.unwrap_or(false),
+                kind: VariationAxisKind::Continuous {
+                    minimum: user_minimum,
+                    default: user_default,
+                    maximum: user_maximum,
+                },
+            });
+            axis_mappings.push(mapping);
+            interpolation_axes.push(InterpolationAxis {
+                tag: axis.tag.clone(),
+                minimum: design_minimum,
+                default: design_default,
+                maximum: design_maximum,
+            });
+        }
+        let glyphs = source
+            .glyphs
+            .values()
+            .enumerate()
+            .map(|(index, glyph)| DirectoryGlyph {
+                index: GlyphIndex::new(index as u32),
+                name: glyph.name.to_string(),
+                unicodes: glyph
+                    .unicode
+                    .iter()
+                    .copied()
+                    .collect::<Vec<_>>()
+                    .into_boxed_slice(),
+            })
+            .collect::<Vec<_>>();
+        let directory = FontDirectory::new(
+            FontFormat::Glyphs,
+            source
+                .get_default_name("familyNames")
+                .map(ToString::to_string),
+            default_master.map(|master| master.name.clone()),
+            f64::from(source.units_per_em),
+            glyphs,
+            axes,
+        )?;
+        let glyphs_by_name = directory
+            .glyphs
+            .iter()
+            .map(|glyph| (glyph.name.clone(), glyph.index))
+            .collect();
+        let master_locations = source
+            .masters
+            .iter()
+            .map(|master| {
+                (0..source.axes.len())
+                    .map(|index| {
+                        master
+                            .axes_values
+                            .get(index)
+                            .map(|value| value.into_inner())
+                            .unwrap_or(interpolation_axes[index].default)
+                    })
+                    .collect()
+            })
+            .collect();
+        Ok(Self {
+            path: path.to_path_buf(),
+            stamp,
+            changed: AtomicBool::new(false),
+            source,
+            directory,
+            glyphs_by_name,
+            master_locations,
+            axis_mappings,
+            interpolation_axes,
+        })
+    }
+
+    fn verify_source(&self) -> Result<(), FontReadError> {
+        if self.changed.load(Ordering::Acquire) || !self.stamp.matches(&self.path) {
+            self.changed.store(true, Ordering::Release);
+            return Err(FontReadError::SourceChanged {
+                path: self.path.clone(),
+            });
+        }
+        Ok(())
+    }
+
+    fn parsed_glyph(&self, glyph: GlyphIndex) -> Result<&ParsedGlyph, FontReadError> {
+        let entry =
+            self.directory
+                .glyphs
+                .get(glyph.to_usize())
+                .ok_or(FontReadError::GlyphOutOfRange {
+                    glyph,
+                    glyph_count: self.directory.glyphs.len() as u32,
+                })?;
+        self.source.glyphs.get(entry.name.as_str()).ok_or_else(|| {
+            FontReadError::InvalidDisplayGlyph {
+                details: format!("Glyphs directory lost glyph {:?}", entry.name),
+            }
+        })
+    }
+}
+
+impl RandomAccessFont for GlyphsFont {
+    fn directory(&self) -> &FontDirectory {
+        &self.directory
+    }
+
+    fn read_glyph(
+        &self,
+        glyph: GlyphIndex,
+        location: &VariationLocation,
+    ) -> Result<DisplayGlyph, FontReadError> {
+        self.verify_source()?;
+        if location.coordinates().len() != self.directory.axes.len() {
+            return Err(FontReadError::InvalidDisplayGlyph {
+                details: format!(
+                    "location has {} coordinates for {} axes",
+                    location.coordinates().len(),
+                    self.directory.axes.len()
+                ),
+            });
+        }
+        for (axis, value) in self.directory.axes.iter().zip(location.coordinates()) {
+            axis.kind.validate_for_read(axis.index, *value)?;
+        }
+        let design_location = self
+            .axis_mappings
+            .iter()
+            .zip(location.coordinates())
+            .map(|(mapping, value)| mapping.map(*value))
+            .collect::<Vec<_>>();
+        let mut resolver = GlyphsResolver {
+            font: self,
+            location: &design_location,
+            indices: HashMap::new(),
+            states: Vec::new(),
+            geometries: Vec::new(),
+            root_metrics: None,
+        };
+        resolver.resolve_geometry(glyph)?;
+        let metrics = resolver
+            .root_metrics
+            .ok_or_else(|| FontReadError::InvalidDisplayGlyph {
+                details: "resolved Glyphs glyph has no metrics".into(),
+            })?;
+        build_display_glyph(glyph, location.clone(), resolver.geometries, metrics)
+    }
+}
+
+impl FontImporter for GlyphsFont {
+    fn begin_import(&self) -> BackendResult<FontImport> {
+        self.verify_source().map_err(|error| {
+            BackendError::load(
+                FontFormat::Glyphs,
+                self.path.clone(),
+                crate::FormatBackendError::Glyphs(error.to_string()),
+            )
+        })?;
+        let (header, stream) = crate::glyphs::stream_retained(self.source.clone())
+            .map_err(|source| BackendError::load(FontFormat::Glyphs, self.path.clone(), source))?;
+        Ok(FontImport::new(
+            header,
+            Box::new(stream),
+            FontFormat::Glyphs,
+            self.path.clone(),
+        ))
+    }
+}
+
+#[derive(Clone)]
+struct ResolvedLayer {
+    geometry: SourceGeometry,
+    metrics: GlyphMetrics,
+}
+
+struct GlyphsResolver<'a> {
+    font: &'a GlyphsFont,
+    location: &'a [f64],
+    indices: HashMap<GlyphIndex, usize>,
+    states: Vec<u8>,
+    geometries: Vec<SourceGeometry>,
+    root_metrics: Option<GlyphMetrics>,
+}
+
+impl GlyphsResolver<'_> {
+    fn resolve_geometry(&mut self, glyph: GlyphIndex) -> Result<usize, FontReadError> {
+        if let Some(index) = self.indices.get(&glyph).copied() {
+            return match self.states[index] {
+                1 => Err(FontReadError::ComponentCycle { glyph }),
+                2 => Ok(index),
+                _ => Err(FontReadError::InvalidDisplayGlyph {
+                    details: "Glyphs geometry has an invalid resolution state".into(),
+                }),
+            };
+        }
+        let parsed = self.font.parsed_glyph(glyph)?;
+        let layer = resolve_glyphs_layer(self.font, parsed, glyph, self.location)?;
+        let index = self.geometries.len();
+        self.indices.insert(glyph, index);
+        self.states.push(1);
+        self.geometries.push(SourceGeometry {
+            glyph,
+            contours: Vec::new(),
+            components: Vec::new(),
+            anchors: Vec::new(),
+            guides: Vec::new(),
+        });
+        if index == 0 {
+            self.root_metrics = Some(layer.metrics);
+        }
+        for component in &layer.geometry.components {
+            self.resolve_geometry(component.glyph)?;
+        }
+        self.geometries[index] = layer.geometry;
+        self.states[index] = 2;
+        Ok(index)
+    }
+}
+
+fn resolve_glyphs_layer(
+    font: &GlyphsFont,
+    glyph: &ParsedGlyph,
+    glyph_index: GlyphIndex,
+    location: &[f64],
+) -> Result<ResolvedLayer, FontReadError> {
+    if glyph.layers.iter().any(|layer| {
+        layer.is_intermediate()
+            || !layer.attributes.axis_rules.is_empty()
+            || !layer.smart_component_positions.is_empty()
+    }) {
+        return Err(malformed(
+            &font.path,
+            format!(
+                "glyph {:?} uses intermediate, bracket, or smart-component layers",
+                glyph.name
+            ),
+        ));
+    }
+    let layers = font
+        .source
+        .masters
+        .iter()
+        .enumerate()
+        .filter_map(|(master_index, master)| {
+            glyph
+                .layers
+                .iter()
+                .find(|layer| layer.master_id() == master.id)
+                .map(|layer| (master_index, layer))
+        })
+        .collect::<Vec<_>>();
+    if layers.is_empty() {
+        return Ok(ResolvedLayer {
+            geometry: SourceGeometry {
+                glyph: glyph_index,
+                contours: Vec::new(),
+                components: Vec::new(),
+                anchors: Vec::new(),
+                guides: Vec::new(),
+            },
+            metrics: GlyphMetrics {
+                x_advance: 0.0,
+                y_advance: None,
+            },
+        });
+    }
+
+    if let Some((_, layer)) = layers
+        .iter()
+        .find(|(master, _)| font.master_locations[*master] == location)
+    {
+        return convert_glyphs_layer(font, glyph_index, layer);
+    }
+    let reference_position = layers
+        .iter()
+        .position(|(master, _)| *master == font.source.default_master_idx)
+        .unwrap_or(0);
+    let reference = convert_glyphs_layer(font, glyph_index, layers[reference_position].1)?;
+    let mut compatible = Vec::new();
+    for (master, layer) in layers {
+        let converted = convert_glyphs_layer(font, glyph_index, layer)?;
+        if layer_compatible(&reference, &converted) {
+            compatible.push((master, converted));
+        }
+    }
+    let source_locations = compatible
+        .iter()
+        .map(|(master, _)| font.master_locations[*master].clone())
+        .collect::<Vec<_>>();
+    let Some(weights) =
+        interpolation_weights(&source_locations, &font.interpolation_axes, location)
+    else {
+        return Ok(reference);
+    };
+    interpolate_layers(&reference, &compatible, &weights)
+}
+
+fn convert_glyphs_layer(
+    font: &GlyphsFont,
+    glyph: GlyphIndex,
+    layer: &Layer,
+) -> Result<ResolvedLayer, FontReadError> {
+    let mut contours = Vec::new();
+    let mut components = Vec::new();
+    for shape in &layer.shapes {
+        match shape {
+            Shape::Path(path) => contours.push(normalize_glyphs_contour(&path.nodes, path.closed)?),
+            Shape::Component(component) => {
+                if !component.smart_component_values.is_empty() {
+                    return Err(malformed(
+                        &font.path,
+                        format!(
+                            "smart component {:?} requires an instance-specific geometry location",
+                            component.name
+                        ),
+                    ));
+                }
+                let base = font
+                    .glyphs_by_name
+                    .get(component.name.as_str())
+                    .copied()
+                    .ok_or_else(|| {
+                        malformed(
+                            &font.path,
+                            format!("component base glyph {:?} does not exist", component.name),
+                        )
+                    })?;
+                let coefficients = component.transform.as_coeffs();
+                components.push(SourceComponent {
+                    glyph: base,
+                    transform: AffineTransform {
+                        xx: coefficients[0],
+                        xy: coefficients[1],
+                        yx: coefficients[2],
+                        yy: coefficients[3],
+                        dx: coefficients[4],
+                        dy: coefficients[5],
+                    },
+                });
+            }
+        }
+    }
+    Ok(ResolvedLayer {
+        geometry: SourceGeometry {
+            glyph,
+            contours,
+            components,
+            anchors: layer
+                .anchors
+                .iter()
+                .map(|anchor| GlyphAnchor {
+                    name: (!anchor.name.is_empty()).then(|| anchor.name.to_string()),
+                    x: anchor.pos.x,
+                    y: anchor.pos.y,
+                })
+                .collect(),
+            guides: Vec::new(),
+        },
+        metrics: GlyphMetrics {
+            x_advance: layer.width.into_inner(),
+            y_advance: layer.vert_width.map(|value| value.into_inner()),
+        },
+    })
+}
+
+fn layer_compatible(reference: &ResolvedLayer, candidate: &ResolvedLayer) -> bool {
+    reference.geometry.contours.len() == candidate.geometry.contours.len()
+        && reference
+            .geometry
+            .contours
+            .iter()
+            .zip(&candidate.geometry.contours)
+            .all(|(left, right)| {
+                left.closed == right.closed
+                    && left.points.len() == right.points.len()
+                    && left
+                        .points
+                        .iter()
+                        .zip(&right.points)
+                        .all(|(left, right)| left.kind == right.kind)
+            })
+        && reference.geometry.components.len() == candidate.geometry.components.len()
+        && reference
+            .geometry
+            .components
+            .iter()
+            .zip(&candidate.geometry.components)
+            .all(|(left, right)| left.glyph == right.glyph)
+        && reference.geometry.anchors.len() == candidate.geometry.anchors.len()
+        && reference
+            .geometry
+            .anchors
+            .iter()
+            .zip(&candidate.geometry.anchors)
+            .all(|(left, right)| left.name == right.name)
+}
+
+fn interpolate_layers(
+    reference: &ResolvedLayer,
+    sources: &[(usize, ResolvedLayer)],
+    weights: &[f64],
+) -> Result<ResolvedLayer, FontReadError> {
+    if sources.len() != weights.len() {
+        return Err(FontReadError::InvalidDisplayGlyph {
+            details: "interpolation source and weight counts disagree".into(),
+        });
+    }
+    let mut result = reference.clone();
+    for (contour_index, contour) in result.geometry.contours.iter_mut().enumerate() {
+        for (point_index, point) in contour.points.iter_mut().enumerate() {
+            point.x = weighted(sources, weights, |source| {
+                source.geometry.contours[contour_index].points[point_index].x
+            });
+            point.y = weighted(sources, weights, |source| {
+                source.geometry.contours[contour_index].points[point_index].y
+            });
+        }
+    }
+    for (component_index, component) in result.geometry.components.iter_mut().enumerate() {
+        component.transform.xx = weighted(sources, weights, |source| {
+            source.geometry.components[component_index].transform.xx
+        });
+        component.transform.xy = weighted(sources, weights, |source| {
+            source.geometry.components[component_index].transform.xy
+        });
+        component.transform.yx = weighted(sources, weights, |source| {
+            source.geometry.components[component_index].transform.yx
+        });
+        component.transform.yy = weighted(sources, weights, |source| {
+            source.geometry.components[component_index].transform.yy
+        });
+        component.transform.dx = weighted(sources, weights, |source| {
+            source.geometry.components[component_index].transform.dx
+        });
+        component.transform.dy = weighted(sources, weights, |source| {
+            source.geometry.components[component_index].transform.dy
+        });
+    }
+    for (anchor_index, anchor) in result.geometry.anchors.iter_mut().enumerate() {
+        anchor.x = weighted(sources, weights, |source| {
+            source.geometry.anchors[anchor_index].x
+        });
+        anchor.y = weighted(sources, weights, |source| {
+            source.geometry.anchors[anchor_index].y
+        });
+    }
+    result.metrics.x_advance = weighted(sources, weights, |source| source.metrics.x_advance);
+    result.metrics.y_advance = if sources
+        .iter()
+        .all(|(_, source)| source.metrics.y_advance.is_some())
+    {
+        Some(weighted(sources, weights, |source| {
+            source.metrics.y_advance.unwrap_or_default()
+        }))
+    } else {
+        None
+    };
+    Ok(result)
+}
+
+fn weighted(
+    sources: &[(usize, ResolvedLayer)],
+    weights: &[f64],
+    value: impl Fn(&ResolvedLayer) -> f64,
+) -> f64 {
+    sources
+        .iter()
+        .zip(weights)
+        .map(|((_, source), weight)| value(source) * weight)
+        .sum()
+}
+
+fn piecewise_map(points: &[(f64, f64)], value: f64) -> f64 {
+    match points {
+        [] => value,
+        [point] => point.1,
+        _ => {
+            let segment = if value <= points[0].0 {
+                [points[0], points[1]]
+            } else if value >= points[points.len() - 1].0 {
+                [points[points.len() - 2], points[points.len() - 1]]
+            } else {
+                let upper = points.partition_point(|point| point.0 < value);
+                [points[upper - 1], points[upper]]
+            };
+            if segment[0].0 == segment[1].0 {
+                return segment[0].1;
+            }
+            segment[0].1
+                + (segment[1].1 - segment[0].1) * (value - segment[0].0)
+                    / (segment[1].0 - segment[0].0)
+        }
+    }
+}
+
+fn normalize_glyphs_contour(nodes: &[Node], closed: bool) -> Result<SourceContour, FontReadError> {
+    let points = nodes
+        .iter()
+        .enumerate()
+        .map(|(index, node)| {
+            Ok(ContourPoint {
+                x: node.pt.x,
+                y: node.pt.y,
+                kind: glyphs_point_kind(nodes, index, closed)?,
+                smooth: matches!(
+                    node.node_type,
+                    NodeType::LineSmooth | NodeType::CurveSmooth | NodeType::QCurveSmooth
+                ),
+                provenance: PointProvenance::Native {
+                    ttf_point_index: None,
+                },
+            })
+        })
+        .collect::<Result<Vec<_>, FontReadError>>()?;
+    normalize_contour(points, closed)
+}
+
+fn glyphs_point_kind(
+    nodes: &[Node],
+    index: usize,
+    closed: bool,
+) -> Result<GlyphPointKind, FontReadError> {
+    if nodes[index].node_type != NodeType::OffCurve {
+        return Ok(GlyphPointKind::OnCurve);
+    }
+    let mut next = next_index(index, nodes.len(), closed);
+    for _ in 0..nodes.len() {
+        let Some(next_position) = next else {
+            break;
+        };
+        match nodes[next_position].node_type {
+            NodeType::OffCurve => next = next_index(next_position, nodes.len(), closed),
+            NodeType::QCurve | NodeType::QCurveSmooth => {
+                return Ok(GlyphPointKind::QuadraticControl)
+            }
+            NodeType::Curve | NodeType::CurveSmooth => return Ok(GlyphPointKind::CubicControl),
+            NodeType::Line | NodeType::LineSmooth => {
+                return Err(FontReadError::InvalidDisplayGlyph {
+                    details: "off-curve Glyphs node is followed by a line endpoint".into(),
+                })
+            }
+        }
+    }
+    if closed {
+        return Ok(GlyphPointKind::QuadraticControl);
+    }
+    Err(FontReadError::InvalidDisplayGlyph {
+        details: "open Glyphs path ends with an off-curve node".into(),
+    })
+}
+
+fn next_index(index: usize, count: usize, closed: bool) -> Option<usize> {
+    if index + 1 < count {
+        Some(index + 1)
+    } else if closed {
+        Some(0)
+    } else {
+        None
+    }
+}
+
+fn malformed(path: &Path, details: String) -> FontReadError {
+    FontReadError::MalformedSource {
+        format: FontFormat::Glyphs,
+        path: path.to_path_buf(),
+        details,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture(name: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("fixtures/fonts")
+            .join(name)
+    }
+
+    #[test]
+    fn glyphs_selected_glyph_resolves_without_shift_identity() {
+        let font = GlyphsFont::open(&fixture("Homenaje.glyphs")).unwrap();
+        let glyph = font
+            .directory()
+            .glyphs
+            .iter()
+            .find(|glyph| glyph.name == "Aacute")
+            .expect("fixture should contain Aacute");
+        let display = font
+            .read_glyph(glyph.index, font.directory().default_location())
+            .unwrap();
+
+        assert_eq!(display.glyph, glyph.index);
+        assert!(!display.geometries.is_empty());
+        assert!(!display.components.is_empty());
+    }
+
+    #[test]
+    fn glyphs_selected_glyph_changes_at_a_non_default_location() {
+        let font = GlyphsFont::open(&fixture("MutatorSansVariable.glyphs")).unwrap();
+        let glyph = font
+            .directory()
+            .glyphs
+            .iter()
+            .find(|glyph| glyph.name == "A")
+            .expect("fixture should contain A");
+        let default = font
+            .read_glyph(glyph.index, font.directory().default_location())
+            .unwrap();
+        let axis = &font.directory().axes[0];
+        let maximum = match axis.kind {
+            VariationAxisKind::Continuous { maximum, .. } => maximum,
+            VariationAxisKind::Discrete { .. } => panic!("fixture axis should be continuous"),
+        };
+        let location = font
+            .directory()
+            .location(&[crate::font_source::VariationCoordinate {
+                axis: axis.index,
+                value: maximum,
+            }])
+            .unwrap();
+        let changed = font.read_glyph(glyph.index, &location).unwrap();
+
+        assert_ne!(default.points, changed.points);
+    }
+}

--- a/crates/shift-backends/src/font_source/interpolation.rs
+++ b/crates/shift-backends/src/font_source/interpolation.rs
@@ -1,0 +1,165 @@
+use std::collections::{hash_map::Entry, HashMap, HashSet};
+use std::str::FromStr;
+
+use fontdrasil::coords::{NormalizedCoord, NormalizedLocation};
+use fontdrasil::types::Tag;
+use fontdrasil::variations::{RoundingBehaviour, VariationModel};
+
+#[derive(Clone, Debug)]
+pub(crate) struct InterpolationAxis {
+    pub(crate) tag: String,
+    pub(crate) minimum: f64,
+    pub(crate) default: f64,
+    pub(crate) maximum: f64,
+}
+
+pub(crate) fn interpolation_weights(
+    source_locations: &[Vec<f64>],
+    axes: &[InterpolationAxis],
+    location: &[f64],
+) -> Option<Vec<f64>> {
+    if source_locations.is_empty()
+        || axes.len() != location.len()
+        || source_locations
+            .iter()
+            .any(|source| source.len() != axes.len())
+    {
+        return None;
+    }
+    if source_locations.len() == 1 {
+        return Some(vec![1.0]);
+    }
+
+    let tags = axes
+        .iter()
+        .map(|axis| Tag::from_str(&axis.tag).ok())
+        .collect::<Option<Vec<_>>>()?;
+    let normalized_sources = source_locations
+        .iter()
+        .map(|source| normalized_location(source, axes, &tags))
+        .collect::<Vec<_>>();
+    let mut samples = HashMap::new();
+    for (index, source) in normalized_sources.iter().enumerate() {
+        let mut unit = vec![0.0; source_locations.len()];
+        unit[index] = 1.0;
+        if samples.insert(source.clone(), unit).is_some() {
+            return None;
+        }
+    }
+
+    let default_location = normalized_location(
+        &axes.iter().map(|axis| axis.default).collect::<Vec<_>>(),
+        axes,
+        &tags,
+    );
+    if let Entry::Vacant(entry) = samples.entry(default_location) {
+        entry.insert(virtual_default_coefficients(&normalized_sources)?);
+    }
+    let model = VariationModel::new(
+        samples
+            .keys()
+            .cloned()
+            .collect::<HashSet<NormalizedLocation>>(),
+        tags.clone(),
+    );
+    let deltas = model
+        .deltas_with_rounding::<f64, f64>(&samples, RoundingBehaviour::None)
+        .ok()?;
+    let target = normalized_location(location, axes, &tags);
+    Some(model.interpolate_from_deltas(&target, &deltas))
+}
+
+fn normalized_location(
+    location: &[f64],
+    axes: &[InterpolationAxis],
+    tags: &[Tag],
+) -> NormalizedLocation {
+    axes.iter()
+        .zip(location)
+        .zip(tags)
+        .map(|((axis, value), tag)| (*tag, NormalizedCoord::new(normalize(axis, *value))))
+        .collect()
+}
+
+fn normalize(axis: &InterpolationAxis, value: f64) -> f64 {
+    if value == axis.default {
+        return 0.0;
+    }
+    if value < axis.default {
+        let span = axis.default - axis.minimum;
+        return if span == 0.0 {
+            0.0
+        } else {
+            ((value - axis.default) / span).max(-1.0)
+        };
+    }
+
+    let span = axis.maximum - axis.default;
+    if span == 0.0 {
+        0.0
+    } else {
+        ((value - axis.default) / span).min(1.0)
+    }
+}
+
+fn virtual_default_coefficients(sources: &[NormalizedLocation]) -> Option<Vec<f64>> {
+    let mut negative: Option<(usize, Tag, f64)> = None;
+    let mut positive: Option<(usize, Tag, f64)> = None;
+
+    for (index, location) in sources.iter().enumerate() {
+        let nonzero = location
+            .iter()
+            .filter_map(|(tag, coordinate)| {
+                let value = coordinate.to_f64();
+                (value != 0.0).then_some((*tag, value))
+            })
+            .collect::<Vec<_>>();
+        let [(tag, value)] = nonzero.as_slice() else {
+            continue;
+        };
+        if *value < 0.0
+            && negative
+                .as_ref()
+                .is_none_or(|(_, _, current)| *value > *current)
+        {
+            negative = Some((index, *tag, *value));
+        }
+        if *value > 0.0
+            && positive
+                .as_ref()
+                .is_none_or(|(_, _, current)| *value < *current)
+        {
+            positive = Some((index, *tag, *value));
+        }
+    }
+
+    let (negative_index, negative_axis, negative_value) = negative?;
+    let (positive_index, positive_axis, positive_value) = positive?;
+    if negative_axis != positive_axis {
+        return None;
+    }
+    let span = positive_value - negative_value;
+    let mut coefficients = vec![0.0; sources.len()];
+    coefficients[negative_index] = positive_value / span;
+    coefficients[positive_index] = -negative_value / span;
+    Some(coefficients)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interpolates_two_source_values_in_source_order() {
+        let axes = [InterpolationAxis {
+            tag: "wght".into(),
+            minimum: 100.0,
+            default: 400.0,
+            maximum: 900.0,
+        }];
+        let weights = interpolation_weights(&[vec![400.0], vec![900.0]], &axes, &[650.0]).unwrap();
+
+        assert!((weights[0] - 0.5).abs() < 1e-9);
+        assert!((weights[1] - 0.5).abs() < 1e-9);
+    }
+}

--- a/crates/shift-backends/src/font_source/mod.rs
+++ b/crates/shift-backends/src/font_source/mod.rs
@@ -1,0 +1,77 @@
+mod binary;
+mod error;
+mod geometry;
+mod glif;
+mod glyphs;
+mod interpolation;
+mod types;
+
+pub use binary::BinaryFont;
+pub use error::FontReadError;
+pub use glif::GlifFont;
+pub use glyphs::GlyphsFont;
+pub use types::{
+    AffineTransform, AnchorRange, AxisIndex, ComponentInstance, ComponentRange, ContourRange,
+    DirectoryGlyph, DisplayGlyph, FontDirectory, GeometryIndex, GlyphAnchor, GlyphBounds,
+    GlyphContour, GlyphGeometry, GlyphGuide, GlyphIndex, GlyphMetrics, GlyphPoint, GlyphPointKind,
+    GuideRange, PointProvenance, PointRange, TrueTypePointIndex, VariationAxis, VariationAxisKind,
+    VariationCoordinate, VariationLocation,
+};
+
+use crate::{BackendResult, FontImport};
+
+/// Retained random access to one opened non-native font source.
+pub trait RandomAccessFont: Send + Sync {
+    fn directory(&self) -> &FontDirectory;
+
+    fn read_glyph(
+        &self,
+        glyph: GlyphIndex,
+        location: &VariationLocation,
+    ) -> Result<DisplayGlyph, FontReadError>;
+}
+
+/// Exhaustive authored conversion from the original retained source semantics.
+pub trait FontImporter: RandomAccessFont {
+    fn begin_import(&self) -> BackendResult<FontImport>;
+}
+
+/// One retained source selected by [`crate::font_loader::FontLoader`].
+pub enum FontSource {
+    Binary(BinaryFont),
+    Glif(GlifFont),
+    Glyphs(GlyphsFont),
+}
+
+impl FontSource {
+    /// Returns exhaustive authored conversion only for product-convertible sources.
+    pub fn importer(&self) -> Option<&dyn FontImporter> {
+        match self {
+            Self::Binary(_) => None,
+            Self::Glif(font) => Some(font),
+            Self::Glyphs(font) => Some(font),
+        }
+    }
+}
+
+impl RandomAccessFont for FontSource {
+    fn directory(&self) -> &FontDirectory {
+        match self {
+            Self::Binary(font) => font.directory(),
+            Self::Glif(font) => font.directory(),
+            Self::Glyphs(font) => font.directory(),
+        }
+    }
+
+    fn read_glyph(
+        &self,
+        glyph: GlyphIndex,
+        location: &VariationLocation,
+    ) -> Result<DisplayGlyph, FontReadError> {
+        match self {
+            Self::Binary(font) => font.read_glyph(glyph, location),
+            Self::Glif(font) => font.read_glyph(glyph, location),
+            Self::Glyphs(font) => font.read_glyph(glyph, location),
+        }
+    }
+}

--- a/crates/shift-backends/src/font_source/types.rs
+++ b/crates/shift-backends/src/font_source/types.rs
@@ -1,0 +1,809 @@
+use std::collections::HashSet;
+
+use crate::font_source::FontReadError;
+use crate::FontFormat;
+
+macro_rules! index_type {
+    ($name:ident) => {
+        #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+        pub struct $name(u32);
+
+        impl $name {
+            pub const fn new(value: u32) -> Self {
+                Self(value)
+            }
+
+            pub const fn to_u32(self) -> u32 {
+                self.0
+            }
+
+            pub const fn to_usize(self) -> usize {
+                self.0 as usize
+            }
+        }
+    };
+}
+
+index_type!(GlyphIndex);
+index_type!(AxisIndex);
+index_type!(GeometryIndex);
+index_type!(TrueTypePointIndex);
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct DirectoryGlyph {
+    pub index: GlyphIndex,
+    pub name: String,
+    pub unicodes: Box<[u32]>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum VariationAxisKind {
+    Continuous {
+        minimum: f64,
+        default: f64,
+        maximum: f64,
+    },
+    Discrete {
+        values: Box<[f64]>,
+        default: f64,
+    },
+}
+
+impl VariationAxisKind {
+    pub fn default_value(&self) -> f64 {
+        match self {
+            Self::Continuous { default, .. } | Self::Discrete { default, .. } => *default,
+        }
+    }
+
+    fn validate_definition(&self, axis: AxisIndex) -> Result<(), FontReadError> {
+        match self {
+            Self::Continuous {
+                minimum,
+                default,
+                maximum,
+            } => {
+                if !minimum.is_finite()
+                    || !default.is_finite()
+                    || !maximum.is_finite()
+                    || minimum > default
+                    || default > maximum
+                {
+                    return Err(FontReadError::InvalidDisplayGlyph {
+                        details: format!("continuous axis {axis:?} has invalid bounds"),
+                    });
+                }
+            }
+            Self::Discrete { values, default } => {
+                if values.is_empty()
+                    || !default.is_finite()
+                    || !values.iter().all(|value| value.is_finite())
+                    || values.windows(2).any(|pair| pair[0] >= pair[1])
+                    || !values.contains(default)
+                {
+                    return Err(FontReadError::InvalidDisplayGlyph {
+                        details: format!("discrete axis {axis:?} has invalid values"),
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn validate_for_read(
+        &self,
+        axis: AxisIndex,
+        value: f64,
+    ) -> Result<(), FontReadError> {
+        if !value.is_finite() {
+            return Err(FontReadError::NonFiniteCoordinate { axis, value });
+        }
+
+        match self {
+            Self::Continuous {
+                minimum, maximum, ..
+            } if value < *minimum || value > *maximum => Err(FontReadError::CoordinateOutOfRange {
+                axis,
+                value,
+                minimum: *minimum,
+                maximum: *maximum,
+            }),
+            Self::Discrete { values, .. } if !values.contains(&value) => {
+                Err(FontReadError::CoordinateNotAllowed { axis, value })
+            }
+            Self::Continuous { .. } | Self::Discrete { .. } => Ok(()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct VariationAxis {
+    pub index: AxisIndex,
+    pub tag: String,
+    pub name: String,
+    pub hidden: bool,
+    pub kind: VariationAxisKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct VariationCoordinate {
+    pub axis: AxisIndex,
+    pub value: f64,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct VariationLocation {
+    coordinates: Box<[f64]>,
+}
+
+impl VariationLocation {
+    pub(crate) fn from_coordinates(coordinates: Vec<f64>) -> Self {
+        Self {
+            coordinates: coordinates.into_boxed_slice(),
+        }
+    }
+
+    pub fn coordinates(&self) -> &[f64] {
+        &self.coordinates
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct FontDirectory {
+    pub format: FontFormat,
+    pub family_name: Option<String>,
+    pub style_name: Option<String>,
+    pub units_per_em: f64,
+    pub glyphs: Box<[DirectoryGlyph]>,
+    pub axes: Box<[VariationAxis]>,
+    default_location: VariationLocation,
+}
+
+impl FontDirectory {
+    pub(crate) fn new(
+        format: FontFormat,
+        family_name: Option<String>,
+        style_name: Option<String>,
+        units_per_em: f64,
+        glyphs: Vec<DirectoryGlyph>,
+        axes: Vec<VariationAxis>,
+    ) -> Result<Self, FontReadError> {
+        if !units_per_em.is_finite() || units_per_em <= 0.0 {
+            return Err(FontReadError::InvalidDisplayGlyph {
+                details: format!("units per em must be positive and finite, got {units_per_em}"),
+            });
+        }
+
+        for (position, glyph) in glyphs.iter().enumerate() {
+            if glyph.index.to_usize() != position {
+                return Err(FontReadError::InvalidDisplayGlyph {
+                    details: format!(
+                        "glyph directory index {:?} does not match position {position}",
+                        glyph.index
+                    ),
+                });
+            }
+        }
+        let mut axis_tags = HashSet::with_capacity(axes.len());
+        for (position, axis) in axes.iter().enumerate() {
+            if axis.index.to_usize() != position {
+                return Err(FontReadError::InvalidDisplayGlyph {
+                    details: format!(
+                        "axis index {:?} does not match position {position}",
+                        axis.index
+                    ),
+                });
+            }
+            if axis.tag.is_empty() || !axis_tags.insert(axis.tag.as_str()) {
+                return Err(FontReadError::InvalidDisplayGlyph {
+                    details: format!("axis {:?} has an empty or duplicate tag", axis.index),
+                });
+            }
+            axis.kind.validate_definition(axis.index)?;
+        }
+
+        let default_location = VariationLocation::from_coordinates(
+            axes.iter().map(|axis| axis.kind.default_value()).collect(),
+        );
+        Ok(Self {
+            format,
+            family_name,
+            style_name,
+            units_per_em,
+            glyphs: glyphs.into_boxed_slice(),
+            axes: axes.into_boxed_slice(),
+            default_location,
+        })
+    }
+
+    pub fn default_location(&self) -> &VariationLocation {
+        &self.default_location
+    }
+
+    pub fn location(
+        &self,
+        coordinates: &[VariationCoordinate],
+    ) -> Result<VariationLocation, FontReadError> {
+        let mut values = self.default_location.coordinates.to_vec();
+        let mut seen = HashSet::with_capacity(coordinates.len());
+
+        for coordinate in coordinates {
+            let Some(axis) = self.axes.get(coordinate.axis.to_usize()) else {
+                return Err(FontReadError::UnknownAxis {
+                    axis: coordinate.axis,
+                });
+            };
+            if !seen.insert(coordinate.axis) {
+                return Err(FontReadError::DuplicateAxis {
+                    axis: coordinate.axis,
+                });
+            }
+
+            axis.kind.validate_for_read(axis.index, coordinate.value)?;
+            values[axis.index.to_usize()] = coordinate.value;
+        }
+
+        Ok(VariationLocation::from_coordinates(values))
+    }
+}
+
+macro_rules! range_type {
+    ($name:ident) => {
+        #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+        pub struct $name {
+            pub start: u32,
+            pub count: u32,
+        }
+
+        impl $name {
+            pub(crate) fn new(start: usize, count: usize) -> Result<Self, FontReadError> {
+                let start =
+                    u32::try_from(start).map_err(|_| FontReadError::InvalidDisplayGlyph {
+                        details: concat!(stringify!($name), " start exceeds u32").into(),
+                    })?;
+                let count =
+                    u32::try_from(count).map_err(|_| FontReadError::InvalidDisplayGlyph {
+                        details: concat!(stringify!($name), " count exceeds u32").into(),
+                    })?;
+                start
+                    .checked_add(count)
+                    .ok_or_else(|| FontReadError::InvalidDisplayGlyph {
+                        details: concat!(stringify!($name), " overflows u32").into(),
+                    })?;
+                Ok(Self { start, count })
+            }
+
+            pub(crate) fn checked_end(self, arena: &str) -> Result<usize, FontReadError> {
+                let end = self.start.checked_add(self.count).ok_or_else(|| {
+                    FontReadError::InvalidDisplayGlyph {
+                        details: format!("{arena} range overflows u32"),
+                    }
+                })?;
+                Ok(end as usize)
+            }
+        }
+    };
+}
+
+range_type!(PointRange);
+range_type!(ContourRange);
+range_type!(ComponentRange);
+range_type!(AnchorRange);
+range_type!(GuideRange);
+
+/// Column-vector affine transform in y-up design-space font units.
+///
+/// `x' = xx*x + yx*y + dx` and `y' = xy*x + yy*y + dy`. Finite
+/// singular transforms are valid because source components may collapse an axis.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct AffineTransform {
+    pub xx: f64,
+    pub xy: f64,
+    pub yx: f64,
+    pub yy: f64,
+    pub dx: f64,
+    pub dy: f64,
+}
+
+impl AffineTransform {
+    pub const fn identity() -> Self {
+        Self {
+            xx: 1.0,
+            xy: 0.0,
+            yx: 0.0,
+            yy: 1.0,
+            dx: 0.0,
+            dy: 0.0,
+        }
+    }
+
+    /// Composes transforms as `self ∘ inner`: apply `inner`, then `self`.
+    pub fn compose(self, inner: Self) -> Self {
+        Self {
+            xx: self.xx * inner.xx + self.yx * inner.xy,
+            xy: self.xy * inner.xx + self.yy * inner.xy,
+            yx: self.xx * inner.yx + self.yx * inner.yy,
+            yy: self.xy * inner.yx + self.yy * inner.yy,
+            dx: self.xx * inner.dx + self.yx * inner.dy + self.dx,
+            dy: self.xy * inner.dx + self.yy * inner.dy + self.dy,
+        }
+    }
+
+    pub fn transform_point(self, x: f64, y: f64) -> (f64, f64) {
+        (
+            self.xx * x + self.yx * y + self.dx,
+            self.xy * x + self.yy * y + self.dy,
+        )
+    }
+
+    fn is_finite(self) -> bool {
+        [self.xx, self.xy, self.yx, self.yy, self.dx, self.dy]
+            .into_iter()
+            .all(f64::is_finite)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct GlyphGeometry {
+    pub glyph: GlyphIndex,
+    pub contours: ContourRange,
+    pub components: ComponentRange,
+    pub anchors: AnchorRange,
+    pub guides: GuideRange,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct GlyphContour {
+    pub points: PointRange,
+    pub closed: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ComponentInstance {
+    pub geometry: GeometryIndex,
+    pub transform: AffineTransform,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GlyphPointKind {
+    OnCurve,
+    QuadraticControl,
+    CubicControl,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PointProvenance {
+    Native {
+        ttf_point_index: Option<TrueTypePointIndex>,
+    },
+    Implied,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct GlyphPoint {
+    pub x: f64,
+    pub y: f64,
+    pub kind: GlyphPointKind,
+    pub smooth: bool,
+    pub provenance: PointProvenance,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct GlyphAnchor {
+    pub name: Option<String>,
+    pub x: f64,
+    pub y: f64,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum GlyphGuide {
+    Horizontal {
+        y: f64,
+        name: Option<String>,
+        color: Option<String>,
+    },
+    Vertical {
+        x: f64,
+        name: Option<String>,
+        color: Option<String>,
+    },
+    Angled {
+        x: f64,
+        y: f64,
+        degrees: f64,
+        name: Option<String>,
+        color: Option<String>,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct GlyphMetrics {
+    pub x_advance: f64,
+    pub y_advance: Option<f64>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct GlyphBounds {
+    pub min_x: f64,
+    pub min_y: f64,
+    pub max_x: f64,
+    pub max_y: f64,
+}
+
+/// One selected glyph resolved in design-space font units with a y-up axis.
+///
+/// The arenas contain only the selected root and its component closure. Every
+/// range and graph reference is validated by [`DisplayGlyph::validate`].
+#[derive(Clone, Debug, PartialEq)]
+pub struct DisplayGlyph {
+    pub glyph: GlyphIndex,
+    pub location: VariationLocation,
+    pub root_geometry: GeometryIndex,
+    pub geometries: Box<[GlyphGeometry]>,
+    pub contours: Box<[GlyphContour]>,
+    pub components: Box<[ComponentInstance]>,
+    pub points: Box<[GlyphPoint]>,
+    pub anchors: Box<[GlyphAnchor]>,
+    pub guides: Box<[GlyphGuide]>,
+    pub metrics: GlyphMetrics,
+    pub bounds: Option<GlyphBounds>,
+}
+
+impl DisplayGlyph {
+    pub fn validate(&self) -> Result<(), FontReadError> {
+        if self
+            .location
+            .coordinates
+            .iter()
+            .any(|value| !value.is_finite())
+        {
+            return Err(FontReadError::InvalidDisplayGlyph {
+                details: "variation location contains a non-finite coordinate".into(),
+            });
+        }
+        let root = self.root_geometry.to_usize();
+        if root >= self.geometries.len() {
+            return Err(FontReadError::InvalidDisplayGlyph {
+                details: format!("root geometry {root} does not exist"),
+            });
+        }
+        if root != 0 {
+            return Err(FontReadError::InvalidDisplayGlyph {
+                details: "root geometry must be the first geometry".into(),
+            });
+        }
+        if self.geometries[root].glyph != self.glyph {
+            return Err(FontReadError::InvalidDisplayGlyph {
+                details: "root geometry does not represent the requested glyph".into(),
+            });
+        }
+
+        let mut glyphs = HashSet::with_capacity(self.geometries.len());
+        let mut contour_cursor = 0;
+        let mut component_cursor = 0;
+        let mut anchor_cursor = 0;
+        let mut guide_cursor = 0;
+        for geometry in &self.geometries {
+            if !glyphs.insert(geometry.glyph) {
+                return Err(FontReadError::InvalidDisplayGlyph {
+                    details: format!("glyph {:?} has duplicate geometries", geometry.glyph),
+                });
+            }
+            check_partition(
+                geometry.contours.start,
+                geometry.contours.checked_end("contour")?,
+                &mut contour_cursor,
+                self.contours.len(),
+                "contour",
+            )?;
+            check_partition(
+                geometry.components.start,
+                geometry.components.checked_end("component")?,
+                &mut component_cursor,
+                self.components.len(),
+                "component",
+            )?;
+            check_partition(
+                geometry.anchors.start,
+                geometry.anchors.checked_end("anchor")?,
+                &mut anchor_cursor,
+                self.anchors.len(),
+                "anchor",
+            )?;
+            check_partition(
+                geometry.guides.start,
+                geometry.guides.checked_end("guide")?,
+                &mut guide_cursor,
+                self.guides.len(),
+                "guide",
+            )?;
+        }
+        check_partition_end(contour_cursor, self.contours.len(), "contour")?;
+        check_partition_end(component_cursor, self.components.len(), "component")?;
+        check_partition_end(anchor_cursor, self.anchors.len(), "anchor")?;
+        check_partition_end(guide_cursor, self.guides.len(), "guide")?;
+
+        let mut point_cursor = 0;
+        for contour in &self.contours {
+            let end = contour.points.checked_end("point")?;
+            check_partition(
+                contour.points.start,
+                end,
+                &mut point_cursor,
+                self.points.len(),
+                "point",
+            )?;
+            if contour.points.count == 0 {
+                return Err(FontReadError::InvalidDisplayGlyph {
+                    details: "empty contour records are not canonical".into(),
+                });
+            }
+            validate_point_sequence(
+                &self.points[contour.points.start as usize..end],
+                contour.closed,
+            )?;
+        }
+        check_partition_end(point_cursor, self.points.len(), "point")?;
+
+        for component in &self.components {
+            if component.geometry.to_usize() >= self.geometries.len() {
+                return Err(FontReadError::InvalidDisplayGlyph {
+                    details: format!("component geometry {:?} does not exist", component.geometry),
+                });
+            }
+            if !component.transform.is_finite() {
+                return Err(FontReadError::InvalidDisplayGlyph {
+                    details: "component transform contains a non-finite value".into(),
+                });
+            }
+        }
+
+        for point in &self.points {
+            if !point.x.is_finite() || !point.y.is_finite() {
+                return Err(FontReadError::InvalidDisplayGlyph {
+                    details: "point contains a non-finite coordinate".into(),
+                });
+            }
+            if point.provenance == PointProvenance::Implied
+                && (point.kind != GlyphPointKind::OnCurve || point.smooth)
+            {
+                return Err(FontReadError::InvalidDisplayGlyph {
+                    details: "implied points must be non-smooth on-curve points".into(),
+                });
+            }
+        }
+
+        for anchor in &self.anchors {
+            if !anchor.x.is_finite() || !anchor.y.is_finite() {
+                return Err(FontReadError::InvalidDisplayGlyph {
+                    details: "anchor contains a non-finite coordinate".into(),
+                });
+            }
+        }
+        for guide in &self.guides {
+            let finite = match guide {
+                GlyphGuide::Horizontal { y, .. } => y.is_finite(),
+                GlyphGuide::Vertical { x, .. } => x.is_finite(),
+                GlyphGuide::Angled { x, y, degrees, .. } => {
+                    x.is_finite() && y.is_finite() && degrees.is_finite()
+                }
+            };
+            if !finite {
+                return Err(FontReadError::InvalidDisplayGlyph {
+                    details: "guide contains a non-finite value".into(),
+                });
+            }
+        }
+
+        if !self.metrics.x_advance.is_finite()
+            || self
+                .metrics
+                .y_advance
+                .is_some_and(|value| !value.is_finite())
+        {
+            return Err(FontReadError::InvalidDisplayGlyph {
+                details: "glyph metrics contain a non-finite value".into(),
+            });
+        }
+        if let Some(bounds) = self.bounds {
+            if ![bounds.min_x, bounds.min_y, bounds.max_x, bounds.max_y]
+                .into_iter()
+                .all(f64::is_finite)
+                || bounds.min_x > bounds.max_x
+                || bounds.min_y > bounds.max_y
+            {
+                return Err(FontReadError::InvalidDisplayGlyph {
+                    details: "glyph bounds are invalid".into(),
+                });
+            }
+        }
+
+        self.validate_graph()
+    }
+
+    fn validate_graph(&self) -> Result<(), FontReadError> {
+        let mut states = vec![0_u8; self.geometries.len()];
+        self.visit_geometry(self.root_geometry.to_usize(), &mut states)?;
+        if states.contains(&0) {
+            return Err(FontReadError::InvalidDisplayGlyph {
+                details: "display glyph contains unreachable geometry".into(),
+            });
+        }
+        Ok(())
+    }
+
+    fn visit_geometry(&self, index: usize, states: &mut [u8]) -> Result<(), FontReadError> {
+        match states[index] {
+            1 => {
+                return Err(FontReadError::InvalidDisplayGlyph {
+                    details: "display glyph component graph contains a cycle".into(),
+                })
+            }
+            2 => return Ok(()),
+            _ => states[index] = 1,
+        }
+
+        let geometry = &self.geometries[index];
+        let start = geometry.components.start as usize;
+        let end = geometry.components.checked_end("component")?;
+        for component in &self.components[start..end] {
+            self.visit_geometry(component.geometry.to_usize(), states)?;
+        }
+        states[index] = 2;
+        Ok(())
+    }
+}
+
+fn check_partition(
+    start: u32,
+    end: usize,
+    cursor: &mut usize,
+    arena_len: usize,
+    arena: &str,
+) -> Result<(), FontReadError> {
+    if start as usize != *cursor || start as usize > end || end > arena_len {
+        return Err(FontReadError::InvalidDisplayGlyph {
+            details: format!(
+                "{arena} range {start}..{end} does not continue canonical partition at {} of {arena_len}",
+                *cursor
+            ),
+        });
+    }
+    *cursor = end;
+    Ok(())
+}
+
+fn check_partition_end(cursor: usize, arena_len: usize, arena: &str) -> Result<(), FontReadError> {
+    if cursor != arena_len {
+        return Err(FontReadError::InvalidDisplayGlyph {
+            details: format!("{arena} partition ends at {cursor}, not arena length {arena_len}"),
+        });
+    }
+    Ok(())
+}
+
+fn validate_point_sequence(points: &[GlyphPoint], closed: bool) -> Result<(), FontReadError> {
+    if points[0].kind != GlyphPointKind::OnCurve {
+        return Err(FontReadError::InvalidDisplayGlyph {
+            details: "contour does not begin on-curve".into(),
+        });
+    }
+    let limit = if closed {
+        points.len() + 1
+    } else {
+        points.len()
+    };
+    let mut cursor = 1;
+    while cursor < limit {
+        match points[cursor % points.len()].kind {
+            GlyphPointKind::OnCurve => cursor += 1,
+            GlyphPointKind::QuadraticControl => {
+                if cursor + 1 >= limit
+                    || points[(cursor + 1) % points.len()].kind != GlyphPointKind::OnCurve
+                {
+                    return Err(FontReadError::InvalidDisplayGlyph {
+                        details: "quadratic control is not followed by an endpoint".into(),
+                    });
+                }
+                cursor += 2;
+            }
+            GlyphPointKind::CubicControl => {
+                if cursor + 2 >= limit
+                    || points[(cursor + 1) % points.len()].kind != GlyphPointKind::CubicControl
+                    || points[(cursor + 2) % points.len()].kind != GlyphPointKind::OnCurve
+                {
+                    return Err(FontReadError::InvalidDisplayGlyph {
+                        details: "invalid cubic point sequence".into(),
+                    });
+                }
+                cursor += 3;
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn directory() -> FontDirectory {
+        FontDirectory::new(
+            FontFormat::Ttf,
+            Some("Test".into()),
+            Some("Regular".into()),
+            1_000.0,
+            vec![DirectoryGlyph {
+                index: GlyphIndex::new(0),
+                name: ".notdef".into(),
+                unicodes: Box::new([]),
+            }],
+            vec![VariationAxis {
+                index: AxisIndex::new(0),
+                tag: "wght".into(),
+                name: "Weight".into(),
+                hidden: false,
+                kind: VariationAxisKind::Continuous {
+                    minimum: 100.0,
+                    default: 400.0,
+                    maximum: 900.0,
+                },
+            }],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn directory_completes_and_validates_external_locations() {
+        let directory = directory();
+        assert_eq!(directory.default_location().coordinates(), [400.0]);
+        assert_eq!(
+            directory
+                .location(&[VariationCoordinate {
+                    axis: AxisIndex::new(0),
+                    value: 750.0,
+                }])
+                .unwrap()
+                .coordinates(),
+            [750.0]
+        );
+        assert!(matches!(
+            directory.location(&[VariationCoordinate {
+                axis: AxisIndex::new(0),
+                value: 1_000.0,
+            }]),
+            Err(FontReadError::CoordinateOutOfRange { .. })
+        ));
+    }
+
+    #[test]
+    fn finite_singular_affine_transform_is_valid() {
+        let singular = AffineTransform {
+            xx: 0.0,
+            yy: 0.0,
+            ..AffineTransform::identity()
+        };
+
+        assert!(singular.is_finite());
+        assert_eq!(singular.transform_point(4.0, 5.0), (0.0, 0.0));
+    }
+
+    #[test]
+    fn affine_composition_applies_inner_then_outer() {
+        let translate = AffineTransform {
+            dx: 10.0,
+            dy: 20.0,
+            ..AffineTransform::identity()
+        };
+        let scale = AffineTransform {
+            xx: 2.0,
+            yy: 3.0,
+            ..AffineTransform::identity()
+        };
+
+        assert_eq!(
+            translate.compose(scale).transform_point(4.0, 5.0),
+            (18.0, 35.0)
+        );
+    }
+}

--- a/crates/shift-backends/src/glyphs/import.rs
+++ b/crates/shift-backends/src/glyphs/import.rs
@@ -1,6 +1,6 @@
-use std::{collections::HashMap, path::Path};
+use std::{collections::HashMap, path::Path, sync::Arc};
 
-use glyphs_reader::{Font as GlyphsFont, Glyph as GlyphsGlyph};
+use glyphs_reader::Font as GlyphsFont;
 use rayon::prelude::*;
 use shift_font::{Font, Glyph, GlyphId, SourceId};
 
@@ -12,37 +12,38 @@ use crate::{
 
 /// Bounded Shift conversion over one parsed Glyphs source.
 pub(crate) struct GlyphsGlyphStream {
+    source: Arc<GlyphsFont>,
     glyph_ids: HashMap<String, GlyphId>,
-    glyphs: Vec<GlyphsGlyph>,
+    glyph_names: Vec<String>,
     source_ids_by_master_id: HashMap<String, SourceId>,
     next_glyph: usize,
 }
 
 impl GlyphStream for GlyphsGlyphStream {
     fn directory(&self) -> Vec<GlyphDirectoryEntry> {
-        self.glyphs
+        self.glyph_names
             .iter()
-            .map(|glyph| GlyphDirectoryEntry {
-                glyph_id: self.glyph_ids[glyph.name.as_str()].clone(),
-                name: glyph.name.to_string().into(),
+            .map(|name| GlyphDirectoryEntry {
+                glyph_id: self.glyph_ids[name].clone(),
+                name: name.clone().into(),
             })
             .collect()
     }
 
     fn glyph_count(&self) -> usize {
-        self.glyphs.len()
+        self.glyph_names.len()
     }
 
     fn next_batch(&mut self, limit: ImportBatchLimit) -> FormatBackendResult<Vec<Glyph>> {
-        if self.next_glyph == self.glyphs.len() {
+        if self.next_glyph == self.glyph_names.len() {
             return Ok(Vec::new());
         }
 
         let mut end = self.next_glyph;
         let mut layer_count = 0;
-        while end < self.glyphs.len() && end - self.next_glyph < limit.max_glyphs() {
-            let next_layers =
-                imported_layer_count(&self.glyphs[end], &self.source_ids_by_master_id);
+        while end < self.glyph_names.len() && end - self.next_glyph < limit.max_glyphs() {
+            let glyph = &self.source.glyphs[self.glyph_names[end].as_str()];
+            let next_layers = imported_layer_count(glyph, &self.source_ids_by_master_id);
             if end > self.next_glyph && layer_count + next_layers > limit.max_layers() {
                 break;
             }
@@ -51,9 +52,15 @@ impl GlyphStream for GlyphsGlyphStream {
             end += 1;
         }
 
-        let glyphs = self.glyphs[self.next_glyph..end]
+        let glyphs = self.glyph_names[self.next_glyph..end]
             .par_iter()
-            .map(|glyph| convert_glyph(glyph, &self.glyph_ids, &self.source_ids_by_master_id))
+            .map(|name| {
+                convert_glyph(
+                    &self.source.glyphs[name.as_str()],
+                    &self.glyph_ids,
+                    &self.source_ids_by_master_id,
+                )
+            })
             .collect::<FormatBackendResult<Vec<_>>>()?;
         self.next_glyph = end;
         Ok(glyphs)
@@ -61,23 +68,33 @@ impl GlyphStream for GlyphsGlyphStream {
 }
 
 pub(crate) fn stream_font(path: &str) -> FormatBackendResult<(Font, GlyphsGlyphStream)> {
-    let mut glyphs_font = GlyphsFont::load(Path::new(path))
-        .map_err(|error| FormatBackendError::Glyphs(error.to_string()))?;
-    let (header, source_ids_by_master_id) = font_header(&glyphs_font)?;
-    let glyph_ids = glyphs_font
+    let source = Arc::new(
+        GlyphsFont::load(Path::new(path))
+            .map_err(|error| FormatBackendError::Glyphs(error.to_string()))?,
+    );
+    stream_retained(source)
+}
+
+pub(crate) fn stream_retained(
+    source: Arc<GlyphsFont>,
+) -> FormatBackendResult<(Font, GlyphsGlyphStream)> {
+    let (header, source_ids_by_master_id) = font_header(&source)?;
+    let glyph_names = source
         .glyphs
         .values()
-        .map(|glyph| (glyph.name.to_string(), GlyphId::new()))
-        .collect();
-    let glyphs = std::mem::take(&mut glyphs_font.glyphs)
-        .into_values()
+        .map(|glyph| glyph.name.to_string())
+        .collect::<Vec<_>>();
+    let glyph_ids = glyph_names
+        .iter()
+        .map(|name| (name.clone(), GlyphId::new()))
         .collect();
 
     Ok((
         header,
         GlyphsGlyphStream {
+            source,
             glyph_ids,
-            glyphs,
+            glyph_names,
             source_ids_by_master_id,
             next_glyph: 0,
         },

--- a/crates/shift-backends/src/glyphs/mod.rs
+++ b/crates/shift-backends/src/glyphs/mod.rs
@@ -2,7 +2,7 @@ mod conversion;
 mod import;
 mod reader;
 
-pub(crate) use import::stream_font;
+pub(crate) use import::{stream_font, stream_retained};
 pub use reader::GlyphsReader;
 
 #[cfg(test)]

--- a/crates/shift-backends/src/lib.rs
+++ b/crates/shift-backends/src/lib.rs
@@ -4,6 +4,7 @@ pub mod designspace;
 pub mod errors;
 pub mod export;
 pub mod font_loader;
+pub mod font_source;
 pub mod format;
 pub mod glyphs;
 pub mod import;
@@ -14,6 +15,14 @@ pub mod ufo;
 
 pub use errors::{BackendError, BackendResult, FormatBackendError, FormatBackendResult};
 pub use export::{ExportError, ExportFormat, FontExportRequest, FontExportResult, FontExporter};
+pub use font_source::{
+    AffineTransform, AnchorRange, AxisIndex, BinaryFont, ComponentInstance, ComponentRange,
+    ContourRange, DirectoryGlyph, DisplayGlyph, FontDirectory, FontImporter, FontReadError,
+    FontSource, GeometryIndex, GlifFont, GlyphAnchor, GlyphBounds, GlyphContour, GlyphGeometry,
+    GlyphGuide, GlyphIndex, GlyphMetrics, GlyphPoint, GlyphPointKind, GlyphsFont, GuideRange,
+    PointProvenance, PointRange, RandomAccessFont, TrueTypePointIndex, VariationAxis,
+    VariationAxisKind, VariationCoordinate, VariationLocation,
+};
 pub use format::FontFormat;
 pub use import::{FontImport, GlyphDirectoryEntry, ImportBatchLimit};
 pub use traits::{FontBackend, FontReader, FontView, FontWriter};

--- a/crates/shift-backends/src/ufo/import.rs
+++ b/crates/shift-backends/src/ufo/import.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use norad::{DataRequest, Font as NoradFont};
@@ -13,6 +14,13 @@ use crate::{
 
 use super::UfoReader;
 
+#[derive(Clone)]
+pub(crate) struct UfoLayerDirectory {
+    pub(crate) name: String,
+    pub(crate) path: PathBuf,
+    pub(crate) glyphs: BTreeMap<String, PathBuf>,
+}
+
 struct LayerDirectory {
     source_id: SourceId,
     glyphs: BTreeMap<String, PathBuf>,
@@ -20,21 +28,27 @@ struct LayerDirectory {
 
 pub(crate) fn stream_font(path: &str) -> FormatBackendResult<(Font, GlifGlyphStream)> {
     let ufo_path = Path::new(path);
+    let layers = Arc::from(read_ufo_layer_directories(ufo_path)?);
+    stream_retained(ufo_path, layers)
+}
+
+pub(crate) fn stream_retained(
+    ufo_path: &Path,
+    retained: Arc<[UfoLayerDirectory]>,
+) -> FormatBackendResult<(Font, GlifGlyphStream)> {
     let mut header = load_header(ufo_path)?;
     let default_source_id = header.default_source_id().ok_or_else(|| {
         FormatBackendError::Ufo("UFO header is missing its default source".into())
     })?;
-    let layers = load_layer_directories(ufo_path, &mut header, default_source_id)?;
+    let layers = load_layer_directories(&retained, &mut header, default_source_id)?;
     let (glyph_ids, glyphs) = build_glyph_directory(layers);
 
     Ok((header, GlifGlyphStream::new(glyph_ids, glyphs)))
 }
 
-fn load_layer_directories(
+pub(crate) fn read_ufo_layer_directories(
     ufo_path: &Path,
-    header: &mut Font,
-    default_source_id: SourceId,
-) -> FormatBackendResult<Vec<LayerDirectory>> {
+) -> FormatBackendResult<Vec<UfoLayerDirectory>> {
     let mut layer_paths = read_layer_paths(ufo_path)?;
     let default_index = layer_paths
         .iter()
@@ -43,16 +57,31 @@ fn load_layer_directories(
     let default_layer = layer_paths.remove(default_index);
     layer_paths.insert(0, default_layer);
 
-    let mut layers = Vec::with_capacity(layer_paths.len());
-    for (index, (name, relative_path)) in layer_paths.into_iter().enumerate() {
-        let layer_path = ufo_path.join(&relative_path);
-        let contents_path = layer_path.join("contents.plist");
-        let glyphs: BTreeMap<String, PathBuf> = plist_file(&contents_path)?;
-        let (color, lib) = read_layer_info(&layer_path)?;
+    layer_paths
+        .into_iter()
+        .map(|(name, relative_path)| {
+            let path = ufo_path.join(relative_path);
+            let glyphs = plist_file::<BTreeMap<String, PathBuf>>(&path.join("contents.plist"))?
+                .into_iter()
+                .map(|(name, glyph)| (name, path.join(glyph)))
+                .collect();
+            Ok(UfoLayerDirectory { name, path, glyphs })
+        })
+        .collect()
+}
+
+fn load_layer_directories(
+    retained: &[UfoLayerDirectory],
+    header: &mut Font,
+    default_source_id: SourceId,
+) -> FormatBackendResult<Vec<LayerDirectory>> {
+    let mut layers = Vec::with_capacity(retained.len());
+    for (index, retained) in retained.iter().enumerate() {
+        let (color, lib) = read_layer_info(&retained.path)?;
         let source_id = if index == 0 {
             default_source_id.clone()
         } else {
-            header.add_source(Source::layer(name))
+            header.add_source(Source::layer(retained.name.clone()))
         };
         let source = header.source_mut(source_id.clone()).ok_or_else(|| {
             FormatBackendError::Ufo("newly registered UFO source is missing".into())
@@ -63,10 +92,7 @@ fn load_layer_directories(
         }
         layers.push(LayerDirectory {
             source_id,
-            glyphs: glyphs
-                .into_iter()
-                .map(|(name, path)| (name, layer_path.join(path)))
-                .collect(),
+            glyphs: retained.glyphs.clone(),
         });
     }
     Ok(layers)

--- a/crates/shift-backends/src/ufo/mod.rs
+++ b/crates/shift-backends/src/ufo/mod.rs
@@ -2,7 +2,10 @@ mod import;
 mod reader;
 mod writer;
 
-pub(crate) use import::{load_header, read_glyph_paths, stream_font};
+pub(crate) use import::{
+    load_header, read_glyph_paths, read_ufo_layer_directories, stream_font, stream_retained,
+    UfoLayerDirectory,
+};
 pub use reader::UfoReader;
 pub use writer::UfoWriter;
 


### PR DESCRIPTION
## Summary

- add retained `BinaryFont`, `GlifFont`, and `GlyphsFont` handles behind `FontSource`
- add borrowed random-access directories and source-local `GlyphIndex` addressing
- add validated, source-independent `DisplayGlyph` geometry for one selected root and its component closure
- preserve native/implied TrueType point provenance, composite transforms, exact bounds, metrics, anchors, and guides
- reuse retained source state for existing UFO, Designspace, Glyphs, and binary conversion paths
- keep binary sources read-only while exposing exhaustive import only for GLIF and Glyphs sources
- add release profiling and backend architecture documentation

This is the Rust source-reading foundation for direct read-only binary preview and convertible UFO/Designspace/Glyphs opening. It intentionally adds no desktop session lifecycle, TypeScript renderer, or Grid integration.

## Contracts

- `RandomAccessFont::directory()` is borrowed and allocation-free.
- `read_glyph()` resolves only the selected root and transitive component closure.
- `GlyphIndex` is dense, handle-local, nonpersistent, and never converted into a Shift `GlyphId` for display.
- variation locations use validated external/user coordinates; invalid values are rejected rather than clamped.
- retained handles detect source-generation changes and become permanently poisoned after the first mismatch.
- conversion consumes original source semantics, never `DisplayGlyph`.
- binary sources expose no `FontImporter` capability.

## Source Han release profile

Fixture: `SourceHanSans-VF.ttf`, 65,535 glyphs, 12 threads.

- open and complete directory: **57.642 ms**
- selected glyph, default location: **0.010 ms p50 / 0.013 ms p95**
- selected glyph, non-default location: **0.012 ms p50 / 0.014 ms p95**
- complete sequential resolution: **744.298 ms**
- complete parallel resolution: **106.543 ms**
- peak RSS: **114.0 MiB**

Command:

```sh
cargo run -p shift-backends --release --example profile_font_source -- <font.ttf> [glyph-name]
```

## Verification

- `cargo test -p shift-backends` — 103 passed
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p shift-backends --no-deps`
- `git diff --check`

`cargo test --workspace` and `pnpm test:native` could not complete on the profiling host because its SQLite soname symlink/native Node binding was unavailable. Backend tests, workspace Clippy, rustdoc, and commit hooks passed.
