### PR TITLE
Report authoring import losses

### DIFF
--- a/crates/shift-backends/docs/DOCS.md
+++ b/crates/shift-backends/docs/DOCS.md
@@ -12,13 +12,15 @@ Font format backends that convert between on-disk font files and the `Font` IR u
 
 **Architecture Invariant:** Eager reader/writer backends are stateless unit structs. `OpenTypeFont` retains compiled bytes, `UfoFont` and `DesignspaceFont` retain their indexed GLIF payloads, and `GlyphsFont` retains one upstream-parsed source. Paths are provenance and error context only after open. A `FontImport` is a separate exhaustive bounded conversion cursor; OpenType sources intentionally expose no `FontImporter` capability. WHY: imported sessions must remain coherent and readable after the original path changes or disappears.
 
+**Architecture Invariant:** `FontImport::report` describes valid source concepts whose semantics Shift converts, approximates, or omits. Malformed values and parser failures remain errors and never become import losses. WHY: authoring-fidelity limits such as Glyphs bracket layers must be visible without confusing unsupported source semantics with bad data.
+
 **Architecture Invariant:** `UfoWriter` stages a complete UFO beside the destination and swaps it into place only after the staged tree is durable. WHY: a failed save must preserve the previous source rather than leave a partial directory.
 
 **Architecture Invariant:** `UfoWriter` preserves fractional coordinates and widths. Empty contours are skipped because they have no serializable UFO geometry.
 
 **Architecture Invariant:** `GlyphsReader` converts Glyphs-format kerning group prefixes (`@MMK_L_`, `@MMK_R_`) to UFO-convention prefixes (`public.kern1.`, `public.kern2.`) at load time. WHY: The IR stores kerning in UFO conventions; all backends must normalize to this format.
 
-**Architecture Invariant:** `GlyphsReader` only loads kerning from the default master. WHY: The IR currently stores a single static kerning table, not per-master kerning.
+**Architecture Invariant:** `GlyphsReader` only loads kerning from the default master and reports omitted non-default-master or RTL pairs through `ImportReport`. WHY: The IR currently stores a single static kerning table, not per-master or direction-specific kerning.
 
 **Architecture Invariant:** TrueType export compiles an owned snapshot of the Shift `Font` IR directly through fontir/fontc. It must not serialize a temporary UFO or fall back to another authoring format. WHY: `.shift` is the canonical authoring source, and an intermediate format would discard or reinterpret Shift concepts before compilation.
 
@@ -42,7 +44,8 @@ Font format backends that convert between on-disk font files and the `Font` IR u
 src/
   lib.rs             -- public backend and retained-source boundary
   format.rs          -- source format vocabulary
-  import.rs          -- glyph-free foreign header and bounded conversion cursor
+  import.rs          -- glyph-free source header and bounded conversion cursor
+  import_report.rs   -- source-to-Shift fidelity losses
   font_source/
     mod.rs            -- FontSource/FontImporter split and OpenedFont dispatch
     types.rs          -- source-local indexes, directories, shapes, deltas, and projections
@@ -60,14 +63,14 @@ src/
       reader.rs       -- maxp-complete authored conversion stream
     ufo/              -- retained UFO source plus eager reader and atomic writer
     designspace/      -- retained Designspace source, mappings, reader, and writer
