### PR TITLE
Add canonical SQLite document foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2356,6 +2356,7 @@ name = "shift-store"
 version = "0.1.0"
 dependencies = [
  "blake3",
+ "getrandom 0.3.3",
  "rayon",
  "rmp-serde",
  "rusqlite",

--- a/crates/shift-store/Cargo.toml
+++ b/crates/shift-store/Cargo.toml
@@ -6,14 +6,15 @@ edition = "2024"
 [dependencies]
 shift-font = { workspace = true }
 blake3 = "1.8"
+getrandom = "0.3"
 rusqlite = { version = "0.37.0", features = ["blob", "backup", "limits"] }
 rayon = "1.10"
 rmp-serde = "1.3"
 serde = "1.0"
 serde_json = "1.0"
 thiserror = "2"
+tempfile = "3"
 zstd = "0.13"
 
 [dev-dependencies]
 shift-font = { workspace = true, features = ["test-support"] }
-tempfile = "3"

--- a/crates/shift-store/README.md
+++ b/crates/shift-store/README.md
@@ -1,8 +1,16 @@
 # shift-store
 
-`shift-store` owns Shift's durable SQLite working database.
+`shift-store` owns Shift's SQLite persistence boundary: the canonical `.shift` application database and the separate app-local working database used during editing and import.
 
-Callers use typed APIs from this crate rather than preparing SQL or opening a second application-level persistence path.
+Callers use typed APIs from this crate rather than preparing SQL or opening a second application-level persistence path. The desktop app has not yet cut over from the legacy ZIP package, so the canonical document APIs are currently a tested foundation rather than the active Save/Open route.
+
+## Canonical document boundary
+
+- A `.shift` document is the SQLite database itself. It uses application ID `SHFT` (`0x53484654`) and an exact `user_version` contract.
+- `ShiftStore::create_document` writes a complete `shift-font::Font` at a sibling staging path, syncs it, and publishes without clobbering an existing destination.
+- `ShiftStore::open_document` validates the file read-only before opening it with rollback journaling and `synchronous=FULL`. `ShiftStore::verify_document` also runs SQLite integrity and foreign-key checks.
+- `DocumentMetadata` contains the stable `DocumentId`. A raw copy preserves it; Save As will mint a new identity at the workspace boundary.
+- Canonical documents never contain app-local `workspace_state`. Working databases retain WAL + NORMAL and their revision/source-binding row.
 
 ## Storage boundary
 
@@ -30,16 +38,20 @@ only then invoke strict MessagePack decoding. A layer replacement may move betwe
 
 `FontImportWriter` accepts bounded replacement glyph batches without requiring a complete in-memory `Font`. `encode_glyph_batch` MessagePack-encodes, BLAKE3-hashes, and independently compresses an owned batch with Rayon without borrowing the SQLite transaction, allowing the workspace to overlap parsing, encoding/compression, and one stable-order SQLite writer. Streaming inserts, full-state replacement, and change-set replacement share one write implementation parameterized only by insert/upsert mode. Change sets supplied with a committed post-edit font skip incremental decode/re-encode for touched existing layers and write each final layer once. Secondary query indexes are dropped inside the stream transaction and rebuilt in bulk by `finish`; dropping an unfinished writer restores them with the rest of the rollback. Prefix-redundant Unicode-glyph and component-layer indexes are omitted. `finish` is the only stream commit point.
 
-`ShiftStore::open_for_import` uses rollback-capable in-memory journaling and disabled synchronous writes only while the foreign source remains authoritative and the path is disposable. `finish_import` syncs the completed database and restores WAL + NORMAL. Normal edits never use import pragmas. `FontWorkspace` opens imports at a sibling staging path, writes workspace state there, makes the staged database durable, closes it, removes the closed staging WAL/SHM sidecars, atomically installs the main database at the requested destination, and syncs the parent directory. A failure before installation leaves the previous destination untouched.
+`ShiftStore::open_for_import` uses rollback-capable in-memory journaling and disabled synchronous writes only while the authoring source remains authoritative and the path is disposable. `finish_import` syncs the completed database and restores WAL + NORMAL. Normal edits never use import pragmas. `FontWorkspace` opens imports at a sibling staging path, writes workspace state there, makes the staged database durable, closes it, removes the closed staging WAL/SHM sidecars, atomically installs the main database at the requested destination, and syncs the parent directory. A failure before installation leaves the previous destination untouched.
+
+## Preservation and export gate
+
+Canonical SQLite publication must preserve the complete `shift-font::Font`, not a projection chosen for one exporter. The kitchen-sink canonical-document test covers metadata, metrics, axes and mappings, named instances, sources, kerning, features, libs, binary data, guidelines, glyph layers, components, anchors, and stable authored identities through SQLite equality. UFO and Designspace exports must materialize that complete canonical state and use their dedicated writers. Any concept the target format cannot represent requires an explicit export diagnostic; no exporter may silently narrow the canonical document or route through another authoring format.
 
 ## Schema policy
 
-Shift has not shipped this working-store schema. Schema changes therefore update the version-1 baseline directly; there is intentionally no compatibility migration for earlier development databases.
+Shift has not shipped either SQLite schema. Schema changes therefore update the version-1 baselines directly; there is intentionally no compatibility migration for earlier development databases. Canonical document schema stabilization is gated on preservation/export goldens and hostile-input budgets.
 
 ## Responsibilities
 
-- configure SQLite for WAL-backed transactional work and a separately finalized disposable-import mode;
-- own the baseline schema and raw SQL;
+- configure SQLite for canonical rollback/FULL durability, WAL-backed transactional work, and a separately finalized disposable-import mode;
+- own the canonical and working version-1 schemas and raw SQL;
 - preserve stable authored IDs and exact values;
 - provide directory-first and bounded canonical payload APIs rather than row-level outline/component compatibility models;
 - keep canonical payloads and relational query indexes atomic;
@@ -49,8 +61,9 @@ Shift has not shipped this working-store schema. Schema changes therefore update
 
 ```text
 src/
-  connection.rs     # normal WAL opening plus disposable import/finalization posture
-  schema.rs         # pre-release version-1 baseline
+  connection.rs     # canonical, working-WAL, and disposable-import connection postures
+  document.rs       # staged create, validated open/verify, metadata, and durable publication
+  schema.rs         # canonical and working pre-release version-1 baselines
   font_state.rs     # eager metadata/directory and explicit full materialization
   import_writer.rs  # pipelined Rayon encode/compress plus one SQLite transaction owner
   layer/

--- a/crates/shift-store/src/change_set.rs
+++ b/crates/shift-store/src/change_set.rs
@@ -32,6 +32,7 @@ impl ShiftStore {
         change_set: &font::FontChangeSet,
         post_font: Option<&font::Font>,
     ) -> Result<(), StoreError> {
+        let tracks_workspace = self.tracks_workspace();
         let tx = self.conn.transaction()?;
         let mut touched_layer_ids = HashSet::new();
 
@@ -50,7 +51,9 @@ impl ShiftStore {
                 }
             }
         }
-        mark_workspace_dirty_in_tx(&tx)?;
+        if tracks_workspace {
+            mark_workspace_dirty_in_tx(&tx)?;
+        }
 
         tx.commit()?;
         Ok(())

--- a/crates/shift-store/src/connection.rs
+++ b/crates/shift-store/src/connection.rs
@@ -1,27 +1,30 @@
 use std::path::Path;
 
-use crate::{ShiftStore, StoreError, schema};
+use crate::{ShiftStore, StoreError, schema, store::StoreKind};
 
 impl ShiftStore {
     pub fn open(path: impl AsRef<Path>) -> Result<Self, StoreError> {
         let path = path.as_ref();
         let conn = rusqlite::Connection::open(path)?;
-        configure_connection(&conn)?;
+        configure_common(&conn)?;
         schema::ensure_current(&conn)?;
+        configure_working_posture(&conn)?;
         Ok(Self {
             conn,
             path: Some(path.to_path_buf()),
+            kind: StoreKind::Working,
         })
     }
 
     /// Opens a disposable import destination with rollback-capable in-memory
-    /// journaling. The foreign source remains authoritative until
+    /// journaling. The source remains authoritative until
     /// [`Self::finish_import`] makes the completed store durable.
     pub fn open_for_import(path: impl AsRef<Path>) -> Result<Self, StoreError> {
         let path = path.as_ref();
         let conn = rusqlite::Connection::open(path)?;
-        configure_import_connection(&conn)?;
+        configure_common(&conn)?;
         schema::ensure_current(&conn)?;
+        configure_import_posture(&conn)?;
         let has_workspace: bool = conn.query_row(
             "SELECT EXISTS(SELECT 1 FROM workspace_state WHERE id = 1)",
             [],
@@ -33,6 +36,7 @@ impl ShiftStore {
         Ok(Self {
             conn,
             path: Some(path.to_path_buf()),
+            kind: StoreKind::Working,
         })
     }
 
@@ -50,7 +54,7 @@ impl ShiftStore {
         Ok(())
     }
 
-    fn sync_store_file(&self) -> Result<(), StoreError> {
+    pub(crate) fn sync_store_file(&self) -> Result<(), StoreError> {
         if let Some(path) = &self.path {
             std::fs::OpenOptions::new()
                 .read(true)
@@ -63,15 +67,27 @@ impl ShiftStore {
 
     pub fn open_memory_for_test() -> Result<Self, StoreError> {
         let conn = rusqlite::Connection::open_in_memory()?;
-        configure_connection(&conn)?;
+        configure_common(&conn)?;
         schema::ensure_current(&conn)?;
-        Ok(Self { conn, path: None })
+        configure_working_posture(&conn)?;
+        Ok(Self {
+            conn,
+            path: None,
+            kind: StoreKind::Working,
+        })
     }
 }
 
-fn configure_connection(conn: &rusqlite::Connection) -> Result<(), StoreError> {
+pub(crate) fn configure_document_connection(conn: &rusqlite::Connection) -> Result<(), StoreError> {
     configure_common(conn)?;
+    let journal_mode: String =
+        conn.query_row("PRAGMA journal_mode=DELETE", [], |row| row.get(0))?;
+    debug_assert_eq!(journal_mode, "delete");
+    conn.pragma_update(None, "synchronous", "FULL")?;
+    Ok(())
+}
 
+fn configure_working_posture(conn: &rusqlite::Connection) -> Result<(), StoreError> {
     // WAL + NORMAL is the durability/latency posture for a store that
     // commits per user action. In-memory test connections report "memory"
     // for journal_mode; both outcomes are accepted here and the file-mode
@@ -82,8 +98,7 @@ fn configure_connection(conn: &rusqlite::Connection) -> Result<(), StoreError> {
     Ok(())
 }
 
-fn configure_import_connection(conn: &rusqlite::Connection) -> Result<(), StoreError> {
-    configure_common(conn)?;
+fn configure_import_posture(conn: &rusqlite::Connection) -> Result<(), StoreError> {
     let journal_mode: String =
         conn.query_row("PRAGMA journal_mode=MEMORY", [], |row| row.get(0))?;
     debug_assert_eq!(journal_mode, "memory");
@@ -91,9 +106,10 @@ fn configure_import_connection(conn: &rusqlite::Connection) -> Result<(), StoreE
     Ok(())
 }
 
-fn configure_common(conn: &rusqlite::Connection) -> Result<(), StoreError> {
+pub(crate) fn configure_common(conn: &rusqlite::Connection) -> Result<(), StoreError> {
     conn.set_prepared_statement_cache_capacity(64);
     conn.pragma_update(None, "foreign_keys", "ON")?;
+    conn.pragma_update(None, "trusted_schema", "OFF")?;
     conn.busy_timeout(std::time::Duration::from_millis(5_000))?;
     Ok(())
 }

--- a/crates/shift-store/src/document.rs
+++ b/crates/shift-store/src/document.rs
@@ -1,0 +1,209 @@
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+};
+
+use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
+use shift_font::Font;
+
+use crate::{
+    DocumentId, ShiftStore, StoreError,
+    connection::{configure_common, configure_document_connection},
+    schema,
+    store::StoreKind,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DocumentMetadata {
+    pub document_id: DocumentId,
+}
+
+impl ShiftStore {
+    /// Creates and durably publishes a complete canonical Shift document.
+    ///
+    /// The destination is never overwritten. All schema and font writes happen
+    /// at a sibling staging path before one no-clobber publication step.
+    pub fn create_document(path: impl AsRef<Path>, font: &Font) -> Result<Self, StoreError> {
+        let path = path.as_ref();
+        if path.exists() {
+            return Err(StoreError::DocumentAlreadyExists(path.to_path_buf()));
+        }
+
+        let parent = parent_directory(path);
+        let staged = tempfile::Builder::new()
+            .prefix(".shift-document-")
+            .suffix(".shift")
+            .tempfile_in(parent)?
+            .into_temp_path();
+
+        {
+            let conn = Connection::open(&staged)?;
+            configure_document_connection(&conn)?;
+            schema::initialize_document(&conn)?;
+            let mut store = Self {
+                conn,
+                path: Some(staged.to_path_buf()),
+                kind: StoreKind::Document,
+            };
+            store.replace_font_state(font)?;
+            store.insert_document_metadata(&DocumentMetadata {
+                document_id: DocumentId::new(),
+            })?;
+            store.sync_store_file()?;
+        }
+
+        remove_staging_sidecars(&staged)?;
+        match staged.persist_noclobber(path) {
+            Ok(()) => {}
+            Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => {
+                return Err(StoreError::DocumentAlreadyExists(path.to_path_buf()));
+            }
+            Err(error) => return Err(StoreError::Io(error.error)),
+        }
+        sync_parent_directory(path)?;
+
+        Self::open_document(path)
+    }
+
+    /// Opens a canonical Shift document after validating it read-only first.
+    pub fn open_document(path: impl AsRef<Path>) -> Result<Self, StoreError> {
+        let path = path.as_ref();
+
+        {
+            let probe = open_document_read_only(path)?;
+            schema::validate_document_header(&probe)?;
+            validate_document_shape(&probe)?;
+        }
+
+        let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_WRITE)?;
+        schema::validate_document_header(&conn)?;
+        validate_document_shape(&conn)?;
+        configure_document_connection(&conn)?;
+
+        Ok(Self {
+            conn,
+            path: Some(path.to_path_buf()),
+            kind: StoreKind::Document,
+        })
+    }
+
+    /// Performs format, schema, relational, and SQLite integrity validation
+    /// without opening the document for writes.
+    pub fn verify_document(path: impl AsRef<Path>) -> Result<DocumentMetadata, StoreError> {
+        let conn = open_document_read_only(path.as_ref())?;
+        schema::validate_document_header(&conn)?;
+        let metadata = validate_document_shape(&conn)?;
+
+        let integrity: String = conn.query_row("PRAGMA integrity_check", [], |row| row.get(0))?;
+        if integrity != "ok" {
+            return Err(StoreError::InvalidDocument(format!(
+                "SQLite integrity check failed: {integrity}"
+            )));
+        }
+
+        let mut foreign_keys = conn.prepare("PRAGMA foreign_key_check")?;
+        if foreign_keys.exists([])? {
+            return Err(StoreError::InvalidDocument(
+                "SQLite foreign-key check failed".to_string(),
+            ));
+        }
+
+        Ok(metadata)
+    }
+
+    pub fn document_metadata(&self) -> Result<DocumentMetadata, StoreError> {
+        load_document_metadata(&self.conn)
+    }
+
+    fn insert_document_metadata(&mut self, metadata: &DocumentMetadata) -> Result<(), StoreError> {
+        self.conn.execute(
+            "INSERT INTO document_metadata (id, document_id) VALUES (1, ?1)",
+            params![metadata.document_id.as_str()],
+        )?;
+        Ok(())
+    }
+}
+
+fn open_document_read_only(path: &Path) -> Result<Connection, StoreError> {
+    let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+    configure_common(&conn)?;
+    conn.pragma_update(None, "query_only", "ON")?;
+    Ok(conn)
+}
+
+fn validate_document_shape(conn: &Connection) -> Result<DocumentMetadata, StoreError> {
+    let has_workspace_state: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = 'workspace_state')",
+        [],
+        |row| row.get(0),
+    )?;
+    if has_workspace_state {
+        return Err(StoreError::InvalidDocument(
+            "canonical document contains app-local workspace state".to_string(),
+        ));
+    }
+
+    load_document_metadata(conn)
+}
+
+fn load_document_metadata(conn: &Connection) -> Result<DocumentMetadata, StoreError> {
+    let count: i64 = conn.query_row("SELECT COUNT(*) FROM document_metadata", [], |row| {
+        row.get(0)
+    })?;
+    if count != 1 {
+        return Err(StoreError::InvalidDocument(format!(
+            "expected one document_metadata row, found {count}"
+        )));
+    }
+
+    let stored = conn
+        .query_row(
+            "SELECT document_id FROM document_metadata WHERE id = 1",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .ok_or_else(|| {
+            StoreError::InvalidDocument("missing document_metadata row 1".to_string())
+        })?;
+    let document_id =
+        DocumentId::from_stored(stored.clone()).ok_or(StoreError::InvalidDocumentId(stored))?;
+
+    Ok(DocumentMetadata { document_id })
+}
+
+fn parent_directory(path: &Path) -> &Path {
+    match path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent,
+        _ => Path::new("."),
+    }
+}
+
+fn remove_staging_sidecars(path: &Path) -> Result<(), StoreError> {
+    for suffix in ["-journal", "-wal", "-shm"] {
+        let sidecar = sqlite_sidecar_path(path, suffix);
+        match std::fs::remove_file(sidecar) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(())
+}
+
+fn sqlite_sidecar_path(path: &Path, suffix: &str) -> PathBuf {
+    let mut sidecar = OsString::from(path.as_os_str());
+    sidecar.push(suffix);
+    PathBuf::from(sidecar)
+}
+
+#[cfg(unix)]
+fn sync_parent_directory(path: &Path) -> Result<(), StoreError> {
+    std::fs::File::open(parent_directory(path))?.sync_all()?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn sync_parent_directory(_path: &Path) -> Result<(), StoreError> {
+    Ok(())
+}

--- a/crates/shift-store/src/error.rs
+++ b/crates/shift-store/src/error.rs
@@ -63,9 +63,29 @@ pub enum StoreError {
     #[error("import destination already contains published workspace state: {0}")]
     ImportDestinationNotEmpty(std::path::PathBuf),
 
+    #[error("document already exists: {0}")]
+    DocumentAlreadyExists(std::path::PathBuf),
+
+    #[error("invalid SQLite application ID {found:#010x}; expected {expected:#010x}")]
+    InvalidApplicationId { found: i64, expected: i64 },
+
+    #[error("canonical Shift documents must be opened with ShiftStore::open_document")]
+    DocumentRequiresDocumentOpen,
+
+    #[error("invalid Shift document: {0}")]
+    InvalidDocument(String),
+
+    #[error("invalid document ID: {0}")]
+    InvalidDocumentId(String),
+
     #[error("missing {kind}: {id}")]
     MissingEntity { kind: &'static str, id: String },
 
     #[error("store schema version {found} is newer than supported version {supported}")]
     UnsupportedSchemaVersion { found: i64, supported: i64 },
+
+    #[error(
+        "Shift document schema version {found} is unsupported; this build supports {supported}"
+    )]
+    UnsupportedDocumentSchemaVersion { found: i64, supported: i64 },
 }

--- a/crates/shift-store/src/layer/write.rs
+++ b/crates/shift-store/src/layer/write.rs
@@ -15,6 +15,7 @@ impl ShiftStore {
     /// rows in one transaction. The workspace revision advances only after
     /// encoding and index derivation have succeeded.
     pub fn replace_glyph_layer(&mut self, layer: &font::GlyphLayer) -> Result<(), StoreError> {
+        let tracks_workspace = self.tracks_workspace();
         let owner =
             layer_owner(&self.conn, &layer.id())?.ok_or_else(|| StoreError::MissingEntity {
                 kind: "glyph layer",
@@ -22,7 +23,9 @@ impl ShiftStore {
             })?;
         let tx = self.conn.transaction()?;
         write_layer_in_tx(&tx, &owner, layer)?;
-        mark_workspace_dirty_in_tx(&tx)?;
+        if tracks_workspace {
+            mark_workspace_dirty_in_tx(&tx)?;
+        }
         tx.commit()?;
         Ok(())
     }

--- a/crates/shift-store/src/lib.rs
+++ b/crates/shift-store/src/lib.rs
@@ -1,5 +1,6 @@
 mod change_set;
 mod connection;
+mod document;
 mod error;
 mod font;
 mod font_state;
@@ -13,6 +14,7 @@ mod types;
 mod workspace_state;
 mod write_mode;
 
+pub use document::DocumentMetadata;
 pub use error::StoreError;
 pub use font::FontInfo;
 pub use glyph::{GlyphRecord, NewGlyph};
@@ -21,9 +23,12 @@ pub use layer::{
     GLYPH_LAYER_FORMAT, GlyphLayerDirectoryEntry, MAX_LAYER_READ_BATCH_COUNT,
     MAX_LAYER_READ_BATCH_DECODED_BYTES,
 };
+pub use schema::SHIFT_APPLICATION_ID;
 pub use source::{AxisRecord, NewAxis, NewSource, SourceAxisLocation, SourceKind, SourceRecord};
 pub use store::ShiftStore;
-pub use types::{AxisId, GlyphId, GlyphWriteBatch, LayerBatchTiming, RevisionId, SourceId};
+pub use types::{
+    AxisId, DocumentId, GlyphId, GlyphWriteBatch, LayerBatchTiming, RevisionId, SourceId,
+};
 pub use workspace_state::{
     Evidence, FileIdentity, SourceIdentitySnapshot, WorkspaceSourceKind, WorkspaceState,
 };

--- a/crates/shift-store/src/schema.rs
+++ b/crates/shift-store/src/schema.rs
@@ -16,7 +16,7 @@ CREATE INDEX glyph_layers_source_id_idx ON glyph_layers(source_id);
 CREATE INDEX glyph_components_base_glyph_id_idx ON glyph_components(base_glyph_id);
 "#;
 
-pub(crate) const SCHEMA_V1: &str = r#"
+pub(crate) const DOCUMENT_SCHEMA_V1: &str = r#"
 CREATE TABLE IF NOT EXISTS font_info (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     family_name TEXT,
@@ -242,6 +242,13 @@ CREATE TABLE IF NOT EXISTS font_binaries (
     PRIMARY KEY (kind, path)
 );
 
+CREATE TABLE IF NOT EXISTS document_metadata (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    document_id TEXT NOT NULL
+);
+"#;
+
+const WORKSPACE_SCHEMA_V1: &str = r#"
 CREATE TABLE IF NOT EXISTS workspace_state (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     document_id TEXT,
@@ -262,6 +269,7 @@ CREATE TABLE IF NOT EXISTS workspace_state (
 );
 "#;
 
+pub const SHIFT_APPLICATION_ID: i64 = 0x5348_4654;
 pub(crate) const SCHEMA_VERSION: i64 = 1;
 
 pub(crate) fn defer_import_indexes(tx: &Transaction<'_>) -> Result<(), StoreError> {
@@ -280,8 +288,18 @@ pub(crate) fn restore_import_indexes(tx: &Transaction<'_>) -> Result<(), StoreEr
 /// baseline batch in place instead of adding migration steps. A database
 /// from a NEWER app version is refused rather than silently mangled.
 pub(crate) fn ensure_current(conn: &rusqlite::Connection) -> Result<(), StoreError> {
-    let version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+    let application_id = application_id(conn)?;
+    if application_id == SHIFT_APPLICATION_ID {
+        return Err(StoreError::DocumentRequiresDocumentOpen);
+    }
+    if application_id != 0 {
+        return Err(StoreError::InvalidApplicationId {
+            found: application_id,
+            expected: 0,
+        });
+    }
 
+    let version = schema_version(conn)?;
     if version > SCHEMA_VERSION {
         return Err(StoreError::UnsupportedSchemaVersion {
             found: version,
@@ -290,9 +308,63 @@ pub(crate) fn ensure_current(conn: &rusqlite::Connection) -> Result<(), StoreErr
     }
 
     if version < 1 {
-        conn.execute_batch(SCHEMA_V1)?;
+        conn.execute_batch(DOCUMENT_SCHEMA_V1)?;
+        conn.execute_batch(WORKSPACE_SCHEMA_V1)?;
         conn.pragma_update(None, "user_version", SCHEMA_VERSION)?;
     }
 
     Ok(())
+}
+
+pub(crate) fn initialize_document(conn: &rusqlite::Connection) -> Result<(), StoreError> {
+    let application_id = application_id(conn)?;
+    if application_id != 0 {
+        return Err(StoreError::InvalidApplicationId {
+            found: application_id,
+            expected: 0,
+        });
+    }
+
+    let version = schema_version(conn)?;
+    if version != 0 {
+        return Err(StoreError::UnsupportedDocumentSchemaVersion {
+            found: version,
+            supported: SCHEMA_VERSION,
+        });
+    }
+
+    conn.execute_batch(DOCUMENT_SCHEMA_V1)?;
+    conn.pragma_update(None, "application_id", SHIFT_APPLICATION_ID)?;
+    conn.pragma_update(None, "user_version", SCHEMA_VERSION)?;
+    Ok(())
+}
+
+pub(crate) fn validate_document_header(conn: &rusqlite::Connection) -> Result<(), StoreError> {
+    let application_id = application_id(conn)?;
+    if application_id != SHIFT_APPLICATION_ID {
+        return Err(StoreError::InvalidApplicationId {
+            found: application_id,
+            expected: SHIFT_APPLICATION_ID,
+        });
+    }
+
+    let version = schema_version(conn)?;
+    if version != SCHEMA_VERSION {
+        return Err(StoreError::UnsupportedDocumentSchemaVersion {
+            found: version,
+            supported: SCHEMA_VERSION,
+        });
+    }
+
+    Ok(())
+}
+
+fn application_id(conn: &rusqlite::Connection) -> Result<i64, StoreError> {
+    conn.query_row("PRAGMA application_id", [], |row| row.get(0))
+        .map_err(StoreError::from)
+}
+
+fn schema_version(conn: &rusqlite::Connection) -> Result<i64, StoreError> {
+    conn.query_row("PRAGMA user_version", [], |row| row.get(0))
+        .map_err(StoreError::from)
 }

--- a/crates/shift-store/src/store.rs
+++ b/crates/shift-store/src/store.rs
@@ -1,4 +1,17 @@
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum StoreKind {
+    Document,
+    Working,
+}
+
 pub struct ShiftStore {
     pub(crate) conn: rusqlite::Connection,
     pub(crate) path: Option<std::path::PathBuf>,
+    pub(crate) kind: StoreKind,
+}
+
+impl ShiftStore {
+    pub(crate) fn tracks_workspace(&self) -> bool {
+        self.kind == StoreKind::Working
+    }
 }

--- a/crates/shift-store/src/types.rs
+++ b/crates/shift-store/src/types.rs
@@ -4,6 +4,10 @@ use shift_font::{Glyph, LayerId};
 
 use crate::layer::StoredLayerPayload;
 
+const DOCUMENT_ID_PREFIX: &str = "document_";
+const DOCUMENT_ID_BYTES: usize = 16;
+const DOCUMENT_ID_HEX_LENGTH: usize = DOCUMENT_ID_BYTES * 2;
+
 pub(crate) type EncodedGlyphLayers = Vec<Vec<(LayerId, Vec<u8>)>>;
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -32,6 +36,48 @@ impl GlyphWriteBatch {
 pub(crate) struct PackedGlyph {
     pub(crate) glyph: Glyph,
     pub(crate) layers: Vec<(LayerId, StoredLayerPayload)>,
+}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct DocumentId(String);
+
+impl DocumentId {
+    pub fn new() -> Self {
+        let mut bytes = [0; DOCUMENT_ID_BYTES];
+        getrandom::fill(&mut bytes).expect("secure random document ID generation failed");
+        let suffix = bytes
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+
+        Self(format!("{DOCUMENT_ID_PREFIX}{suffix}"))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub(crate) fn from_stored(value: String) -> Option<Self> {
+        let suffix = value.strip_prefix(DOCUMENT_ID_PREFIX)?;
+        let valid = suffix.len() == DOCUMENT_ID_HEX_LENGTH
+            && suffix
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'));
+
+        valid.then_some(Self(value))
+    }
+}
+
+impl Default for DocumentId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for DocumentId {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]

--- a/crates/shift-store/tests/store_test.rs
+++ b/crates/shift-store/tests/store_test.rs
@@ -1,7 +1,7 @@
 use shift_font::{FontMetadata, test_support::sample_font};
 use shift_store::{
-    AxisId, Evidence, FileIdentity, FontInfo, GlyphId, NewAxis, NewGlyph, NewSource, ShiftStore,
-    SourceId, SourceIdentitySnapshot, SourceKind, WorkspaceState,
+    AxisId, Evidence, FileIdentity, FontInfo, GlyphId, NewAxis, NewGlyph, NewSource,
+    SHIFT_APPLICATION_ID, ShiftStore, SourceId, SourceIdentitySnapshot, SourceKind, WorkspaceState,
 };
 
 #[test]
@@ -985,6 +985,12 @@ fn temp_store_path(label: &str) -> std::path::PathBuf {
     dir.join("store.sqlite")
 }
 
+fn sqlite_sidecar_path(path: &std::path::Path, suffix: &str) -> std::path::PathBuf {
+    let mut sidecar = std::ffi::OsString::from(path.as_os_str());
+    sidecar.push(suffix);
+    std::path::PathBuf::from(sidecar)
+}
+
 #[test]
 fn file_stores_run_wal_with_verified_pragmas() {
     let path = temp_store_path("pragmas");
@@ -1002,6 +1008,159 @@ fn file_stores_run_wal_with_verified_pragmas() {
     assert_eq!(version, 1);
 
     std::fs::remove_dir_all(path.parent().unwrap()).ok();
+}
+
+#[test]
+fn canonical_document_round_trip_preserves_kitchen_sink_font_for_export() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let path = temp.path().join("Dogfood.shift");
+    let original = sample_font();
+
+    let store = ShiftStore::create_document(&path, &original).expect("create document");
+    let metadata = store.document_metadata().expect("document metadata");
+    assert!(metadata.document_id.as_str().starts_with("document_"));
+    assert_eq!(metadata.document_id.as_str().len(), 41);
+    assert_eq!(store.load_font_state().expect("load document"), original);
+    drop(store);
+
+    let magic = std::fs::read(&path).expect("read document");
+    assert_eq!(&magic[..16], b"SQLite format 3\0");
+    assert!(!sqlite_sidecar_path(&path, "-journal").exists());
+    assert!(!sqlite_sidecar_path(&path, "-wal").exists());
+    assert!(!sqlite_sidecar_path(&path, "-shm").exists());
+
+    let conn = rusqlite::Connection::open(&path).expect("raw reopen");
+    let application_id: i64 = conn
+        .query_row("PRAGMA application_id", [], |row| row.get(0))
+        .expect("application_id");
+    assert_eq!(application_id, SHIFT_APPLICATION_ID);
+    let version: i64 = conn
+        .query_row("PRAGMA user_version", [], |row| row.get(0))
+        .expect("user_version");
+    assert_eq!(version, 1);
+    let journal: String = conn
+        .query_row("PRAGMA journal_mode", [], |row| row.get(0))
+        .expect("journal_mode");
+    assert_eq!(journal, "delete");
+    let has_workspace_state: bool = conn
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = 'workspace_state')",
+            [],
+            |row| row.get(0),
+        )
+        .expect("workspace schema check");
+    assert!(!has_workspace_state);
+    drop(conn);
+
+    let reopened = ShiftStore::open_document(&path).expect("reopen document");
+    assert_eq!(
+        reopened.document_metadata().expect("reopened metadata"),
+        metadata
+    );
+    assert_eq!(reopened.load_font_state().expect("reloaded font"), original);
+}
+
+#[test]
+fn raw_document_copy_preserves_document_identity() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let original_path = temp.path().join("Original.shift");
+    let copy_path = temp.path().join("Copy.shift");
+    let font = sample_font();
+    let original = ShiftStore::create_document(&original_path, &font).expect("create document");
+    let metadata = original.document_metadata().expect("document metadata");
+    drop(original);
+
+    std::fs::copy(&original_path, &copy_path).expect("copy document");
+
+    assert_eq!(
+        ShiftStore::verify_document(&copy_path).expect("verify copy"),
+        metadata
+    );
+}
+
+#[test]
+fn create_document_never_clobbers_an_existing_destination() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let path = temp.path().join("Existing.shift");
+    std::fs::write(&path, b"retain me").expect("write destination");
+
+    let error = match ShiftStore::create_document(&path, &sample_font()) {
+        Ok(_) => panic!("existing destination must not be replaced"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(
+        error,
+        shift_store::StoreError::DocumentAlreadyExists(existing) if existing == path
+    ));
+    assert_eq!(
+        std::fs::read(&path).expect("read destination"),
+        b"retain me"
+    );
+}
+
+#[test]
+fn document_open_rejects_plain_corrupt_and_future_sqlite_files() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let plain_path = temp.path().join("Plain.shift");
+    let corrupt_path = temp.path().join("Corrupt.shift");
+    let future_path = temp.path().join("Future.shift");
+
+    rusqlite::Connection::open(&plain_path).expect("create plain sqlite");
+    let plain_error = match ShiftStore::open_document(&plain_path) {
+        Ok(_) => panic!("plain SQLite must not open as Shift"),
+        Err(error) => error,
+    };
+    assert!(matches!(
+        plain_error,
+        shift_store::StoreError::InvalidApplicationId { found: 0, expected }
+            if expected == SHIFT_APPLICATION_ID
+    ));
+
+    std::fs::write(&corrupt_path, b"not sqlite").expect("write corrupt file");
+    assert!(ShiftStore::open_document(&corrupt_path).is_err());
+
+    drop(ShiftStore::create_document(&future_path, &sample_font()).expect("create future base"));
+    let conn = rusqlite::Connection::open(&future_path).expect("open future raw");
+    conn.pragma_update(None, "user_version", 999)
+        .expect("stamp future schema");
+    drop(conn);
+    let future_error = match ShiftStore::open_document(&future_path) {
+        Ok(_) => panic!("future document must be refused"),
+        Err(error) => error,
+    };
+    assert!(matches!(
+        future_error,
+        shift_store::StoreError::UnsupportedDocumentSchemaVersion {
+            found: 999,
+            supported: 1
+        }
+    ));
+}
+
+#[test]
+fn canonical_document_requires_document_open_posture() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let path = temp.path().join("Canonical.shift");
+    drop(ShiftStore::create_document(&path, &sample_font()).expect("create document"));
+
+    let error = match ShiftStore::open(&path) {
+        Ok(_) => panic!("canonical document must not use working-store WAL posture"),
+        Err(error) => error,
+    };
+    assert!(matches!(
+        error,
+        shift_store::StoreError::DocumentRequiresDocumentOpen
+    ));
+
+    let conn = rusqlite::Connection::open(&path).expect("raw reopen");
+    let journal: String = conn
+        .query_row("PRAGMA journal_mode", [], |row| row.get(0))
+        .expect("journal mode");
+    assert_eq!(journal, "delete");
+    drop(conn);
+    assert!(!sqlite_sidecar_path(&path, "-wal").exists());
+    assert!(!sqlite_sidecar_path(&path, "-shm").exists());
 }
 
 #[test]

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -19,7 +19,7 @@ Central routing table for Shift's distributed documentation. Before creating new
 | `crates/shift-font/**`      | [`crates/shift-font/docs/DOCS.md`](../../crates/shift-font/docs/DOCS.md)           | First-class Rust font object model and editing behavior                                    |
 | `crates/shift-slug/**`      | [`crates/shift-slug/docs/DOCS.md`](../../crates/shift-slug/docs/DOCS.md)           | GPU-independent Slug curves, retained compilation, and packing                             |
 | `crates/shift-source/**`    | [`crates/shift-source/docs/DOCS.md`](../../crates/shift-source/docs/DOCS.md)       | User-authored `.shift` source package layout                                               |
-| `crates/shift-store/**`     | [`crates/shift-store/README.md`](../../crates/shift-store/README.md)               | SQLite directory, independently compressed canonical layer payloads, and reference indexes |
+| `crates/shift-store/**`     | [`crates/shift-store/README.md`](../../crates/shift-store/README.md)               | Canonical SQLite `.shift`, working persistence, compressed layer payloads, and indexes       |
 | `crates/shift-workspace/**` | [`crates/shift-workspace/docs/DOCS.md`](../../crates/shift-workspace/docs/DOCS.md) | Open font workspace runtime over source, store, and font                                   |
 | `crates/shift-bridge/**`    | [`crates/shift-bridge/docs/DOCS.md`](../../crates/shift-bridge/docs/DOCS.md)       | NAPI bridge exposing Rust to Node.js/Electron                                              |
 


### PR DESCRIPTION
## Summary

- add staged `ShiftStore::create_document`, validated `open_document`, and read-only `verify_document` APIs
- stamp canonical databases with the `SHFT` SQLite application ID, schema v1, and stable `document_…` identity
- keep canonical rollback/FULL durability separate from app-local WAL working stores
- exclude `workspace_state` from canonical documents and retain independently compressed layer payloads
- prove exact kitchen-sink `Font` preservation through canonical SQLite for later UFO/Designspace export

This is the storage foundation only. It does not switch desktop Save/Open away from the existing ZIP package; export fidelity goldens and the cutover will be separate PRs.

## Validation

- `cargo test -p shift-store`
- `cargo test -p shift-workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- repository pre-commit suite
