### PR TITLE
Prove native document UFO and Designspace exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2269,6 +2269,7 @@ dependencies = [
  "shift-font",
  "shift-slug",
  "shift-source",
+ "shift-store",
  "skrifa",
  "tempfile",
  "thiserror",

--- a/crates/shift-backends/Cargo.toml
+++ b/crates/shift-backends/Cargo.toml
@@ -31,6 +31,7 @@ write-fonts = "0.44"
 
 [dev-dependencies]
 shift-font = { workspace = true, features = ["test-support"] }
+shift-store = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/shift-backends/docs/DOCS.md
+++ b/crates/shift-backends/docs/DOCS.md
@@ -18,6 +18,8 @@ Font format backends that convert between on-disk font files and the `Font` IR u
 
 **Architecture Invariant:** `UfoWriter` preserves fractional coordinates and widths. Empty contours are skipped because they have no serializable UFO geometry.
 
+**Architecture Invariant:** Exporting a `Font` materialized from canonical SQLite must produce byte-identical UFO and Designspace artifacts to exporting the same supported in-memory `Font` directly. WHY: native persistence must preserve authored export inputs rather than narrowing them to a storage-specific projection.
+
 **Architecture Invariant:** `GlyphsReader` converts Glyphs-format kerning group prefixes (`@MMK_L_`, `@MMK_R_`) to UFO-convention prefixes (`public.kern1.`, `public.kern2.`) at load time. WHY: The IR stores kerning in UFO conventions; all backends must normalize to this format.
 
 **Architecture Invariant:** `GlyphsReader` only loads kerning from the default master and reports omitted non-default-master or RTL pairs through `ImportReport`. WHY: The IR currently stores a single static kerning table, not per-master or direction-specific kerning.
@@ -176,6 +178,7 @@ cargo test -p shift-backends writer_preserves_fractional_coordinates_and_skips_e
 cargo test -p shift-backends loads_homenaje_glyphs_file
 cargo test -p shift-backends loads_glyphs_package
 cargo test -p shift-backends --test export
+cargo test -p shift-backends --test native_document_export
 
 # Manual release profile: open/directory, selected projection,
 # complete sequential/parallel projection, and peak RSS

--- a/crates/shift-backends/tests/native_document_export.rs
+++ b/crates/shift-backends/tests/native_document_export.rs
@@ -1,0 +1,94 @@
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
+
+use shift_backends::font_loader::FontLoader;
+use shift_font::{test_support::sample_font, Font, LibValue};
+use shift_store::ShiftStore;
+
+fn native_round_trip(temp: &Path, font: &Font) -> Font {
+    let path = temp.join("Native.shift");
+    let store = ShiftStore::create_document(path, font).expect("create native document");
+    store.load_font_state().expect("load native document")
+}
+
+fn exportable_sample_font() -> Font {
+    let mut font = sample_font();
+    let key = "com.shift.allLibVariants";
+    let Some(LibValue::Array(values)) = font.lib_mut().remove(key) else {
+        panic!("sample font should contain every lib variant");
+    };
+    font.lib_mut().set(
+        key.to_string(),
+        LibValue::Array(
+            values
+                .into_iter()
+                .filter(|value| !matches!(value, LibValue::Uid(_)))
+                .collect(),
+        ),
+    );
+    font
+}
+
+fn tree_snapshot(root: &Path) -> BTreeMap<PathBuf, Vec<u8>> {
+    fn collect(root: &Path, path: &Path, snapshot: &mut BTreeMap<PathBuf, Vec<u8>>) {
+        if path.is_file() {
+            snapshot.insert(
+                path.strip_prefix(root).unwrap().to_path_buf(),
+                std::fs::read(path).unwrap(),
+            );
+            return;
+        }
+
+        for entry in std::fs::read_dir(path).unwrap() {
+            collect(root, &entry.unwrap().path(), snapshot);
+        }
+    }
+
+    let mut snapshot = BTreeMap::new();
+    collect(root, root, &mut snapshot);
+    snapshot
+}
+
+#[test]
+fn native_document_ufo_export_matches_direct_font_export() {
+    let temp = tempfile::tempdir().unwrap();
+    let original = exportable_sample_font();
+    let native = native_round_trip(temp.path(), &original);
+    let direct_root = temp.path().join("direct-ufo");
+    let native_root = temp.path().join("native-ufo");
+    let direct_path = direct_root.join("Dogfood.ufo");
+    let native_path = native_root.join("Dogfood.ufo");
+
+    FontLoader::new()
+        .write_font(&original, direct_path.to_str().unwrap())
+        .expect("direct UFO export");
+    FontLoader::new()
+        .write_font(&native, native_path.to_str().unwrap())
+        .expect("native UFO export");
+
+    assert_eq!(native, original);
+    assert_eq!(tree_snapshot(&native_root), tree_snapshot(&direct_root));
+}
+
+#[test]
+fn native_document_designspace_export_matches_direct_font_export() {
+    let temp = tempfile::tempdir().unwrap();
+    let original = exportable_sample_font();
+    let native = native_round_trip(temp.path(), &original);
+    let direct_root = temp.path().join("direct-designspace");
+    let native_root = temp.path().join("native-designspace");
+    let direct_path = direct_root.join("Dogfood.designspace");
+    let native_path = native_root.join("Dogfood.designspace");
+
+    FontLoader::new()
+        .write_font(&original, direct_path.to_str().unwrap())
+        .expect("direct Designspace export");
+    FontLoader::new()
+        .write_font(&native, native_path.to_str().unwrap())
+        .expect("native Designspace export");
+
+    assert_eq!(native, original);
+    assert_eq!(tree_snapshot(&native_root), tree_snapshot(&direct_root));
+}


### PR DESCRIPTION
## Summary
- run an export-compatible kitchen-sink `Font` through canonical SQLite before UFO and Designspace export
- compare native-document and direct in-memory artifact trees byte-for-byte
- keep target-format reporting outside this PR; this golden proves only that SQLite does not change supported export inputs

The broader canonical-document equality test still covers every `LibValue`, including binary-plist UID values that UFO XML cannot encode. This export golden removes only that target-incompatible value from both compared inputs.

## Stack
- #184 — canonical SQLite document foundation
- #185 — authoring import fidelity reports
- this PR — native `.shift` → UFO/Designspace export goldens

## Verification
- `cargo test -p shift-backends --test native_document_export`
- `cargo test -p shift-backends`
- `cargo clippy --workspace --all-targets -- -D warnings`
- repository pre-commit suite