### PR TITLE
Add native document Save As snapshot

### DIFF
--- a/crates/shift-store/README.md
+++ b/crates/shift-store/README.md
@@ -8,8 +8,9 @@ Callers use typed APIs from this crate rather than preparing SQL or opening a se
 
 - A `.shift` document is the SQLite database itself. It uses application ID `SHFT` (`0x53484654`) and an exact `user_version` contract.
 - `ShiftStore::create_document` writes a complete `shift-font::Font` at a sibling staging path, syncs it, and publishes without clobbering an existing destination.
+- `ShiftStore::save_as_document` takes a consistent SQLite snapshot of a working or canonical store without materializing a complete `Font`, removes app-local workspace state, mints a new document identity, validates and syncs the staged canonical database, and publishes without clobbering.
 - `ShiftStore::open_document` validates the file read-only before opening it with rollback journaling and `synchronous=FULL`. `ShiftStore::verify_document` also runs SQLite integrity and foreign-key checks.
-- `DocumentMetadata` contains the stable `DocumentId`. A raw copy preserves it; Save As will mint a new identity at the workspace boundary.
+- `DocumentMetadata` contains the stable `DocumentId`. A raw copy preserves it; Save As mints a new identity.
 - Canonical documents never contain app-local `workspace_state`. Working databases retain WAL + NORMAL and their revision/source-binding row.
 
 ## Storage boundary
