### PR TITLE
Compile binary fonts directly to Grid atlases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2267,6 +2267,7 @@ dependencies = [
  "rayon",
  "serde",
  "shift-font",
+ "shift-slug",
  "shift-source",
  "skrifa",
  "tempfile",

--- a/crates/shift-backends/Cargo.toml
+++ b/crates/shift-backends/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["rlib"]
 
 [dependencies]
 shift-font = { workspace = true }
+shift-slug = { workspace = true }
 shift-source = { workspace = true }
 
 norad = "0.18.4"

--- a/crates/shift-backends/docs/DOCS.md
+++ b/crates/shift-backends/docs/DOCS.md
@@ -32,6 +32,8 @@ Font format backends that convert between on-disk font files and the `Font` IR u
 
 **Architecture Invariant:** `DisplayGlyph` is a validated flat arena containing only one selected root and its component closure. Geometry, contour, component, point, anchor, and guide ranges form complete non-overlapping partitions; all geometry is reachable from root index zero. Coordinates use y-up design-space font units. Native TrueType points retain local point indexes and implied quadratic points are explicit unindexed on-curve values. WHY: drawing and passive inspection need one coherent source-independent value without recursive duplication, hidden I/O, or synthetic Shift IDs.
 
+**Architecture Invariant:** `build_binary_atlas_page` compiles ordered glyf/gvar roots directly into a location-independent `SourceAtlasPage`; it never constructs `DisplayGlyph` or authored Shift geometry. Page-local OpenType regions are deduplicated, while each distinct glyph region set receives its own complement weight so unrelated tuple supports cannot alter that glyph's base geometry. Before packing, `into_parts` separates CPU atlas geometry from a small `SourceAtlasDescriptor`; the consumer then drops the geometry after packing while retaining the descriptor for glyph mapping and weight evaluation. Fixed pages are bounded compilation/transfer units, not viewport residency: the Grid consumer must install the complete page set before presentation. WHY: variable-axis frames and scrolling must perform no complete outline rebuild, source acquisition, geometry upload, or duplicate CPU atlas residency.
+
 **Architecture Invariant:** Retained handles represent immutable source generations. Binary/Glyphs source stamps and GLIF manifests/selected paths are checked before reads; the first mismatch permanently returns the structured source-changed error from that handle. WHY: mixing directory data and geometry from different on-disk generations would produce incoherent display and conversion results.
 
 ## Codemap
@@ -44,7 +46,12 @@ src/
     mod.rs          -- RandomAccessFont/FontImporter capability split and FontSource dispatch value
     types.rs        -- source-local indexes, directories, locations, and validated DisplayGlyph arenas
     geometry.rs     -- shared contour normalization, component-graph assembly, and exact bounds
+    atlas.rs        -- source atlas page, location weights, region deduplication, and errors
     binary.rs       -- retained TTF/OTF bytes, GID access, glyf/gvar/CFF resolution
+    binary/atlas.rs -- direct ordered glyf/gvar page compilation and source-to-atlas mapping
+    binary/atlas/geometry.rs -- stable raw-point expressions, IUP deltas, and flattened composites
+    binary/atlas/geometry/curves.rs -- normalized quadratic contours and Slug curve conversion
+    binary/atlas/metrics.rs  -- HVAR or gvar phantom-point advance contributions
     glif.rs         -- retained UFO/Designspace manifests, paths, interpolation, and conversion cursor
     glyphs.rs       -- retained parsed Glyphs source, mappings, interpolation, and conversion cursor
     interpolation.rs -- source-location variation weights
@@ -81,6 +88,9 @@ src/
 - `FontSource` -- dispatched `Binary`, `Glif`, or `Glyphs` retained handle returned by `FontLoader::open_source`
 - `FontDirectory` / `GlyphIndex` / `VariationLocation` -- source-local immutable directory and validated external-coordinate addressing
 - `DisplayGlyph` -- validated root/component closure in flat indexed arenas with exact bounds, metrics, anchors, guides, and point provenance
+- `SourceAtlasPage` -- immutable source-indexed `VariableAtlas` page plus location-to-weight evaluation; its ordered roots contain no Shift IDs
+- `SourceAtlasDescriptor` -- small mapping and weight evaluator retained after `SourceAtlasPage::into_parts` separates disposable CPU geometry
+- `SourceAtlasError` -- direct atlas read, format-capability, and Slug construction failures
 - `BinaryFont` / `GlifFont` / `GlyphsFont` -- concrete retained source generations
 - `FontImport` -- top-level authored header, an immediately publishable stable-ID/name directory, and layer-aware `next_batch(limit)`, with no glyphs stored in the header
 - `GlyphDirectoryEntry` -- cheap foreign glyph ID and name used before geometry batches are parsed
@@ -105,6 +115,8 @@ src/
 **Multi-layer support:** `UfoReader` publishes `public.default` first, then preserves the relative authored order of every other entry in `layercontents.plist`. The default layer maps to the IR's default layer; other layers are represented by layer sources. Glyphs in non-default layers are merged into existing `Glyph` entries when the glyph already exists from another layer.
 
 **Binary variation metadata:** The retained TTF/OTF handle exposes `fvar` axes in external/user coordinates and resolves selected glyphs at arbitrary valid locations. TrueType resolution applies `gvar` tuple scalars and IUP deltas, preserves native point indexes, inserts explicit implied quadratic points, and retains composite transforms as indexed geometry references. CFF outlines preserve cubic geometry with unindexed native provenance. The authored compatibility importer still materializes binary geometry only at the default location; recovering editable `gvar` masters remains separate work.
+
+**Direct binary atlas:** `build_binary_atlas_page` reads raw glyf points and tuple regions from the retained bytes. It applies IUP independently to each unscaled tuple, preserves a stable quadratic topology, flattens ordinary glyf components exactly, and combines HVAR or gvar phantom-point advance contributions with the same region weights. The page stores absolute region-peak curves because `VariableAtlas` consumes weighted source values; a deduplicated complement weight makes every glyph's participating source weights sum to one. The consumer separates the atlas and descriptor with `into_parts`, packs and drops the former, and retains the latter. Axis updates evaluate fvar/avar 1 normalization and OpenType support scalars without touching geometry. CFF/CFF2, cubic glyf extensions, avar version 2, and VARC remain explicit unsupported capabilities in this first compiler slice.
 
 **Glyphs-format specifics:** `GlyphsReader` also extracts axes, sources, and per-master locations -- data that UFO does not natively represent. Kerning group membership is derived from per-glyph `right_kern`/`left_kern` fields and normalized to `public.kern1.*`/`public.kern2.*` conventions. The upstream parser currently materializes its complete normalized Glyphs source model before the bounded cursor begins; batching bounds Shift glyph conversion and persistence, not source-syntax parsing.
 
@@ -148,7 +160,27 @@ src/
 - **Glyphs source parsing is eager:** `glyphs-reader` materializes one normalized source model before `GlyphsGlyphStream` starts. Shift geometry conversion, packing, compression, and SQLite writes remain bounded.
 - **Glyphs kerning is default-master only:** Multi-master kerning is silently dropped to a single master's values.
 - **Cross-axis mappings:** Direct TTF compilation rejects cross-axis mappings until the compiler stack supports `avar` version 2. It never flattens the mapping or falls back to temporary UFO compilation.
+- **First binary atlas slice:** Direct Grid compilation supports quadratic glyf/gvar plus HVAR or phantom advances. CFF/CFF2, cubic glyf extensions, avar version 2, and VARC fail explicitly rather than falling back to selected-glyph or authored conversion.
 - **Authored STAT tables:** When Shift axis labels exist, export appends a generated `STAT` feature block. If authored feature text also declares `STAT`, the feature compiler reports the conflict.
+
+## Direct binary atlas profile
+
+Release profiling on 2026-08-03 retained every packed page to model complete Grid residency. Source Han Sans VF compiled all 65,535 ordered roots into 256 fixed pages without `DisplayGlyph`, authored `Font`, or SQLite materialization:
+
+```text
+open + directory                         68.458 ms
+location-independent page compilation 2,056.228 ms
+packing all pages                       412.204 ms
+complete build + pack                 2,469.520 ms
+page build p50 / p95                   8.366 / 11.727 ms
+all-page weight update                    0.071 ms
+packed resident bytes                 267,786,324 (255.381 MiB)
+maximum packed page                     1,813,572 (1.730 MiB)
+peak RSS                                  315.9 MiB
+base / stored delta curves       5,489,581 / 5,483,385
+```
+
+The 448-glyph Host Grotesk variable UI font compiled into two pages in 6.814 ms and packed in 0.953 ms, producing 481,448 bytes. Default, midpoint, and maximum-location simple/composite curves and advances match Skrifa's unrounded HarfBuzz-style glyf resolution within 0.001 font units. These are native compiler measurements; transfer, WebGPU upload, complete page-set installation, and first frame belong to the desktop follow-on.
 
 ## Verification
 
@@ -167,6 +199,9 @@ cargo test -p shift-backends --test export
 # Manual release profile: open/directory, selected default/non-default,
 # complete sequential/parallel binary resolution, and peak RSS
 cargo run -p shift-backends --release --example profile_font_source -- <font.ttf> [glyph-name]
+
+# Complete location-independent binary atlas pages, packing, and retained bytes
+cargo run -p shift-backends --release --example profile_binary_atlas -- <font.ttf>
 ```
 
 ## Related

--- a/crates/shift-backends/examples/profile_binary_atlas.rs
+++ b/crates/shift-backends/examples/profile_binary_atlas.rs
@@ -1,0 +1,125 @@
+use std::env;
+use std::error::Error;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use shift_backends::{
+    build_binary_atlas_page, BinaryFont, GlyphIndex, RandomAccessFont, SourceAtlasDescriptor,
+};
+use shift_slug::{PackedVariableAtlas, DEFAULT_BAND_COUNT};
+
+const ROOTS_PER_PAGE: usize = 256;
+const ALIGNMENT: usize = 256;
+
+type Result<T> = std::result::Result<T, Box<dyn Error>>;
+
+fn main() -> Result<()> {
+    let path = env::args_os()
+        .nth(1)
+        .map(PathBuf::from)
+        .ok_or("usage: profile_binary_atlas <font.ttf>")?;
+    let open_started = Instant::now();
+    let source = BinaryFont::open(&path)?;
+    let open_elapsed = open_started.elapsed();
+    let roots = source
+        .directory()
+        .glyphs
+        .iter()
+        .map(|glyph| glyph.index)
+        .collect::<Vec<GlyphIndex>>();
+    let mut packed_pages = Vec::<PackedVariableAtlas>::new();
+    let mut descriptors = Vec::<SourceAtlasDescriptor>::new();
+    let mut build_samples = Vec::new();
+    let mut pack_samples = Vec::new();
+    let mut packed_bytes = 0_usize;
+    let mut maximum_page_bytes = 0_usize;
+    let mut base_curves = 0_usize;
+    let mut delta_curves = 0_usize;
+    let mut sparse_delta_indices = 0_usize;
+    let mut sources = 0_usize;
+    let mut maximum_weights = 0_usize;
+
+    let complete_started = Instant::now();
+    for page_roots in roots.chunks(ROOTS_PER_PAGE) {
+        let build_started = Instant::now();
+        let page = build_binary_atlas_page(&source, page_roots, DEFAULT_BAND_COUNT)?;
+        build_samples.push(build_started.elapsed());
+        let (atlas, descriptor) = page.into_parts();
+        let statistics = atlas.statistics();
+        base_curves += statistics.curve_count;
+        delta_curves += statistics.delta_curve_count;
+        sparse_delta_indices += statistics.delta_index_count;
+        sources += statistics.source_count;
+        maximum_weights = maximum_weights.max(
+            descriptor
+                .weights(source.directory().default_location())?
+                .len(),
+        );
+
+        let pack_started = Instant::now();
+        let packed = atlas.pack(ALIGNMENT)?;
+        pack_samples.push(pack_started.elapsed());
+        let page_bytes = packed.as_bytes().len();
+        packed_bytes = packed_bytes
+            .checked_add(page_bytes)
+            .ok_or("packed byte count overflow")?;
+        maximum_page_bytes = maximum_page_bytes.max(page_bytes);
+        packed_pages.push(packed);
+        descriptors.push(descriptor);
+    }
+    let complete_elapsed = complete_started.elapsed();
+    let weights_started = Instant::now();
+    for descriptor in &descriptors {
+        descriptor.weights(source.directory().default_location())?;
+    }
+    let weights_elapsed = weights_started.elapsed();
+    let build_total = build_samples.iter().sum::<Duration>();
+    let pack_total = pack_samples.iter().sum::<Duration>();
+    build_samples.sort_unstable();
+    pack_samples.sort_unstable();
+
+    println!("source={}", path.display());
+    println!(
+        "open_ms={:.3} glyphs={} pages={} roots_per_page={} complete_ms={:.3}",
+        milliseconds(open_elapsed),
+        roots.len(),
+        packed_pages.len(),
+        ROOTS_PER_PAGE,
+        milliseconds(complete_elapsed),
+    );
+    println!(
+        "build_ms={:.3} page_p50_ms={:.3} page_p95_ms={:.3}",
+        milliseconds(build_total),
+        milliseconds(percentile(&build_samples, 0.50)),
+        milliseconds(percentile(&build_samples, 0.95)),
+    );
+    println!(
+        "pack_ms={:.3} page_p50_ms={:.3} page_p95_ms={:.3}",
+        milliseconds(pack_total),
+        milliseconds(percentile(&pack_samples, 0.50)),
+        milliseconds(percentile(&pack_samples, 0.95)),
+    );
+    println!(
+        "packed_bytes={} maximum_page_bytes={} base_curves={} delta_curves={} sparse_delta_indices={} sources={} maximum_weights={} all_page_weights_ms={:.3}",
+        packed_bytes,
+        maximum_page_bytes,
+        base_curves,
+        delta_curves,
+        sparse_delta_indices,
+        sources,
+        maximum_weights,
+        milliseconds(weights_elapsed),
+    );
+    Ok(())
+}
+
+fn percentile(samples: &[Duration], fraction: f64) -> Duration {
+    samples
+        .get(((samples.len().saturating_sub(1)) as f64 * fraction) as usize)
+        .copied()
+        .unwrap_or_default()
+}
+
+fn milliseconds(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000.0
+}

--- a/crates/shift-backends/src/font_source/atlas.rs
+++ b/crates/shift-backends/src/font_source/atlas.rs
@@ -1,0 +1,329 @@
+use std::collections::HashMap;
+
+use shift_slug::VariableAtlas;
+use skrifa::raw::types::F2Dot14;
+
+use crate::font_source::{
+    FontReadError, GlyphIndex, VariationAxis, VariationAxisKind, VariationLocation,
+};
+
+/// A location-independent Slug page compiled directly from retained source semantics.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SourceAtlasPage {
+    atlas: VariableAtlas,
+    descriptor: SourceAtlasDescriptor,
+}
+
+impl SourceAtlasPage {
+    pub(crate) fn new(
+        atlas: VariableAtlas,
+        glyphs: Vec<(GlyphIndex, u32)>,
+        axes: Vec<AtlasAxis>,
+        regions: Vec<AtlasRegion>,
+        complements: Vec<Box<[u32]>>,
+    ) -> Self {
+        Self {
+            atlas,
+            descriptor: SourceAtlasDescriptor {
+                glyphs: glyphs.into_boxed_slice(),
+                axes: axes.into_boxed_slice(),
+                regions: regions.into_boxed_slice(),
+                complements: complements.into_boxed_slice(),
+            },
+        }
+    }
+
+    pub fn atlas(&self) -> &VariableAtlas {
+        &self.atlas
+    }
+
+    pub fn glyphs(&self) -> &[(GlyphIndex, u32)] {
+        self.descriptor.glyphs()
+    }
+
+    /// Evaluates the small page-local weight buffer without rebuilding resident geometry.
+    pub fn weights(&self, location: &VariationLocation) -> Result<Vec<f32>, SourceAtlasError> {
+        self.descriptor.weights(location)
+    }
+
+    /// Separates disposable CPU atlas geometry from its small retained descriptor.
+    pub fn into_parts(self) -> (VariableAtlas, SourceAtlasDescriptor) {
+        (self.atlas, self.descriptor)
+    }
+}
+
+/// Small retained mapping needed after a source atlas has been packed and uploaded.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SourceAtlasDescriptor {
+    glyphs: Box<[(GlyphIndex, u32)]>,
+    axes: Box<[AtlasAxis]>,
+    regions: Box<[AtlasRegion]>,
+    complements: Box<[Box<[u32]>]>,
+}
+
+impl SourceAtlasDescriptor {
+    pub fn glyphs(&self) -> &[(GlyphIndex, u32)] {
+        &self.glyphs
+    }
+
+    /// Evaluates the small page-local weight buffer without resident CPU geometry.
+    pub fn weights(&self, location: &VariationLocation) -> Result<Vec<f32>, SourceAtlasError> {
+        if location.coordinates().len() != self.axes.len() {
+            return Err(FontReadError::InvalidDisplayGlyph {
+                details: format!(
+                    "location has {} coordinates for {} source atlas axes",
+                    location.coordinates().len(),
+                    self.axes.len()
+                ),
+            }
+            .into());
+        }
+
+        let coordinates = self
+            .axes
+            .iter()
+            .zip(location.coordinates())
+            .map(|(axis, value)| axis.normalize(*value))
+            .collect::<Result<Vec<_>, _>>()?;
+        let mut weights = Vec::with_capacity(
+            1_usize
+                .checked_add(self.regions.len())
+                .and_then(|length| length.checked_add(self.complements.len()))
+                .ok_or(shift_slug::SlugError::LengthOverflow)?,
+        );
+        weights.push(1.0);
+        for region in &self.regions {
+            weights.push(region.scalar(&coordinates)?);
+        }
+        for complement in &self.complements {
+            let region_sum = complement.iter().try_fold(0.0_f32, |sum, index| {
+                let weight = weights
+                    .get(*index as usize)
+                    .ok_or(shift_slug::SlugError::VariableWeightIndexOutOfRange(*index))?;
+                Ok::<_, shift_slug::SlugError>(sum + weight)
+            })?;
+            weights.push(1.0 - region_sum);
+        }
+        Ok(weights)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SourceAtlasError {
+    #[error(transparent)]
+    Read(#[from] FontReadError),
+
+    #[error(transparent)]
+    Slug(#[from] shift_slug::SlugError),
+
+    #[error("unsupported binary atlas source: {details}")]
+    UnsupportedBinary { details: &'static str },
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct AtlasAxis {
+    axis: VariationAxis,
+    mapping: Box<[(i16, i16)]>,
+}
+
+impl AtlasAxis {
+    pub(crate) fn new(axis: VariationAxis, mapping: Vec<(i16, i16)>) -> Self {
+        Self {
+            axis,
+            mapping: mapping.into_boxed_slice(),
+        }
+    }
+
+    fn normalize(&self, value: f64) -> Result<i16, FontReadError> {
+        self.axis.kind.validate_for_read(self.axis.index, value)?;
+        let VariationAxisKind::Continuous {
+            minimum,
+            default,
+            maximum,
+        } = self.axis.kind
+        else {
+            return Err(FontReadError::InvalidDisplayGlyph {
+                details: format!(
+                    "binary source axis {:?} is unexpectedly discrete",
+                    self.axis.index
+                ),
+            });
+        };
+        let normalized = if value == default {
+            0.0
+        } else if value < default {
+            if default == minimum {
+                0.0
+            } else {
+                (value - default) / (default - minimum)
+            }
+        } else if maximum == default {
+            0.0
+        } else {
+            (value - default) / (maximum - default)
+        };
+        let coordinate = F2Dot14::from_f32(normalized as f32).to_bits();
+        Ok(apply_mapping(coordinate, &self.mapping))
+    }
+}
+
+fn apply_mapping(coordinate: i16, mapping: &[(i16, i16)]) -> i16 {
+    let Some(position) = mapping.iter().position(|(source, _)| *source >= coordinate) else {
+        return coordinate;
+    };
+    let (source, target) = mapping[position];
+    if source == coordinate {
+        return target;
+    }
+    let Some(&(previous_source, previous_target)) = position
+        .checked_sub(1)
+        .and_then(|previous| mapping.get(previous))
+    else {
+        return coordinate;
+    };
+    if source == previous_source {
+        return previous_target;
+    }
+    let fraction = f64::from(i32::from(coordinate) - i32::from(previous_source))
+        / f64::from(i32::from(source) - i32::from(previous_source));
+    let mapped = f64::from(previous_target)
+        + f64::from(i32::from(target) - i32::from(previous_target)) * fraction;
+    F2Dot14::from_f32(mapped as f32 / 16384.0).to_bits()
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct AtlasRegion {
+    axes: Box<[RegionAxis]>,
+}
+
+impl AtlasRegion {
+    pub(crate) fn new(axes: Vec<RegionAxis>) -> Self {
+        Self {
+            axes: axes.into_boxed_slice(),
+        }
+    }
+
+    fn scalar(&self, coordinates: &[i16]) -> Result<f32, SourceAtlasError> {
+        if self.axes.len() != coordinates.len() {
+            return Err(FontReadError::InvalidDisplayGlyph {
+                details: format!(
+                    "source atlas region has {} axes for {} coordinates",
+                    self.axes.len(),
+                    coordinates.len()
+                ),
+            }
+            .into());
+        }
+        let mut scalar = 1.0_f32;
+        for (axis, coordinate) in self.axes.iter().zip(coordinates) {
+            let start = i32::from(axis.start);
+            let peak = i32::from(axis.peak);
+            let end = i32::from(axis.end);
+            let coordinate = i32::from(*coordinate);
+            if peak == 0 || peak == coordinate {
+                continue;
+            }
+            if start > peak || peak > end || (start < 0 && end > 0) {
+                continue;
+            }
+            if coordinate < start || coordinate > end {
+                return Ok(0.0);
+            }
+            if coordinate < peak {
+                if peak != start {
+                    scalar *= (coordinate - start) as f32 / (peak - start) as f32;
+                }
+            } else if peak != end {
+                scalar *= (end - coordinate) as f32 / (end - peak) as f32;
+            }
+        }
+        Ok(scalar)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct RegionAxis {
+    pub(crate) start: i16,
+    pub(crate) peak: i16,
+    pub(crate) end: i16,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct RegionRegistry {
+    regions: Vec<AtlasRegion>,
+    indices: HashMap<AtlasRegion, u32>,
+}
+
+impl RegionRegistry {
+    pub(crate) fn weight_index(&mut self, region: AtlasRegion) -> Result<u32, SourceAtlasError> {
+        if let Some(index) = self.indices.get(&region) {
+            return Ok(*index);
+        }
+        let index = u32::try_from(self.regions.len())
+            .map_err(|_| shift_slug::SlugError::LengthOverflow)?
+            .checked_add(1)
+            .ok_or(shift_slug::SlugError::LengthOverflow)?;
+        self.regions.push(region.clone());
+        self.indices.insert(region, index);
+        Ok(index)
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.regions.len()
+    }
+
+    pub(crate) fn into_regions(self) -> Vec<AtlasRegion> {
+        self.regions
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use shift_slug::VariableAtlas;
+
+    use super::{AtlasAxis, AtlasRegion, RegionAxis, SourceAtlasPage};
+    use crate::font_source::{AxisIndex, VariationAxis, VariationAxisKind, VariationLocation};
+
+    #[test]
+    fn page_weights_keep_glyph_region_complements_independent() {
+        let axis = VariationAxis {
+            index: AxisIndex::new(0),
+            tag: "wght".into(),
+            name: "Weight".into(),
+            hidden: false,
+            kind: VariationAxisKind::Continuous {
+                minimum: -1.0,
+                default: 0.0,
+                maximum: 1.0,
+            },
+        };
+        let page = SourceAtlasPage::new(
+            VariableAtlas::default(),
+            Vec::new(),
+            vec![AtlasAxis::new(axis, Vec::new())],
+            vec![
+                AtlasRegion::new(vec![RegionAxis {
+                    start: 0,
+                    peak: 16384,
+                    end: 16384,
+                }]),
+                AtlasRegion::new(vec![RegionAxis {
+                    start: -16384,
+                    peak: -16384,
+                    end: 0,
+                }]),
+            ],
+            vec![vec![1].into_boxed_slice(), vec![2].into_boxed_slice()],
+        );
+
+        let (atlas, descriptor) = page.into_parts();
+
+        assert_eq!(atlas, VariableAtlas::default());
+        assert_eq!(
+            descriptor
+                .weights(&VariationLocation::from_coordinates(vec![1.0]))
+                .unwrap(),
+            vec![1.0, 1.0, 0.0, 0.0, 1.0]
+        );
+    }
+}

--- a/crates/shift-backends/src/font_source/binary.rs
+++ b/crates/shift-backends/src/font_source/binary.rs
@@ -28,6 +28,9 @@ use crate::font_source::{
 };
 use crate::FontFormat;
 
+mod atlas;
+pub use atlas::build_binary_atlas_page;
+
 #[derive(Clone, Copy)]
 struct SourceStamp {
     length: u64,

--- a/crates/shift-backends/src/font_source/binary/atlas.rs
+++ b/crates/shift-backends/src/font_source/binary/atlas.rs
@@ -1,0 +1,502 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+
+use shift_slug::VariableAtlasBuilder;
+use skrifa::raw::tables::gvar::GlyphDelta;
+use skrifa::raw::tables::variations::TupleVariation;
+use skrifa::raw::types::MajorMinor;
+use skrifa::raw::{ReadError, TableProvider};
+use skrifa::FontRef;
+
+use crate::font_source::atlas::{
+    AtlasAxis, AtlasRegion, RegionAxis, RegionRegistry, SourceAtlasError, SourceAtlasPage,
+};
+use crate::font_source::{GlyphIndex, RandomAccessFont};
+
+use super::{malformed, BinaryFont};
+
+mod geometry;
+mod metrics;
+
+struct PendingGlyph {
+    root: GlyphIndex,
+    curves: geometry::VariableCurves,
+    base_advance: f32,
+    advance_deltas: BTreeMap<u32, f32>,
+    source_weights: BTreeSet<u32>,
+}
+
+/// Compiles one deterministic root batch directly from retained glyf/gvar semantics.
+pub fn build_binary_atlas_page(
+    source: &BinaryFont,
+    roots: &[GlyphIndex],
+    band_count: u32,
+) -> Result<SourceAtlasPage, SourceAtlasError> {
+    source.verify_source()?;
+    validate_roots(source, roots)?;
+    let font = FontRef::new(source.bytes().as_ref()).map_err(|error| {
+        malformed(
+            &source.path,
+            format!("failed to reopen retained font: {error}"),
+        )
+    })?;
+    let loca = font.loca(None).map_err(|error| match error {
+        ReadError::TableIsMissing(_) => SourceAtlasError::UnsupportedBinary {
+            details: "the first direct atlas slice supports glyf outlines only",
+        },
+        error => malformed(&source.path, format!("failed to read loca table: {error}")).into(),
+    })?;
+    let glyf = font.glyf().map_err(|error| match error {
+        ReadError::TableIsMissing(_) => SourceAtlasError::UnsupportedBinary {
+            details: "the first direct atlas slice supports glyf outlines only",
+        },
+        error => malformed(&source.path, format!("failed to read glyf table: {error}")).into(),
+    })?;
+    let gvar = match font.gvar() {
+        Ok(gvar) => Some(gvar),
+        Err(ReadError::TableIsMissing(_)) => None,
+        Err(error) => {
+            return Err(
+                malformed(&source.path, format!("failed to read gvar table: {error}")).into(),
+            )
+        }
+    };
+    let axes = atlas_axes(source, &font)?;
+    let mut registry = RegionRegistry::default();
+    let mut pending = Vec::with_capacity(roots.len());
+
+    for root in roots {
+        let curves = geometry::resolve_variable_curves(
+            &source.path,
+            loca.clone(),
+            glyf.clone(),
+            gvar.clone(),
+            &mut registry,
+            *root,
+        )?;
+        let (base_advance, advance_deltas) = metrics::advance_contributions(
+            &source.path,
+            &font,
+            loca.clone(),
+            glyf.clone(),
+            gvar.clone(),
+            &mut registry,
+            *root,
+        )?;
+        let source_weights = curves
+            .sources
+            .keys()
+            .chain(advance_deltas.keys())
+            .copied()
+            .collect();
+        pending.push(PendingGlyph {
+            root: *root,
+            curves,
+            base_advance,
+            advance_deltas,
+            source_weights,
+        });
+    }
+
+    let complement_start = u32::try_from(registry.len())
+        .map_err(|_| shift_slug::SlugError::LengthOverflow)?
+        .checked_add(1)
+        .ok_or(shift_slug::SlugError::LengthOverflow)?;
+    let mut complement_indices = HashMap::<Vec<u32>, u32>::new();
+    let mut complements = Vec::<Box<[u32]>>::new();
+    let mut builder = VariableAtlasBuilder::new(band_count)?;
+    let mut glyphs = Vec::with_capacity(pending.len());
+
+    for pending in pending {
+        let source_weights = pending.source_weights.into_iter().collect::<Vec<_>>();
+        let base_weight = if source_weights.is_empty() {
+            0
+        } else if let Some(weight) = complement_indices.get(&source_weights) {
+            *weight
+        } else {
+            let weight = complement_start
+                .checked_add(
+                    u32::try_from(complements.len())
+                        .map_err(|_| shift_slug::SlugError::LengthOverflow)?,
+                )
+                .ok_or(shift_slug::SlugError::LengthOverflow)?;
+            complements.push(source_weights.clone().into_boxed_slice());
+            complement_indices.insert(source_weights.clone(), weight);
+            weight
+        };
+        let mut variable_sources = pending.curves.sources;
+        let base_curves = pending.curves.base;
+        let source_curves = source_weights
+            .iter()
+            .map(|weight| {
+                (
+                    *weight,
+                    variable_sources
+                        .remove(weight)
+                        .unwrap_or_else(|| base_curves.clone()),
+                )
+            })
+            .collect::<Vec<_>>();
+        let atlas_glyph = builder.add_curve_glyph_with_sources_and_lines(
+            base_curves,
+            pending.curves.line_flags,
+            base_weight,
+            source_curves,
+        )?;
+        builder.set_glyph_source_advances(
+            atlas_glyph,
+            std::iter::once(pending.base_advance).chain(source_weights.iter().map(|weight| {
+                pending.base_advance + pending.advance_deltas.get(weight).copied().unwrap_or(0.0)
+            })),
+        )?;
+        glyphs.push((pending.root, atlas_glyph));
+    }
+
+    Ok(SourceAtlasPage::new(
+        builder.finish(),
+        glyphs,
+        axes,
+        registry.into_regions(),
+        complements,
+    ))
+}
+
+fn validate_roots(source: &BinaryFont, roots: &[GlyphIndex]) -> Result<(), SourceAtlasError> {
+    let mut unique = HashSet::with_capacity(roots.len());
+    for root in roots {
+        if source.directory().glyphs.get(root.to_usize()).is_none() {
+            return Err(crate::font_source::FontReadError::GlyphOutOfRange {
+                glyph: *root,
+                glyph_count: source.directory().glyphs.len() as u32,
+            }
+            .into());
+        }
+        if !unique.insert(*root) {
+            return Err(crate::font_source::FontReadError::InvalidDisplayGlyph {
+                details: format!("source atlas page repeats glyph {root:?}"),
+            }
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn atlas_axes(source: &BinaryFont, font: &FontRef<'_>) -> Result<Vec<AtlasAxis>, SourceAtlasError> {
+    let mappings = match font.avar() {
+        Ok(avar) => {
+            if avar.version() != MajorMinor::VERSION_1_0 {
+                return Err(SourceAtlasError::UnsupportedBinary {
+                    details:
+                        "avar version 2 requires a location mapping model in the resident page",
+                });
+            }
+            if avar.axis_count() as usize != source.directory.axes.len() {
+                return Err(
+                    malformed(&source.path, "avar axis count does not match fvar".into()).into(),
+                );
+            }
+            avar.axis_segment_maps()
+                .iter()
+                .map(|mapping| {
+                    let mapping = mapping.map_err(|error| {
+                        malformed(
+                            &source.path,
+                            format!("failed to read avar segment map: {error}"),
+                        )
+                    })?;
+                    Ok(mapping
+                        .axis_value_maps()
+                        .iter()
+                        .map(|value| {
+                            (
+                                value.from_coordinate().to_bits(),
+                                value.to_coordinate().to_bits(),
+                            )
+                        })
+                        .collect::<Vec<_>>())
+                })
+                .collect::<Result<Vec<_>, SourceAtlasError>>()?
+        }
+        Err(ReadError::TableIsMissing(_)) => vec![Vec::new(); source.directory.axes.len()],
+        Err(error) => {
+            return Err(
+                malformed(&source.path, format!("failed to read avar table: {error}")).into(),
+            )
+        }
+    };
+    Ok(source
+        .directory
+        .axes
+        .iter()
+        .cloned()
+        .zip(mappings)
+        .map(|(axis, mapping)| AtlasAxis::new(axis, mapping))
+        .collect())
+}
+
+pub(super) fn tuple_region(tuple: &TupleVariation<'_, GlyphDelta>) -> AtlasRegion {
+    let peak = tuple.peak();
+    let start = tuple.intermediate_start();
+    let end = tuple.intermediate_end();
+    AtlasRegion::new(
+        peak.values()
+            .iter()
+            .enumerate()
+            .map(|(index, peak)| {
+                let peak = peak.get().to_bits();
+                match (&start, &end) {
+                    (Some(start), Some(end)) => RegionAxis {
+                        start: start.values()[index].get().to_bits(),
+                        peak,
+                        end: end.values()[index].get().to_bits(),
+                    },
+                    _ if peak < 0 => RegionAxis {
+                        start: peak,
+                        peak,
+                        end: 0,
+                    },
+                    _ => RegionAxis {
+                        start: 0,
+                        peak,
+                        end: peak,
+                    },
+                }
+            })
+            .collect(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use shift_slug::{AtlasBuilder, Curve, OutlineCommand, DEFAULT_BAND_COUNT};
+    use skrifa::outline::pen::PathStyle;
+    use skrifa::outline::{DrawSettings, OutlinePen};
+    use skrifa::prelude::{LocationRef, Size};
+    use skrifa::{FontRef, MetadataProvider};
+
+    use super::{build_binary_atlas_page, BinaryFont, SourceAtlasError};
+    use crate::font_source::{RandomAccessFont, VariationAxisKind, VariationCoordinate};
+
+    #[derive(Default)]
+    struct CommandPen(Vec<OutlineCommand<f32>>);
+
+    impl OutlinePen for CommandPen {
+        fn move_to(&mut self, x: f32, y: f32) {
+            self.0.push(OutlineCommand::Move { x, y });
+        }
+
+        fn line_to(&mut self, x: f32, y: f32) {
+            self.0.push(OutlineCommand::Line { x, y });
+        }
+
+        fn quad_to(&mut self, cx: f32, cy: f32, x: f32, y: f32) {
+            self.0.push(OutlineCommand::Quad { cx, cy, x, y });
+        }
+
+        fn curve_to(&mut self, c1x: f32, c1y: f32, c2x: f32, c2y: f32, x: f32, y: f32) {
+            self.0.push(OutlineCommand::Cubic {
+                c1x,
+                c1y,
+                c2x,
+                c2y,
+                x,
+                y,
+            });
+        }
+
+        fn close(&mut self) {
+            self.0.push(OutlineCommand::Close);
+        }
+    }
+
+    fn repository_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .to_path_buf()
+    }
+
+    fn fixture(name: &str) -> PathBuf {
+        repository_root()
+            .join("fixtures/fonts/mutatorsans")
+            .join(name)
+    }
+
+    #[test]
+    fn direct_page_matches_variable_simple_and_composite_outlines() {
+        let source =
+            BinaryFont::open(&repository_root().join(
+                "apps/desktop/src/renderer/src/assets/fonts/HostGrotesk-VariableFont_wght.ttf",
+            ))
+            .unwrap();
+        let roots = ["A", "Aacute", "space"].map(|name| {
+            source
+                .directory()
+                .glyphs
+                .iter()
+                .find(|glyph| glyph.name == name)
+                .unwrap()
+                .index
+        });
+        assert!(!source
+            .read_glyph(roots[1], source.directory().default_location())
+            .unwrap()
+            .components
+            .is_empty());
+        let page = build_binary_atlas_page(&source, &roots, DEFAULT_BAND_COUNT).unwrap();
+        let axis = &source.directory().axes[0];
+        let (default, maximum) = match axis.kind {
+            VariationAxisKind::Continuous {
+                default, maximum, ..
+            } => (default, maximum),
+            VariationAxisKind::Discrete { .. } => panic!("fixture axis should be continuous"),
+        };
+        let midpoint_location = source
+            .directory()
+            .location(&[VariationCoordinate {
+                axis: axis.index,
+                value: (default + maximum) * 0.5,
+            }])
+            .unwrap();
+        let maximum_location = source
+            .directory()
+            .location(&[VariationCoordinate {
+                axis: axis.index,
+                value: maximum,
+            }])
+            .unwrap();
+
+        for location in [
+            source.directory().default_location(),
+            &midpoint_location,
+            &maximum_location,
+        ] {
+            let weights = page.weights(location).unwrap();
+            for (glyph, atlas_glyph) in page.glyphs() {
+                let actual = page
+                    .atlas()
+                    .resolve_glyph_with_weights(*atlas_glyph, &weights)
+                    .unwrap();
+                let expected = skrifa_curves(&source, *glyph, location);
+                assert_curves_close(&actual, &expected);
+                let actual_advance = page
+                    .atlas()
+                    .resolve_advance_with_weights(*atlas_glyph, &weights)
+                    .unwrap();
+                let expected_advance = source
+                    .read_glyph(*glyph, location)
+                    .unwrap()
+                    .metrics
+                    .x_advance;
+                assert!((f64::from(actual_advance) - expected_advance).abs() < 0.001);
+            }
+        }
+    }
+
+    #[test]
+    fn direct_page_matches_a_uniform_host_grotesk_sample() {
+        let source =
+            BinaryFont::open(&repository_root().join(
+                "apps/desktop/src/renderer/src/assets/fonts/HostGrotesk-VariableFont_wght.ttf",
+            ))
+            .unwrap();
+        let roots = source
+            .directory()
+            .glyphs
+            .iter()
+            .step_by(17)
+            .map(|glyph| glyph.index)
+            .collect::<Vec<_>>();
+        let page = build_binary_atlas_page(&source, &roots, DEFAULT_BAND_COUNT).unwrap();
+        let axis = &source.directory().axes[0];
+        let (default, maximum) = match axis.kind {
+            VariationAxisKind::Continuous {
+                default, maximum, ..
+            } => (default, maximum),
+            VariationAxisKind::Discrete { .. } => panic!("fixture axis should be continuous"),
+        };
+        let location = source
+            .directory()
+            .location(&[VariationCoordinate {
+                axis: axis.index,
+                value: (default + maximum) * 0.5,
+            }])
+            .unwrap();
+        let weights = page.weights(&location).unwrap();
+
+        for (glyph, atlas_glyph) in page.glyphs() {
+            let actual = page
+                .atlas()
+                .resolve_glyph_with_weights(*atlas_glyph, &weights)
+                .unwrap();
+            assert_curves_close(&actual, &skrifa_curves(&source, *glyph, &location));
+        }
+    }
+
+    #[test]
+    fn direct_page_rejects_cff_sources_explicitly() {
+        let source = BinaryFont::open(&fixture("MutatorSans.otf")).unwrap();
+        let error = build_binary_atlas_page(
+            &source,
+            &[source.directory().glyphs[0].index],
+            DEFAULT_BAND_COUNT,
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, SourceAtlasError::UnsupportedBinary { .. }));
+    }
+
+    fn skrifa_curves(
+        source: &BinaryFont,
+        glyph: crate::font_source::GlyphIndex,
+        location: &crate::font_source::VariationLocation,
+    ) -> Vec<Curve> {
+        let font = FontRef::new(source.bytes().as_ref()).unwrap();
+        let location = source.skrifa_location(&font, location).unwrap();
+        let mut pen = CommandPen::default();
+        if let Some(outline) = font
+            .outline_glyphs()
+            .get(skrifa::GlyphId::new(glyph.to_u32()))
+        {
+            outline
+                .draw(
+                    DrawSettings::unhinted(Size::unscaled(), LocationRef::from(&location))
+                        .with_path_style(PathStyle::HarfBuzz),
+                    &mut pen,
+                )
+                .unwrap();
+        }
+        let mut builder = AtlasBuilder::new(DEFAULT_BAND_COUNT).unwrap();
+        builder.add_glyph(pen.0).unwrap();
+        builder.finish().curves().to_vec()
+    }
+
+    fn assert_curves_close(actual: &[Curve], expected: &[Curve]) {
+        assert_eq!(actual.len(), expected.len());
+        for (actual, expected) in actual.iter().zip(expected) {
+            for (actual, expected) in [
+                (actual.p0, expected.p0),
+                (actual.p1, expected.p1),
+                (actual.p2, expected.p2),
+            ] {
+                assert!(
+                    (actual.x - expected.x).abs() < 0.001,
+                    "x mismatch: actual={} expected={} delta={}",
+                    actual.x,
+                    expected.x,
+                    actual.x - expected.x
+                );
+                assert!(
+                    (actual.y - expected.y).abs() < 0.001,
+                    "y mismatch: actual={} expected={} delta={}",
+                    actual.y,
+                    expected.y,
+                    actual.y - expected.y
+                );
+            }
+        }
+    }
+}

--- a/crates/shift-backends/src/font_source/binary/atlas/geometry.rs
+++ b/crates/shift-backends/src/font_source/binary/atlas/geometry.rs
@@ -1,0 +1,447 @@
+use std::collections::{BTreeMap, HashMap};
+use std::path::Path;
+
+use shift_slug::{Curve, Point};
+use skrifa::raw::tables::glyf::{
+    Anchor as GlyfAnchor, CompositeGlyphFlags, Glyf, Glyph as GlyfGlyph, PointFlags,
+};
+use skrifa::raw::tables::gvar::Gvar;
+use skrifa::raw::tables::loca::Loca;
+use skrifa::raw::types::{GlyphId, Point as RawPoint};
+
+use crate::font_source::atlas::{RegionRegistry, SourceAtlasError};
+use crate::font_source::{AffineTransform, FontReadError, GlyphIndex, GlyphPointKind};
+
+use super::super::{approximate_hypot, component_transform, infer_tuple_deltas, malformed};
+use super::tuple_region;
+
+mod curves;
+use curves::{curves_from_geometry, normalize_contour};
+
+pub(super) struct VariableCurves {
+    pub(super) base: Vec<Curve>,
+    pub(super) line_flags: Vec<bool>,
+    pub(super) sources: BTreeMap<u32, Vec<Curve>>,
+}
+
+pub(super) fn resolve_variable_curves(
+    path: &Path,
+    loca: Loca<'_>,
+    glyf: Glyf<'_>,
+    gvar: Option<Gvar<'_>>,
+    registry: &mut RegionRegistry,
+    root: GlyphIndex,
+) -> Result<VariableCurves, SourceAtlasError> {
+    let geometry = ExpressionResolver::new(path, loca, glyf, gvar, registry).resolve(root)?;
+    curves_from_geometry(&geometry)
+}
+
+#[derive(Clone, Debug, Default)]
+struct VariablePosition {
+    x: f64,
+    y: f64,
+    deltas: BTreeMap<u32, (f64, f64)>,
+}
+
+impl VariablePosition {
+    fn new(x: f64, y: f64) -> Self {
+        Self {
+            x,
+            y,
+            deltas: BTreeMap::new(),
+        }
+    }
+
+    fn add_delta(&mut self, weight: u32, delta: (f64, f64)) {
+        let value = self.deltas.entry(weight).or_default();
+        value.0 += delta.0;
+        value.1 += delta.1;
+    }
+
+    fn at(&self, weight: Option<u32>) -> Point {
+        let delta = weight
+            .and_then(|weight| self.deltas.get(&weight))
+            .copied()
+            .unwrap_or_default();
+        Point::new((self.x + delta.0) as f32, (self.y + delta.1) as f32)
+    }
+
+    fn transformed(&self, transform: AffineTransform) -> Self {
+        let mut transformed = Self::new(
+            transform.xx * self.x + transform.xy * self.y,
+            transform.yx * self.x + transform.yy * self.y,
+        );
+        for (weight, (x, y)) in &self.deltas {
+            transformed.add_delta(
+                *weight,
+                (
+                    transform.xx * x + transform.xy * y,
+                    transform.yx * x + transform.yy * y,
+                ),
+            );
+        }
+        transformed
+    }
+
+    fn add_assign(&mut self, other: &Self) {
+        self.x += other.x;
+        self.y += other.y;
+        for (weight, delta) in &other.deltas {
+            self.add_delta(*weight, *delta);
+        }
+    }
+
+    fn subtract(first: &Self, second: &Self) -> Self {
+        let mut result = Self::new(first.x - second.x, first.y - second.y);
+        for (weight, delta) in &first.deltas {
+            result.add_delta(*weight, *delta);
+        }
+        for (weight, (x, y)) in &second.deltas {
+            result.add_delta(*weight, (-x, -y));
+        }
+        result
+    }
+
+    fn midpoint(first: &Self, second: &Self) -> Self {
+        let mut result = Self::new((first.x + second.x) * 0.5, (first.y + second.y) * 0.5);
+        for (weight, (x, y)) in &first.deltas {
+            result.add_delta(*weight, (x * 0.5, y * 0.5));
+        }
+        for (weight, (x, y)) in &second.deltas {
+            result.add_delta(*weight, (x * 0.5, y * 0.5));
+        }
+        result
+    }
+}
+
+#[derive(Clone, Debug)]
+struct VariablePoint {
+    position: VariablePosition,
+    kind: GlyphPointKind,
+}
+
+impl VariablePoint {
+    fn midpoint(first: &Self, second: &Self) -> Self {
+        Self {
+            position: VariablePosition::midpoint(&first.position, &second.position),
+            kind: GlyphPointKind::OnCurve,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct VariableContour {
+    points: Vec<VariablePoint>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct VariableGeometry {
+    contours: Vec<VariableContour>,
+    attachment_points: Vec<VariablePosition>,
+}
+
+struct ExpressionResolver<'a, 'registry> {
+    path: &'a Path,
+    loca: Loca<'a>,
+    glyf: Glyf<'a>,
+    gvar: Option<Gvar<'a>>,
+    registry: &'registry mut RegionRegistry,
+    indices: HashMap<GlyphIndex, usize>,
+    states: Vec<u8>,
+    geometries: Vec<Option<VariableGeometry>>,
+}
+
+impl<'a, 'registry> ExpressionResolver<'a, 'registry> {
+    fn new(
+        path: &'a Path,
+        loca: Loca<'a>,
+        glyf: Glyf<'a>,
+        gvar: Option<Gvar<'a>>,
+        registry: &'registry mut RegionRegistry,
+    ) -> Self {
+        Self {
+            path,
+            loca,
+            glyf,
+            gvar,
+            registry,
+            indices: HashMap::new(),
+            states: Vec::new(),
+            geometries: Vec::new(),
+        }
+    }
+
+    fn resolve(mut self, root: GlyphIndex) -> Result<VariableGeometry, SourceAtlasError> {
+        let index = self.resolve_geometry(root)?;
+        self.geometries[index]
+            .take()
+            .ok_or_else(|| invalid_geometry("binary atlas root geometry is unavailable"))
+    }
+
+    fn resolve_geometry(&mut self, glyph: GlyphIndex) -> Result<usize, SourceAtlasError> {
+        if let Some(index) = self.indices.get(&glyph).copied() {
+            return match self.states[index] {
+                1 => Err(FontReadError::ComponentCycle { glyph }.into()),
+                2 => Ok(index),
+                _ => Err(invalid_geometry(
+                    "binary atlas geometry has an invalid resolution state",
+                )),
+            };
+        }
+
+        let index = self.geometries.len();
+        self.indices.insert(glyph, index);
+        self.states.push(1);
+        self.geometries.push(None);
+        let raw_id = GlyphId::new(glyph.to_u32());
+        let raw = self.loca.get_glyf(raw_id, &self.glyf).map_err(|error| {
+            malformed(self.path, format!("failed to read glyph {raw_id}: {error}"))
+        })?;
+        let geometry = match raw {
+            None => VariableGeometry::default(),
+            Some(GlyfGlyph::Simple(simple)) => self.resolve_simple(raw_id, &simple)?,
+            Some(GlyfGlyph::Composite(composite)) => {
+                let components = composite.components().collect::<Vec<_>>();
+                let component_deltas = self.composite_deltas(raw_id, components.len())?;
+                let mut geometry = VariableGeometry::default();
+
+                for (component_index, component) in components.into_iter().enumerate() {
+                    let child_glyph = GlyphIndex::new(component.glyph.to_u32());
+                    let child_index = self.resolve_geometry(child_glyph)?;
+                    let child = self.geometries[child_index]
+                        .as_ref()
+                        .ok_or_else(|| invalid_geometry("resolved component is unavailable"))?
+                        .clone();
+                    let transform = component_transform(&component);
+                    let translation = match component.anchor {
+                        GlyfAnchor::Offset { x, y } => {
+                            let mut x = f64::from(x);
+                            let mut y = f64::from(y);
+                            if component
+                                .flags
+                                .contains(CompositeGlyphFlags::SCALED_COMPONENT_OFFSET)
+                                && !component
+                                    .flags
+                                    .contains(CompositeGlyphFlags::UNSCALED_COMPONENT_OFFSET)
+                            {
+                                x *= approximate_hypot(transform.xx, transform.yx);
+                                y *= approximate_hypot(transform.yy, transform.xy);
+                            }
+                            let mut translation = VariablePosition::new(x, y);
+                            if let Some(deltas) = component_deltas.get(component_index) {
+                                translation.add_assign(deltas);
+                            }
+                            translation
+                        }
+                        GlyfAnchor::Point { base, component } => {
+                            let base =
+                                geometry
+                                    .attachment_points
+                                    .get(base as usize)
+                                    .ok_or_else(|| {
+                                        malformed(
+                                            self.path,
+                                            format!(
+                                            "invalid base anchor point {base} in glyph {raw_id}"
+                                        ),
+                                        )
+                                    })?;
+                            let component = child
+                                .attachment_points
+                                .get(component as usize)
+                                .ok_or_else(|| {
+                                    malformed(
+                                        self.path,
+                                        format!(
+                                            "invalid component anchor point {component} in glyph {raw_id}"
+                                        ),
+                                    )
+                                })?
+                                .transformed(transform);
+                            VariablePosition::subtract(base, &component)
+                        }
+                    };
+
+                    geometry.attachment_points.extend(
+                        child
+                            .attachment_points
+                            .iter()
+                            .map(|point| transform_and_translate(point, transform, &translation)),
+                    );
+                    geometry
+                        .contours
+                        .extend(child.contours.iter().map(|contour| {
+                            VariableContour {
+                                points: contour
+                                    .points
+                                    .iter()
+                                    .map(|point| VariablePoint {
+                                        position: transform_and_translate(
+                                            &point.position,
+                                            transform,
+                                            &translation,
+                                        ),
+                                        kind: point.kind,
+                                    })
+                                    .collect(),
+                            }
+                        }));
+                }
+                geometry
+            }
+        };
+        self.geometries[index] = Some(geometry);
+        self.states[index] = 2;
+        Ok(index)
+    }
+
+    fn resolve_simple(
+        &mut self,
+        glyph: GlyphId,
+        simple: &skrifa::raw::tables::glyf::SimpleGlyph<'_>,
+    ) -> Result<VariableGeometry, SourceAtlasError> {
+        let point_count = simple.num_points();
+        let mut raw_points = vec![RawPoint::<i32>::default(); point_count];
+        let mut flags = vec![PointFlags::default(); point_count];
+        simple
+            .read_points_fast(&mut raw_points, &mut flags)
+            .map_err(|error| {
+                malformed(
+                    self.path,
+                    format!("failed to read points for glyph {glyph}: {error}"),
+                )
+            })?;
+        if flags.iter().any(|flags| flags.is_off_curve_cubic()) {
+            return Err(SourceAtlasError::UnsupportedBinary {
+                details: "cubic glyf contours are not supported by the first direct atlas slice",
+            });
+        }
+        let contour_ends = simple
+            .end_pts_of_contours()
+            .iter()
+            .map(|end| end.get())
+            .collect::<Vec<_>>();
+        let mut points = raw_points
+            .iter()
+            .zip(&flags)
+            .map(|(point, flags)| VariablePoint {
+                position: VariablePosition::new(f64::from(point.x), f64::from(point.y)),
+                kind: if flags.is_on_curve() {
+                    GlyphPointKind::OnCurve
+                } else {
+                    GlyphPointKind::QuadraticControl
+                },
+            })
+            .collect::<Vec<_>>();
+
+        if let Some(gvar) = &self.gvar {
+            let variation = gvar.glyph_variation_data(glyph).map_err(|error| {
+                malformed(
+                    self.path,
+                    format!("failed to read variation data for glyph {glyph}: {error}"),
+                )
+            })?;
+            if let Some(variation) = variation {
+                for tuple in variation.tuples() {
+                    let mut deltas = vec![None; points.len()];
+                    for delta in tuple.deltas() {
+                        let position = delta.position as usize;
+                        if position < deltas.len() {
+                            deltas[position] =
+                                Some((f64::from(delta.x_delta), f64::from(delta.y_delta)));
+                        }
+                    }
+                    infer_tuple_deltas(&raw_points, &contour_ends, &mut deltas)?;
+                    if !deltas
+                        .iter()
+                        .flatten()
+                        .any(|delta| delta.0 != 0.0 || delta.1 != 0.0)
+                    {
+                        continue;
+                    }
+                    let weight = self.registry.weight_index(tuple_region(&tuple))?;
+                    for (point, delta) in points.iter_mut().zip(deltas) {
+                        if let Some(delta) = delta {
+                            point.position.add_delta(weight, delta);
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut contours = Vec::with_capacity(contour_ends.len());
+        let mut start = 0;
+        for end in contour_ends {
+            let end = end as usize;
+            if end < start || end >= points.len() {
+                return Err(malformed(
+                    self.path,
+                    format!("invalid contour endpoint {end} in glyph {glyph}"),
+                )
+                .into());
+            }
+            contours.push(normalize_contour(points[start..=end].to_vec())?);
+            start = end + 1;
+        }
+
+        Ok(VariableGeometry {
+            contours,
+            attachment_points: points.into_iter().map(|point| point.position).collect(),
+        })
+    }
+
+    fn composite_deltas(
+        &mut self,
+        glyph: GlyphId,
+        component_count: usize,
+    ) -> Result<Vec<VariablePosition>, SourceAtlasError> {
+        let mut deltas = vec![VariablePosition::default(); component_count];
+        let Some(gvar) = &self.gvar else {
+            return Ok(deltas);
+        };
+        let Some(variation) = gvar.glyph_variation_data(glyph).map_err(|error| {
+            malformed(
+                self.path,
+                format!("failed to read variation data for glyph {glyph}: {error}"),
+            )
+        })?
+        else {
+            return Ok(deltas);
+        };
+        for tuple in variation.tuples() {
+            let tuple_deltas = tuple
+                .deltas()
+                .filter(|delta| (delta.position as usize) < component_count)
+                .collect::<Vec<_>>();
+            if !tuple_deltas
+                .iter()
+                .any(|delta| delta.x_delta != 0 || delta.y_delta != 0)
+            {
+                continue;
+            }
+            let weight = self.registry.weight_index(tuple_region(&tuple))?;
+            for delta in tuple_deltas {
+                deltas[delta.position as usize]
+                    .add_delta(weight, (f64::from(delta.x_delta), f64::from(delta.y_delta)));
+            }
+        }
+        Ok(deltas)
+    }
+}
+
+fn transform_and_translate(
+    point: &VariablePosition,
+    transform: AffineTransform,
+    translation: &VariablePosition,
+) -> VariablePosition {
+    let mut point = point.transformed(transform);
+    point.add_assign(translation);
+    point
+}
+
+fn invalid_geometry(details: &str) -> SourceAtlasError {
+    FontReadError::InvalidDisplayGlyph {
+        details: details.into(),
+    }
+    .into()
+}

--- a/crates/shift-backends/src/font_source/binary/atlas/geometry/curves.rs
+++ b/crates/shift-backends/src/font_source/binary/atlas/geometry/curves.rs
@@ -1,0 +1,170 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use shift_slug::Curve;
+
+use crate::font_source::atlas::SourceAtlasError;
+use crate::font_source::GlyphPointKind;
+
+use super::{
+    invalid_geometry, VariableContour, VariableCurves, VariableGeometry, VariablePoint,
+    VariablePosition,
+};
+
+pub(super) fn normalize_contour(
+    points: Vec<VariablePoint>,
+) -> Result<VariableContour, SourceAtlasError> {
+    if points.is_empty() {
+        return Err(invalid_geometry("binary atlas contour has no points"));
+    }
+    let first_on = points
+        .iter()
+        .position(|point| point.kind == GlyphPointKind::OnCurve);
+    let (start, indexes, all_off_curve) = match first_on {
+        Some(start) => (
+            points[start].clone(),
+            (1..points.len())
+                .map(|offset| (start + offset) % points.len())
+                .collect::<Vec<_>>(),
+            false,
+        ),
+        None => (
+            VariablePoint::midpoint(points.last().expect("contour is non-empty"), &points[0]),
+            (0..points.len()).collect(),
+            true,
+        ),
+    };
+    let mut normalized = Vec::with_capacity(points.len() * 2);
+    normalized.push(start);
+    for (position, index) in indexes.iter().copied().enumerate() {
+        let point = &points[index];
+        normalized.push(point.clone());
+        let next = (index + 1) % points.len();
+        let closes_all_off_curve = all_off_curve && position + 1 == indexes.len();
+        if point.kind == GlyphPointKind::QuadraticControl
+            && !closes_all_off_curve
+            && points[next].kind == GlyphPointKind::QuadraticControl
+        {
+            normalized.push(VariablePoint::midpoint(point, &points[next]));
+        }
+    }
+    Ok(VariableContour { points: normalized })
+}
+
+pub(super) fn curves_from_geometry(
+    geometry: &VariableGeometry,
+) -> Result<VariableCurves, SourceAtlasError> {
+    let weights = geometry
+        .contours
+        .iter()
+        .flat_map(|contour| &contour.points)
+        .flat_map(|point| point.position.deltas.keys().copied())
+        .collect::<BTreeSet<_>>();
+    let mut base = Vec::new();
+    let mut line_flags = Vec::new();
+    let mut sources = weights
+        .iter()
+        .map(|weight| (*weight, Vec::new()))
+        .collect::<BTreeMap<_, _>>();
+
+    for contour in &geometry.contours {
+        let points = &contour.points;
+        if points.is_empty() || points[0].kind != GlyphPointKind::OnCurve {
+            return Err(invalid_geometry(
+                "normalized binary atlas contour does not begin on-curve",
+            ));
+        }
+        let mut current = &points[0].position;
+        let mut cursor = 1;
+        while cursor <= points.len() {
+            let point = &points[cursor % points.len()];
+            match point.kind {
+                GlyphPointKind::OnCurve => {
+                    push_line(
+                        &mut base,
+                        &mut line_flags,
+                        &mut sources,
+                        current,
+                        &point.position,
+                    );
+                    current = &point.position;
+                    cursor += 1;
+                }
+                GlyphPointKind::QuadraticControl => {
+                    if cursor + 1 > points.len() {
+                        return Err(invalid_geometry(
+                            "quadratic control is missing its endpoint",
+                        ));
+                    }
+                    let endpoint = &points[(cursor + 1) % points.len()];
+                    if endpoint.kind != GlyphPointKind::OnCurve {
+                        return Err(invalid_geometry(
+                            "quadratic control is not followed by an endpoint",
+                        ));
+                    }
+                    push_quadratic(
+                        &mut base,
+                        &mut line_flags,
+                        &mut sources,
+                        current,
+                        &point.position,
+                        &endpoint.position,
+                    );
+                    current = &endpoint.position;
+                    cursor += 2;
+                }
+                GlyphPointKind::CubicControl => {
+                    return Err(SourceAtlasError::UnsupportedBinary {
+                        details:
+                            "cubic glyf contours are not supported by the first direct atlas slice",
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(VariableCurves {
+        base,
+        line_flags,
+        sources,
+    })
+}
+
+fn push_line(
+    base: &mut Vec<Curve>,
+    line_flags: &mut Vec<bool>,
+    sources: &mut BTreeMap<u32, Vec<Curve>>,
+    start: &VariablePosition,
+    end: &VariablePosition,
+) {
+    base.push(Curve::from_line(start.at(None), end.at(None)));
+    line_flags.push(true);
+    for (weight, curves) in sources {
+        curves.push(Curve::from_line(
+            start.at(Some(*weight)),
+            end.at(Some(*weight)),
+        ));
+    }
+}
+
+fn push_quadratic(
+    base: &mut Vec<Curve>,
+    line_flags: &mut Vec<bool>,
+    sources: &mut BTreeMap<u32, Vec<Curve>>,
+    start: &VariablePosition,
+    control: &VariablePosition,
+    end: &VariablePosition,
+) {
+    base.push(Curve {
+        p0: start.at(None),
+        p1: control.at(None),
+        p2: end.at(None),
+    });
+    line_flags.push(false);
+    for (weight, curves) in sources {
+        curves.push(Curve {
+            p0: start.at(Some(*weight)),
+            p1: control.at(Some(*weight)),
+            p2: end.at(Some(*weight)),
+        });
+    }
+}

--- a/crates/shift-backends/src/font_source/binary/atlas/metrics.rs
+++ b/crates/shift-backends/src/font_source/binary/atlas/metrics.rs
@@ -1,0 +1,215 @@
+use std::collections::{BTreeMap, HashSet};
+use std::path::Path;
+
+use skrifa::prelude::{LocationRef, Size};
+use skrifa::raw::tables::glyf::{CompositeGlyphFlags, Glyf, Glyph as GlyfGlyph};
+use skrifa::raw::tables::gvar::Gvar;
+use skrifa::raw::tables::loca::Loca;
+use skrifa::raw::tables::variations::DeltaSetIndex;
+use skrifa::raw::types::GlyphId;
+use skrifa::raw::{ReadError, TableProvider};
+use skrifa::{FontRef, MetadataProvider};
+
+use crate::font_source::atlas::{AtlasRegion, RegionAxis, RegionRegistry, SourceAtlasError};
+use crate::font_source::GlyphIndex;
+
+use super::super::malformed;
+use super::tuple_region;
+
+pub(super) fn advance_contributions(
+    path: &Path,
+    font: &FontRef<'_>,
+    loca: Loca<'_>,
+    glyf: Glyf<'_>,
+    gvar: Option<Gvar<'_>>,
+    registry: &mut RegionRegistry,
+    glyph: GlyphIndex,
+) -> Result<(f32, BTreeMap<u32, f32>), SourceAtlasError> {
+    let raw_glyph = GlyphId::new(glyph.to_u32());
+    let base = font
+        .glyph_metrics(Size::unscaled(), LocationRef::default())
+        .advance_width(raw_glyph)
+        .ok_or_else(|| malformed(path, format!("missing advance width for glyph {raw_glyph}")))?;
+
+    match font.hvar() {
+        Ok(hvar) => {
+            let contributions = hvar_contributions(path, hvar, registry, raw_glyph)?;
+            Ok((base, contributions))
+        }
+        Err(ReadError::TableIsMissing(_)) => {
+            let contributions = match gvar {
+                Some(gvar) => gvar_contributions(path, loca, glyf, gvar, registry, raw_glyph)?,
+                None => BTreeMap::new(),
+            };
+            Ok((base, contributions))
+        }
+        Err(error) => Err(malformed(path, format!("failed to read HVAR table: {error}")).into()),
+    }
+}
+
+fn hvar_contributions(
+    path: &Path,
+    hvar: skrifa::raw::tables::hvar::Hvar<'_>,
+    registry: &mut RegionRegistry,
+    glyph: GlyphId,
+) -> Result<BTreeMap<u32, f32>, SourceAtlasError> {
+    let index = match hvar.advance_width_mapping() {
+        Some(mapping) => mapping
+            .map_err(|error| {
+                malformed(
+                    path,
+                    format!("failed to read HVAR advance mapping: {error}"),
+                )
+            })?
+            .get(glyph.to_u32())
+            .map_err(|error| {
+                malformed(
+                    path,
+                    format!("failed to map HVAR advance for glyph {glyph}: {error}"),
+                )
+            })?,
+        None => DeltaSetIndex {
+            outer: 0,
+            inner: glyph.to_u32() as u16,
+        },
+    };
+    let store = hvar.item_variation_store().map_err(|error| {
+        malformed(
+            path,
+            format!("failed to read HVAR item variation store: {error}"),
+        )
+    })?;
+    let Some(data) = store.item_variation_data().get(index.outer as usize) else {
+        return Ok(BTreeMap::new());
+    };
+    let data = data
+        .map_err(|error| malformed(path, format!("failed to read HVAR variation data: {error}")))?;
+    let regions = store
+        .variation_region_list()
+        .map_err(|error| {
+            malformed(
+                path,
+                format!("failed to read HVAR variation regions: {error}"),
+            )
+        })?
+        .variation_regions();
+    let mut contributions = BTreeMap::new();
+    for (position, delta) in data.delta_set(index.inner).enumerate() {
+        if delta == 0 {
+            continue;
+        }
+        let region_index = data
+            .region_indexes()
+            .get(position)
+            .ok_or_else(|| malformed(path, "HVAR region index is missing".into()))?
+            .get() as usize;
+        let region = regions.get(region_index).map_err(|error| {
+            malformed(
+                path,
+                format!("failed to read HVAR region {region_index}: {error}"),
+            )
+        })?;
+        let region = AtlasRegion::new(
+            region
+                .region_axes()
+                .iter()
+                .map(|axis| RegionAxis {
+                    start: axis.start_coord().to_bits(),
+                    peak: axis.peak_coord().to_bits(),
+                    end: axis.end_coord().to_bits(),
+                })
+                .collect(),
+        );
+        let weight = registry.weight_index(region)?;
+        *contributions.entry(weight).or_default() += delta as f32;
+    }
+    Ok(contributions)
+}
+
+fn gvar_contributions(
+    path: &Path,
+    loca: Loca<'_>,
+    glyf: Glyf<'_>,
+    gvar: Gvar<'_>,
+    registry: &mut RegionRegistry,
+    glyph: GlyphId,
+) -> Result<BTreeMap<u32, f32>, SourceAtlasError> {
+    let (glyph, point_count) = metrics_glyph(path, loca, glyf, glyph, &mut HashSet::new())?;
+    let Some(variation) = gvar.glyph_variation_data(glyph).map_err(|error| {
+        malformed(
+            path,
+            format!("failed to read metric variation data for glyph {glyph}: {error}"),
+        )
+    })?
+    else {
+        return Ok(BTreeMap::new());
+    };
+    let left = point_count;
+    let right = point_count
+        .checked_add(1)
+        .ok_or_else(|| malformed(path, "phantom point index overflow".into()))?;
+    let mut contributions = BTreeMap::new();
+    for tuple in variation.tuples() {
+        let mut left_delta = 0_i32;
+        let mut right_delta = 0_i32;
+        for delta in tuple.deltas() {
+            let position = delta.position as usize;
+            if position == left {
+                left_delta = delta.x_delta;
+            } else if position == right {
+                right_delta = delta.x_delta;
+            }
+        }
+        let delta = right_delta - left_delta;
+        if delta == 0 {
+            continue;
+        }
+        let weight = registry.weight_index(tuple_region(&tuple))?;
+        *contributions.entry(weight).or_default() += delta as f32;
+    }
+    Ok(contributions)
+}
+
+fn metrics_glyph(
+    path: &Path,
+    loca: Loca<'_>,
+    glyf: Glyf<'_>,
+    glyph: GlyphId,
+    ancestry: &mut HashSet<GlyphId>,
+) -> Result<(GlyphId, usize), SourceAtlasError> {
+    if !ancestry.insert(glyph) {
+        return Err(malformed(
+            path,
+            format!("cyclic USE_MY_METRICS component at glyph {glyph}"),
+        )
+        .into());
+    }
+    let raw = loca
+        .get_glyf(glyph, &glyf)
+        .map_err(|error| malformed(path, format!("failed to read glyph {glyph}: {error}")))?;
+    let result = match raw {
+        None => (glyph, 0),
+        Some(GlyfGlyph::Simple(simple)) => (glyph, simple.num_points()),
+        Some(GlyfGlyph::Composite(composite)) => {
+            let components = composite.components().collect::<Vec<_>>();
+            let mut metrics = None;
+            for component in &components {
+                if component
+                    .flags
+                    .contains(CompositeGlyphFlags::USE_MY_METRICS)
+                {
+                    metrics = Some(metrics_glyph(
+                        path,
+                        loca.clone(),
+                        glyf.clone(),
+                        component.glyph.into(),
+                        ancestry,
+                    )?);
+                }
+            }
+            metrics.unwrap_or((glyph, components.len()))
+        }
+    };
+    ancestry.remove(&glyph);
+    Ok(result)
+}

--- a/crates/shift-backends/src/font_source/mod.rs
+++ b/crates/shift-backends/src/font_source/mod.rs
@@ -1,3 +1,4 @@
+mod atlas;
 mod binary;
 mod error;
 mod geometry;
@@ -6,7 +7,8 @@ mod glyphs;
 mod interpolation;
 mod types;
 
-pub use binary::BinaryFont;
+pub use atlas::{SourceAtlasDescriptor, SourceAtlasError, SourceAtlasPage};
+pub use binary::{build_binary_atlas_page, BinaryFont};
 pub use error::FontReadError;
 pub use glif::GlifFont;
 pub use glyphs::GlyphsFont;

--- a/crates/shift-backends/src/lib.rs
+++ b/crates/shift-backends/src/lib.rs
@@ -16,12 +16,13 @@ pub mod ufo;
 pub use errors::{BackendError, BackendResult, FormatBackendError, FormatBackendResult};
 pub use export::{ExportError, ExportFormat, FontExportRequest, FontExportResult, FontExporter};
 pub use font_source::{
-    AffineTransform, AnchorRange, AxisIndex, BinaryFont, ComponentInstance, ComponentRange,
-    ContourRange, DirectoryGlyph, DisplayGlyph, FontDirectory, FontImporter, FontReadError,
-    FontSource, GeometryIndex, GlifFont, GlyphAnchor, GlyphBounds, GlyphContour, GlyphGeometry,
-    GlyphGuide, GlyphIndex, GlyphMetrics, GlyphPoint, GlyphPointKind, GlyphsFont, GuideRange,
-    PointProvenance, PointRange, RandomAccessFont, TrueTypePointIndex, VariationAxis,
-    VariationAxisKind, VariationCoordinate, VariationLocation,
+    build_binary_atlas_page, AffineTransform, AnchorRange, AxisIndex, BinaryFont,
+    ComponentInstance, ComponentRange, ContourRange, DirectoryGlyph, DisplayGlyph, FontDirectory,
+    FontImporter, FontReadError, FontSource, GeometryIndex, GlifFont, GlyphAnchor, GlyphBounds,
+    GlyphContour, GlyphGeometry, GlyphGuide, GlyphIndex, GlyphMetrics, GlyphPoint, GlyphPointKind,
+    GlyphsFont, GuideRange, PointProvenance, PointRange, RandomAccessFont, SourceAtlasDescriptor,
+    SourceAtlasError, SourceAtlasPage, TrueTypePointIndex, VariationAxis, VariationAxisKind,
+    VariationCoordinate, VariationLocation,
 };
 pub use format::FontFormat;
 pub use import::{FontImport, GlyphDirectoryEntry, ImportBatchLimit};


### PR DESCRIPTION
## Summary

- compile ordered glyf/gvar roots directly from retained `BinaryFont` bytes into bounded location-independent Slug atlas pages
- preserve stable quadratic topology through IUP, ordinary composite flattening, gvar component deltas, HVAR, and phantom-point advance variation
- evaluate fvar/avar 1 region weights without rebuilding geometry, including per-glyph complement weights for disjoint tuple supports
- split disposable CPU geometry from retained `SourceAtlasDescriptor` mappings via `SourceAtlasPage::into_parts`
- reject CFF/CFF2, cubic glyf extensions, avar 2, and VARC explicitly instead of falling back to authored or selected-glyph conversion
- add Host Grotesk interpolation comparisons and a complete-atlas release profiler

Stacked on #177. This PR intentionally adds the source-to-atlas compiler boundary only; desktop scheduling, transfer, complete-before-present upload, and Grid integration follow separately.

## Correctness

Host Grotesk simple, composite, empty, and uniformly sampled glyphs match Skrifa's unrounded HarfBuzz-style glyf resolution at default, midpoint, and maximum locations within 0.001 font units. Tests also cover independent per-glyph region complements and explicit unsupported CFF behavior.

## Source Han profile

65,535 glyphs, 256 pages of 256 roots, all packed pages retained:

- direct page compilation: 2,056.228 ms
- packing: 412.204 ms
- complete build + pack: 2,469.520 ms
- page build p50 / p95: 8.366 / 11.727 ms
- all-page weight update: 0.071 ms
- packed bytes: 255.381 MiB
- maximum packed page: 1.730 MiB
- peak RSS: 315.9 MiB

## Validation

- repository commit hooks
- `cargo test -p shift-backends`
- `cargo test -p shift-slug --all-features`
- `cargo test --workspace --exclude shift-bridge`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo doc -p shift-backends --no-deps`
- `cargo fmt --check`