-    glyphs/           -- retained Glyphs source, conversion stream, and reader
+    glyphs/           -- retained Glyphs source, conversion stream, fidelity report, and reader
   shift2fontir/       -- owned Shift FontView -> fontir/fontc adapter
   export.rs           -- direct fontc TTF compilation and atomic output write
 ```
 
 ## Key Types
 
-- `FontSource` -- immutable directory plus lazy `glyph(GlyphIndex) -> ProjectedGlyph` acquisition, implemented by every retained foreign handle
+- `FontSource` -- immutable directory plus lazy `glyph(GlyphIndex) -> ProjectedGlyph` acquisition, implemented by every retained source handle
 - `FontImporter` -- optional authored-conversion capability implemented by GLIF and Glyphs handles, but not binary handles
 - `OpenedFont` -- dispatched `OpenType`, `Ufo`, `Designspace`, or `Glyphs` retained handle returned by `FontLoader::open_source`
 - `FontDirectory` / `GlyphIndex` -- source-local immutable directory built by `FontDirectory::from_font`, with private fields, read-only accessors, and backend-local addressing
@@ -77,8 +80,9 @@ src/
 - `SourceAtlasDescriptor` -- small mapping and weight evaluator retained after `SourceAtlasPage::into_parts` separates disposable CPU geometry
 - `SourceAtlasError` -- direct atlas read, format-capability, and Slug construction failures
 - `OpenTypeFont` / `UfoFont` / `DesignspaceFont` / `GlyphsFont` -- concrete retained source generations
-- `FontImport` -- top-level authored header, an immediately publishable stable-ID/name directory, and layer-aware `next_batch(limit)`, with no glyphs stored in the header
-- `GlyphDirectoryEntry` -- cheap foreign glyph ID and name used before geometry batches are parsed
+- `FontImport` -- top-level authored header, an immediately publishable stable-ID/name directory, `ImportReport`, and layer-aware `next_batch(limit)`, with no glyphs stored in the header
+- `ImportReport` / `ImportLoss` -- source concepts converted, approximated, or omitted because Shift cannot represent identical semantics; never malformed-data diagnostics
+- `GlyphDirectoryEntry` -- cheap source glyph ID and name used before geometry batches are parsed
 - `ImportBatchLimit` -- simultaneous glyph and authored-layer limits; multi-source projects cannot turn a glyph-count bound into an unbounded layer batch
 - `FontReader` -- trait with `load(&self, path) -> Result<Font, String>` plus default methods for extracting glyphs, kerning, features from a loaded `Font`
 - `FontWriter` -- trait with `save(&self, font, path) -> Result<(), String>`
@@ -103,7 +107,7 @@ src/
 
 **Direct OpenType atlas:** `build_binary_atlas_page` reads raw glyf points and tuple regions from retained bytes. It applies IUP independently to each unscaled tuple, preserves a stable quadratic topology, flattens ordinary glyf components exactly, and combines HVAR or gvar phantom-point advance contributions with the same region weights. Curves stream directly into `shift_slug::retained::PageCompiler`; static CFF uses that compiler too. The page stores absolute region-peak curves because the retained atlas consumes weighted source values; a deduplicated complement weight makes every glyph's participating source weights sum to one. The consumer separates the atlas and descriptor with `into_parts`, packs and drops the former, and retains the latter. Axis updates evaluate fvar/avar 1 normalization and OpenType support scalars without touching geometry. Static CFF is supported; CFF2, cubic glyf extensions, avar version 2, and VARC remain explicit unsupported capabilities.
 
-**Glyphs-format specifics:** `GlyphsReader` also extracts axes, sources, and per-master locations -- data that UFO does not natively represent. Kerning group membership is derived from per-glyph `right_kern`/`left_kern` fields and normalized to `public.kern1.*`/`public.kern2.*` conventions. The upstream parser currently materializes its complete normalized Glyphs source model before the bounded cursor begins; batching bounds Shift glyph conversion and persistence, not source-syntax parsing.
+**Glyphs-format specifics:** `GlyphsReader` also extracts axes, sources, and per-master locations -- data that UFO does not natively represent. Kerning group membership is derived from per-glyph `right_kern`/`left_kern` fields and normalized to `public.kern1.*`/`public.kern2.*` conventions. Before conversion begins, `ImportReport` records bracket layers omitted because Shift has no conditional-layer model, intermediate and smart-component semantics approximated as ordinary layers/components, and non-default-master or RTL kerning omitted because Shift has one static table. The upstream parser currently materializes its complete normalized Glyphs source model before the bounded cursor begins; batching bounds Shift glyph conversion and persistence, not source-syntax parsing.
 
 **Designspace mapping:** Per-axis `<map>` entries become independent `AxisMapping` values. Designspace 5.1+ `<mappings>` entries become the font's single cross-axis mapping group. Axis value labels use the standard Designspace 5.0 `<labels>` representation; imported labels receive newly minted Shift identity because Designspace has no equivalent stable label ID.
 
@@ -143,7 +147,7 @@ src/
 - **Cross-platform UFO replacement:** macOS and Linux use an atomic directory exchange when supported. The fallback moves the old tree aside first and restores it if installing the staged tree fails.
 - **OnCurve ambiguity on write:** The IR's `OnCurve` type is context-dependent when writing. The first point of an open contour becomes `Move`, a point after `OffCurve` becomes `Curve`, everything else becomes `Line`. If contour structure is malformed, this heuristic may produce wrong results.
 - **Glyphs source parsing is eager:** `glyphs-reader` materializes one normalized source model before `GlyphsGlyphStream` starts. Shift geometry conversion, packing, compression, and SQLite writes remain bounded.
-- **Glyphs kerning is default-master only:** Multi-master kerning is silently dropped to a single master's values.
+- **Glyphs kerning is default-master only:** Multi-master and RTL kerning are reduced to the default LTR table; omitted pairs are listed in `ImportReport`.
 - **Cross-axis mappings:** Direct TTF compilation rejects cross-axis mappings until the compiler stack supports `avar` version 2. It never flattens the mapping or falls back to temporary UFO compilation.
 - **Binary atlas capabilities:** Direct Grid compilation supports quadratic glyf/gvar plus HVAR or phantom advances and static CFF. CFF2, cubic glyf extensions, avar version 2, and VARC fail explicitly rather than falling back to another renderer or authored conversion.
 - **Authored STAT tables:** When Shift axis labels exist, export appends a generated `STAT` feature block. If authored feature text also declares `STAT`, the feature compiler reports the conflict.

--- a/crates/shift-backends/src/font_loader.rs
+++ b/crates/shift-backends/src/font_loader.rs
@@ -11,14 +11,15 @@ use crate::formats::designspace::{DesignspaceFont, DesignspaceReader, Designspac
 use crate::formats::glyphs::{GlyphsFont, GlyphsReader};
 use crate::formats::opentype::{BytesFontAdaptor, OpenTypeFont};
 use crate::formats::ufo::{UfoFont, UfoReader, UfoWriter};
-use crate::import::{FontImport, GlyphStream};
+use crate::import::{FontImport, PreparedImport};
 use crate::traits::{FontReader, FontWriter};
+use crate::ImportReport;
 
 pub(crate) trait FontAdaptor {
     fn read_font(&self, path: &str) -> FormatBackendResult<Font>;
     fn write_font(&self, font: &Font, path: &str) -> FormatBackendResult<()>;
 
-    fn stream(&self, _path: &str) -> FormatBackendResult<Option<(Font, Box<dyn GlyphStream>)>> {
+    fn stream(&self, _path: &str) -> FormatBackendResult<Option<PreparedImport>> {
         Ok(None)
     }
 }
@@ -49,9 +50,9 @@ impl FontAdaptor for UfoFontAdaptor {
         UfoWriter::new().save(font, path)
     }
 
-    fn stream(&self, path: &str) -> FormatBackendResult<Option<(Font, Box<dyn GlyphStream>)>> {
+    fn stream(&self, path: &str) -> FormatBackendResult<Option<PreparedImport>> {
         let (header, stream) = crate::formats::ufo::stream_font(path)?;
-        Ok(Some((header, Box::new(stream))))
+        Ok(Some((header, Box::new(stream), ImportReport::default())))
     }
 }
 
@@ -64,9 +65,9 @@ impl FontAdaptor for GlyphsFontAdaptor {
         Err(FormatBackendError::WriteUnsupported)
     }
 
-    fn stream(&self, path: &str) -> FormatBackendResult<Option<(Font, Box<dyn GlyphStream>)>> {
-        let (header, stream) = crate::formats::glyphs::stream_font(path)?;
-        Ok(Some((header, Box::new(stream))))
+    fn stream(&self, path: &str) -> FormatBackendResult<Option<PreparedImport>> {
+        let (header, stream, report) = crate::formats::glyphs::stream_font(path)?;
+        Ok(Some((header, Box::new(stream), report)))
     }
 }
 
@@ -79,9 +80,9 @@ impl FontAdaptor for DesignspaceFontAdaptor {
         DesignspaceWriter::new().save(font, path)
     }
 
-    fn stream(&self, path: &str) -> FormatBackendResult<Option<(Font, Box<dyn GlyphStream>)>> {
+    fn stream(&self, path: &str) -> FormatBackendResult<Option<PreparedImport>> {
         let (header, stream) = crate::formats::designspace::stream_font(path)?;
-        Ok(Some((header, Box::new(stream))))
+        Ok(Some((header, Box::new(stream), ImportReport::default())))
     }
 }
 
@@ -196,9 +197,11 @@ impl FontLoader {
             .ok_or(BackendError::StreamingUnsupported {
                 format: resolved.format,
             })?;
+        let (header, stream, report) = streamed;
         Ok(FontImport::new(
-            streamed.0,
-            streamed.1,
+            header,
+            stream,
+            report,
             resolved.format,
             resolved.path_buf,
         ))
@@ -215,8 +218,8 @@ impl FontLoader {
         let streamed = adaptor.stream(resolved.path).map_err(|source| {
             BackendError::load(resolved.format, resolved.path_buf.clone(), source)
         })?;
-        if let Some((header, stream)) = streamed {
-            return FontImport::new(header, stream, resolved.format, resolved.path_buf)
+        if let Some((header, stream, report)) = streamed {
+            return FontImport::new(header, stream, report, resolved.format, resolved.path_buf)
                 .collect_font();
         }
 

--- a/crates/shift-backends/src/formats/designspace/source.rs
+++ b/crates/shift-backends/src/formats/designspace/source.rs
@@ -12,7 +12,7 @@ use crate::font_source::{
 use crate::formats::ufo::glif::{
     glyph_directory, project_glif_glyph, retained_layer, RetainedUfoLayer,
 };
-use crate::{BackendError, BackendResult, FontFormat, FontImport};
+use crate::{BackendError, BackendResult, FontFormat, FontImport, ImportReport};
 
 use super::{derive_axis_range, find_default_source_index, map_axis_value, stream_retained};
 
@@ -156,6 +156,7 @@ impl FontImporter for DesignspaceFont {
         Ok(FontImport::new(
             header,
             Box::new(stream),
+            ImportReport::default(),
             FontFormat::Designspace,
             self.path.clone(),
         ))

--- a/crates/shift-backends/src/formats/glyphs/import.rs
+++ b/crates/shift-backends/src/formats/glyphs/import.rs
@@ -4,10 +4,13 @@ use glyphs_reader::Font as GlyphsFont;
 use rayon::prelude::*;
 use shift_font::{Font, Glyph, GlyphId, SourceId};
 
-use super::conversion::{convert_glyph, font_header, imported_layer_count};
+use super::{
+    conversion::{convert_glyph, font_header, imported_layer_count},
+    report::import_report,
+};
 use crate::{
     import::{GlyphDirectoryEntry, GlyphStream, ImportBatchLimit},
-    FormatBackendError, FormatBackendResult,
+    FormatBackendError, FormatBackendResult, ImportReport,
 };
 
 /// Bounded Shift conversion over one parsed Glyphs source.
@@ -67,7 +70,9 @@ impl GlyphStream for GlyphsGlyphStream {
     }
 }
 
-pub(crate) fn stream_font(path: &str) -> FormatBackendResult<(Font, GlyphsGlyphStream)> {
+pub(crate) fn stream_font(
+    path: &str,
+) -> FormatBackendResult<(Font, GlyphsGlyphStream, ImportReport)> {
     let source = Arc::new(
         GlyphsFont::load(Path::new(path))
             .map_err(|error| FormatBackendError::Glyphs(error.to_string()))?,
@@ -77,7 +82,8 @@ pub(crate) fn stream_font(path: &str) -> FormatBackendResult<(Font, GlyphsGlyphS
 
 pub(crate) fn stream_retained(
     source: Arc<GlyphsFont>,
-) -> FormatBackendResult<(Font, GlyphsGlyphStream)> {
+) -> FormatBackendResult<(Font, GlyphsGlyphStream, ImportReport)> {
+    let report = import_report(&source);
     let (header, source_ids_by_master_id) = font_header(&source)?;
     let glyph_names = source
         .glyphs
@@ -98,5 +104,6 @@ pub(crate) fn stream_retained(
             source_ids_by_master_id,
             next_glyph: 0,
         },
+        report,
     ))
 }

--- a/crates/shift-backends/src/formats/glyphs/mod.rs
+++ b/crates/shift-backends/src/formats/glyphs/mod.rs
@@ -1,6 +1,7 @@
 mod conversion;
 mod import;
 mod reader;
+mod report;
 mod source;
 
 pub(crate) use conversion::{

--- a/crates/shift-backends/src/formats/glyphs/reader.rs
+++ b/crates/shift-backends/src/formats/glyphs/reader.rs
@@ -18,7 +18,7 @@ impl Default for GlyphsReader {
 
 impl FontReader for GlyphsReader {
     fn load(&self, path: &str) -> FormatBackendResult<Font> {
-        let (header, mut stream) = super::stream_font(path)?;
+        let (header, mut stream, _report) = super::stream_font(path)?;
         collect_streamed_font(header, &mut stream)
     }
 }

--- a/crates/shift-backends/src/formats/glyphs/report.rs
+++ b/crates/shift-backends/src/formats/glyphs/report.rs
@@ -1,0 +1,144 @@
+use glyphs_reader::{Font as GlyphsFont, Shape};
+
+use crate::{ImportLoss, ImportLossKind, ImportReport};
+
+pub(super) fn import_report(source: &GlyphsFont) -> ImportReport {
+    let mut report = ImportReport::default();
+
+    let bracket_layers = source
+        .glyphs
+        .values()
+        .map(|glyph| glyph.bracket_layers.len())
+        .sum::<usize>();
+    if bracket_layers > 0 {
+        report.losses.push(ImportLoss {
+            kind: ImportLossKind::Omitted,
+            message: format!(
+                "Shift does not represent Glyphs bracket layers; {bracket_layers} conditional layers were omitted."
+            ),
+        });
+    }
+
+    let intermediate_layers = source
+        .glyphs
+        .values()
+        .flat_map(|glyph| &glyph.layers)
+        .filter(|layer| layer.is_intermediate())
+        .count();
+    if intermediate_layers > 0 {
+        report.losses.push(ImportLoss {
+            kind: ImportLossKind::Approximated,
+            message: format!(
+                "Shift does not represent Glyphs intermediate-layer locations; {intermediate_layers} layers were retained as ordinary layers without their intermediate locations."
+            ),
+        });
+    }
+
+    let smart_component_glyphs = source
+        .glyphs
+        .values()
+        .filter(|glyph| {
+            !glyph.smart_component_axes.is_empty()
+                || glyph
+                    .layers
+                    .iter()
+                    .chain(&glyph.bracket_layers)
+                    .any(|layer| {
+                        !layer.smart_component_positions.is_empty()
+                            || layer.shapes.iter().any(|shape| {
+                                matches!(shape, Shape::Component(component) if !component.smart_component_values.is_empty())
+                            })
+                    })
+        })
+        .count();
+    if smart_component_glyphs > 0 {
+        report.losses.push(ImportLoss {
+            kind: ImportLossKind::Approximated,
+            message: format!(
+                "Shift does not represent Glyphs smart-component axes and locations; smart geometry in {smart_component_glyphs} glyphs was retained as ordinary layers and components."
+            ),
+        });
+    }
+
+    let default_master_id = source
+        .masters
+        .get(source.default_master_idx)
+        .map(|master| master.id.as_str());
+    let non_default_kerning_pairs = source
+        .kerning_ltr
+        .iter()
+        .filter(|(master_id, _)| Some(master_id.as_str()) != default_master_id)
+        .map(|(_, pairs)| pairs.len())
+        .sum::<usize>();
+    if non_default_kerning_pairs > 0 {
+        report.losses.push(ImportLoss {
+            kind: ImportLossKind::Omitted,
+            message: format!(
+                "Shift stores one kerning table; {non_default_kerning_pairs} non-default-master Glyphs kerning pairs were omitted."
+            ),
+        });
+    }
+
+    let rtl_kerning_pairs = source
+        .kerning_rtl
+        .iter()
+        .map(|(_, pairs)| pairs.len())
+        .sum::<usize>();
+    if rtl_kerning_pairs > 0 {
+        report.losses.push(ImportLoss {
+            kind: ImportLossKind::Omitted,
+            message: format!(
+                "Shift does not represent Glyphs RTL kerning separately; {rtl_kerning_pairs} RTL kerning pairs were omitted."
+            ),
+        });
+    }
+
+    report
+}
+
+#[cfg(test)]
+mod tests {
+    use glyphs_reader::{AxisRule, Font as GlyphsFont, Glyph, Layer, LayerAttributes};
+    use ordered_float::OrderedFloat;
+
+    use super::*;
+
+    #[test]
+    fn reports_source_concepts_shift_cannot_represent() {
+        let mut source = GlyphsFont::default();
+        let mut glyph = Glyph {
+            name: "A".into(),
+            ..Glyph::default()
+        };
+        glyph.bracket_layers.push(Layer {
+            attributes: LayerAttributes {
+                axis_rules: vec![AxisRule {
+                    min: Some(400),
+                    max: None,
+                }],
+                ..LayerAttributes::default()
+            },
+            ..Layer::default()
+        });
+        glyph.layers.push(Layer {
+            associated_master_id: Some("master01".to_string()),
+            attributes: LayerAttributes {
+                coordinates: vec![OrderedFloat(500.0)],
+                ..LayerAttributes::default()
+            },
+            ..Layer::default()
+        });
+        glyph.smart_component_axes.insert("Width".into(), 0..=100);
+        source.glyphs.insert("A".into(), glyph);
+
+        let report = import_report(&source);
+
+        assert_eq!(report.losses.len(), 3);
+        assert_eq!(report.losses[0].kind, ImportLossKind::Omitted);
+        assert!(report.losses[0].message.contains("bracket layers"));
+        assert_eq!(report.losses[1].kind, ImportLossKind::Approximated);
+        assert!(report.losses[1].message.contains("intermediate-layer"));
+        assert_eq!(report.losses[2].kind, ImportLossKind::Approximated);
+        assert!(report.losses[2].message.contains("smart-component"));
+    }
+}

--- a/crates/shift-backends/src/formats/glyphs/source.rs
+++ b/crates/shift-backends/src/formats/glyphs/source.rs
@@ -179,11 +179,12 @@ fn project_glyphs_glyph(
 
 impl FontImporter for GlyphsFont {
     fn begin_import(&self) -> BackendResult<FontImport> {
-        let (header, stream) = super::stream_retained(self.source.clone())
+        let (header, stream, report) = super::stream_retained(self.source.clone())
             .map_err(|source| BackendError::load(FontFormat::Glyphs, self.path.clone(), source))?;
         Ok(FontImport::new(
             header,
             Box::new(stream),
+            report,
             FontFormat::Glyphs,
             self.path.clone(),
         ))

--- a/crates/shift-backends/src/formats/opentype/mod.rs
+++ b/crates/shift-backends/src/formats/opentype/mod.rs
@@ -11,7 +11,8 @@ pub use source::OpenTypeFont;
 
 use crate::errors::{FormatBackendError, FormatBackendResult};
 use crate::font_loader::FontAdaptor;
-use crate::import::GlyphStream;
+use crate::import::PreparedImport;
+use crate::ImportReport;
 use shift_font::Font;
 use skrifa::string::StringId;
 use skrifa::{FontRef, MetadataProvider};
@@ -34,8 +35,8 @@ impl FontAdaptor for BytesFontAdaptor {
         Err(FormatBackendError::WriteUnsupported)
     }
 
-    fn stream(&self, path: &str) -> FormatBackendResult<Option<(Font, Box<dyn GlyphStream>)>> {
+    fn stream(&self, path: &str) -> FormatBackendResult<Option<PreparedImport>> {
         let (header, stream) = reader::stream_font_file(path)?;
-        Ok(Some((header, Box::new(stream))))
+        Ok(Some((header, Box::new(stream), ImportReport::default())))
     }
 }

--- a/crates/shift-backends/src/formats/ufo/source.rs
+++ b/crates/shift-backends/src/formats/ufo/source.rs
@@ -6,7 +6,7 @@ use crate::font_source::projection::resolve_projection_closure;
 use crate::font_source::{
     malformed, FontDirectory, FontImporter, FontReadError, FontSource, GlyphIndex, ProjectedGlyph,
 };
-use crate::{BackendError, BackendResult, FontFormat, FontImport};
+use crate::{BackendError, BackendResult, FontFormat, FontImport, ImportReport};
 
 use super::glif::{glyph_directory, project_glif_glyph, retained_layer, RetainedUfoLayer};
 use super::{load_header, read_ufo_layer_directories, stream_retained, UfoLayerDirectory};
@@ -91,6 +91,7 @@ impl FontImporter for UfoFont {
         Ok(FontImport::new(
             header,
             Box::new(stream),
+            ImportReport::default(),
             FontFormat::Ufo,
             self.path.clone(),
         ))

--- a/crates/shift-backends/src/import.rs
+++ b/crates/shift-backends/src/import.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, path::PathBuf};
 use rayon::prelude::*;
 use shift_font::{Font, Glyph, GlyphId, GlyphName, LayerId, SourceId};
 
-use crate::{BackendError, BackendResult, FontFormat, FormatBackendResult};
+use crate::{BackendError, BackendResult, FontFormat, FormatBackendResult, ImportReport};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GlyphDirectoryEntry {
@@ -140,6 +140,8 @@ fn load_glif_glyph(
     Ok(glyph)
 }
 
+pub(crate) type PreparedImport = (Font, Box<dyn GlyphStream>, ImportReport);
+
 pub(crate) trait GlyphStream: Send {
     fn directory(&self) -> Vec<GlyphDirectoryEntry>;
     fn glyph_count(&self) -> usize;
@@ -164,13 +166,14 @@ pub(crate) fn collect_streamed_font(
     Ok(header)
 }
 
-/// A bounded foreign-font import.
+/// A bounded source-to-Shift import.
 ///
 /// The header contains top-level authored state but no glyphs. Glyph geometry
 /// is materialized only in batches requested by [`Self::next_batch`].
 pub struct FontImport {
     header: Font,
     stream: Box<dyn GlyphStream>,
+    report: ImportReport,
     format: FontFormat,
     path: PathBuf,
 }
@@ -179,12 +182,14 @@ impl FontImport {
     pub(crate) fn new(
         header: Font,
         stream: Box<dyn GlyphStream>,
+        report: ImportReport,
         format: FontFormat,
         path: PathBuf,
     ) -> Self {
         Self {
             header,
             stream,
+            report,
             format,
             path,
         }
@@ -196,6 +201,10 @@ impl FontImport {
 
     pub fn directory(&self) -> Vec<GlyphDirectoryEntry> {
         self.stream.directory()
+    }
+
+    pub fn report(&self) -> &ImportReport {
+        &self.report
     }
 
     pub fn glyph_count(&self) -> usize {
@@ -215,6 +224,7 @@ impl FontImport {
         let Self {
             header,
             mut stream,
+            report: _,
             format,
             path,
         } = self;

--- a/crates/shift-backends/src/import_report.rs
+++ b/crates/shift-backends/src/import_report.rs
@@ -1,0 +1,19 @@
+/// Describes source concepts changed or omitted while importing into Shift.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ImportReport {
+    pub losses: Vec<ImportLoss>,
+}
+
+/// One source concept that Shift cannot represent with identical semantics.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ImportLoss {
+    pub kind: ImportLossKind,
+    pub message: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ImportLossKind {
+    Converted,
+    Approximated,
+    Omitted,
+}

--- a/crates/shift-backends/src/lib.rs
+++ b/crates/shift-backends/src/lib.rs
@@ -6,6 +6,7 @@ pub mod font_source;
 pub mod format;
 pub mod formats;
 pub mod import;
+mod import_report;
 mod metrics;
 mod shift2fontir;
 mod traits;
@@ -25,4 +26,5 @@ pub use font_source::{
 };
 pub use format::FontFormat;
 pub use import::{FontImport, GlyphDirectoryEntry, ImportBatchLimit};
+pub use import_report::{ImportLoss, ImportLossKind, ImportReport};
 pub use traits::{FontBackend, FontReader, FontView, FontWriter};

--- a/crates/shift-backends/tests/import_report.rs
+++ b/crates/shift-backends/tests/import_report.rs
@@ -1,0 +1,36 @@
+use std::path::PathBuf;
+
+use shift_backends::{font_loader::FontLoader, ImportLossKind};
+
+fn fixture(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("fixtures/fonts")
+        .join(name)
+}
+
+#[test]
+fn glyphs_import_reports_unrepresented_bracket_layers() {
+    let path = fixture("GlyphsImportLosses.glyphs");
+    let import = FontLoader::new()
+        .stream_font(path.to_str().unwrap())
+        .expect("Glyphs source should import");
+
+    assert_eq!(import.report().losses.len(), 2);
+    let bracket_loss = &import.report().losses[0];
+    assert_eq!(bracket_loss.kind, ImportLossKind::Omitted);
+    assert!(bracket_loss.message.contains("2 conditional layers"));
+    assert!(bracket_loss.message.contains("bracket layers"));
+    let kerning_loss = &import.report().losses[1];
+    assert_eq!(kerning_loss.kind, ImportLossKind::Omitted);
+    assert!(kerning_loss.message.contains("1 non-default-master"));
+
+    let font = import
+        .collect_font()
+        .expect("reported source concepts must not block import");
+    let glyph = font.glyph_by_name("space").expect("space should import");
+    assert_eq!(glyph.layers().len(), 2);
+}

--- a/fixtures/fonts/GlyphsImportLosses.glyphs
+++ b/fixtures/fonts/GlyphsImportLosses.glyphs
@@ -1,0 +1,77 @@
+{
+.appVersion = "3343";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+familyName = "Glyphs Import Losses";
+fontMaster = (
+{
+axesValues = (
+40
+);
+id = master01;
+name = Regular;
+},
+{
+axesValues = (
+200
+);
+id = master02;
+name = Bold;
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+layerId = master01;
+width = 600;
+},
+{
+layerId = master02;
+width = 700;
+},
+{
+associatedMasterId = master01;
+attr = {
+axisRules = (
+{
+min = 150;
+}
+);
+};
+layerId = bracket01;
+name = "Regular [150]";
+width = 650;
+},
+{
+associatedMasterId = master02;
+attr = {
+axisRules = (
+{
+min = 150;
+}
+);
+};
+layerId = bracket02;
+name = "Bold [150]";
+width = 750;
+}
+);
+unicode = 32;
+}
+);
+kerning = {
+master02 = {
+space = {
+space = -10;
+};
+};
+};
+unitsPerEm = 1000;
+}


### PR DESCRIPTION
## Summary
- attach a compact `ImportReport` to bounded source-to-Shift imports
- classify source concepts as `Converted`, `Approximated`, or `Omitted` only when Shift cannot represent identical semantics
- report Glyphs bracket layers, intermediate-layer locations, smart-component semantics, non-default-master kerning, and RTL kerning
- keep malformed source values and parser failures as errors rather than import losses
- prove bracket-layer loss is reported while the supported master layers still import

## Stack
- base: #184
- this PR: authoring import fidelity reporting

## Verification
- `cargo test -p shift-backends`
- `cargo test -p shift-workspace`
- `cargo clippy -p shift-backends --all-targets -- -D warnings`
- repository pre-commit suite