@@ -62,7 +63,7 @@ Shift has not shipped either SQLite schema. Schema changes therefore update the 
 ```text
 src/
   connection.rs     # canonical, working-WAL, and disposable-import connection postures
-  document.rs       # staged create, validated open/verify, metadata, and durable publication
+  document.rs       # staged create/Save As, validated open/verify, metadata, and durable publication
   schema.rs         # canonical and working pre-release version-1 baselines
   font_state.rs     # eager metadata/directory and explicit full materialization
   import_writer.rs  # pipelined Rayon encode/compress plus one SQLite transaction owner

--- a/crates/shift-store/src/document.rs
+++ b/crates/shift-store/src/document.rs
@@ -1,9 +1,10 @@
 use std::{
     ffi::OsString,
     path::{Path, PathBuf},
+    time::Duration,
 };
 
-use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
+use rusqlite::{Connection, OpenFlags, OptionalExtension, backup::Backup, params};
 use shift_font::Font;
 
 use crate::{
@@ -63,6 +64,72 @@ impl ShiftStore {
         sync_parent_directory(path)?;
 
         Self::open_document(path)
+    }
+
+    /// Saves a consistent snapshot of this store as a new canonical document.
+    ///
+    /// The source remains open and unchanged. The destination receives a new
+    /// document identity, excludes app-local workspace state, and is validated
+    /// and synced at a sibling staging path before no-clobber publication.
+    pub fn save_as_document(&self, path: impl AsRef<Path>) -> Result<DocumentMetadata, StoreError> {
+        let path = path.as_ref();
+        if path.exists() {
+            return Err(StoreError::DocumentAlreadyExists(path.to_path_buf()));
+        }
+
+        let parent = parent_directory(path);
+        let staged = tempfile::Builder::new()
+            .prefix(".shift-document-")
+            .suffix(".shift")
+            .tempfile_in(parent)?
+            .into_temp_path();
+        let mut conn = Connection::open(&staged)?;
+
+        {
+            let backup = Backup::new(&self.conn, &mut conn)?;
+            backup.run_to_completion(256, Duration::from_millis(1), None)?;
+        }
+
+        configure_document_connection(&conn)?;
+        let metadata = DocumentMetadata {
+            document_id: DocumentId::new(),
+        };
+        let tx = conn.transaction()?;
+        tx.execute_batch("DROP TABLE IF EXISTS workspace_state; DELETE FROM document_metadata;")?;
+        tx.execute(
+            "INSERT INTO document_metadata (id, document_id) VALUES (1, ?1)",
+            params![metadata.document_id.as_str()],
+        )?;
+        tx.pragma_update(None, "application_id", schema::SHIFT_APPLICATION_ID)?;
+        tx.pragma_update(None, "user_version", schema::SCHEMA_VERSION)?;
+        tx.commit()?;
+
+        let staged_store = Self {
+            conn,
+            path: Some(staged.to_path_buf()),
+            kind: StoreKind::Document,
+        };
+        staged_store.sync_store_file()?;
+        drop(staged_store);
+        remove_staging_sidecars(&staged)?;
+
+        let verified = Self::verify_document(&staged)?;
+        if verified != metadata {
+            return Err(StoreError::InvalidDocument(
+                "staged document identity changed during validation".to_string(),
+            ));
+        }
+
+        match staged.persist_noclobber(path) {
+            Ok(()) => {}
+            Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => {
+                return Err(StoreError::DocumentAlreadyExists(path.to_path_buf()));
+            }
+            Err(error) => return Err(StoreError::Io(error.error)),
+        }
+        sync_parent_directory(path)?;
+
+        Ok(metadata)
     }
 
     /// Opens a canonical Shift document after validating it read-only first.

--- a/crates/shift-store/src/document.rs
+++ b/crates/shift-store/src/document.rs
@@ -91,6 +91,7 @@ impl ShiftStore {
         }
 
         configure_document_connection(&conn)?;
+        conn.pragma_update(None, "secure_delete", "ON")?;
         let metadata = DocumentMetadata {
             document_id: DocumentId::new(),
         };
@@ -103,6 +104,7 @@ impl ShiftStore {
         tx.pragma_update(None, "application_id", schema::SHIFT_APPLICATION_ID)?;
         tx.pragma_update(None, "user_version", schema::SCHEMA_VERSION)?;
         tx.commit()?;
+        conn.pragma_update(None, "secure_delete", "OFF")?;
 
         let staged_store = Self {
             conn,

--- a/crates/shift-store/tests/store_test.rs
+++ b/crates/shift-store/tests/store_test.rs
@@ -1088,7 +1088,8 @@ fn save_as_document_snapshots_working_store_without_workspace_state() {
     working
         .replace_font_state(&font)
         .expect("write complete font state");
-    let mut state = WorkspaceState::untitled(Some("workspace-1".to_string()));
+    let private_marker = "PRIVATE_WORKSPACE_ORIGIN_MARKER_9f4902c5";
+    let mut state = WorkspaceState::imported(private_marker, Some("workspace-1".to_string()));
     state.dirty = true;
     state.revision = 7;
     working
@@ -1113,6 +1114,12 @@ fn save_as_document_snapshots_working_store_without_workspace_state() {
     assert!(!sqlite_sidecar_path(&document_path, "-journal").exists());
     assert!(!sqlite_sidecar_path(&document_path, "-wal").exists());
     assert!(!sqlite_sidecar_path(&document_path, "-shm").exists());
+    let document_bytes = std::fs::read(&document_path).expect("read document bytes");
+    assert!(
+        !document_bytes
+            .windows(private_marker.len())
+            .any(|bytes| bytes == private_marker.as_bytes())
+    );
 }
 
 #[test]

--- a/crates/shift-store/tests/store_test.rs
+++ b/crates/shift-store/tests/store_test.rs
@@ -1079,6 +1079,93 @@ fn raw_document_copy_preserves_document_identity() {
 }
 
 #[test]
+fn save_as_document_snapshots_working_store_without_workspace_state() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let working_path = temp.path().join("Working.sqlite");
+    let document_path = temp.path().join("Saved.shift");
+    let font = sample_font();
+    let mut working = ShiftStore::open(&working_path).expect("open working store");
+    working
+        .replace_font_state(&font)
+        .expect("write complete font state");
+    let mut state = WorkspaceState::untitled(Some("workspace-1".to_string()));
+    state.dirty = true;
+    state.revision = 7;
+    working
+        .set_workspace_state(state.clone())
+        .expect("write workspace state");
+
+    let metadata = working
+        .save_as_document(&document_path)
+        .expect("save document snapshot");
+
+    assert_eq!(
+        working.workspace_state().expect("read source state"),
+        Some(state)
+    );
+    let document = ShiftStore::open_document(&document_path).expect("open saved document");
+    assert_eq!(
+        document.document_metadata().expect("document metadata"),
+        metadata
+    );
+    assert_eq!(document.load_font_state().expect("load saved font"), font);
+    drop(document);
+    assert!(!sqlite_sidecar_path(&document_path, "-journal").exists());
+    assert!(!sqlite_sidecar_path(&document_path, "-wal").exists());
+    assert!(!sqlite_sidecar_path(&document_path, "-shm").exists());
+}
+
+#[test]
+fn save_as_document_from_document_mints_a_new_identity() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let original_path = temp.path().join("Original.shift");
+    let saved_as_path = temp.path().join("SavedAs.shift");
+    let font = sample_font();
+    let original =
+        ShiftStore::create_document(&original_path, &font).expect("create original document");
+    let original_metadata = original.document_metadata().expect("original metadata");
+
+    let saved_as_metadata = original
+        .save_as_document(&saved_as_path)
+        .expect("save document as new document");
+
+    assert_ne!(saved_as_metadata, original_metadata);
+    assert_eq!(
+        original
+            .document_metadata()
+            .expect("unchanged source metadata"),
+        original_metadata
+    );
+    let saved_as = ShiftStore::open_document(&saved_as_path).expect("open saved-as document");
+    assert_eq!(
+        saved_as.load_font_state().expect("load saved-as font"),
+        font
+    );
+}
+
+#[test]
+fn save_as_document_never_clobbers_an_existing_destination() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let working_path = temp.path().join("Working.sqlite");
+    let document_path = temp.path().join("Existing.shift");
+    let working = ShiftStore::open(&working_path).expect("open working store");
+    std::fs::write(&document_path, b"retain me").expect("write destination");
+
+    let error = working
+        .save_as_document(&document_path)
+        .expect_err("existing destination must not be replaced");
+
+    assert!(matches!(
+        error,
+        shift_store::StoreError::DocumentAlreadyExists(existing) if existing == document_path
+    ));
+    assert_eq!(
+        std::fs::read(&document_path).expect("read destination"),
+        b"retain me"
+    );
+}
+
+#[test]
 fn create_document_never_clobbers_an_existing_destination() {
     let temp = tempfile::tempdir().expect("temp dir");
     let path = temp.path().join("Existing.shift");


### PR DESCRIPTION
## Summary
- add `ShiftStore::save_as_document` using SQLite's online backup without materializing a complete font
- canonicalize staged snapshots by securely removing workspace state and minting a new `DocumentId`
- validate, sync, and publish without clobbering an existing destination
- cover working-store snapshots, document-to-document identity, raw provenance scrubbing, preservation, and sidecar cleanup

## Stack
- depends on #186

## Verification
- `cargo test -p shift-store`
- `cargo test -p shift-workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- repository pre-commit suite