### PR TITLE
Add sparse native document recovery overlays

### DIFF
--- a/crates/shift-store/README.md
+++ b/crates/shift-store/README.md
@@ -62,7 +62,7 @@ Canonical SQLite publication must preserve the complete `shift-font::Font`, not 
 
 ## Schema policy
 
-Shift has not shipped either SQLite schema. Schema changes therefore update the version-1 baselines directly; there is intentionally no compatibility migration for earlier development databases. Canonical document schema stabilization is gated on preservation/export goldens and hostile-input budgets.
+Shift has not shipped either SQLite schema. Schema changes therefore update the version-1 baselines directly; there is intentionally no compatibility migration for earlier development databases. Every canonical table must be classified in the recovery catalog; open validates the overlay's columns, primary keys, foreign keys, and dependency order before installing generated merged views. Canonical document schema stabilization is gated on preservation/export goldens and hostile-input budgets.
 
 ## Responsibilities
 
@@ -79,7 +79,7 @@ Shift has not shipped either SQLite schema. Schema changes therefore update the 
 src/
   connection.rs     # canonical, working-WAL, and disposable-import connection postures
   document.rs       # staged create/Save As, validated open/verify, metadata, and durable publication
-  recovery/         # sparse overlay state, patch writes, merged reads, and commit-ID Save
+  recovery/         # schema-catalogued sparse overlays, merged reads, and commit-ID Save
   schema.rs         # canonical and working pre-release version-1 baselines
   font_state.rs     # eager metadata/directory and explicit full materialization
   import_writer.rs  # pipelined Rayon encode/compress plus one SQLite transaction owner

--- a/crates/shift-store/README.md
+++ b/crates/shift-store/README.md
@@ -1,8 +1,8 @@
 # shift-store
 
-`shift-store` owns Shift's SQLite persistence boundary: the canonical `.shift` application database and the separate app-local working database used during editing and import.
+`shift-store` owns Shift's SQLite persistence boundary: the canonical `.shift` application database, sparse app-local recovery overlays for saved documents, and complete app-local working databases for unsaved imports and new documents.
 
-Callers use typed APIs from this crate rather than preparing SQL or opening a second application-level persistence path. The desktop app has not yet cut over from the legacy ZIP package, so the canonical document APIs are currently a tested foundation rather than the active Save/Open route.
+Callers use typed APIs from this crate rather than preparing SQL or opening a second application-level persistence path. The desktop app has not yet cut over from the legacy ZIP package, so the native document and recovery APIs are currently a tested foundation rather than the active Save/Open route.
 
 ## Canonical document boundary
 
@@ -10,8 +10,23 @@ Callers use typed APIs from this crate rather than preparing SQL or opening a se
 - `ShiftStore::create_document` writes a complete `shift-font::Font` at a sibling staging path, syncs it, and publishes without clobbering an existing destination.
 - `ShiftStore::save_as_document` takes a consistent SQLite snapshot of a working or canonical store without materializing a complete `Font`, removes app-local workspace state, mints a new document identity, validates and syncs the staged canonical database, and publishes without clobbering.
 - `ShiftStore::open_document` validates the file read-only before opening it with rollback journaling and `synchronous=FULL`. `ShiftStore::verify_document` also runs SQLite integrity and foreign-key checks.
-- `DocumentMetadata` contains the stable `DocumentId`. A raw copy preserves it; Save As mints a new identity.
-- Canonical documents never contain app-local `workspace_state`. Working databases retain WAL + NORMAL and their revision/source-binding row.
+- `ShiftStore::open_document_with_recovery` binds a separate sparse `RecoveryOverlay`, reconciles it by commit identity, and installs connection-local merged views. Directory and payload reads prefer changed overlay rows and fall back to the canonical document without copying unrelated layers.
+- `DocumentMetadata` contains the stable `DocumentId` and current `saved_commit_id`. A raw copy preserves both; Save As mints a new document identity and saved commit.
+- Canonical documents never contain app-local `workspace_state` or recovery rows. Working databases retain WAL + NORMAL and their revision/source-binding row.
+
+## Recovery boundary
+
+`RecoveryOverlay` is an app-data SQLite database bound to one `DocumentId` and `base_commit_id`. A completed semantic edit transaction writes only replacement rows, complete replacement layer BLOBs, earned component rows, collection-replacement markers, and deletion tombstones. The canonical `.shift` remains the last explicitly saved document.
+
+Recovery states are `Clean`, `Dirty`, `SavePending`, and `Conflict`:
+
+- an edit moves `Clean` to `Dirty`;
+- `save_document` first persists a new `pending_commit_id`, applies only overlay changes to the canonical document in one short transaction, writes the same ID as `saved_commit_id`, then acknowledges and clears the overlay;
+- reopening after a crash compares commit IDs: a matching pending/saved ID proves Save committed and clears the overlay, while an unchanged base returns to `Dirty`;
+- a changed canonical base moves a dirty overlay to `Conflict` rather than applying stale rows silently;
+- `discard_recovery` clears the overlay and immediately exposes canonical rows through the same merged views.
+
+`save_as_document` snapshots the canonical main database and applies the current merged overlay only to the staged destination. It mints a new identity while leaving the source document and its unsaved recovery state unchanged. Recovery databases use WAL with `synchronous=FULL`; canonical documents retain rollback/FULL and no required idle sidecars.
 
 ## Storage boundary
 
@@ -64,6 +79,7 @@ Shift has not shipped either SQLite schema. Schema changes therefore update the 
 src/
   connection.rs     # canonical, working-WAL, and disposable-import connection postures
   document.rs       # staged create/Save As, validated open/verify, metadata, and durable publication
+  recovery/         # sparse overlay state, patch writes, merged reads, and commit-ID Save
   schema.rs         # canonical and working pre-release version-1 baselines
   font_state.rs     # eager metadata/directory and explicit full materialization
   import_writer.rs  # pipelined Rayon encode/compress plus one SQLite transaction owner

--- a/crates/shift-store/src/change_set.rs
+++ b/crates/shift-store/src/change_set.rs
@@ -32,6 +32,22 @@ impl ShiftStore {
         change_set: &font::FontChangeSet,
         post_font: Option<&font::Font>,
     ) -> Result<(), StoreError> {
+        let preserved_font_info = (self.recovery.is_some()
+            && change_set
+                .changes
+                .iter()
+                .any(|change| matches!(change, font::FontChange::FontMetadataUpdated(_))))
+        .then(|| self.get_font_info())
+        .transpose()?
+        .flatten();
+        if let Some(recovery) = self.recovery.as_mut() {
+            let post_font = post_font.ok_or(StoreError::RecoveryRequiresPostFont)?;
+            return recovery.apply_change_set(change_set, post_font, preserved_font_info.as_ref());
+        }
+        if self.kind == crate::store::StoreKind::Document {
+            return Err(StoreError::DocumentRequiresRecoveryOverlay);
+        }
+
         let tracks_workspace = self.tracks_workspace();
         let tx = self.conn.transaction()?;
         let mut touched_layer_ids = HashSet::new();
@@ -523,7 +539,7 @@ fn contour_from_value(value: &font::ContourValue) -> font::Contour {
     contour
 }
 
-fn upsert_axis_with_order(
+pub(crate) fn upsert_axis_with_order(
     tx: &Transaction<'_>,
     axis: &font::Axis,
     order_index: i64,
@@ -573,7 +589,7 @@ fn insert_axis(
     Ok(())
 }
 
-fn replace_axis_mappings(
+pub(crate) fn replace_axis_mappings(
     tx: &Transaction<'_>,
     mappings: &[font::AxisMapping],
 ) -> Result<(), StoreError> {
@@ -591,7 +607,7 @@ fn replace_axis_mappings(
     Ok(())
 }
 
-fn replace_named_instances(
+pub(crate) fn replace_named_instances(
     tx: &Transaction<'_>,
     instances: &[font::NamedInstance],
 ) -> Result<(), StoreError> {
@@ -609,7 +625,7 @@ fn replace_named_instances(
     Ok(())
 }
 
-fn replace_metric_definitions(
+pub(crate) fn replace_metric_definitions(
     tx: &Transaction<'_>,
     definitions: &[font::MetricDefinition],
 ) -> Result<(), StoreError> {
@@ -734,6 +750,45 @@ fn upsert_source(
     Ok(())
 }
 
+pub(crate) fn write_source_snapshot_in_tx(
+    tx: &Transaction<'_>,
+    source: &font::Source,
+    order_index: i64,
+) -> Result<(), StoreError> {
+    upsert_source(
+        tx,
+        &source.id(),
+        SourceRow {
+            name: Some(source.name()),
+            filename: source.filename(),
+            color: source.color(),
+            kind: SourceKind::from(source.role()),
+            layer_name: source.layer_name(),
+            italic_angle: source.italic_angle(),
+            line_gap: source.line_gap(),
+            underline_position: source.underline_position(),
+            underline_thickness: source.underline_thickness(),
+            order_index,
+        },
+    )?;
+    tx.execute(
+        "DELETE FROM source_locations WHERE source_id = ?1",
+        [source.id().to_string()],
+    )?;
+    for (axis_id, value) in source.location().iter() {
+        upsert_source_location(tx, &source.id(), axis_id, *value)?;
+    }
+    replace_source_metric_values(tx, source.id(), source.metric_values().iter())?;
+    replace_lib_data(
+        tx,
+        "source_lib",
+        "source_id",
+        Some(&source.id().to_string()),
+        source.lib(),
+    )?;
+    Ok(())
+}
+
 fn upsert_glyph(
     tx: &Transaction<'_>,
     glyph_id: &font::GlyphId,
@@ -822,7 +877,7 @@ fn update_font_metadata(
     require_changed(rows_changed, "font info", "1".to_string())
 }
 
-fn upsert_font_info(tx: &Transaction<'_>, font: &font::Font) -> Result<(), StoreError> {
+pub(crate) fn upsert_font_info(tx: &Transaction<'_>, font: &font::Font) -> Result<(), StoreError> {
     let metadata = font.metadata();
     let metrics = font.metrics();
     tx.execute(

--- a/crates/shift-store/src/connection.rs
+++ b/crates/shift-store/src/connection.rs
@@ -13,6 +13,7 @@ impl ShiftStore {
             conn,
             path: Some(path.to_path_buf()),
             kind: StoreKind::Working,
+            recovery: None,
         })
     }
 
@@ -37,6 +38,7 @@ impl ShiftStore {
             conn,
             path: Some(path.to_path_buf()),
             kind: StoreKind::Working,
+            recovery: None,
         })
     }
 
@@ -74,6 +76,7 @@ impl ShiftStore {
             conn,
             path: None,
             kind: StoreKind::Working,
+            recovery: None,
         })
     }
 }

--- a/crates/shift-store/src/document.rs
+++ b/crates/shift-store/src/document.rs
@@ -8,7 +8,7 @@ use rusqlite::{Connection, OpenFlags, OptionalExtension, backup::Backup, params}
 use shift_font::Font;
 
 use crate::{
-    DocumentId, ShiftStore, StoreError,
+    CommitId, DocumentId, RecoveryState, ShiftStore, StoreError,
     connection::{configure_common, configure_document_connection},
     schema,
     store::StoreKind,
@@ -17,6 +17,7 @@ use crate::{
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DocumentMetadata {
     pub document_id: DocumentId,
+    pub saved_commit_id: CommitId,
 }
 
 impl ShiftStore {
@@ -45,10 +46,12 @@ impl ShiftStore {
                 conn,
                 path: Some(staged.to_path_buf()),
                 kind: StoreKind::Document,
+                recovery: None,
             };
             store.replace_font_state(font)?;
             store.insert_document_metadata(&DocumentMetadata {
                 document_id: DocumentId::new(),
+                saved_commit_id: CommitId::new(),
             })?;
             store.sync_store_file()?;
         }
@@ -91,15 +94,40 @@ impl ShiftStore {
         }
 
         configure_document_connection(&conn)?;
-        conn.pragma_update(None, "secure_delete", "ON")?;
         let metadata = DocumentMetadata {
             document_id: DocumentId::new(),
+            saved_commit_id: CommitId::new(),
         };
+        if let Some(recovery) = self.recovery.as_ref() {
+            let state = recovery.state()?;
+            match state {
+                RecoveryState::Clean => {}
+                RecoveryState::Dirty | RecoveryState::Conflict => {
+                    crate::recovery::apply_overlay_to_snapshot(
+                        &mut conn,
+                        recovery,
+                        &metadata.saved_commit_id,
+                    )?;
+                }
+                RecoveryState::SavePending => {
+                    return Err(StoreError::InvalidRecoveryTransition {
+                        expected: "clean, dirty, or conflict",
+                        found: state.as_str(),
+                    });
+                }
+            }
+        }
+        conn.pragma_update(None, "secure_delete", "ON")?;
         let tx = conn.transaction()?;
-        tx.execute_batch("DROP TABLE IF EXISTS workspace_state; DELETE FROM document_metadata;")?;
+        tx.execute_batch(
+            "DROP TABLE IF EXISTS main.workspace_state; DELETE FROM main.document_metadata;",
+        )?;
         tx.execute(
-            "INSERT INTO document_metadata (id, document_id) VALUES (1, ?1)",
-            params![metadata.document_id.as_str()],
+            "INSERT INTO main.document_metadata (id, document_id, saved_commit_id) VALUES (1, ?1, ?2)",
+            params![
+                metadata.document_id.as_str(),
+                metadata.saved_commit_id.as_str()
+            ],
         )?;
         tx.pragma_update(None, "application_id", schema::SHIFT_APPLICATION_ID)?;
         tx.pragma_update(None, "user_version", schema::SCHEMA_VERSION)?;
@@ -110,6 +138,7 @@ impl ShiftStore {
             conn,
             path: Some(staged.to_path_buf()),
             kind: StoreKind::Document,
+            recovery: None,
         };
         staged_store.sync_store_file()?;
         drop(staged_store);
@@ -153,6 +182,7 @@ impl ShiftStore {
             conn,
             path: Some(path.to_path_buf()),
             kind: StoreKind::Document,
+            recovery: None,
         })
     }
 
@@ -186,8 +216,11 @@ impl ShiftStore {
 
     fn insert_document_metadata(&mut self, metadata: &DocumentMetadata) -> Result<(), StoreError> {
         self.conn.execute(
-            "INSERT INTO document_metadata (id, document_id) VALUES (1, ?1)",
-            params![metadata.document_id.as_str()],
+            "INSERT INTO document_metadata (id, document_id, saved_commit_id) VALUES (1, ?1, ?2)",
+            params![
+                metadata.document_id.as_str(),
+                metadata.saved_commit_id.as_str()
+            ],
         )?;
         Ok(())
     }
@@ -227,18 +260,23 @@ fn load_document_metadata(conn: &Connection) -> Result<DocumentMetadata, StoreEr
 
     let stored = conn
         .query_row(
-            "SELECT document_id FROM document_metadata WHERE id = 1",
+            "SELECT document_id, saved_commit_id FROM document_metadata WHERE id = 1",
             [],
-            |row| row.get::<_, String>(0),
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
         )
         .optional()?
         .ok_or_else(|| {
             StoreError::InvalidDocument("missing document_metadata row 1".to_string())
         })?;
     let document_id =
-        DocumentId::from_stored(stored.clone()).ok_or(StoreError::InvalidDocumentId(stored))?;
+        DocumentId::from_stored(stored.0.clone()).ok_or(StoreError::InvalidDocumentId(stored.0))?;
+    let saved_commit_id =
+        CommitId::from_stored(stored.1.clone()).ok_or(StoreError::InvalidCommitId(stored.1))?;
 
-    Ok(DocumentMetadata { document_id })
+    Ok(DocumentMetadata {
+        document_id,
+        saved_commit_id,
+    })
 }
 
 fn parent_directory(path: &Path) -> &Path {

--- a/crates/shift-store/src/error.rs
+++ b/crates/shift-store/src/error.rs
@@ -66,6 +66,9 @@ pub enum StoreError {
     #[error("document already exists: {0}")]
     DocumentAlreadyExists(std::path::PathBuf),
 
+    #[error("recovery overlay already exists: {0}")]
+    RecoveryAlreadyExists(std::path::PathBuf),
+
     #[error("invalid SQLite application ID {found:#010x}; expected {expected:#010x}")]
     InvalidApplicationId { found: i64, expected: i64 },
 
@@ -77,6 +80,24 @@ pub enum StoreError {
 
     #[error("invalid document ID: {0}")]
     InvalidDocumentId(String),
+
+    #[error("invalid commit ID: {0}")]
+    InvalidCommitId(String),
+
+    #[error("recovery overlay belongs to document {found}, not {expected}")]
+    RecoveryDocumentMismatch { found: String, expected: String },
+
+    #[error("recovery operation requires state {expected}, found {found}")]
+    InvalidRecoveryTransition {
+        expected: &'static str,
+        found: &'static str,
+    },
+
+    #[error("canonical document edits require a recovery overlay")]
+    DocumentRequiresRecoveryOverlay,
+
+    #[error("recovery edits require the committed post-edit font")]
+    RecoveryRequiresPostFont,
 
     #[error("missing {kind}: {id}")]
     MissingEntity { kind: &'static str, id: String },

--- a/crates/shift-store/src/layer/write.rs
+++ b/crates/shift-store/src/layer/write.rs
@@ -15,12 +15,19 @@ impl ShiftStore {
     /// rows in one transaction. The workspace revision advances only after
     /// encoding and index derivation have succeeded.
     pub fn replace_glyph_layer(&mut self, layer: &font::GlyphLayer) -> Result<(), StoreError> {
-        let tracks_workspace = self.tracks_workspace();
         let owner =
             layer_owner(&self.conn, &layer.id())?.ok_or_else(|| StoreError::MissingEntity {
                 kind: "glyph layer",
                 id: layer.id().to_string(),
             })?;
+        if let Some(recovery) = self.recovery.as_mut() {
+            return recovery.replace_layer(&owner, layer);
+        }
+        if self.kind == crate::store::StoreKind::Document {
+            return Err(StoreError::DocumentRequiresRecoveryOverlay);
+        }
+
+        let tracks_workspace = self.tracks_workspace();
         let tx = self.conn.transaction()?;
         write_layer_in_tx(&tx, &owner, layer)?;
         if tracks_workspace {

--- a/crates/shift-store/src/lib.rs
+++ b/crates/shift-store/src/lib.rs
@@ -7,6 +7,7 @@ mod font_state;
 mod glyph;
 mod import_writer;
 mod layer;
+mod recovery;
 mod schema;
 mod source;
 mod store;
@@ -23,11 +24,12 @@ pub use layer::{
     GLYPH_LAYER_FORMAT, GlyphLayerDirectoryEntry, MAX_LAYER_READ_BATCH_COUNT,
     MAX_LAYER_READ_BATCH_DECODED_BYTES,
 };
+pub use recovery::{RecoveryOverlay, RecoveryState};
 pub use schema::SHIFT_APPLICATION_ID;
 pub use source::{AxisRecord, NewAxis, NewSource, SourceAxisLocation, SourceKind, SourceRecord};
 pub use store::ShiftStore;
 pub use types::{
-    AxisId, DocumentId, GlyphId, GlyphWriteBatch, LayerBatchTiming, RevisionId, SourceId,
+    AxisId, CommitId, DocumentId, GlyphId, GlyphWriteBatch, LayerBatchTiming, RevisionId, SourceId,
 };
 pub use workspace_state::{
     Evidence, FileIdentity, SourceIdentitySnapshot, WorkspaceSourceKind, WorkspaceState,

--- a/crates/shift-store/src/recovery/catalog.rs
+++ b/crates/shift-store/src/recovery/catalog.rs
@@ -1,0 +1,486 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use rusqlite::{Connection, Transaction};
+
+use crate::StoreError;
+
+const NO_BASE_FALLBACK_COLUMNS: &[&str] = &[];
+const FONT_INFO_BASE_FALLBACK_COLUMNS: &[&str] = &["sample_text", "vendor_id"];
+const SOURCE_BASE_FALLBACK_COLUMNS: &[&str] = &["family_name", "style_name"];
+
+/// Declares how one canonical table participates in sparse recovery.
+///
+/// `OverlayRows` writers persist complete authored rows; `base_fallback_columns`
+/// are limited to store-only values absent from the font model. Collection
+/// replacements persist the complete final collection for each marked owner;
+/// parent collections preserve matching identities so cascades affect only
+/// deleted parents, while leaf collections are replaced wholesale.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum RecoveryMode {
+    OverlayRows {
+        tombstone_kind: Option<&'static str>,
+        base_fallback_columns: &'static [&'static str],
+    },
+    ReplaceCollection {
+        owner_column: Option<&'static str>,
+        preserve_matching_rows: bool,
+    },
+    CanonicalOnly,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct RecoveryTable {
+    name: &'static str,
+    mode: RecoveryMode,
+}
+
+impl RecoveryTable {
+    const fn overlay_rows(
+        name: &'static str,
+        tombstone_kind: Option<&'static str>,
+        base_fallback_columns: &'static [&'static str],
+    ) -> Self {
+        Self {
+            name,
+            mode: RecoveryMode::OverlayRows {
+                tombstone_kind,
+                base_fallback_columns,
+            },
+        }
+    }
+
+    const fn replace_collection(
+        name: &'static str,
+        owner_column: Option<&'static str>,
+        preserve_matching_rows: bool,
+    ) -> Self {
+        Self {
+            name,
+            mode: RecoveryMode::ReplaceCollection {
+                owner_column,
+                preserve_matching_rows,
+            },
+        }
+    }
+
+    const fn canonical_only(name: &'static str) -> Self {
+        Self {
+            name,
+            mode: RecoveryMode::CanonicalOnly,
+        }
+    }
+
+    pub(super) const fn name(self) -> &'static str {
+        self.name
+    }
+
+    pub(super) const fn mode(self) -> RecoveryMode {
+        self.mode
+    }
+
+    pub(super) fn tombstone_kind(self) -> Option<&'static str> {
+        match self.mode {
+            RecoveryMode::OverlayRows { tombstone_kind, .. } => tombstone_kind,
+            RecoveryMode::ReplaceCollection { .. } | RecoveryMode::CanonicalOnly => None,
+        }
+    }
+
+    pub(super) const fn preserve_matching_rows(self) -> bool {
+        match self.mode {
+            RecoveryMode::ReplaceCollection {
+                preserve_matching_rows,
+                ..
+            } => preserve_matching_rows,
+            RecoveryMode::OverlayRows { .. } | RecoveryMode::CanonicalOnly => false,
+        }
+    }
+}
+
+pub(super) const FONT_INFO: RecoveryTable =
+    RecoveryTable::overlay_rows("font_info", None, FONT_INFO_BASE_FALLBACK_COLUMNS);
+pub(super) const METRIC_DEFINITIONS: RecoveryTable =
+    RecoveryTable::replace_collection("metric_definitions", None, true);
+pub(super) const AXES: RecoveryTable =
+    RecoveryTable::overlay_rows("axes", Some("axis"), NO_BASE_FALLBACK_COLUMNS);
+pub(super) const AXIS_MAPPINGS: RecoveryTable =
+    RecoveryTable::replace_collection("axis_mappings", None, false);
+pub(super) const NAMED_INSTANCES: RecoveryTable =
+    RecoveryTable::replace_collection("named_instances", None, false);
+pub(super) const SOURCES: RecoveryTable =
+    RecoveryTable::overlay_rows("sources", Some("source"), SOURCE_BASE_FALLBACK_COLUMNS);
+pub(super) const GLYPHS: RecoveryTable =
+    RecoveryTable::overlay_rows("glyphs", Some("glyph"), NO_BASE_FALLBACK_COLUMNS);
+pub(super) const GLYPH_UNICODES: RecoveryTable =
+    RecoveryTable::replace_collection("glyph_unicodes", Some("glyph_id"), false);
+pub(super) const FONT_GUIDELINES: RecoveryTable = RecoveryTable::canonical_only("font_guidelines");
+pub(super) const SOURCE_LOCATIONS: RecoveryTable =
+    RecoveryTable::replace_collection("source_locations", Some("source_id"), false);
+pub(super) const SOURCE_METRIC_VALUES: RecoveryTable =
+    RecoveryTable::replace_collection("source_metric_values", Some("source_id"), false);
+pub(super) const FEATURE_TEXT: RecoveryTable = RecoveryTable::canonical_only("feature_text");
+pub(super) const KERNING_GROUPS: RecoveryTable = RecoveryTable::canonical_only("kerning_groups");
+pub(super) const KERNING_GROUP_MEMBERS: RecoveryTable =
+    RecoveryTable::canonical_only("kerning_group_members");
+pub(super) const KERNING_PAIRS: RecoveryTable = RecoveryTable::canonical_only("kerning_pairs");
+pub(super) const FONT_LIB: RecoveryTable = RecoveryTable::canonical_only("font_lib");
+pub(super) const FONTINFO_REMAINDER: RecoveryTable =
+    RecoveryTable::canonical_only("fontinfo_remainder");
+pub(super) const SOURCE_LIB: RecoveryTable =
+    RecoveryTable::replace_collection("source_lib", Some("source_id"), false);
+pub(super) const GLYPH_LIB: RecoveryTable =
+    RecoveryTable::replace_collection("glyph_lib", Some("glyph_id"), false);
+pub(super) const FONT_BINARIES: RecoveryTable = RecoveryTable::canonical_only("font_binaries");
+pub(super) const GLYPH_LAYERS: RecoveryTable =
+    RecoveryTable::overlay_rows("glyph_layers", Some("layer"), NO_BASE_FALLBACK_COLUMNS);
+pub(super) const GLYPH_LAYER_PAYLOADS: RecoveryTable =
+    RecoveryTable::overlay_rows("glyph_layer_payloads", None, NO_BASE_FALLBACK_COLUMNS);
+pub(super) const GLYPH_COMPONENTS: RecoveryTable =
+    RecoveryTable::replace_collection("glyph_components", Some("layer_id"), false);
+pub(super) const DOCUMENT_METADATA: RecoveryTable =
+    RecoveryTable::canonical_only("document_metadata");
+
+const RECOVERY_TABLES: &[RecoveryTable] = &[
+    FONT_INFO,
+    METRIC_DEFINITIONS,
+    AXES,
+    AXIS_MAPPINGS,
+    NAMED_INSTANCES,
+    SOURCES,
+    GLYPHS,
+    GLYPH_UNICODES,
+    FONT_GUIDELINES,
+    SOURCE_LOCATIONS,
+    SOURCE_METRIC_VALUES,
+    FEATURE_TEXT,
+    KERNING_GROUPS,
+    KERNING_GROUP_MEMBERS,
+    KERNING_PAIRS,
+    FONT_LIB,
+    FONTINFO_REMAINDER,
+    SOURCE_LIB,
+    GLYPH_LIB,
+    FONT_BINARIES,
+    GLYPH_LAYERS,
+    GLYPH_LAYER_PAYLOADS,
+    GLYPH_COMPONENTS,
+    DOCUMENT_METADATA,
+];
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct ForeignKey {
+    pub(super) parent_table: String,
+    pub(super) on_delete: String,
+    pub(super) columns: Vec<ForeignKeyColumn>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct ForeignKeyColumn {
+    pub(super) child: String,
+    pub(super) parent: String,
+}
+
+pub(super) struct RecoveryTableShape {
+    pub(super) table: RecoveryTable,
+    pub(super) columns: Vec<String>,
+    pub(super) primary_key: Vec<String>,
+    pub(super) foreign_keys: Vec<ForeignKey>,
+}
+
+pub(super) fn load_recovery_table_shapes(
+    conn: &Connection,
+) -> Result<Vec<RecoveryTableShape>, StoreError> {
+    let mut tables = Vec::with_capacity(RECOVERY_TABLES.len());
+    let positions = RECOVERY_TABLES
+        .iter()
+        .enumerate()
+        .map(|(index, table)| (table.name(), index))
+        .collect::<HashMap<_, _>>();
+
+    for (index, table) in RECOVERY_TABLES.iter().copied().enumerate() {
+        let main = load_table_shape(conn, "main", table.name())?;
+        let recovery = load_table_shape(conn, "recovery", table.name())?;
+        if main != recovery {
+            return Err(StoreError::InvalidDocument(format!(
+                "recovery table {} does not match the canonical schema",
+                table.name()
+            )));
+        }
+        if main.columns.is_empty() {
+            return Err(StoreError::InvalidDocument(format!(
+                "missing recovery table {}",
+                table.name()
+            )));
+        }
+        if main.primary_key.is_empty() {
+            return Err(StoreError::InvalidDocument(format!(
+                "recovery table {} has no primary key",
+                table.name()
+            )));
+        }
+
+        if table.tombstone_kind().is_some() && main.primary_key.len() != 1 {
+            return Err(StoreError::InvalidDocument(format!(
+                "tombstoned recovery table {} must have one primary-key column",
+                table.name()
+            )));
+        }
+
+        match table.mode() {
+            RecoveryMode::OverlayRows {
+                base_fallback_columns,
+                ..
+            } => {
+                for column in base_fallback_columns {
+                    if !main.columns.iter().any(|candidate| candidate == column) {
+                        return Err(StoreError::InvalidDocument(format!(
+                            "recovery table {} is missing base fallback column {column}",
+                            table.name()
+                        )));
+                    }
+                }
+            }
+            RecoveryMode::ReplaceCollection {
+                owner_column: Some(owner_column),
+                ..
+            } => {
+                if !main.columns.iter().any(|column| column == owner_column) {
+                    return Err(StoreError::InvalidDocument(format!(
+                        "recovery table {} is missing owner column {owner_column}",
+                        table.name()
+                    )));
+                }
+            }
+            RecoveryMode::ReplaceCollection {
+                owner_column: None, ..
+            }
+            | RecoveryMode::CanonicalOnly => {}
+        }
+
+        for foreign_key in &main.foreign_keys {
+            if let Some(parent_index) = positions.get(foreign_key.parent_table.as_str())
+                && *parent_index >= index
+                && foreign_key.parent_table != table.name()
+            {
+                return Err(StoreError::InvalidDocument(format!(
+                    "recovery table {} must follow parent table {}",
+                    table.name(),
+                    foreign_key.parent_table
+                )));
+            }
+        }
+
+        tables.push(RecoveryTableShape {
+            table,
+            columns: main.columns,
+            primary_key: main.primary_key,
+            foreign_keys: main.foreign_keys,
+        });
+    }
+
+    let referenced_tables = tables
+        .iter()
+        .flat_map(|table| &table.foreign_keys)
+        .map(|foreign_key| foreign_key.parent_table.as_str())
+        .collect::<HashSet<_>>();
+    for table in &tables {
+        if matches!(table.table.mode(), RecoveryMode::ReplaceCollection { .. })
+            && referenced_tables.contains(table.table.name())
+            && !table.table.preserve_matching_rows()
+        {
+            return Err(StoreError::InvalidDocument(format!(
+                "parent recovery collection {} must preserve matching rows",
+                table.table.name()
+            )));
+        }
+
+        for foreign_key in &table.foreign_keys {
+            let parent = RECOVERY_TABLES
+                .iter()
+                .find(|candidate| candidate.name() == foreign_key.parent_table);
+            if parent.is_some_and(|parent| parent.preserve_matching_rows())
+                && foreign_key.on_delete != "CASCADE"
+            {
+                return Err(StoreError::InvalidDocument(format!(
+                    "recovery collection {} requires cascading child table {}",
+                    foreign_key.parent_table,
+                    table.table.name()
+                )));
+            }
+        }
+    }
+
+    Ok(tables)
+}
+
+pub(super) fn clear_recovery(tx: &Transaction<'_>) -> Result<(), StoreError> {
+    for table in RECOVERY_TABLES.iter().rev() {
+        tx.execute(&format!("DELETE FROM {}", identifier(table.name())), [])?;
+    }
+    tx.execute("DELETE FROM recovery_replacements", [])?;
+    tx.execute("DELETE FROM recovery_tombstones", [])?;
+    Ok(())
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct StoredTableShape {
+    columns: Vec<String>,
+    primary_key: Vec<String>,
+    foreign_keys: Vec<ForeignKey>,
+}
+
+fn load_table_shape(
+    conn: &Connection,
+    database: &str,
+    table: &str,
+) -> Result<StoredTableShape, StoreError> {
+    let mut columns_statement = conn.prepare(&format!(
+        "PRAGMA {}.table_info({})",
+        identifier(database),
+        identifier(table)
+    ))?;
+    let stored_columns = columns_statement
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(1)?, row.get::<_, i64>(5)?))
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    let columns = stored_columns
+        .iter()
+        .map(|(name, _)| name.clone())
+        .collect::<Vec<_>>();
+    let mut primary_key = stored_columns
+        .into_iter()
+        .filter(|(_, order)| *order > 0)
+        .collect::<Vec<_>>();
+    primary_key.sort_by_key(|(_, order)| *order);
+    let primary_key = primary_key
+        .into_iter()
+        .map(|(name, _)| name)
+        .collect::<Vec<_>>();
+
+    let mut foreign_key_statement = conn.prepare(&format!(
+        "PRAGMA {}.foreign_key_list({})",
+        identifier(database),
+        identifier(table)
+    ))?;
+    let stored_foreign_keys = foreign_key_statement
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, Option<String>>(4)?,
+                row.get::<_, String>(6)?,
+            ))
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut grouped = BTreeMap::<i64, (String, String, Vec<(i64, ForeignKeyColumn)>)>::new();
+    for (id, sequence, parent_table, child, parent, on_delete) in stored_foreign_keys {
+        let parent = parent.ok_or_else(|| {
+            StoreError::InvalidDocument(format!(
+                "table {table} has a foreign key with an implicit parent column"
+            ))
+        })?;
+        let entry = grouped
+            .entry(id)
+            .or_insert_with(|| (parent_table, on_delete, Vec::new()));
+        entry.2.push((sequence, ForeignKeyColumn { child, parent }));
+    }
+    let foreign_keys = grouped
+        .into_values()
+        .map(|(parent_table, on_delete, mut columns)| {
+            columns.sort_by_key(|(sequence, _)| *sequence);
+            ForeignKey {
+                parent_table,
+                on_delete,
+                columns: columns.into_iter().map(|(_, column)| column).collect(),
+            }
+        })
+        .collect();
+
+    Ok(StoredTableShape {
+        columns,
+        primary_key,
+        foreign_keys,
+    })
+}
+
+pub(super) fn matching_columns(left_alias: &str, right_alias: &str, columns: &[String]) -> String {
+    columns
+        .iter()
+        .map(|column| {
+            let column = identifier(column);
+            format!("{left_alias}.{column} = {right_alias}.{column}")
+        })
+        .collect::<Vec<_>>()
+        .join(" AND ")
+}
+
+pub(super) fn identifier(value: &str) -> String {
+    format!("\"{}\"", value.replace('"', "\"\""))
+}
+
+pub(super) fn string_literal(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    #[test]
+    fn recovery_catalog_classifies_every_document_table() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(crate::schema::DOCUMENT_SCHEMA_V1)
+            .unwrap();
+        let mut statement = conn
+            .prepare(
+                "SELECT name FROM sqlite_schema
+                 WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+                 ORDER BY name",
+            )
+            .unwrap();
+        let schema_tables = statement
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<Result<HashSet<_>, _>>()
+            .unwrap();
+        let catalog_tables = RECOVERY_TABLES
+            .iter()
+            .map(|table| table.name().to_string())
+            .collect::<HashSet<_>>();
+
+        assert_eq!(catalog_tables, schema_tables);
+        assert_eq!(catalog_tables.len(), RECOVERY_TABLES.len());
+    }
+
+    #[test]
+    fn recovery_catalog_rejects_a_different_overlay_shape() {
+        let temp = tempfile::tempdir().unwrap();
+        let recovery_path = temp.path().join("recovery.sqlite");
+        let recovery = Connection::open(&recovery_path).unwrap();
+        recovery
+            .execute_batch(crate::schema::DOCUMENT_SCHEMA_V1)
+            .unwrap();
+        drop(recovery);
+
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(crate::schema::DOCUMENT_SCHEMA_V1)
+            .unwrap();
+        conn.execute(
+            "ATTACH DATABASE ?1 AS recovery",
+            [recovery_path.to_str().unwrap()],
+        )
+        .unwrap();
+        assert!(load_recovery_table_shapes(&conn).is_ok());
+
+        conn.execute_batch("ALTER TABLE recovery.sources ADD COLUMN unexpected TEXT")
+            .unwrap();
+        assert!(matches!(
+            load_recovery_table_shapes(&conn),
+            Err(StoreError::InvalidDocument(_))
+        ));
+    }
+}

--- a/crates/shift-store/src/recovery/mod.rs
+++ b/crates/shift-store/src/recovery/mod.rs
@@ -1,3 +1,4 @@
+mod catalog;
 mod overlay;
 mod patch;
 mod save;

--- a/crates/shift-store/src/recovery/mod.rs
+++ b/crates/shift-store/src/recovery/mod.rs
@@ -1,0 +1,103 @@
+mod overlay;
+mod patch;
+mod save;
+mod views;
+
+use std::path::Path;
+
+use crate::{ShiftStore, StoreError};
+
+pub use overlay::{RecoveryOverlay, RecoveryState};
+
+pub(crate) fn apply_overlay_to_snapshot(
+    conn: &mut rusqlite::Connection,
+    recovery: &RecoveryOverlay,
+    commit_id: &crate::CommitId,
+) -> Result<(), StoreError> {
+    views::attach_recovery(conn, recovery.path())?;
+    views::install_merged_views(conn)?;
+    save::apply_recovery_to_document(conn, commit_id)
+}
+
+impl ShiftStore {
+    /// Opens a canonical document with an app-owned sparse recovery overlay.
+    ///
+    /// Existing unsaved changes are reconciled by document and commit identity,
+    /// then exposed through merged lazy reads without modifying the canonical file.
+    pub fn open_document_with_recovery(
+        document_path: impl AsRef<Path>,
+        recovery_path: impl AsRef<Path>,
+    ) -> Result<Self, StoreError> {
+        let mut store = Self::open_document(document_path)?;
+        let document = store.document_metadata()?;
+        let recovery_path = recovery_path.as_ref();
+        let mut recovery = if recovery_path.exists() {
+            RecoveryOverlay::open(recovery_path)?
+        } else {
+            RecoveryOverlay::create(
+                recovery_path,
+                &document.document_id,
+                &document.saved_commit_id,
+            )?
+        };
+        let recovery_document_id = recovery.document_id()?;
+        if recovery_document_id != document.document_id {
+            return Err(StoreError::RecoveryDocumentMismatch {
+                found: recovery_document_id.to_string(),
+                expected: document.document_id.to_string(),
+            });
+        }
+        recovery.reconcile(&document.saved_commit_id)?;
+        views::attach_recovery(&store.conn, recovery.path())?;
+        views::install_merged_views(&store.conn)?;
+        store.recovery = Some(recovery);
+        Ok(store)
+    }
+
+    /// Returns the attached recovery lifecycle state, if this is a recovered document.
+    pub fn recovery_state(&self) -> Result<Option<RecoveryState>, StoreError> {
+        self.recovery
+            .as_ref()
+            .map(RecoveryOverlay::state)
+            .transpose()
+    }
+
+    /// Clears unsaved overlay changes and exposes the canonical saved rows immediately.
+    pub fn discard_recovery(&mut self) -> Result<(), StoreError> {
+        let saved_commit_id = self.document_metadata()?.saved_commit_id;
+        let recovery = self
+            .recovery
+            .as_mut()
+            .ok_or(StoreError::DocumentRequiresRecoveryOverlay)?;
+        recovery.discard(&saved_commit_id)
+    }
+
+    /// Applies sparse unsaved changes to the canonical document and acknowledges the commit.
+    pub fn save_document(&mut self) -> Result<crate::DocumentMetadata, StoreError> {
+        let state = self
+            .recovery_state()?
+            .ok_or(StoreError::DocumentRequiresRecoveryOverlay)?;
+        if state == RecoveryState::Clean {
+            return self.document_metadata();
+        }
+        if state != RecoveryState::Dirty {
+            return Err(StoreError::InvalidRecoveryTransition {
+                expected: "dirty",
+                found: state.as_str(),
+            });
+        }
+
+        let commit_id = self
+            .recovery
+            .as_mut()
+            .expect("recovery state came from an attached overlay")
+            .begin_save()?;
+        save::apply_recovery_to_document(&mut self.conn, &commit_id)?;
+        self.sync_store_file()?;
+        self.recovery
+            .as_mut()
+            .expect("recovery overlay remains attached during save")
+            .acknowledge_save(&commit_id)?;
+        self.document_metadata()
+    }
+}

--- a/crates/shift-store/src/recovery/overlay.rs
+++ b/crates/shift-store/src/recovery/overlay.rs
@@ -29,26 +29,6 @@ CREATE TABLE IF NOT EXISTS recovery_tombstones (
 );
 "#;
 
-const CLEAR_PATCH_SQL: &str = r#"
-DELETE FROM glyph_components;
-DELETE FROM glyph_layer_payloads;
-DELETE FROM glyph_layers;
-DELETE FROM glyph_unicodes;
-DELETE FROM glyph_lib;
-DELETE FROM glyphs;
-DELETE FROM source_locations;
-DELETE FROM source_metric_values;
-DELETE FROM source_lib;
-DELETE FROM sources;
-DELETE FROM metric_definitions;
-DELETE FROM axis_mappings;
-DELETE FROM named_instances;
-DELETE FROM axes;
-DELETE FROM font_info;
-DELETE FROM recovery_replacements;
-DELETE FROM recovery_tombstones;
-"#;
-
 /// Persisted lifecycle state of one sparse recovery overlay.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RecoveryState {
@@ -254,7 +234,7 @@ impl RecoveryOverlay {
 
     fn set_clean(&mut self, base_commit_id: &CommitId) -> Result<(), StoreError> {
         let tx = self.conn.transaction()?;
-        tx.execute_batch(CLEAR_PATCH_SQL)?;
+        super::catalog::clear_recovery(&tx)?;
         tx.execute(
             "UPDATE recovery_metadata
              SET base_commit_id = ?1, pending_commit_id = NULL, state = 'clean'

--- a/crates/shift-store/src/recovery/overlay.rs
+++ b/crates/shift-store/src/recovery/overlay.rs
@@ -1,0 +1,415 @@
+use std::path::{Path, PathBuf};
+
+use rusqlite::{Connection, OpenFlags, params};
+
+use crate::{CommitId, DocumentId, StoreError, connection::configure_common, schema};
+
+const RECOVERY_APPLICATION_ID: i64 = 0x5348_4652;
+const RECOVERY_SCHEMA_VERSION: i64 = 1;
+
+const RECOVERY_SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS recovery_metadata (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    document_id TEXT NOT NULL,
+    base_commit_id TEXT NOT NULL,
+    pending_commit_id TEXT,
+    state TEXT NOT NULL CHECK (state IN ('clean', 'dirty', 'save_pending', 'conflict'))
+);
+
+CREATE TABLE IF NOT EXISTS recovery_replacements (
+    collection TEXT NOT NULL,
+    owner_id TEXT NOT NULL,
+    PRIMARY KEY (collection, owner_id)
+);
+
+CREATE TABLE IF NOT EXISTS recovery_tombstones (
+    entity_kind TEXT NOT NULL,
+    entity_id TEXT NOT NULL,
+    PRIMARY KEY (entity_kind, entity_id)
+);
+"#;
+
+const CLEAR_PATCH_SQL: &str = r#"
+DELETE FROM glyph_components;
+DELETE FROM glyph_layer_payloads;
+DELETE FROM glyph_layers;
+DELETE FROM glyph_unicodes;
+DELETE FROM glyph_lib;
+DELETE FROM glyphs;
+DELETE FROM source_locations;
+DELETE FROM source_metric_values;
+DELETE FROM source_lib;
+DELETE FROM sources;
+DELETE FROM metric_definitions;
+DELETE FROM axis_mappings;
+DELETE FROM named_instances;
+DELETE FROM axes;
+DELETE FROM font_info;
+DELETE FROM recovery_replacements;
+DELETE FROM recovery_tombstones;
+"#;
+
+/// Persisted lifecycle state of one sparse recovery overlay.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RecoveryState {
+    /// The overlay contains no unsaved authored changes.
+    Clean,
+    /// Sparse changes are based on the canonical saved commit.
+    Dirty,
+    /// A commit ID was persisted before applying changes to the canonical document.
+    SavePending,
+    /// The canonical saved commit changed from the overlay's base.
+    Conflict,
+}
+
+impl RecoveryState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Clean => "clean",
+            Self::Dirty => "dirty",
+            Self::SavePending => "save_pending",
+            Self::Conflict => "conflict",
+        }
+    }
+
+    fn parse(value: &str) -> Result<Self, StoreError> {
+        match value {
+            "clean" => Ok(Self::Clean),
+            "dirty" => Ok(Self::Dirty),
+            "save_pending" => Ok(Self::SavePending),
+            "conflict" => Ok(Self::Conflict),
+            other => Err(StoreError::InvalidDocument(format!(
+                "unknown recovery state {other:?}"
+            ))),
+        }
+    }
+}
+
+/// App-owned SQLite file containing only unsaved canonical row replacements and tombstones.
+pub struct RecoveryOverlay {
+    pub(super) conn: Connection,
+    path: PathBuf,
+}
+
+struct RecoveryMetadata {
+    document_id: DocumentId,
+    base_commit_id: CommitId,
+    pending_commit_id: Option<CommitId>,
+    state: RecoveryState,
+}
+
+impl RecoveryOverlay {
+    pub fn create(
+        path: impl AsRef<Path>,
+        document_id: &DocumentId,
+        base_commit_id: &CommitId,
+    ) -> Result<Self, StoreError> {
+        let path = path.as_ref();
+        if path.exists() {
+            return Err(StoreError::RecoveryAlreadyExists(path.to_path_buf()));
+        }
+        let conn = Connection::open_with_flags(
+            path,
+            OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_CREATE,
+        )?;
+        configure_recovery_connection(&conn)?;
+        let application_id: i64 = conn.query_row("PRAGMA application_id", [], |row| row.get(0))?;
+        let version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+        let schema_rows: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM sqlite_schema WHERE name NOT LIKE 'sqlite_%'",
+            [],
+            |row| row.get(0),
+        )?;
+        if application_id != 0 || version != 0 || schema_rows != 0 {
+            return Err(StoreError::RecoveryAlreadyExists(path.to_path_buf()));
+        }
+
+        conn.execute_batch(schema::DOCUMENT_SCHEMA_V1)?;
+        conn.execute_batch(RECOVERY_SCHEMA)?;
+        conn.pragma_update(None, "application_id", RECOVERY_APPLICATION_ID)?;
+        conn.pragma_update(None, "user_version", RECOVERY_SCHEMA_VERSION)?;
+        conn.execute(
+            "INSERT INTO recovery_metadata (
+                id, document_id, base_commit_id, pending_commit_id, state
+             ) VALUES (1, ?1, ?2, NULL, 'clean')",
+            params![document_id.as_str(), base_commit_id.as_str()],
+        )?;
+        sync_path(path)?;
+
+        Ok(Self {
+            conn,
+            path: path.to_path_buf(),
+        })
+    }
+
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, StoreError> {
+        let path = path.as_ref();
+        let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_WRITE)?;
+        configure_recovery_connection(&conn)?;
+        validate_recovery_header(&conn)?;
+        let overlay = Self {
+            conn,
+            path: path.to_path_buf(),
+        };
+        overlay.metadata()?;
+        Ok(overlay)
+    }
+
+    pub fn state(&self) -> Result<RecoveryState, StoreError> {
+        Ok(self.metadata()?.state)
+    }
+
+    pub fn document_id(&self) -> Result<DocumentId, StoreError> {
+        Ok(self.metadata()?.document_id)
+    }
+
+    pub fn base_commit_id(&self) -> Result<CommitId, StoreError> {
+        Ok(self.metadata()?.base_commit_id)
+    }
+
+    pub fn pending_commit_id(&self) -> Result<Option<CommitId>, StoreError> {
+        Ok(self.metadata()?.pending_commit_id)
+    }
+
+    pub fn reconcile(&mut self, saved_commit_id: &CommitId) -> Result<RecoveryState, StoreError> {
+        let metadata = self.metadata()?;
+        let next = match metadata.state {
+            RecoveryState::Clean => {
+                if metadata.base_commit_id != *saved_commit_id {
+                    self.set_clean(saved_commit_id)?;
+                }
+                RecoveryState::Clean
+            }
+            RecoveryState::Dirty if metadata.base_commit_id == *saved_commit_id => {
+                RecoveryState::Dirty
+            }
+            RecoveryState::SavePending
+                if metadata.pending_commit_id.as_ref() == Some(saved_commit_id) =>
+            {
+                self.set_clean(saved_commit_id)?;
+                RecoveryState::Clean
+            }
+            RecoveryState::SavePending if metadata.base_commit_id == *saved_commit_id => {
+                self.conn.execute(
+                    "UPDATE recovery_metadata
+                     SET pending_commit_id = NULL, state = 'dirty'
+                     WHERE id = 1",
+                    [],
+                )?;
+                RecoveryState::Dirty
+            }
+            RecoveryState::Conflict => RecoveryState::Conflict,
+            RecoveryState::Dirty | RecoveryState::SavePending => {
+                self.conn.execute(
+                    "UPDATE recovery_metadata SET state = 'conflict' WHERE id = 1",
+                    [],
+                )?;
+                RecoveryState::Conflict
+            }
+        };
+        Ok(next)
+    }
+
+    pub fn discard(&mut self, saved_commit_id: &CommitId) -> Result<(), StoreError> {
+        self.set_clean(saved_commit_id)
+    }
+
+    pub(crate) fn begin_save(&mut self) -> Result<CommitId, StoreError> {
+        let state = self.state()?;
+        if state != RecoveryState::Dirty {
+            return Err(StoreError::InvalidRecoveryTransition {
+                expected: "dirty",
+                found: state.as_str(),
+            });
+        }
+
+        let commit_id = CommitId::new();
+        self.conn.execute(
+            "UPDATE recovery_metadata
+             SET pending_commit_id = ?1, state = 'save_pending'
+             WHERE id = 1",
+            [commit_id.as_str()],
+        )?;
+        sync_path(&self.path)?;
+        Ok(commit_id)
+    }
+
+    pub(crate) fn acknowledge_save(&mut self, commit_id: &CommitId) -> Result<(), StoreError> {
+        let metadata = self.metadata()?;
+        if metadata.state != RecoveryState::SavePending
+            || metadata.pending_commit_id.as_ref() != Some(commit_id)
+        {
+            return Err(StoreError::InvalidRecoveryTransition {
+                expected: "matching save_pending",
+                found: metadata.state.as_str(),
+            });
+        }
+
+        self.set_clean(commit_id)
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn set_clean(&mut self, base_commit_id: &CommitId) -> Result<(), StoreError> {
+        let tx = self.conn.transaction()?;
+        tx.execute_batch(CLEAR_PATCH_SQL)?;
+        tx.execute(
+            "UPDATE recovery_metadata
+             SET base_commit_id = ?1, pending_commit_id = NULL, state = 'clean'
+             WHERE id = 1",
+            [base_commit_id.as_str()],
+        )?;
+        tx.commit()?;
+        sync_path(&self.path)
+    }
+
+    fn metadata(&self) -> Result<RecoveryMetadata, StoreError> {
+        let stored = self.conn.query_row(
+            "SELECT document_id, base_commit_id, pending_commit_id, state
+             FROM recovery_metadata WHERE id = 1",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                    row.get::<_, String>(3)?,
+                ))
+            },
+        )?;
+        let document_id = DocumentId::from_stored(stored.0.clone())
+            .ok_or(StoreError::InvalidDocumentId(stored.0))?;
+        let base_commit_id =
+            CommitId::from_stored(stored.1.clone()).ok_or(StoreError::InvalidCommitId(stored.1))?;
+        let pending_commit_id = stored
+            .2
+            .map(|value| {
+                CommitId::from_stored(value.clone()).ok_or(StoreError::InvalidCommitId(value))
+            })
+            .transpose()?;
+
+        Ok(RecoveryMetadata {
+            document_id,
+            base_commit_id,
+            pending_commit_id,
+            state: RecoveryState::parse(&stored.3)?,
+        })
+    }
+}
+
+fn configure_recovery_connection(conn: &Connection) -> Result<(), StoreError> {
+    configure_common(conn)?;
+    conn.pragma_update(None, "foreign_keys", "OFF")?;
+    let journal_mode: String = conn.query_row("PRAGMA journal_mode=WAL", [], |row| row.get(0))?;
+    debug_assert_eq!(journal_mode, "wal");
+    conn.pragma_update(None, "synchronous", "FULL")?;
+    Ok(())
+}
+
+fn validate_recovery_header(conn: &Connection) -> Result<(), StoreError> {
+    let application_id: i64 = conn.query_row("PRAGMA application_id", [], |row| row.get(0))?;
+    if application_id != RECOVERY_APPLICATION_ID {
+        return Err(StoreError::InvalidApplicationId {
+            found: application_id,
+            expected: RECOVERY_APPLICATION_ID,
+        });
+    }
+    let version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+    if version != RECOVERY_SCHEMA_VERSION {
+        return Err(StoreError::UnsupportedSchemaVersion {
+            found: version,
+            supported: RECOVERY_SCHEMA_VERSION,
+        });
+    }
+    Ok(())
+}
+
+fn sync_path(path: &Path) -> Result<(), StoreError> {
+    std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)?
+        .sync_all()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use shift_font::test_support::sample_font;
+
+    use super::*;
+    use crate::ShiftStore;
+
+    #[test]
+    fn pending_commit_reconciles_against_canonical_commit() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("recovery.sqlite");
+        let document_id = DocumentId::new();
+        let base = CommitId::new();
+        let mut overlay = RecoveryOverlay::create(&path, &document_id, &base).unwrap();
+        let journal_mode: String = overlay
+            .conn
+            .query_row("PRAGMA journal_mode", [], |row| row.get(0))
+            .unwrap();
+        let synchronous: i64 = overlay
+            .conn
+            .query_row("PRAGMA synchronous", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(journal_mode, "wal");
+        assert_eq!(synchronous, 2);
+
+        overlay
+            .conn
+            .execute(
+                "UPDATE recovery_metadata SET state = 'dirty' WHERE id = 1",
+                [],
+            )
+            .unwrap();
+        let pending = overlay.begin_save().unwrap();
+        drop(overlay);
+
+        let mut overlay = RecoveryOverlay::open(&path).unwrap();
+        assert_eq!(overlay.reconcile(&base).unwrap(), RecoveryState::Dirty);
+        overlay.conn.execute(
+            "UPDATE recovery_metadata SET pending_commit_id = ?1, state = 'save_pending' WHERE id = 1",
+            [pending.as_str()],
+        ).unwrap();
+        assert_eq!(overlay.reconcile(&pending).unwrap(), RecoveryState::Clean);
+        assert_eq!(overlay.base_commit_id().unwrap(), pending);
+    }
+
+    #[test]
+    fn committed_save_without_acknowledgement_reopens_clean() {
+        let temp = tempfile::tempdir().unwrap();
+        let document_path = temp.path().join("Dogfood.shift");
+        let recovery_path = temp.path().join("recovery.sqlite");
+        let layer_id = shift_font::LayerId::from_raw("A_regular");
+        drop(ShiftStore::create_document(&document_path, &sample_font()).unwrap());
+
+        let mut store =
+            ShiftStore::open_document_with_recovery(&document_path, &recovery_path).unwrap();
+        let mut layer = store.load_glyph_layer(&layer_id).unwrap().unwrap();
+        layer.set_width(777.0);
+        store.replace_glyph_layer(&layer).unwrap();
+        let commit_id = store.recovery.as_mut().unwrap().begin_save().unwrap();
+        crate::recovery::save::apply_recovery_to_document(&mut store.conn, &commit_id).unwrap();
+        drop(store);
+
+        let reopened =
+            ShiftStore::open_document_with_recovery(&document_path, &recovery_path).unwrap();
+        assert_eq!(
+            reopened.recovery_state().unwrap(),
+            Some(RecoveryState::Clean)
+        );
+        assert_eq!(
+            reopened
+                .load_glyph_layer(&layer_id)
+                .unwrap()
+                .unwrap()
+                .width(),
+            777.0
+        );
+    }
+}

--- a/crates/shift-store/src/recovery/patch.rs
+++ b/crates/shift-store/src/recovery/patch.rs
@@ -1,0 +1,303 @@
+use std::collections::HashSet;
+
+use rusqlite::{Transaction, params};
+use shift_font as font;
+
+use super::{RecoveryOverlay, RecoveryState};
+use crate::{
+    FontInfo, StoreError,
+    change_set::{
+        replace_axis_mappings, replace_metric_definitions, replace_named_instances,
+        upsert_axis_with_order, upsert_font_info, write_glyph_directory_in_tx,
+        write_source_snapshot_in_tx,
+    },
+    layer::write_layer_in_tx,
+    write_mode::WriteMode,
+};
+
+const GLOBAL_OWNER: &str = "";
+const AXIS: &str = "axis";
+const SOURCE: &str = "source";
+const GLYPH: &str = "glyph";
+const LAYER: &str = "layer";
+const AXIS_MAPPINGS: &str = "axis_mappings";
+const METRIC_DEFINITIONS: &str = "metric_definitions";
+const NAMED_INSTANCES: &str = "named_instances";
+const SOURCE_LOCATIONS: &str = "source_locations";
+const SOURCE_METRIC_VALUES: &str = "source_metric_values";
+const SOURCE_LIB: &str = "source_lib";
+const GLYPH_UNICODES: &str = "glyph_unicodes";
+const GLYPH_LIB: &str = "glyph_lib";
+const GLYPH_COMPONENTS: &str = "glyph_components";
+
+impl RecoveryOverlay {
+    pub(crate) fn apply_change_set(
+        &mut self,
+        change_set: &font::FontChangeSet,
+        post_font: &font::Font,
+        preserved_font_info: Option<&FontInfo>,
+    ) -> Result<(), StoreError> {
+        if change_set.is_empty() {
+            return Ok(());
+        }
+
+        let state = self.state()?;
+        if !matches!(state, RecoveryState::Clean | RecoveryState::Dirty) {
+            return Err(StoreError::InvalidRecoveryTransition {
+                expected: "clean or dirty",
+                found: state.as_str(),
+            });
+        }
+
+        let mut metadata_changed = false;
+        let mut mappings_changed = false;
+        let mut definitions_changed = false;
+        let mut instances_changed = false;
+        let mut axis_ids = HashSet::new();
+        let mut source_ids = HashSet::new();
+        let mut glyph_ids = HashSet::new();
+        let mut layer_ids = HashSet::new();
+
+        for change in &change_set.changes {
+            match change {
+                font::FontChange::FontMetadataUpdated(_) => metadata_changed = true,
+                font::FontChange::AxisCreated(change) => {
+                    axis_ids.insert(change.axis.id());
+                }
+                font::FontChange::AxisUpdated(change) => {
+                    axis_ids.insert(change.axis.id());
+                }
+                font::FontChange::AxisDeleted(change) => {
+                    axis_ids.insert(change.axis_id.clone());
+                }
+                font::FontChange::AxisMappingsUpdated(_) => mappings_changed = true,
+                font::FontChange::MetricDefinitionsUpdated(_) => definitions_changed = true,
+                font::FontChange::NamedInstancesUpdated(_) => instances_changed = true,
+                font::FontChange::SourceCreated(change) => {
+                    source_ids.insert(change.source_id.clone());
+                }
+                font::FontChange::SourceUpdated(change) => {
+                    source_ids.insert(change.source.id());
+                }
+                font::FontChange::SourceDeleted(change) => {
+                    source_ids.insert(change.source_id.clone());
+                }
+                font::FontChange::GlyphCreated(change) => {
+                    glyph_ids.insert(change.glyph_id.clone());
+                }
+                font::FontChange::GlyphDeleted(change) => {
+                    glyph_ids.insert(change.glyph_id.clone());
+                }
+                font::FontChange::GlyphIdentityChanged(change) => {
+                    glyph_ids.insert(change.glyph_id.clone());
+                }
+                _ => {
+                    if let Some(layer_id) = change.layer_id() {
+                        layer_ids.insert(layer_id.clone());
+                    }
+                }
+            }
+        }
+
+        let tx = self.conn.transaction()?;
+        if metadata_changed {
+            upsert_font_info(&tx, post_font)?;
+            if let Some(preserved) = preserved_font_info {
+                tx.execute(
+                    "UPDATE font_info SET sample_text = ?1, vendor_id = ?2 WHERE id = 1",
+                    params![
+                        preserved.sample_text.as_deref(),
+                        preserved.vendor_id.as_deref()
+                    ],
+                )?;
+            }
+        }
+        if mappings_changed {
+            replace_axis_mappings(&tx, post_font.axis_mappings())?;
+            mark_replaced(&tx, AXIS_MAPPINGS, GLOBAL_OWNER)?;
+        }
+        if definitions_changed {
+            replace_metric_definitions(&tx, post_font.metric_definitions())?;
+            mark_replaced(&tx, METRIC_DEFINITIONS, GLOBAL_OWNER)?;
+        }
+        if instances_changed {
+            replace_named_instances(&tx, post_font.named_instances())?;
+            mark_replaced(&tx, NAMED_INSTANCES, GLOBAL_OWNER)?;
+        }
+
+        for axis_id in axis_ids {
+            if let Some((order_index, axis)) = post_font
+                .axes()
+                .iter()
+                .enumerate()
+                .find(|(_, axis)| axis.id() == axis_id)
+            {
+                clear_tombstone(&tx, AXIS, axis_id.as_str())?;
+                upsert_axis_with_order(&tx, axis, order_index as i64)?;
+            } else {
+                delete_axis_override(&tx, &axis_id)?;
+                mark_tombstone(&tx, AXIS, axis_id.as_str())?;
+            }
+        }
+
+        for source_id in source_ids {
+            if let Some((order_index, source)) = post_font
+                .sources()
+                .iter()
+                .enumerate()
+                .find(|(_, source)| source.id() == source_id)
+            {
+                clear_tombstone(&tx, SOURCE, source_id.as_str())?;
+                write_source_snapshot_in_tx(&tx, source, order_index as i64)?;
+                mark_replaced(&tx, SOURCE_LOCATIONS, source_id.as_str())?;
+                mark_replaced(&tx, SOURCE_METRIC_VALUES, source_id.as_str())?;
+                mark_replaced(&tx, SOURCE_LIB, source_id.as_str())?;
+            } else {
+                delete_source_override(&tx, &source_id)?;
+                mark_tombstone(&tx, SOURCE, source_id.as_str())?;
+            }
+        }
+
+        for glyph_id in glyph_ids {
+            if let Some((order_index, glyph)) = post_font
+                .glyphs()
+                .enumerate()
+                .find(|(_, glyph)| glyph.id() == glyph_id)
+            {
+                clear_tombstone(&tx, GLYPH, glyph_id.as_str())?;
+                write_glyph_directory_in_tx(&tx, glyph, order_index as i64, WriteMode::Upsert)?;
+                mark_replaced(&tx, GLYPH_UNICODES, glyph_id.as_str())?;
+                mark_replaced(&tx, GLYPH_LIB, glyph_id.as_str())?;
+            } else {
+                delete_glyph_override(&tx, &glyph_id)?;
+                mark_tombstone(&tx, GLYPH, glyph_id.as_str())?;
+            }
+        }
+
+        for layer_id in layer_ids {
+            if let Some((glyph_id, layer)) = find_layer(post_font, &layer_id) {
+                clear_tombstone(&tx, LAYER, layer_id.as_str())?;
+                write_layer_in_tx(&tx, &glyph_id, layer)?;
+                mark_replaced(&tx, GLYPH_COMPONENTS, layer_id.as_str())?;
+            } else {
+                delete_layer_override(&tx, &layer_id)?;
+                mark_tombstone(&tx, LAYER, layer_id.as_str())?;
+            }
+        }
+
+        tx.execute(
+            "UPDATE recovery_metadata SET state = 'dirty', pending_commit_id = NULL WHERE id = 1",
+            [],
+        )?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub(crate) fn replace_layer(
+        &mut self,
+        glyph_id: &font::GlyphId,
+        layer: &font::GlyphLayer,
+    ) -> Result<(), StoreError> {
+        let state = self.state()?;
+        if !matches!(state, RecoveryState::Clean | RecoveryState::Dirty) {
+            return Err(StoreError::InvalidRecoveryTransition {
+                expected: "clean or dirty",
+                found: state.as_str(),
+            });
+        }
+
+        let tx = self.conn.transaction()?;
+        clear_tombstone(&tx, LAYER, layer.id().as_str())?;
+        write_layer_in_tx(&tx, glyph_id, layer)?;
+        mark_replaced(&tx, GLYPH_COMPONENTS, layer.id().as_str())?;
+        tx.execute(
+            "UPDATE recovery_metadata SET state = 'dirty', pending_commit_id = NULL WHERE id = 1",
+            [],
+        )?;
+        tx.commit()?;
+        Ok(())
+    }
+}
+
+fn mark_replaced(tx: &Transaction<'_>, collection: &str, owner_id: &str) -> Result<(), StoreError> {
+    tx.execute(
+        "INSERT OR IGNORE INTO recovery_replacements (collection, owner_id) VALUES (?1, ?2)",
+        params![collection, owner_id],
+    )?;
+    Ok(())
+}
+
+fn mark_tombstone(
+    tx: &Transaction<'_>,
+    entity_kind: &str,
+    entity_id: &str,
+) -> Result<(), StoreError> {
+    tx.execute(
+        "INSERT OR IGNORE INTO recovery_tombstones (entity_kind, entity_id) VALUES (?1, ?2)",
+        params![entity_kind, entity_id],
+    )?;
+    Ok(())
+}
+
+fn clear_tombstone(
+    tx: &Transaction<'_>,
+    entity_kind: &str,
+    entity_id: &str,
+) -> Result<(), StoreError> {
+    tx.execute(
+        "DELETE FROM recovery_tombstones WHERE entity_kind = ?1 AND entity_id = ?2",
+        params![entity_kind, entity_id],
+    )?;
+    Ok(())
+}
+
+fn delete_axis_override(tx: &Transaction<'_>, axis_id: &font::AxisId) -> Result<(), StoreError> {
+    tx.execute("DELETE FROM axes WHERE id = ?1", [axis_id.to_string()])?;
+    Ok(())
+}
+
+fn delete_source_override(
+    tx: &Transaction<'_>,
+    source_id: &font::SourceId,
+) -> Result<(), StoreError> {
+    let id = source_id.to_string();
+    tx.execute("DELETE FROM source_locations WHERE source_id = ?1", [&id])?;
+    tx.execute(
+        "DELETE FROM source_metric_values WHERE source_id = ?1",
+        [&id],
+    )?;
+    tx.execute("DELETE FROM source_lib WHERE source_id = ?1", [&id])?;
+    tx.execute("DELETE FROM sources WHERE id = ?1", [&id])?;
+    Ok(())
+}
+
+fn delete_glyph_override(tx: &Transaction<'_>, glyph_id: &font::GlyphId) -> Result<(), StoreError> {
+    let id = glyph_id.to_string();
+    tx.execute("DELETE FROM glyph_unicodes WHERE glyph_id = ?1", [&id])?;
+    tx.execute("DELETE FROM glyph_lib WHERE glyph_id = ?1", [&id])?;
+    tx.execute("DELETE FROM glyphs WHERE id = ?1", [&id])?;
+    Ok(())
+}
+
+fn delete_layer_override(tx: &Transaction<'_>, layer_id: &font::LayerId) -> Result<(), StoreError> {
+    let id = layer_id.to_string();
+    tx.execute("DELETE FROM glyph_components WHERE layer_id = ?1", [&id])?;
+    tx.execute(
+        "DELETE FROM glyph_layer_payloads WHERE layer_id = ?1",
+        [&id],
+    )?;
+    tx.execute("DELETE FROM glyph_layers WHERE id = ?1", [&id])?;
+    Ok(())
+}
+
+fn find_layer<'a>(
+    font: &'a font::Font,
+    layer_id: &font::LayerId,
+) -> Option<(font::GlyphId, &'a font::GlyphLayer)> {
+    font.glyphs().find_map(|glyph| {
+        glyph
+            .layers()
+            .get(layer_id)
+            .map(|layer| (glyph.id(), layer.as_ref()))
+    })
+}

--- a/crates/shift-store/src/recovery/patch.rs
+++ b/crates/shift-store/src/recovery/patch.rs
@@ -3,7 +3,14 @@ use std::collections::HashSet;
 use rusqlite::{Transaction, params};
 use shift_font as font;
 
-use super::{RecoveryOverlay, RecoveryState};
+use super::{
+    RecoveryOverlay, RecoveryState,
+    catalog::{
+        AXES, AXIS_MAPPINGS, GLYPH_COMPONENTS, GLYPH_LAYERS, GLYPH_LIB, GLYPH_UNICODES, GLYPHS,
+        METRIC_DEFINITIONS, NAMED_INSTANCES, RecoveryTable, SOURCE_LIB, SOURCE_LOCATIONS,
+        SOURCE_METRIC_VALUES, SOURCES,
+    },
+};
 use crate::{
     FontInfo, StoreError,
     change_set::{
@@ -16,19 +23,6 @@ use crate::{
 };
 
 const GLOBAL_OWNER: &str = "";
-const AXIS: &str = "axis";
-const SOURCE: &str = "source";
-const GLYPH: &str = "glyph";
-const LAYER: &str = "layer";
-const AXIS_MAPPINGS: &str = "axis_mappings";
-const METRIC_DEFINITIONS: &str = "metric_definitions";
-const NAMED_INSTANCES: &str = "named_instances";
-const SOURCE_LOCATIONS: &str = "source_locations";
-const SOURCE_METRIC_VALUES: &str = "source_metric_values";
-const SOURCE_LIB: &str = "source_lib";
-const GLYPH_UNICODES: &str = "glyph_unicodes";
-const GLYPH_LIB: &str = "glyph_lib";
-const GLYPH_COMPONENTS: &str = "glyph_components";
 
 impl RecoveryOverlay {
     pub(crate) fn apply_change_set(
@@ -132,11 +126,11 @@ impl RecoveryOverlay {
                 .enumerate()
                 .find(|(_, axis)| axis.id() == axis_id)
             {
-                clear_tombstone(&tx, AXIS, axis_id.as_str())?;
+                clear_tombstone(&tx, AXES, axis_id.as_str())?;
                 upsert_axis_with_order(&tx, axis, order_index as i64)?;
             } else {
                 delete_axis_override(&tx, &axis_id)?;
-                mark_tombstone(&tx, AXIS, axis_id.as_str())?;
+                mark_tombstone(&tx, AXES, axis_id.as_str())?;
             }
         }
 
@@ -147,14 +141,14 @@ impl RecoveryOverlay {
                 .enumerate()
                 .find(|(_, source)| source.id() == source_id)
             {
-                clear_tombstone(&tx, SOURCE, source_id.as_str())?;
+                clear_tombstone(&tx, SOURCES, source_id.as_str())?;
                 write_source_snapshot_in_tx(&tx, source, order_index as i64)?;
                 mark_replaced(&tx, SOURCE_LOCATIONS, source_id.as_str())?;
                 mark_replaced(&tx, SOURCE_METRIC_VALUES, source_id.as_str())?;
                 mark_replaced(&tx, SOURCE_LIB, source_id.as_str())?;
             } else {
                 delete_source_override(&tx, &source_id)?;
-                mark_tombstone(&tx, SOURCE, source_id.as_str())?;
+                mark_tombstone(&tx, SOURCES, source_id.as_str())?;
             }
         }
 
@@ -164,24 +158,24 @@ impl RecoveryOverlay {
                 .enumerate()
                 .find(|(_, glyph)| glyph.id() == glyph_id)
             {
-                clear_tombstone(&tx, GLYPH, glyph_id.as_str())?;
+                clear_tombstone(&tx, GLYPHS, glyph_id.as_str())?;
                 write_glyph_directory_in_tx(&tx, glyph, order_index as i64, WriteMode::Upsert)?;
                 mark_replaced(&tx, GLYPH_UNICODES, glyph_id.as_str())?;
                 mark_replaced(&tx, GLYPH_LIB, glyph_id.as_str())?;
             } else {
                 delete_glyph_override(&tx, &glyph_id)?;
-                mark_tombstone(&tx, GLYPH, glyph_id.as_str())?;
+                mark_tombstone(&tx, GLYPHS, glyph_id.as_str())?;
             }
         }
 
         for layer_id in layer_ids {
             if let Some((glyph_id, layer)) = find_layer(post_font, &layer_id) {
-                clear_tombstone(&tx, LAYER, layer_id.as_str())?;
+                clear_tombstone(&tx, GLYPH_LAYERS, layer_id.as_str())?;
                 write_layer_in_tx(&tx, &glyph_id, layer)?;
                 mark_replaced(&tx, GLYPH_COMPONENTS, layer_id.as_str())?;
             } else {
                 delete_layer_override(&tx, &layer_id)?;
-                mark_tombstone(&tx, LAYER, layer_id.as_str())?;
+                mark_tombstone(&tx, GLYPH_LAYERS, layer_id.as_str())?;
             }
         }
 
@@ -207,7 +201,7 @@ impl RecoveryOverlay {
         }
 
         let tx = self.conn.transaction()?;
-        clear_tombstone(&tx, LAYER, layer.id().as_str())?;
+        clear_tombstone(&tx, GLYPH_LAYERS, layer.id().as_str())?;
         write_layer_in_tx(&tx, glyph_id, layer)?;
         mark_replaced(&tx, GLYPH_COMPONENTS, layer.id().as_str())?;
         tx.execute(
@@ -219,34 +213,44 @@ impl RecoveryOverlay {
     }
 }
 
-fn mark_replaced(tx: &Transaction<'_>, collection: &str, owner_id: &str) -> Result<(), StoreError> {
+fn mark_replaced(
+    tx: &Transaction<'_>,
+    table: RecoveryTable,
+    owner_id: &str,
+) -> Result<(), StoreError> {
     tx.execute(
         "INSERT OR IGNORE INTO recovery_replacements (collection, owner_id) VALUES (?1, ?2)",
-        params![collection, owner_id],
+        params![table.name(), owner_id],
     )?;
     Ok(())
 }
 
 fn mark_tombstone(
     tx: &Transaction<'_>,
-    entity_kind: &str,
+    table: RecoveryTable,
     entity_id: &str,
 ) -> Result<(), StoreError> {
     tx.execute(
         "INSERT OR IGNORE INTO recovery_tombstones (entity_kind, entity_id) VALUES (?1, ?2)",
-        params![entity_kind, entity_id],
+        params![
+            table.tombstone_kind().expect("table supports tombstones"),
+            entity_id
+        ],
     )?;
     Ok(())
 }
 
 fn clear_tombstone(
     tx: &Transaction<'_>,
-    entity_kind: &str,
+    table: RecoveryTable,
     entity_id: &str,
 ) -> Result<(), StoreError> {
     tx.execute(
         "DELETE FROM recovery_tombstones WHERE entity_kind = ?1 AND entity_id = ?2",
-        params![entity_kind, entity_id],
+        params![
+            table.tombstone_kind().expect("table supports tombstones"),
+            entity_id
+        ],
     )?;
     Ok(())
 }

--- a/crates/shift-store/src/recovery/save.rs
+++ b/crates/shift-store/src/recovery/save.rs
@@ -1,0 +1,156 @@
+use rusqlite::Connection;
+
+use crate::{CommitId, StoreError};
+
+pub(super) fn apply_recovery_to_document(
+    conn: &mut Connection,
+    commit_id: &CommitId,
+) -> Result<(), StoreError> {
+    let tx = conn.transaction()?;
+    tx.execute_batch(APPLY_RECOVERY_SQL)?;
+    tx.execute(
+        "UPDATE main.document_metadata SET saved_commit_id = ?1 WHERE id = 1",
+        [commit_id.as_str()],
+    )?;
+    tx.commit()?;
+    Ok(())
+}
+
+const APPLY_RECOVERY_SQL: &str = r#"
+DELETE FROM main.glyph_layers
+WHERE id IN (SELECT entity_id FROM recovery.recovery_tombstones WHERE entity_kind = 'layer');
+DELETE FROM main.glyphs
+WHERE id IN (SELECT entity_id FROM recovery.recovery_tombstones WHERE entity_kind = 'glyph');
+DELETE FROM main.sources
+WHERE id IN (SELECT entity_id FROM recovery.recovery_tombstones WHERE entity_kind = 'source');
+DELETE FROM main.axes
+WHERE id IN (SELECT entity_id FROM recovery.recovery_tombstones WHERE entity_kind = 'axis');
+
+UPDATE main.font_info
+SET family_name = r.family_name,
+    style_name = r.style_name,
+    copyright = r.copyright,
+    trademark = r.trademark,
+    description = r.description,
+    note = r.note,
+    sample_text = r.sample_text,
+    designer = r.designer,
+    designer_url = r.designer_url,
+    manufacturer = r.manufacturer,
+    manufacturer_url = r.manufacturer_url,
+    license_description = r.license_description,
+    license_info_url = r.license_info_url,
+    vendor_id = r.vendor_id,
+    version_major = r.version_major,
+    version_minor = r.version_minor,
+    units_per_em = r.units_per_em,
+    default_source_id = r.default_source_id
+FROM recovery.font_info r
+WHERE main.font_info.id = r.id;
+INSERT INTO main.font_info SELECT * FROM recovery.font_info r
+WHERE NOT EXISTS (SELECT 1 FROM main.font_info m WHERE m.id = r.id);
+
+UPDATE main.axes
+SET tag = r.tag, name = r.name, min_value = r.min_value,
+    default_value = r.default_value, max_value = r.max_value, role = r.role,
+    discrete_values_json = r.discrete_values_json, labels_json = r.labels_json,
+    hidden = r.hidden, order_index = r.order_index
+FROM recovery.axes r WHERE main.axes.id = r.id;
+INSERT INTO main.axes SELECT * FROM recovery.axes r
+WHERE NOT EXISTS (SELECT 1 FROM main.axes m WHERE m.id = r.id);
+
+DELETE FROM main.axis_mappings
+WHERE EXISTS (SELECT 1 FROM recovery.recovery_replacements WHERE collection = 'axis_mappings' AND owner_id = '');
+INSERT INTO main.axis_mappings SELECT * FROM recovery.axis_mappings
+WHERE EXISTS (SELECT 1 FROM recovery.recovery_replacements WHERE collection = 'axis_mappings' AND owner_id = '');
+
+UPDATE main.metric_definitions
+SET kind = r.kind, name = r.name, order_index = r.order_index
+FROM recovery.metric_definitions r WHERE main.metric_definitions.id = r.id;
+INSERT INTO main.metric_definitions SELECT * FROM recovery.metric_definitions r
+WHERE NOT EXISTS (SELECT 1 FROM main.metric_definitions m WHERE m.id = r.id);
+DELETE FROM main.source_metric_values
+WHERE metric_id NOT IN (SELECT id FROM recovery.metric_definitions)
+  AND EXISTS (SELECT 1 FROM recovery.recovery_replacements WHERE collection = 'metric_definitions' AND owner_id = '');
+DELETE FROM main.metric_definitions
+WHERE id NOT IN (SELECT id FROM recovery.metric_definitions)
+  AND EXISTS (SELECT 1 FROM recovery.recovery_replacements WHERE collection = 'metric_definitions' AND owner_id = '');
+
+DELETE FROM main.named_instances
+WHERE EXISTS (SELECT 1 FROM recovery.recovery_replacements WHERE collection = 'named_instances' AND owner_id = '');
+INSERT INTO main.named_instances SELECT * FROM recovery.named_instances
+WHERE EXISTS (SELECT 1 FROM recovery.recovery_replacements WHERE collection = 'named_instances' AND owner_id = '');
+
+UPDATE main.sources
+SET name = r.name,
+    family_name = COALESCE(r.family_name, main.sources.family_name),
+    style_name = COALESCE(r.style_name, main.sources.style_name),
+    filename = r.filename, color = r.color, layer_name = r.layer_name,
+    italic_angle = r.italic_angle, line_gap = r.line_gap,
+    underline_position = r.underline_position,
+    underline_thickness = r.underline_thickness, kind = r.kind,
+    order_index = r.order_index
+FROM recovery.sources r WHERE main.sources.id = r.id;
+INSERT INTO main.sources SELECT * FROM recovery.sources r
+WHERE NOT EXISTS (SELECT 1 FROM main.sources m WHERE m.id = r.id);
+
+DELETE FROM main.source_locations
+WHERE source_id IN (SELECT owner_id FROM recovery.recovery_replacements WHERE collection = 'source_locations');
+INSERT INTO main.source_locations
+SELECT v.* FROM temp.source_locations v
+WHERE v.source_id IN (
+    SELECT owner_id FROM recovery.recovery_replacements WHERE collection = 'source_locations'
+);
+DELETE FROM main.source_metric_values
+WHERE source_id IN (SELECT owner_id FROM recovery.recovery_replacements WHERE collection = 'source_metric_values');
+INSERT INTO main.source_metric_values
+SELECT v.* FROM temp.source_metric_values v
+WHERE v.source_id IN (
+    SELECT owner_id FROM recovery.recovery_replacements WHERE collection = 'source_metric_values'
+);
+DELETE FROM main.source_lib
+WHERE source_id IN (SELECT owner_id FROM recovery.recovery_replacements WHERE collection = 'source_lib');
+INSERT INTO main.source_lib
+SELECT v.* FROM temp.source_lib v
+WHERE v.source_id IN (
+    SELECT owner_id FROM recovery.recovery_replacements WHERE collection = 'source_lib'
+);
+
+UPDATE main.glyphs
+SET name = r.name, order_index = r.order_index
+FROM recovery.glyphs r WHERE main.glyphs.id = r.id;
+INSERT INTO main.glyphs SELECT * FROM recovery.glyphs r
+WHERE NOT EXISTS (SELECT 1 FROM main.glyphs m WHERE m.id = r.id);
+DELETE FROM main.glyph_unicodes
+WHERE glyph_id IN (SELECT owner_id FROM recovery.recovery_replacements WHERE collection = 'glyph_unicodes');
+INSERT INTO main.glyph_unicodes
+SELECT v.* FROM temp.glyph_unicodes v
+WHERE v.glyph_id IN (
+    SELECT owner_id FROM recovery.recovery_replacements WHERE collection = 'glyph_unicodes'
+);
+DELETE FROM main.glyph_lib
+WHERE glyph_id IN (SELECT owner_id FROM recovery.recovery_replacements WHERE collection = 'glyph_lib');
+INSERT INTO main.glyph_lib
+SELECT v.* FROM temp.glyph_lib v
+WHERE v.glyph_id IN (
+    SELECT owner_id FROM recovery.recovery_replacements WHERE collection = 'glyph_lib'
+);
+
+UPDATE main.glyph_layers
+SET glyph_id = r.glyph_id, source_id = r.source_id, width = r.width, height = r.height
+FROM recovery.glyph_layers r WHERE main.glyph_layers.id = r.id;
+INSERT INTO main.glyph_layers
+SELECT v.* FROM temp.glyph_layers v
+WHERE EXISTS (SELECT 1 FROM recovery.glyph_layers r WHERE r.id = v.id)
+  AND NOT EXISTS (SELECT 1 FROM main.glyph_layers m WHERE m.id = v.id);
+INSERT OR REPLACE INTO main.glyph_layer_payloads
+SELECT v.* FROM temp.glyph_layer_payloads v
+WHERE EXISTS (SELECT 1 FROM recovery.glyph_layer_payloads r WHERE r.layer_id = v.layer_id);
+DELETE FROM main.glyph_components
+WHERE layer_id IN (SELECT owner_id FROM recovery.recovery_replacements WHERE collection = 'glyph_components');
+INSERT INTO main.glyph_components
+SELECT v.* FROM temp.glyph_components v
+WHERE v.layer_id IN (
+    SELECT owner_id FROM recovery.recovery_replacements WHERE collection = 'glyph_components'
+);
+"#;

--- a/crates/shift-store/src/recovery/save.rs
+++ b/crates/shift-store/src/recovery/save.rs
@@ -1,5 +1,11 @@
-use rusqlite::Connection;
+use std::collections::HashSet;
 
+use rusqlite::{Connection, Transaction};
+
+use super::catalog::{
+    RecoveryMode, RecoveryTableShape, identifier, load_recovery_table_shapes, matching_columns,
+    string_literal,
+};
 use crate::{CommitId, StoreError};
 
 pub(super) fn apply_recovery_to_document(
@@ -7,7 +13,7 @@ pub(super) fn apply_recovery_to_document(
     commit_id: &CommitId,
 ) -> Result<(), StoreError> {
     let tx = conn.transaction()?;
-    tx.execute_batch(APPLY_RECOVERY_SQL)?;
+    apply_recovery(&tx)?;
     tx.execute(
         "UPDATE main.document_metadata SET saved_commit_id = ?1 WHERE id = 1",
         [commit_id.as_str()],
@@ -16,141 +22,167 @@ pub(super) fn apply_recovery_to_document(
     Ok(())
 }
 
-const APPLY_RECOVERY_SQL: &str = r#"
-DELETE FROM main.glyph_layers
-WHERE id IN (SELECT entity_id FROM recovery.recovery_tombstones WHERE entity_kind = 'layer');
-DELETE FROM main.glyphs
-WHERE id IN (SELECT entity_id FROM recovery.recovery_tombstones WHERE entity_kind = 'glyph');
-DELETE FROM main.sources
-WHERE id IN (SELECT entity_id FROM recovery.recovery_tombstones WHERE entity_kind = 'source');
-DELETE FROM main.axes
-WHERE id IN (SELECT entity_id FROM recovery.recovery_tombstones WHERE entity_kind = 'axis');
+fn apply_recovery(tx: &Transaction<'_>) -> Result<(), StoreError> {
+    let tables = load_recovery_table_shapes(tx)?;
 
-UPDATE main.font_info
-SET family_name = r.family_name,
-    style_name = r.style_name,
-    copyright = r.copyright,
-    trademark = r.trademark,
-    description = r.description,
-    note = r.note,
-    sample_text = r.sample_text,
-    designer = r.designer,
-    designer_url = r.designer_url,
-    manufacturer = r.manufacturer,
-    manufacturer_url = r.manufacturer_url,
-    license_description = r.license_description,
-    license_info_url = r.license_info_url,
-    vendor_id = r.vendor_id,
-    version_major = r.version_major,
-    version_minor = r.version_minor,
-    units_per_em = r.units_per_em,
-    default_source_id = r.default_source_id
-FROM recovery.font_info r
-WHERE main.font_info.id = r.id;
-INSERT INTO main.font_info SELECT * FROM recovery.font_info r
-WHERE NOT EXISTS (SELECT 1 FROM main.font_info m WHERE m.id = r.id);
+    for table in tables.iter().rev() {
+        delete_replaced_rows(tx, table, table.table.preserve_matching_rows())?;
+    }
 
-UPDATE main.axes
-SET tag = r.tag, name = r.name, min_value = r.min_value,
-    default_value = r.default_value, max_value = r.max_value, role = r.role,
-    discrete_values_json = r.discrete_values_json, labels_json = r.labels_json,
-    hidden = r.hidden, order_index = r.order_index
-FROM recovery.axes r WHERE main.axes.id = r.id;
-INSERT INTO main.axes SELECT * FROM recovery.axes r
-WHERE NOT EXISTS (SELECT 1 FROM main.axes m WHERE m.id = r.id);
+    for table in &tables {
+        upsert_recovery_rows(tx, table, table.table.preserve_matching_rows())?;
+    }
 
-DELETE FROM main.axis_mappings
-WHERE EXISTS (SELECT 1 FROM recovery.recovery_replacements WHERE collection = 'axis_mappings' AND owner_id = '');
-INSERT INTO main.axis_mappings SELECT * FROM recovery.axis_mappings
-WHERE EXISTS (SELECT 1 FROM recovery.recovery_replacements WHERE collection = 'axis_mappings' AND owner_id = '');
+    Ok(())
+}
 
-UPDATE main.metric_definitions
-SET kind = r.kind, name = r.name, order_index = r.order_index
-FROM recovery.metric_definitions r WHERE main.metric_definitions.id = r.id;
-INSERT INTO main.metric_definitions SELECT * FROM recovery.metric_definitions r
-WHERE NOT EXISTS (SELECT 1 FROM main.metric_definitions m WHERE m.id = r.id);
-DELETE FROM main.source_metric_values
-WHERE metric_id NOT IN (SELECT id FROM recovery.metric_definitions)
-  AND EXISTS (SELECT 1 FROM recovery.recovery_replacements WHERE collection = 'metric_definitions' AND owner_id = '');
-DELETE FROM main.metric_definitions
-WHERE id NOT IN (SELECT id FROM recovery.metric_definitions)
-  AND EXISTS (SELECT 1 FROM recovery.recovery_replacements WHERE collection = 'metric_definitions' AND owner_id = '');
+fn delete_replaced_rows(
+    tx: &Transaction<'_>,
+    table: &RecoveryTableShape,
+    preserve_matching_rows: bool,
+) -> Result<(), StoreError> {
+    let name = identifier(table.table.name());
+    let absent_from_final = if preserve_matching_rows {
+        format!(
+            " AND NOT EXISTS (
+                 SELECT 1 FROM temp.{name} AS v WHERE {}
+             )",
+            matching_columns("v", "m", &table.primary_key)
+        )
+    } else {
+        String::new()
+    };
+    let sql = match table.table.mode() {
+        RecoveryMode::OverlayRows {
+            tombstone_kind: Some(kind),
+            ..
+        } => format!(
+            "DELETE FROM main.{name} AS m
+             WHERE EXISTS (
+                 SELECT 1 FROM recovery.recovery_tombstones AS t
+                 WHERE t.entity_kind = {}
+                   AND t.entity_id = m.{}
+             )",
+            string_literal(kind),
+            identifier(&table.primary_key[0])
+        ),
+        RecoveryMode::ReplaceCollection {
+            owner_column: None, ..
+        } => format!(
+            "DELETE FROM main.{name} AS m
+             WHERE EXISTS (
+                 SELECT 1 FROM recovery.recovery_replacements AS x
+                 WHERE x.collection = {} AND x.owner_id = ''
+             ){absent_from_final}",
+            string_literal(table.table.name())
+        ),
+        RecoveryMode::ReplaceCollection {
+            owner_column: Some(owner_column),
+            ..
+        } => format!(
+            "DELETE FROM main.{name} AS m
+             WHERE EXISTS (
+                 SELECT 1 FROM recovery.recovery_replacements AS x
+                 WHERE x.collection = {}
+                   AND x.owner_id = m.{}
+             ){absent_from_final}",
+            string_literal(table.table.name()),
+            identifier(owner_column)
+        ),
+        RecoveryMode::OverlayRows {
+            tombstone_kind: None,
+            ..
+        }
+        | RecoveryMode::CanonicalOnly => return Ok(()),
+    };
+    tx.execute(&sql, [])?;
+    Ok(())
+}
 
-DELETE FROM main.named_instances
-WHERE EXISTS (SELECT 1 FROM recovery.recovery_replacements WHERE collection = 'named_instances' AND owner_id = '');
-INSERT INTO main.named_instances SELECT * FROM recovery.named_instances
-WHERE EXISTS (SELECT 1 FROM recovery.recovery_replacements WHERE collection = 'named_instances' AND owner_id = '');
+fn upsert_recovery_rows(
+    tx: &Transaction<'_>,
+    table: &RecoveryTableShape,
+    preserve_matching_rows: bool,
+) -> Result<(), StoreError> {
+    let scope = match table.table.mode() {
+        RecoveryMode::OverlayRows { .. } => format!(
+            "EXISTS (
+                SELECT 1 FROM recovery.{} AS r WHERE {}
+            )",
+            identifier(table.table.name()),
+            matching_columns("r", "v", &table.primary_key)
+        ),
+        RecoveryMode::ReplaceCollection {
+            owner_column: None, ..
+        } => format!(
+            "EXISTS (
+                SELECT 1 FROM recovery.recovery_replacements AS x
+                WHERE x.collection = {} AND x.owner_id = ''
+            )",
+            string_literal(table.table.name())
+        ),
+        RecoveryMode::ReplaceCollection {
+            owner_column: Some(owner_column),
+            ..
+        } => format!(
+            "EXISTS (
+                SELECT 1 FROM recovery.recovery_replacements AS x
+                WHERE x.collection = {}
+                  AND x.owner_id = v.{}
+            )",
+            string_literal(table.table.name()),
+            identifier(owner_column)
+        ),
+        RecoveryMode::CanonicalOnly => return Ok(()),
+    };
 
-UPDATE main.sources
-SET name = r.name,
-    family_name = COALESCE(r.family_name, main.sources.family_name),
-    style_name = COALESCE(r.style_name, main.sources.style_name),
-    filename = r.filename, color = r.color, layer_name = r.layer_name,
-    italic_angle = r.italic_angle, line_gap = r.line_gap,
-    underline_position = r.underline_position,
-    underline_thickness = r.underline_thickness, kind = r.kind,
-    order_index = r.order_index
-FROM recovery.sources r WHERE main.sources.id = r.id;
-INSERT INTO main.sources SELECT * FROM recovery.sources r
-WHERE NOT EXISTS (SELECT 1 FROM main.sources m WHERE m.id = r.id);
-
-DELETE FROM main.source_locations
-WHERE source_id IN (SELECT owner_id FROM recovery.recovery_replacements WHERE collection = 'source_locations');
-INSERT INTO main.source_locations
-SELECT v.* FROM temp.source_locations v
-WHERE v.source_id IN (
-    SELECT owner_id FROM recovery.recovery_replacements WHERE collection = 'source_locations'
-);
-DELETE FROM main.source_metric_values
-WHERE source_id IN (SELECT owner_id FROM recovery.recovery_replacements WHERE collection = 'source_metric_values');
-INSERT INTO main.source_metric_values
-SELECT v.* FROM temp.source_metric_values v
-WHERE v.source_id IN (
-    SELECT owner_id FROM recovery.recovery_replacements WHERE collection = 'source_metric_values'
-);
-DELETE FROM main.source_lib
-WHERE source_id IN (SELECT owner_id FROM recovery.recovery_replacements WHERE collection = 'source_lib');
-INSERT INTO main.source_lib
-SELECT v.* FROM temp.source_lib v
-WHERE v.source_id IN (
-    SELECT owner_id FROM recovery.recovery_replacements WHERE collection = 'source_lib'
-);
-
-UPDATE main.glyphs
-SET name = r.name, order_index = r.order_index
-FROM recovery.glyphs r WHERE main.glyphs.id = r.id;
-INSERT INTO main.glyphs SELECT * FROM recovery.glyphs r
-WHERE NOT EXISTS (SELECT 1 FROM main.glyphs m WHERE m.id = r.id);
-DELETE FROM main.glyph_unicodes
-WHERE glyph_id IN (SELECT owner_id FROM recovery.recovery_replacements WHERE collection = 'glyph_unicodes');
-INSERT INTO main.glyph_unicodes
-SELECT v.* FROM temp.glyph_unicodes v
-WHERE v.glyph_id IN (
-    SELECT owner_id FROM recovery.recovery_replacements WHERE collection = 'glyph_unicodes'
-);
-DELETE FROM main.glyph_lib
-WHERE glyph_id IN (SELECT owner_id FROM recovery.recovery_replacements WHERE collection = 'glyph_lib');
-INSERT INTO main.glyph_lib
-SELECT v.* FROM temp.glyph_lib v
-WHERE v.glyph_id IN (
-    SELECT owner_id FROM recovery.recovery_replacements WHERE collection = 'glyph_lib'
-);
-
-UPDATE main.glyph_layers
-SET glyph_id = r.glyph_id, source_id = r.source_id, width = r.width, height = r.height
-FROM recovery.glyph_layers r WHERE main.glyph_layers.id = r.id;
-INSERT INTO main.glyph_layers
-SELECT v.* FROM temp.glyph_layers v
-WHERE EXISTS (SELECT 1 FROM recovery.glyph_layers r WHERE r.id = v.id)
-  AND NOT EXISTS (SELECT 1 FROM main.glyph_layers m WHERE m.id = v.id);
-INSERT OR REPLACE INTO main.glyph_layer_payloads
-SELECT v.* FROM temp.glyph_layer_payloads v
-WHERE EXISTS (SELECT 1 FROM recovery.glyph_layer_payloads r WHERE r.layer_id = v.layer_id);
-DELETE FROM main.glyph_components
-WHERE layer_id IN (SELECT owner_id FROM recovery.recovery_replacements WHERE collection = 'glyph_components');
-INSERT INTO main.glyph_components
-SELECT v.* FROM temp.glyph_components v
-WHERE v.layer_id IN (
-    SELECT owner_id FROM recovery.recovery_replacements WHERE collection = 'glyph_components'
-);
-"#;
+    let name = identifier(table.table.name());
+    let columns = table
+        .columns
+        .iter()
+        .map(|column| identifier(column))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let selected_columns = table
+        .columns
+        .iter()
+        .map(|column| format!("v.{}", identifier(column)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let conflict_columns = table
+        .primary_key
+        .iter()
+        .map(|column| identifier(column))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let primary_key = table.primary_key.iter().collect::<HashSet<_>>();
+    let updates = table
+        .columns
+        .iter()
+        .filter(|column| !primary_key.contains(column))
+        .map(|column| {
+            let column = identifier(column);
+            format!("{column} = excluded.{column}")
+        })
+        .collect::<Vec<_>>();
+    let conflict = if matches!(table.table.mode(), RecoveryMode::ReplaceCollection { .. })
+        && !preserve_matching_rows
+    {
+        String::new()
+    } else if updates.is_empty() {
+        format!("ON CONFLICT ({conflict_columns}) DO NOTHING")
+    } else {
+        format!(
+            "ON CONFLICT ({conflict_columns}) DO UPDATE SET {}",
+            updates.join(", ")
+        )
+    };
+    let sql = format!(
+        "INSERT INTO main.{name} ({columns})
+         SELECT {selected_columns} FROM temp.{name} AS v
+         WHERE {scope}
+         {conflict}"
+    );
+    tx.execute(&sql, [])?;
+    Ok(())
+}

--- a/crates/shift-store/src/recovery/views.rs
+++ b/crates/shift-store/src/recovery/views.rs
@@ -1,0 +1,146 @@
+use std::path::Path;
+
+use rusqlite::Connection;
+
+use crate::StoreError;
+
+pub(super) fn attach_recovery(conn: &Connection, path: &Path) -> Result<(), StoreError> {
+    let path = path
+        .to_str()
+        .ok_or_else(|| StoreError::InvalidDocument("recovery path is not valid UTF-8".into()))?;
+    conn.execute("ATTACH DATABASE ?1 AS recovery", [path])?;
+    Ok(())
+}
+
+pub(super) fn install_merged_views(conn: &Connection) -> Result<(), StoreError> {
+    conn.execute_batch(MERGED_VIEWS_SQL)?;
+    Ok(())
+}
+
+const MERGED_VIEWS_SQL: &str = r#"
+CREATE TEMP VIEW font_info AS
+SELECT * FROM recovery.font_info
+UNION ALL SELECT * FROM main.font_info WHERE NOT EXISTS (SELECT 1 FROM recovery.font_info);
+
+CREATE TEMP VIEW axes AS
+SELECT r.* FROM recovery.axes r
+WHERE NOT EXISTS (SELECT 1 FROM recovery.recovery_tombstones t WHERE t.entity_kind = 'axis' AND t.entity_id = r.id)
+UNION ALL
+SELECT m.* FROM main.axes m
+WHERE NOT EXISTS (SELECT 1 FROM recovery.axes r WHERE r.id = m.id)
+  AND NOT EXISTS (SELECT 1 FROM recovery.recovery_tombstones t WHERE t.entity_kind = 'axis' AND t.entity_id = m.id);
+
+CREATE TEMP VIEW axis_mappings AS
+SELECT * FROM recovery.axis_mappings
+UNION ALL SELECT * FROM main.axis_mappings
+WHERE NOT EXISTS (SELECT 1 FROM recovery.recovery_replacements WHERE collection = 'axis_mappings' AND owner_id = '');
+
+CREATE TEMP VIEW metric_definitions AS
+SELECT * FROM recovery.metric_definitions
+UNION ALL SELECT * FROM main.metric_definitions
+WHERE NOT EXISTS (SELECT 1 FROM recovery.recovery_replacements WHERE collection = 'metric_definitions' AND owner_id = '');
+
+CREATE TEMP VIEW named_instances AS
+SELECT * FROM recovery.named_instances
+UNION ALL SELECT * FROM main.named_instances
+WHERE NOT EXISTS (SELECT 1 FROM recovery.recovery_replacements WHERE collection = 'named_instances' AND owner_id = '');
+
+CREATE TEMP VIEW sources AS
+SELECT r.id, r.name,
+       COALESCE(r.family_name, m.family_name) AS family_name,
+       COALESCE(r.style_name, m.style_name) AS style_name,
+       r.filename, r.color, r.layer_name, r.italic_angle, r.line_gap,
+       r.underline_position, r.underline_thickness, r.kind, r.order_index
+FROM recovery.sources r
+LEFT JOIN main.sources m ON m.id = r.id
+WHERE NOT EXISTS (SELECT 1 FROM recovery.recovery_tombstones t WHERE t.entity_kind = 'source' AND t.entity_id = r.id)
+UNION ALL
+SELECT m.* FROM main.sources m
+WHERE NOT EXISTS (SELECT 1 FROM recovery.sources r WHERE r.id = m.id)
+  AND NOT EXISTS (SELECT 1 FROM recovery.recovery_tombstones t WHERE t.entity_kind = 'source' AND t.entity_id = m.id);
+
+CREATE TEMP VIEW source_locations AS
+SELECT r.* FROM recovery.source_locations r
+WHERE EXISTS (SELECT 1 FROM sources s WHERE s.id = r.source_id)
+  AND EXISTS (SELECT 1 FROM axes a WHERE a.id = r.axis_id)
+UNION ALL
+SELECT m.* FROM main.source_locations m
+WHERE NOT EXISTS (SELECT 1 FROM recovery.recovery_replacements x WHERE x.collection = 'source_locations' AND x.owner_id = m.source_id)
+  AND EXISTS (SELECT 1 FROM sources s WHERE s.id = m.source_id)
+  AND EXISTS (SELECT 1 FROM axes a WHERE a.id = m.axis_id);
+
+CREATE TEMP VIEW source_metric_values AS
+SELECT r.* FROM recovery.source_metric_values r
+WHERE EXISTS (SELECT 1 FROM sources s WHERE s.id = r.source_id)
+  AND EXISTS (SELECT 1 FROM metric_definitions d WHERE d.id = r.metric_id)
+UNION ALL
+SELECT m.* FROM main.source_metric_values m
+WHERE NOT EXISTS (SELECT 1 FROM recovery.recovery_replacements x WHERE x.collection = 'source_metric_values' AND x.owner_id = m.source_id)
+  AND EXISTS (SELECT 1 FROM sources s WHERE s.id = m.source_id)
+  AND EXISTS (SELECT 1 FROM metric_definitions d WHERE d.id = m.metric_id);
+
+CREATE TEMP VIEW source_lib AS
+SELECT r.* FROM recovery.source_lib r WHERE EXISTS (SELECT 1 FROM sources s WHERE s.id = r.source_id)
+UNION ALL
+SELECT m.* FROM main.source_lib m
+WHERE NOT EXISTS (SELECT 1 FROM recovery.recovery_replacements x WHERE x.collection = 'source_lib' AND x.owner_id = m.source_id)
+  AND EXISTS (SELECT 1 FROM sources s WHERE s.id = m.source_id);
+
+CREATE TEMP VIEW glyphs AS
+SELECT r.* FROM recovery.glyphs r
+WHERE NOT EXISTS (SELECT 1 FROM recovery.recovery_tombstones t WHERE t.entity_kind = 'glyph' AND t.entity_id = r.id)
+UNION ALL
+SELECT m.* FROM main.glyphs m
+WHERE NOT EXISTS (SELECT 1 FROM recovery.glyphs r WHERE r.id = m.id)
+  AND NOT EXISTS (SELECT 1 FROM recovery.recovery_tombstones t WHERE t.entity_kind = 'glyph' AND t.entity_id = m.id);
+
+CREATE TEMP VIEW glyph_unicodes AS
+SELECT r.* FROM recovery.glyph_unicodes r WHERE EXISTS (SELECT 1 FROM glyphs g WHERE g.id = r.glyph_id)
+UNION ALL
+SELECT m.* FROM main.glyph_unicodes m
+WHERE NOT EXISTS (SELECT 1 FROM recovery.recovery_replacements x WHERE x.collection = 'glyph_unicodes' AND x.owner_id = m.glyph_id)
+  AND EXISTS (SELECT 1 FROM glyphs g WHERE g.id = m.glyph_id);
+
+CREATE TEMP VIEW glyph_lib AS
+SELECT r.* FROM recovery.glyph_lib r WHERE EXISTS (SELECT 1 FROM glyphs g WHERE g.id = r.glyph_id)
+UNION ALL
+SELECT m.* FROM main.glyph_lib m
+WHERE NOT EXISTS (SELECT 1 FROM recovery.recovery_replacements x WHERE x.collection = 'glyph_lib' AND x.owner_id = m.glyph_id)
+  AND EXISTS (SELECT 1 FROM glyphs g WHERE g.id = m.glyph_id);
+
+CREATE TEMP VIEW glyph_layers AS
+SELECT r.* FROM recovery.glyph_layers r
+WHERE NOT EXISTS (SELECT 1 FROM recovery.recovery_tombstones t WHERE t.entity_kind = 'layer' AND t.entity_id = r.id)
+  AND EXISTS (SELECT 1 FROM glyphs g WHERE g.id = r.glyph_id)
+  AND EXISTS (SELECT 1 FROM sources s WHERE s.id = r.source_id)
+UNION ALL
+SELECT m.* FROM main.glyph_layers m
+WHERE NOT EXISTS (SELECT 1 FROM recovery.glyph_layers r WHERE r.id = m.id)
+  AND NOT EXISTS (SELECT 1 FROM recovery.recovery_tombstones t WHERE t.entity_kind = 'layer' AND t.entity_id = m.id)
+  AND EXISTS (SELECT 1 FROM glyphs g WHERE g.id = m.glyph_id)
+  AND EXISTS (SELECT 1 FROM sources s WHERE s.id = m.source_id);
+
+CREATE TEMP VIEW glyph_layer_payloads AS
+SELECT r.* FROM recovery.glyph_layer_payloads r WHERE EXISTS (SELECT 1 FROM glyph_layers l WHERE l.id = r.layer_id)
+UNION ALL
+SELECT m.* FROM main.glyph_layer_payloads m
+WHERE NOT EXISTS (SELECT 1 FROM recovery.glyph_layer_payloads r WHERE r.layer_id = m.layer_id)
+  AND EXISTS (SELECT 1 FROM glyph_layers l WHERE l.id = m.layer_id);
+
+CREATE TEMP VIEW glyph_components AS
+SELECT r.* FROM recovery.glyph_components r WHERE EXISTS (SELECT 1 FROM glyph_layers l WHERE l.id = r.layer_id)
+UNION ALL
+SELECT m.* FROM main.glyph_components m
+WHERE NOT EXISTS (SELECT 1 FROM recovery.recovery_replacements x WHERE x.collection = 'glyph_components' AND x.owner_id = m.layer_id)
+  AND EXISTS (SELECT 1 FROM glyph_layers l WHERE l.id = m.layer_id);
+
+CREATE TEMP VIEW feature_text AS SELECT * FROM main.feature_text;
+CREATE TEMP VIEW font_guidelines AS SELECT * FROM main.font_guidelines;
+CREATE TEMP VIEW kerning_groups AS SELECT * FROM main.kerning_groups;
+CREATE TEMP VIEW kerning_group_members AS SELECT * FROM main.kerning_group_members;
+CREATE TEMP VIEW kerning_pairs AS SELECT * FROM main.kerning_pairs;
+CREATE TEMP VIEW font_lib AS SELECT * FROM main.font_lib;
+CREATE TEMP VIEW fontinfo_remainder AS SELECT * FROM main.fontinfo_remainder;
+CREATE TEMP VIEW font_binaries AS SELECT * FROM main.font_binaries;
+CREATE TEMP VIEW document_metadata AS SELECT * FROM main.document_metadata;
+"#;

--- a/crates/shift-store/src/recovery/views.rs
+++ b/crates/shift-store/src/recovery/views.rs
@@ -2,6 +2,10 @@ use std::path::Path;
 
 use rusqlite::Connection;
 
+use super::catalog::{
+    RecoveryMode, RecoveryTableShape, identifier, load_recovery_table_shapes, matching_columns,
+    string_literal,
+};
 use crate::StoreError;
 
 pub(super) fn attach_recovery(conn: &Connection, path: &Path) -> Result<(), StoreError> {
@@ -13,134 +17,167 @@ pub(super) fn attach_recovery(conn: &Connection, path: &Path) -> Result<(), Stor
 }
 
 pub(super) fn install_merged_views(conn: &Connection) -> Result<(), StoreError> {
-    conn.execute_batch(MERGED_VIEWS_SQL)?;
+    let tables = load_recovery_table_shapes(conn)?;
+    for table in &tables {
+        conn.execute_batch(&merged_view_sql(table))?;
+    }
     Ok(())
 }
 
-const MERGED_VIEWS_SQL: &str = r#"
-CREATE TEMP VIEW font_info AS
-SELECT * FROM recovery.font_info
-UNION ALL SELECT * FROM main.font_info WHERE NOT EXISTS (SELECT 1 FROM recovery.font_info);
+fn merged_view_sql(table: &RecoveryTableShape) -> String {
+    let name = identifier(table.table.name());
+    let main_projection = projection(&table.columns, "m", None, &[]);
+    let main_parent_visibility = parent_visibility(table, "m");
 
-CREATE TEMP VIEW axes AS
-SELECT r.* FROM recovery.axes r
-WHERE NOT EXISTS (SELECT 1 FROM recovery.recovery_tombstones t WHERE t.entity_kind = 'axis' AND t.entity_id = r.id)
-UNION ALL
-SELECT m.* FROM main.axes m
-WHERE NOT EXISTS (SELECT 1 FROM recovery.axes r WHERE r.id = m.id)
-  AND NOT EXISTS (SELECT 1 FROM recovery.recovery_tombstones t WHERE t.entity_kind = 'axis' AND t.entity_id = m.id);
+    let select = match table.table.mode() {
+        RecoveryMode::CanonicalOnly => format!(
+            "SELECT {main_projection} FROM main.{name} AS m{}",
+            where_clause(main_parent_visibility)
+        ),
+        RecoveryMode::OverlayRows {
+            tombstone_kind,
+            base_fallback_columns,
+        } => {
+            let recovery_projection =
+                projection(&table.columns, "r", Some("m"), base_fallback_columns);
+            let base_join = (!base_fallback_columns.is_empty()).then(|| {
+                format!(
+                    " LEFT JOIN main.{name} AS m ON {}",
+                    matching_columns("r", "m", &table.primary_key)
+                )
+            });
+            let mut recovery_predicates = parent_visibility(table, "r");
+            let mut main_predicates = parent_visibility(table, "m");
+            main_predicates.push(format!(
+                "NOT EXISTS (SELECT 1 FROM recovery.{name} AS r WHERE {})",
+                matching_columns("r", "m", &table.primary_key)
+            ));
+            if let Some(kind) = tombstone_kind {
+                let primary_key = identifier(&table.primary_key[0]);
+                recovery_predicates.push(tombstone_absent(kind, "r", &primary_key));
+                main_predicates.push(tombstone_absent(kind, "m", &primary_key));
+            }
 
-CREATE TEMP VIEW axis_mappings AS
-SELECT * FROM recovery.axis_mappings
-UNION ALL SELECT * FROM main.axis_mappings
-WHERE NOT EXISTS (SELECT 1 FROM recovery.recovery_replacements WHERE collection = 'axis_mappings' AND owner_id = '');
+            format!(
+                "SELECT {recovery_projection} FROM recovery.{name} AS r{}{}\nUNION ALL\nSELECT {main_projection} FROM main.{name} AS m{}",
+                base_join.unwrap_or_default(),
+                where_clause(recovery_predicates),
+                where_clause(main_predicates)
+            )
+        }
+        RecoveryMode::ReplaceCollection { owner_column, .. } => {
+            let recovery_projection = projection(&table.columns, "r", None, &[]);
+            let mut recovery_predicates = parent_visibility(table, "r");
+            let mut main_predicates = parent_visibility(table, "m");
+            recovery_predicates.push(replacement_marker(
+                table.table.name(),
+                owner_column.map(|column| ("r", column)),
+                false,
+            ));
+            main_predicates.push(replacement_marker(
+                table.table.name(),
+                owner_column.map(|column| ("m", column)),
+                true,
+            ));
 
-CREATE TEMP VIEW metric_definitions AS
-SELECT * FROM recovery.metric_definitions
-UNION ALL SELECT * FROM main.metric_definitions
-WHERE NOT EXISTS (SELECT 1 FROM recovery.recovery_replacements WHERE collection = 'metric_definitions' AND owner_id = '');
+            format!(
+                "SELECT {recovery_projection} FROM recovery.{name} AS r{}\nUNION ALL\nSELECT {main_projection} FROM main.{name} AS m{}",
+                where_clause(recovery_predicates),
+                where_clause(main_predicates)
+            )
+        }
+    };
 
-CREATE TEMP VIEW named_instances AS
-SELECT * FROM recovery.named_instances
-UNION ALL SELECT * FROM main.named_instances
-WHERE NOT EXISTS (SELECT 1 FROM recovery.recovery_replacements WHERE collection = 'named_instances' AND owner_id = '');
+    format!("CREATE TEMP VIEW {name} AS\n{select};")
+}
 
-CREATE TEMP VIEW sources AS
-SELECT r.id, r.name,
-       COALESCE(r.family_name, m.family_name) AS family_name,
-       COALESCE(r.style_name, m.style_name) AS style_name,
-       r.filename, r.color, r.layer_name, r.italic_angle, r.line_gap,
-       r.underline_position, r.underline_thickness, r.kind, r.order_index
-FROM recovery.sources r
-LEFT JOIN main.sources m ON m.id = r.id
-WHERE NOT EXISTS (SELECT 1 FROM recovery.recovery_tombstones t WHERE t.entity_kind = 'source' AND t.entity_id = r.id)
-UNION ALL
-SELECT m.* FROM main.sources m
-WHERE NOT EXISTS (SELECT 1 FROM recovery.sources r WHERE r.id = m.id)
-  AND NOT EXISTS (SELECT 1 FROM recovery.recovery_tombstones t WHERE t.entity_kind = 'source' AND t.entity_id = m.id);
+fn projection(
+    columns: &[String],
+    row_alias: &str,
+    base_alias: Option<&str>,
+    base_fallback_columns: &[&str],
+) -> String {
+    columns
+        .iter()
+        .map(|column| {
+            let quoted = identifier(column);
+            if base_fallback_columns.contains(&column.as_str()) {
+                format!(
+                    "COALESCE({row_alias}.{quoted}, {}.{quoted}) AS {quoted}",
+                    base_alias.expect("base fallback projection requires a base row")
+                )
+            } else {
+                format!("{row_alias}.{quoted} AS {quoted}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
 
-CREATE TEMP VIEW source_locations AS
-SELECT r.* FROM recovery.source_locations r
-WHERE EXISTS (SELECT 1 FROM sources s WHERE s.id = r.source_id)
-  AND EXISTS (SELECT 1 FROM axes a WHERE a.id = r.axis_id)
-UNION ALL
-SELECT m.* FROM main.source_locations m
-WHERE NOT EXISTS (SELECT 1 FROM recovery.recovery_replacements x WHERE x.collection = 'source_locations' AND x.owner_id = m.source_id)
-  AND EXISTS (SELECT 1 FROM sources s WHERE s.id = m.source_id)
-  AND EXISTS (SELECT 1 FROM axes a WHERE a.id = m.axis_id);
+fn parent_visibility(table: &RecoveryTableShape, row_alias: &str) -> Vec<String> {
+    table
+        .foreign_keys
+        .iter()
+        .map(|foreign_key| {
+            let nullable = foreign_key
+                .columns
+                .iter()
+                .map(|column| format!("{row_alias}.{} IS NULL", identifier(&column.child)))
+                .collect::<Vec<_>>()
+                .join(" OR ");
+            let matches = foreign_key
+                .columns
+                .iter()
+                .map(|column| {
+                    format!(
+                        "p.{} = {row_alias}.{}",
+                        identifier(&column.parent),
+                        identifier(&column.child)
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(" AND ");
+            format!(
+                "(({nullable}) OR EXISTS (
+                    SELECT 1 FROM temp.{} AS p WHERE {matches}
+                ))",
+                identifier(&foreign_key.parent_table)
+            )
+        })
+        .collect()
+}
 
-CREATE TEMP VIEW source_metric_values AS
-SELECT r.* FROM recovery.source_metric_values r
-WHERE EXISTS (SELECT 1 FROM sources s WHERE s.id = r.source_id)
-  AND EXISTS (SELECT 1 FROM metric_definitions d WHERE d.id = r.metric_id)
-UNION ALL
-SELECT m.* FROM main.source_metric_values m
-WHERE NOT EXISTS (SELECT 1 FROM recovery.recovery_replacements x WHERE x.collection = 'source_metric_values' AND x.owner_id = m.source_id)
-  AND EXISTS (SELECT 1 FROM sources s WHERE s.id = m.source_id)
-  AND EXISTS (SELECT 1 FROM metric_definitions d WHERE d.id = m.metric_id);
+fn tombstone_absent(kind: &str, row_alias: &str, primary_key: &str) -> String {
+    format!(
+        "NOT EXISTS (
+            SELECT 1 FROM recovery.recovery_tombstones AS t
+            WHERE t.entity_kind = {}
+              AND t.entity_id = {row_alias}.{primary_key}
+        )",
+        string_literal(kind)
+    )
+}
 
-CREATE TEMP VIEW source_lib AS
-SELECT r.* FROM recovery.source_lib r WHERE EXISTS (SELECT 1 FROM sources s WHERE s.id = r.source_id)
-UNION ALL
-SELECT m.* FROM main.source_lib m
-WHERE NOT EXISTS (SELECT 1 FROM recovery.recovery_replacements x WHERE x.collection = 'source_lib' AND x.owner_id = m.source_id)
-  AND EXISTS (SELECT 1 FROM sources s WHERE s.id = m.source_id);
+fn replacement_marker(table: &str, owner: Option<(&str, &str)>, negated: bool) -> String {
+    let owner = match owner {
+        Some((row_alias, column)) => format!("{row_alias}.{}", identifier(column)),
+        None => "''".to_string(),
+    };
+    format!(
+        "{}EXISTS (
+            SELECT 1 FROM recovery.recovery_replacements AS x
+            WHERE x.collection = {}
+              AND x.owner_id = {owner}
+        )",
+        if negated { "NOT " } else { "" },
+        string_literal(table)
+    )
+}
 
-CREATE TEMP VIEW glyphs AS
-SELECT r.* FROM recovery.glyphs r
-WHERE NOT EXISTS (SELECT 1 FROM recovery.recovery_tombstones t WHERE t.entity_kind = 'glyph' AND t.entity_id = r.id)
-UNION ALL
-SELECT m.* FROM main.glyphs m
-WHERE NOT EXISTS (SELECT 1 FROM recovery.glyphs r WHERE r.id = m.id)
-  AND NOT EXISTS (SELECT 1 FROM recovery.recovery_tombstones t WHERE t.entity_kind = 'glyph' AND t.entity_id = m.id);
-
-CREATE TEMP VIEW glyph_unicodes AS
-SELECT r.* FROM recovery.glyph_unicodes r WHERE EXISTS (SELECT 1 FROM glyphs g WHERE g.id = r.glyph_id)
-UNION ALL
-SELECT m.* FROM main.glyph_unicodes m
-WHERE NOT EXISTS (SELECT 1 FROM recovery.recovery_replacements x WHERE x.collection = 'glyph_unicodes' AND x.owner_id = m.glyph_id)
-  AND EXISTS (SELECT 1 FROM glyphs g WHERE g.id = m.glyph_id);
-
-CREATE TEMP VIEW glyph_lib AS
-SELECT r.* FROM recovery.glyph_lib r WHERE EXISTS (SELECT 1 FROM glyphs g WHERE g.id = r.glyph_id)
-UNION ALL
-SELECT m.* FROM main.glyph_lib m
-WHERE NOT EXISTS (SELECT 1 FROM recovery.recovery_replacements x WHERE x.collection = 'glyph_lib' AND x.owner_id = m.glyph_id)
-  AND EXISTS (SELECT 1 FROM glyphs g WHERE g.id = m.glyph_id);
-
-CREATE TEMP VIEW glyph_layers AS
-SELECT r.* FROM recovery.glyph_layers r
-WHERE NOT EXISTS (SELECT 1 FROM recovery.recovery_tombstones t WHERE t.entity_kind = 'layer' AND t.entity_id = r.id)
-  AND EXISTS (SELECT 1 FROM glyphs g WHERE g.id = r.glyph_id)
-  AND EXISTS (SELECT 1 FROM sources s WHERE s.id = r.source_id)
-UNION ALL
-SELECT m.* FROM main.glyph_layers m
-WHERE NOT EXISTS (SELECT 1 FROM recovery.glyph_layers r WHERE r.id = m.id)
-  AND NOT EXISTS (SELECT 1 FROM recovery.recovery_tombstones t WHERE t.entity_kind = 'layer' AND t.entity_id = m.id)
-  AND EXISTS (SELECT 1 FROM glyphs g WHERE g.id = m.glyph_id)
-  AND EXISTS (SELECT 1 FROM sources s WHERE s.id = m.source_id);
-
-CREATE TEMP VIEW glyph_layer_payloads AS
-SELECT r.* FROM recovery.glyph_layer_payloads r WHERE EXISTS (SELECT 1 FROM glyph_layers l WHERE l.id = r.layer_id)
-UNION ALL
-SELECT m.* FROM main.glyph_layer_payloads m
-WHERE NOT EXISTS (SELECT 1 FROM recovery.glyph_layer_payloads r WHERE r.layer_id = m.layer_id)
-  AND EXISTS (SELECT 1 FROM glyph_layers l WHERE l.id = m.layer_id);
-
-CREATE TEMP VIEW glyph_components AS
-SELECT r.* FROM recovery.glyph_components r WHERE EXISTS (SELECT 1 FROM glyph_layers l WHERE l.id = r.layer_id)
-UNION ALL
-SELECT m.* FROM main.glyph_components m
-WHERE NOT EXISTS (SELECT 1 FROM recovery.recovery_replacements x WHERE x.collection = 'glyph_components' AND x.owner_id = m.layer_id)
-  AND EXISTS (SELECT 1 FROM glyph_layers l WHERE l.id = m.layer_id);
-
-CREATE TEMP VIEW feature_text AS SELECT * FROM main.feature_text;
-CREATE TEMP VIEW font_guidelines AS SELECT * FROM main.font_guidelines;
-CREATE TEMP VIEW kerning_groups AS SELECT * FROM main.kerning_groups;
-CREATE TEMP VIEW kerning_group_members AS SELECT * FROM main.kerning_group_members;
-CREATE TEMP VIEW kerning_pairs AS SELECT * FROM main.kerning_pairs;
-CREATE TEMP VIEW font_lib AS SELECT * FROM main.font_lib;
-CREATE TEMP VIEW fontinfo_remainder AS SELECT * FROM main.fontinfo_remainder;
-CREATE TEMP VIEW font_binaries AS SELECT * FROM main.font_binaries;
-CREATE TEMP VIEW document_metadata AS SELECT * FROM main.document_metadata;
-"#;
+fn where_clause(predicates: Vec<String>) -> String {
+    if predicates.is_empty() {
+        String::new()
+    } else {
+        format!(" WHERE {}", predicates.join(" AND "))
+    }
+}

--- a/crates/shift-store/src/schema.rs
+++ b/crates/shift-store/src/schema.rs
@@ -244,7 +244,8 @@ CREATE TABLE IF NOT EXISTS font_binaries (
 
 CREATE TABLE IF NOT EXISTS document_metadata (
     id INTEGER PRIMARY KEY CHECK (id = 1),
-    document_id TEXT NOT NULL
+    document_id TEXT NOT NULL,
+    saved_commit_id TEXT NOT NULL
 );
 "#;
 

--- a/crates/shift-store/src/store.rs
+++ b/crates/shift-store/src/store.rs
@@ -8,6 +8,7 @@ pub struct ShiftStore {
     pub(crate) conn: rusqlite::Connection,
     pub(crate) path: Option<std::path::PathBuf>,
     pub(crate) kind: StoreKind,
+    pub(crate) recovery: Option<crate::RecoveryOverlay>,
 }
 
 impl ShiftStore {

--- a/crates/shift-store/src/types.rs
+++ b/crates/shift-store/src/types.rs
@@ -5,8 +5,9 @@ use shift_font::{Glyph, LayerId};
 use crate::layer::StoredLayerPayload;
 
 const DOCUMENT_ID_PREFIX: &str = "document_";
-const DOCUMENT_ID_BYTES: usize = 16;
-const DOCUMENT_ID_HEX_LENGTH: usize = DOCUMENT_ID_BYTES * 2;
+const COMMIT_ID_PREFIX: &str = "commit_";
+const RANDOM_ID_BYTES: usize = 16;
+const RANDOM_ID_HEX_LENGTH: usize = RANDOM_ID_BYTES * 2;
 
 pub(crate) type EncodedGlyphLayers = Vec<Vec<(LayerId, Vec<u8>)>>;
 
@@ -43,14 +44,7 @@ pub struct DocumentId(String);
 
 impl DocumentId {
     pub fn new() -> Self {
-        let mut bytes = [0; DOCUMENT_ID_BYTES];
-        getrandom::fill(&mut bytes).expect("secure random document ID generation failed");
-        let suffix = bytes
-            .iter()
-            .map(|byte| format!("{byte:02x}"))
-            .collect::<String>();
-
-        Self(format!("{DOCUMENT_ID_PREFIX}{suffix}"))
+        Self(random_id(DOCUMENT_ID_PREFIX, "document"))
     }
 
     pub fn as_str(&self) -> &str {
@@ -59,10 +53,7 @@ impl DocumentId {
 
     pub(crate) fn from_stored(value: String) -> Option<Self> {
         let suffix = value.strip_prefix(DOCUMENT_ID_PREFIX)?;
-        let valid = suffix.len() == DOCUMENT_ID_HEX_LENGTH
-            && suffix
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'));
+        let valid = valid_random_id_suffix(suffix);
 
         valid.then_some(Self(value))
     }
@@ -78,6 +69,56 @@ impl std::fmt::Display for DocumentId {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter.write_str(self.as_str())
     }
+}
+
+/// Durable identity of one explicitly saved canonical document revision.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct CommitId(String);
+
+impl CommitId {
+    pub fn new() -> Self {
+        Self(random_id(COMMIT_ID_PREFIX, "commit"))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub(crate) fn from_stored(value: String) -> Option<Self> {
+        let suffix = value.strip_prefix(COMMIT_ID_PREFIX)?;
+        valid_random_id_suffix(suffix).then_some(Self(value))
+    }
+}
+
+impl Default for CommitId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for CommitId {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+fn random_id(prefix: &str, kind: &str) -> String {
+    let mut bytes = [0; RANDOM_ID_BYTES];
+    getrandom::fill(&mut bytes)
+        .unwrap_or_else(|_| panic!("secure random {kind} ID generation failed"));
+    let suffix = bytes
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+
+    format!("{prefix}{suffix}")
+}
+
+fn valid_random_id_suffix(suffix: &str) -> bool {
+    suffix.len() == RANDOM_ID_HEX_LENGTH
+        && suffix
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]

--- a/crates/shift-store/tests/recovery_patch_test.rs
+++ b/crates/shift-store/tests/recovery_patch_test.rs
@@ -145,6 +145,68 @@ fn recovery_overlay_reopens_and_saves_semantic_directory_changes() {
 }
 
 #[test]
+fn metric_definition_replacement_preserves_untouched_source_values() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let document_path = temp.path().join("Dogfood.shift");
+    let recovery_path = temp.path().join("recovery.sqlite");
+    let original = sample_font();
+    drop(ShiftStore::create_document(&document_path, &original).expect("create document"));
+
+    let mut post = original;
+    let mut definitions = post.metric_definitions().to_vec();
+    definitions[0].set_name("Recovered Ascender".to_string());
+    post.set_metric_definitions(definitions.clone())
+        .expect("replace metric definitions");
+    let changes = shift_font::FontChangeSet::from(
+        shift_font::FontChange::metric_definitions_updated(&definitions),
+    );
+
+    let mut document = ShiftStore::open_document_with_recovery(&document_path, &recovery_path)
+        .expect("open with recovery");
+    document
+        .apply_change_set_with_font(&changes, &post)
+        .expect("write metric recovery change");
+    document.save_document().expect("save recovered document");
+    drop(document);
+
+    let saved = ShiftStore::open_document(&document_path).expect("open saved document");
+    assert_eq!(saved.load_font_state().unwrap(), post);
+}
+
+#[test]
+fn recovery_save_replaces_reordered_component_collections() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let document_path = temp.path().join("Dogfood.shift");
+    let recovery_path = temp.path().join("recovery.sqlite");
+    let layer_id = shift_font::LayerId::from_raw("A_regular");
+    drop(ShiftStore::create_document(&document_path, &sample_font()).expect("create document"));
+
+    let mut document = ShiftStore::open_document_with_recovery(&document_path, &recovery_path)
+        .expect("open with recovery");
+    let mut layer = document.load_glyph_layer(&layer_id).unwrap().unwrap();
+    let first_id = layer.components_iter().next().unwrap().id();
+    let first = layer.remove_component(first_id).unwrap();
+    layer.add_component(first);
+    let reordered = layer
+        .components_iter()
+        .map(|component| component.id())
+        .collect::<Vec<_>>();
+    document.replace_glyph_layer(&layer).unwrap();
+    document.save_document().unwrap();
+    drop(document);
+
+    let saved = ShiftStore::open_document(&document_path).expect("open saved document");
+    let saved_layer = saved.load_glyph_layer(&layer_id).unwrap().unwrap();
+    assert_eq!(
+        saved_layer
+            .components_iter()
+            .map(|component| component.id())
+            .collect::<Vec<_>>(),
+        reordered
+    );
+}
+
+#[test]
 fn recovered_directory_open_remains_payload_lazy() {
     let temp = tempfile::tempdir().expect("temp dir");
     let document_path = temp.path().join("Dogfood.shift");

--- a/crates/shift-store/tests/recovery_patch_test.rs
+++ b/crates/shift-store/tests/recovery_patch_test.rs
@@ -1,0 +1,286 @@
+use shift_font::test_support::sample_font;
+use shift_store::ShiftStore;
+
+#[test]
+fn recovery_preserves_store_only_font_and_source_fields() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let working_path = temp.path().join("working.sqlite");
+    let document_path = temp.path().join("Dogfood.shift");
+    let recovery_path = temp.path().join("recovery.sqlite");
+    let original = sample_font();
+    let mut working = ShiftStore::open(&working_path).expect("open working store");
+    working
+        .replace_font_state(&original)
+        .expect("write original font");
+    let mut info = working.get_font_info().unwrap().unwrap();
+    info.sample_text = Some("Store sample".to_string());
+    info.vendor_id = Some("SHFT".to_string());
+    working
+        .set_font_info(info)
+        .expect("write store-only sentinels");
+    drop(working);
+    let conn = rusqlite::Connection::open(&working_path).expect("open raw working store");
+    conn.execute(
+        "UPDATE sources SET family_name = 'Source Family', style_name = 'Source Style' WHERE id = 'source_regular'",
+        [],
+    )
+    .expect("write source-only sentinels");
+    drop(conn);
+    let working = ShiftStore::open(&working_path).expect("reopen working store");
+    working
+        .save_as_document(&document_path)
+        .expect("publish canonical document");
+    drop(working);
+
+    let mut post = original;
+    post.metadata_mut().family_name = Some("Recovered Sans".to_string());
+    let source_id = shift_font::SourceId::from_raw("regular");
+    post.source_mut(source_id.clone())
+        .expect("regular source")
+        .set_line_gap(Some(99.0));
+    let source = post
+        .sources()
+        .iter()
+        .find(|source| source.id() == source_id)
+        .expect("updated source")
+        .clone();
+    let change = shift_font::FontChangeSet::new(vec![
+        shift_font::FontChange::font_metadata_updated(post.metadata()),
+        shift_font::FontChange::source_updated(&source),
+    ]);
+    let mut document = ShiftStore::open_document_with_recovery(&document_path, &recovery_path)
+        .expect("open with recovery");
+    document.apply_change_set_with_font(&change, &post).unwrap();
+    let merged_source = document
+        .get_source(&shift_store::SourceId::new("source_regular"))
+        .unwrap()
+        .unwrap();
+    assert_eq!(merged_source.family_name.as_deref(), Some("Source Family"));
+    assert_eq!(merged_source.style_name.as_deref(), Some("Source Style"));
+    document.save_document().unwrap();
+    drop(document);
+
+    let saved = ShiftStore::open_document(&document_path).expect("open saved document");
+    let info = saved.get_font_info().unwrap().unwrap();
+    assert_eq!(info.family_name.as_deref(), Some("Recovered Sans"));
+    assert_eq!(info.sample_text.as_deref(), Some("Store sample"));
+    assert_eq!(info.vendor_id.as_deref(), Some("SHFT"));
+    let source = saved
+        .get_source(&shift_store::SourceId::new("source_regular"))
+        .unwrap()
+        .unwrap();
+    assert_eq!(source.family_name.as_deref(), Some("Source Family"));
+    assert_eq!(source.style_name.as_deref(), Some("Source Style"));
+}
+
+#[test]
+fn recovery_overlay_reopens_and_saves_semantic_directory_changes() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let document_path = temp.path().join("Dogfood.shift");
+    let recovery_path = temp.path().join("Dogfood.recovery.sqlite");
+    let original = sample_font();
+    drop(ShiftStore::create_document(&document_path, &original).expect("create document"));
+
+    let mut post = original.clone();
+    post.metadata_mut().family_name = Some("Recovered Sans".to_string());
+    let deleted_glyph_id = shift_font::GlyphId::from_raw("acute");
+    post.remove_glyph(deleted_glyph_id.clone())
+        .expect("sample glyph");
+    let weight_id = shift_font::AxisId::from_raw("weight");
+    let mut weight = post
+        .axes()
+        .iter()
+        .find(|axis| axis.id() == weight_id)
+        .expect("weight axis")
+        .clone();
+    weight.set_hidden(false);
+    post.replace_axis(weight.clone())
+        .expect("replace weight axis");
+    let regular_source_id = shift_font::SourceId::from_raw("regular");
+    post.source_mut(regular_source_id.clone())
+        .expect("regular source")
+        .set_line_gap(Some(99.0));
+    let regular_source = post
+        .sources()
+        .iter()
+        .find(|source| source.id() == regular_source_id)
+        .expect("updated source")
+        .clone();
+    post.set_axis_mappings(Vec::new()).expect("clear mappings");
+    post.set_named_instances(Vec::new())
+        .expect("clear instances");
+    let mut metric_definitions = post.metric_definitions().to_vec();
+    metric_definitions[0].set_name("Recovered Ascender".to_string());
+    post.set_metric_definitions(metric_definitions.clone())
+        .expect("replace metric definitions");
+    let changes = shift_font::FontChangeSet::new(vec![
+        shift_font::FontChange::font_metadata_updated(post.metadata()),
+        shift_font::FontChange::axis_updated(&weight),
+        shift_font::FontChange::axis_mappings_updated(post.axis_mappings()),
+        shift_font::FontChange::named_instances_updated(post.named_instances()),
+        shift_font::FontChange::metric_definitions_updated(&metric_definitions),
+        shift_font::FontChange::source_updated(&regular_source),
+        shift_font::FontChange::glyph_deleted(deleted_glyph_id),
+    ]);
+
+    let mut document = ShiftStore::open_document_with_recovery(&document_path, &recovery_path)
+        .expect("open with recovery");
+    document
+        .apply_change_set_with_font(&changes, &post)
+        .expect("write semantic recovery changes");
+    drop(document);
+
+    let canonical = ShiftStore::open_document(&document_path).expect("open canonical");
+    assert_eq!(canonical.load_font_state().unwrap(), original);
+    drop(canonical);
+
+    let mut reopened = ShiftStore::open_document_with_recovery(&document_path, &recovery_path)
+        .expect("reopen recovered document");
+    assert_eq!(reopened.load_font_state().unwrap(), post);
+    reopened.save_document().expect("save recovered document");
+    drop(reopened);
+
+    let saved = ShiftStore::open_document(&document_path).expect("open saved document");
+    assert_eq!(saved.load_font_state().unwrap(), post);
+}
+
+#[test]
+fn recovered_directory_open_remains_payload_lazy() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let document_path = temp.path().join("Dogfood.shift");
+    let recovery_path = temp.path().join("recovery.sqlite");
+    let layer_id = shift_font::LayerId::from_raw("A_regular");
+    drop(ShiftStore::create_document(&document_path, &sample_font()).expect("create document"));
+
+    let mut document = ShiftStore::open_document_with_recovery(&document_path, &recovery_path)
+        .expect("open with recovery");
+    let mut layer = document.load_glyph_layer(&layer_id).unwrap().unwrap();
+    layer.set_width(777.0);
+    document.replace_glyph_layer(&layer).unwrap();
+    drop(document);
+    let conn = rusqlite::Connection::open(&recovery_path).expect("open raw recovery");
+    conn.execute(
+        "UPDATE glyph_layer_payloads SET payload = x'00', stored_byte_length = 1 WHERE layer_id = ?1",
+        [layer_id.to_string()],
+    )
+    .expect("corrupt recovery payload");
+    drop(conn);
+
+    let recovered = ShiftStore::open_document_with_recovery(&document_path, &recovery_path)
+        .expect("reopen recovered document");
+    assert_eq!(
+        recovered
+            .load_font_directory()
+            .expect("load directory")
+            .glyph_count(),
+        sample_font().glyph_count()
+    );
+    assert!(recovered.load_glyph_layer(&layer_id).is_err());
+}
+
+#[test]
+fn recovery_overlay_adds_a_new_glyph_and_layer_without_copying_the_directory() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let document_path = temp.path().join("Dogfood.shift");
+    let recovery_path = temp.path().join("recovery.sqlite");
+    let original = sample_font();
+    drop(ShiftStore::create_document(&document_path, &original).expect("create document"));
+
+    let glyph_id = shift_font::GlyphId::from_raw("B");
+    let layer_id = shift_font::LayerId::from_raw("B_regular");
+    let mut glyph = shift_font::Glyph::with_id(glyph_id.clone(), "B");
+    glyph.set_unicodes(vec![0x42]);
+    let layer = shift_font::GlyphLayer::with_width(
+        layer_id.clone(),
+        shift_font::SourceId::from_raw("regular"),
+        620.0,
+    );
+    glyph.set_layer(layer.clone());
+    let mut post = original;
+    post.insert_glyph(glyph.clone()).expect("insert glyph");
+    let changes = shift_font::FontChangeSet::new(vec![
+        shift_font::FontChange::glyph_created(&glyph),
+        shift_font::FontChange::glyph_layer_created(glyph_id.clone(), &layer),
+    ]);
+
+    let mut document = ShiftStore::open_document_with_recovery(&document_path, &recovery_path)
+        .expect("open with recovery");
+    document
+        .apply_change_set_with_font(&changes, &post)
+        .unwrap();
+    let directory = document.load_font_directory().unwrap();
+    assert_eq!(directory.glyph_count(), post.glyph_count());
+    assert_eq!(
+        directory
+            .glyph(glyph_id)
+            .expect("new glyph in merged directory")
+            .layers()
+            .get(&layer_id)
+            .expect("new layer in merged directory")
+            .width(),
+        620.0
+    );
+    assert_eq!(
+        document
+            .load_glyph_layer(&layer_id)
+            .unwrap()
+            .unwrap()
+            .width(),
+        620.0
+    );
+
+    let recovery = rusqlite::Connection::open(&recovery_path).expect("inspect recovery");
+    assert_eq!(
+        recovery
+            .query_row("SELECT COUNT(*) FROM glyphs", [], |row| row
+                .get::<_, i64>(0))
+            .unwrap(),
+        1
+    );
+    assert_eq!(
+        recovery
+            .query_row("SELECT COUNT(*) FROM glyph_layer_payloads", [], |row| row
+                .get::<_, i64>(
+                0
+            ))
+            .unwrap(),
+        1
+    );
+    drop(recovery);
+
+    document.save_document().expect("save additions");
+    drop(document);
+    let saved = ShiftStore::open_document(&document_path).expect("open saved document");
+    assert_eq!(saved.load_font_state().unwrap(), post);
+}
+
+#[test]
+fn parent_deletion_does_not_reinsert_an_earlier_layer_override() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let document_path = temp.path().join("Dogfood.shift");
+    let recovery_path = temp.path().join("recovery.sqlite");
+    let glyph_id = shift_font::GlyphId::from_raw("A");
+    let layer_id = shift_font::LayerId::from_raw("A_regular");
+    let original = sample_font();
+    drop(ShiftStore::create_document(&document_path, &original).expect("create document"));
+
+    let mut document = ShiftStore::open_document_with_recovery(&document_path, &recovery_path)
+        .expect("open with recovery");
+    let mut layer = document.load_glyph_layer(&layer_id).unwrap().unwrap();
+    layer.set_width(777.0);
+    document.replace_glyph_layer(&layer).unwrap();
+
+    let mut post = original;
+    post.remove_glyph(glyph_id.clone()).expect("remove glyph");
+    let changes = shift_font::FontChangeSet::from(shift_font::FontChange::glyph_deleted(glyph_id));
+    document
+        .apply_change_set_with_font(&changes, &post)
+        .unwrap();
+    assert!(document.load_glyph_layer(&layer_id).unwrap().is_none());
+
+    document.save_document().expect("save deletion");
+    drop(document);
+
+    let saved = ShiftStore::open_document(&document_path).expect("open saved document");
+    assert_eq!(saved.load_font_state().unwrap(), post);
+}

--- a/crates/shift-store/tests/recovery_test.rs
+++ b/crates/shift-store/tests/recovery_test.rs
@@ -1,0 +1,332 @@
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+};
+
+use shift_font::test_support::sample_font;
+use shift_store::{RecoveryState, ShiftStore, StoreError};
+
+#[test]
+fn recovery_overlay_reopens_unsaved_layer_edits_and_save_commits_only_the_overlay() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let document_path = temp.path().join("Dogfood.shift");
+    let recovery_path = temp.path().join("Dogfood.recovery.sqlite");
+    let layer_id = shift_font::LayerId::from_raw("A_regular");
+    let original = sample_font();
+    let original_metadata = ShiftStore::create_document(&document_path, &original)
+        .expect("create document")
+        .document_metadata()
+        .expect("document metadata");
+    let unrelated_layer_id = shift_font::LayerId::from_raw("acute_regular");
+    let unrelated_before = stored_payload(&document_path, &unrelated_layer_id);
+
+    let mut document = ShiftStore::open_document_with_recovery(&document_path, &recovery_path)
+        .expect("open with recovery");
+    assert_eq!(
+        document.recovery_state().unwrap(),
+        Some(RecoveryState::Clean)
+    );
+    let mut changed = document
+        .load_glyph_layer(&layer_id)
+        .expect("load layer")
+        .expect("layer exists");
+    changed.set_width(777.0);
+    document
+        .replace_glyph_layer(&changed)
+        .expect("persist recovery edit");
+    assert_eq!(
+        document.recovery_state().unwrap(),
+        Some(RecoveryState::Dirty)
+    );
+    drop(document);
+
+    let canonical = ShiftStore::open_document(&document_path).expect("open canonical document");
+    assert_eq!(
+        canonical
+            .load_glyph_layer(&layer_id)
+            .unwrap()
+            .unwrap()
+            .width(),
+        600.0,
+        "unsaved edit must not mutate the canonical document"
+    );
+    assert_eq!(
+        canonical.document_metadata().unwrap(),
+        original_metadata,
+        "recovery writes must not advance the saved commit"
+    );
+    drop(canonical);
+
+    let recovery = rusqlite::Connection::open(&recovery_path).expect("inspect recovery database");
+    assert_eq!(
+        recovery
+            .query_row("SELECT COUNT(*) FROM glyph_layer_payloads", [], |row| row
+                .get::<_, i64>(
+                0
+            ))
+            .unwrap(),
+        1,
+        "one edited layer must not copy unrelated payloads"
+    );
+    drop(recovery);
+
+    let mut reopened = ShiftStore::open_document_with_recovery(&document_path, &recovery_path)
+        .expect("reopen recovered document");
+    assert_eq!(
+        reopened.recovery_state().unwrap(),
+        Some(RecoveryState::Dirty)
+    );
+    assert_eq!(
+        reopened
+            .load_glyph_layer(&layer_id)
+            .unwrap()
+            .unwrap()
+            .width(),
+        777.0,
+        "the editable view should merge the persisted overlay"
+    );
+
+    let saved_metadata = reopened.save_document().expect("save recovered edits");
+    assert_eq!(saved_metadata.document_id, original_metadata.document_id);
+    assert_ne!(
+        saved_metadata.saved_commit_id,
+        original_metadata.saved_commit_id
+    );
+    assert_eq!(
+        reopened.recovery_state().unwrap(),
+        Some(RecoveryState::Clean)
+    );
+    drop(reopened);
+
+    assert!(!sqlite_sidecar_path(&document_path, "-journal").exists());
+    assert!(!sqlite_sidecar_path(&document_path, "-wal").exists());
+    assert!(!sqlite_sidecar_path(&document_path, "-shm").exists());
+
+    let saved = ShiftStore::open_document(&document_path).expect("open saved document");
+    assert_eq!(saved.document_metadata().unwrap(), saved_metadata);
+    assert_eq!(
+        stored_payload(&document_path, &unrelated_layer_id),
+        unrelated_before,
+        "Save must not rewrite an unrelated layer payload"
+    );
+    assert_eq!(
+        saved.load_glyph_layer(&layer_id).unwrap().unwrap().width(),
+        777.0
+    );
+    drop(saved);
+
+    let recovery = rusqlite::Connection::open(&recovery_path).expect("inspect cleared recovery");
+    assert_eq!(
+        recovery
+            .query_row("SELECT COUNT(*) FROM glyph_layer_payloads", [], |row| row
+                .get::<_, i64>(
+                0
+            ))
+            .unwrap(),
+        0,
+        "successful Save should clear recovery payloads"
+    );
+}
+
+#[test]
+fn save_as_document_includes_recovery_without_mutating_its_source() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let document_path = temp.path().join("Dogfood.shift");
+    let recovery_path = temp.path().join("Dogfood.recovery.sqlite");
+    let saved_as_path = temp.path().join("Dogfood Copy.shift");
+    let layer_id = shift_font::LayerId::from_raw("A_regular");
+    let source_metadata = ShiftStore::create_document(&document_path, &sample_font())
+        .expect("create document")
+        .document_metadata()
+        .expect("source metadata");
+
+    let mut source = ShiftStore::open_document_with_recovery(&document_path, &recovery_path)
+        .expect("open with recovery");
+    let mut changed = source.load_glyph_layer(&layer_id).unwrap().unwrap();
+    changed.set_width(777.0);
+    source.replace_glyph_layer(&changed).unwrap();
+
+    let saved_as_metadata = source
+        .save_as_document(&saved_as_path)
+        .expect("save recovered view as a new document");
+
+    assert_eq!(source.recovery_state().unwrap(), Some(RecoveryState::Dirty));
+    assert_eq!(source.document_metadata().unwrap(), source_metadata);
+    assert_ne!(saved_as_metadata.document_id, source_metadata.document_id);
+    drop(source);
+
+    let canonical_source = ShiftStore::open_document(&document_path).expect("open source");
+    assert_eq!(
+        canonical_source
+            .load_glyph_layer(&layer_id)
+            .unwrap()
+            .unwrap()
+            .width(),
+        600.0
+    );
+    let saved_as = ShiftStore::open_document(&saved_as_path).expect("open saved-as document");
+    assert_eq!(saved_as.document_metadata().unwrap(), saved_as_metadata);
+    assert_eq!(
+        saved_as
+            .load_glyph_layer(&layer_id)
+            .unwrap()
+            .unwrap()
+            .width(),
+        777.0
+    );
+}
+
+#[test]
+fn canonical_document_rejects_an_invalid_saved_commit_id() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let document_path = temp.path().join("Dogfood.shift");
+    drop(ShiftStore::create_document(&document_path, &sample_font()).expect("create document"));
+    let conn = rusqlite::Connection::open(&document_path).expect("open raw document");
+    conn.execute(
+        "UPDATE document_metadata SET saved_commit_id = 'invalid' WHERE id = 1",
+        [],
+    )
+    .expect("corrupt commit ID");
+    drop(conn);
+
+    let error = match ShiftStore::open_document(&document_path) {
+        Ok(_) => panic!("invalid saved commit ID must be refused"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(error, StoreError::InvalidCommitId(_)));
+}
+
+#[test]
+fn recovery_overlay_refuses_a_different_document_identity() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let first_path = temp.path().join("First.shift");
+    let second_path = temp.path().join("Second.shift");
+    let recovery_path = temp.path().join("recovery.sqlite");
+    drop(ShiftStore::create_document(&first_path, &sample_font()).expect("create first"));
+    drop(ShiftStore::create_document(&second_path, &sample_font()).expect("create second"));
+    drop(
+        ShiftStore::open_document_with_recovery(&first_path, &recovery_path)
+            .expect("bind first document"),
+    );
+
+    let error = match ShiftStore::open_document_with_recovery(&second_path, &recovery_path) {
+        Ok(_) => panic!("recovery overlay must not bind to another document"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(error, StoreError::RecoveryDocumentMismatch { .. }));
+}
+
+#[test]
+fn recovery_overlay_detects_a_changed_canonical_base_before_save() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let document_path = temp.path().join("Dogfood.shift");
+    let first_recovery_path = temp.path().join("first.recovery.sqlite");
+    let second_recovery_path = temp.path().join("second.recovery.sqlite");
+    let layer_id = shift_font::LayerId::from_raw("A_regular");
+    drop(ShiftStore::create_document(&document_path, &sample_font()).expect("create document"));
+
+    let mut first = ShiftStore::open_document_with_recovery(&document_path, &first_recovery_path)
+        .expect("open first editor");
+    let mut first_layer = first.load_glyph_layer(&layer_id).unwrap().unwrap();
+    first_layer.set_width(700.0);
+    first.replace_glyph_layer(&first_layer).unwrap();
+    drop(first);
+
+    let mut second = ShiftStore::open_document_with_recovery(&document_path, &second_recovery_path)
+        .expect("open second editor");
+    let mut second_layer = second.load_glyph_layer(&layer_id).unwrap().unwrap();
+    second_layer.set_width(800.0);
+    second.replace_glyph_layer(&second_layer).unwrap();
+    second.save_document().expect("save second editor");
+    drop(second);
+
+    let mut conflicted =
+        ShiftStore::open_document_with_recovery(&document_path, &first_recovery_path)
+            .expect("reopen first editor");
+    assert_eq!(
+        conflicted.recovery_state().unwrap(),
+        Some(RecoveryState::Conflict)
+    );
+    assert_eq!(
+        conflicted
+            .load_glyph_layer(&layer_id)
+            .unwrap()
+            .unwrap()
+            .width(),
+        700.0,
+        "conflict recovery must remain inspectable"
+    );
+    assert!(conflicted.save_document().is_err());
+
+    conflicted
+        .discard_recovery()
+        .expect("discard conflicting recovery");
+    assert_eq!(
+        conflicted.recovery_state().unwrap(),
+        Some(RecoveryState::Clean)
+    );
+    assert_eq!(
+        conflicted
+            .load_glyph_layer(&layer_id)
+            .unwrap()
+            .unwrap()
+            .width(),
+        800.0
+    );
+}
+
+#[test]
+fn discarding_recovery_restores_the_canonical_layer_without_reopening() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let document_path = temp.path().join("Dogfood.shift");
+    let recovery_path = temp.path().join("Dogfood.recovery.sqlite");
+    let layer_id = shift_font::LayerId::from_raw("A_regular");
+    drop(ShiftStore::create_document(&document_path, &sample_font()).expect("create document"));
+
+    let mut document = ShiftStore::open_document_with_recovery(&document_path, &recovery_path)
+        .expect("open with recovery");
+    let mut changed = document.load_glyph_layer(&layer_id).unwrap().unwrap();
+    changed.set_width(888.0);
+    document.replace_glyph_layer(&changed).unwrap();
+    assert_eq!(
+        document
+            .load_glyph_layer(&layer_id)
+            .unwrap()
+            .unwrap()
+            .width(),
+        888.0
+    );
+
+    document.discard_recovery().expect("discard recovery");
+
+    assert_eq!(
+        document.recovery_state().unwrap(),
+        Some(RecoveryState::Clean)
+    );
+    assert_eq!(
+        document
+            .load_glyph_layer(&layer_id)
+            .unwrap()
+            .unwrap()
+            .width(),
+        600.0
+    );
+}
+
+fn stored_payload(path: &Path, layer_id: &shift_font::LayerId) -> Vec<u8> {
+    let conn = rusqlite::Connection::open(path).expect("open raw document");
+    conn.query_row(
+        "SELECT payload FROM glyph_layer_payloads WHERE layer_id = ?1",
+        [layer_id.to_string()],
+        |row| row.get(0),
+    )
+    .expect("stored layer payload")
+}
+
+fn sqlite_sidecar_path(path: &Path, suffix: &str) -> PathBuf {
+    let mut sidecar = OsString::from(path.as_os_str());
+    sidecar.push(suffix);
+    PathBuf::from(sidecar)
+}

--- a/crates/shift-store/tests/store_test.rs
+++ b/crates/shift-store/tests/store_test.rs
@@ -1020,6 +1020,8 @@ fn canonical_document_round_trip_preserves_kitchen_sink_font_for_export() {
     let metadata = store.document_metadata().expect("document metadata");
     assert!(metadata.document_id.as_str().starts_with("document_"));
     assert_eq!(metadata.document_id.as_str().len(), 41);
+    assert!(metadata.saved_commit_id.as_str().starts_with("commit_"));
+    assert_eq!(metadata.saved_commit_id.as_str().len(), 39);
     assert_eq!(store.load_font_state().expect("load document"), original);
     drop(store);
 

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -19,7 +19,7 @@ Central routing table for Shift's distributed documentation. Before creating new
 | `crates/shift-font/**`      | [`crates/shift-font/docs/DOCS.md`](../../crates/shift-font/docs/DOCS.md)           | First-class Rust font object model and editing behavior                                    |
 | `crates/shift-slug/**`      | [`crates/shift-slug/docs/DOCS.md`](../../crates/shift-slug/docs/DOCS.md)           | GPU-independent Slug curves, retained compilation, and packing                             |
 | `crates/shift-source/**`    | [`crates/shift-source/docs/DOCS.md`](../../crates/shift-source/docs/DOCS.md)       | User-authored `.shift` source package layout                                               |
-| `crates/shift-store/**`     | [`crates/shift-store/README.md`](../../crates/shift-store/README.md)               | Canonical SQLite `.shift`, working persistence, compressed layer payloads, and indexes       |
+| `crates/shift-store/**`     | [`crates/shift-store/README.md`](../../crates/shift-store/README.md)               | Canonical SQLite `.shift`, sparse recovery overlays, compressed layer payloads, and indexes  |
 | `crates/shift-workspace/**` | [`crates/shift-workspace/docs/DOCS.md`](../../crates/shift-workspace/docs/DOCS.md) | Open font workspace runtime over source, store, and font                                   |
 | `crates/shift-bridge/**`    | [`crates/shift-bridge/docs/DOCS.md`](../../crates/shift-bridge/docs/DOCS.md)       | NAPI bridge exposing Rust to Node.js/Electron                                              |
 


### PR DESCRIPTION
## Summary

- add durable `saved_commit_id` metadata and `RecoveryState::{Clean, Dirty, SavePending, Conflict}`
- persist only changed rows, complete touched-layer payloads, collection replacements, and deletion tombstones in an app-owned `RecoveryOverlay`
- merge overlay and canonical rows lazily on reopen without copying unrelated glyph layers
- apply sparse changes to the canonical document in one explicit Save transaction, then acknowledge and clear by matching commit ID
- recover deterministically if a crash occurs between canonical commit and overlay acknowledgement
- include the merged recovered view in Save As while leaving the source document and its overlay unchanged

## Tests

- recovery survives close/reopen while canonical bytes remain unchanged
- one-layer edit stores one overlay payload and leaves unrelated canonical payload bytes untouched
- successful Save preserves `DocumentId`, advances `saved_commit_id`, clears recovery rows, and leaves no canonical sidecars
- incomplete and completed pending Saves reconcile by commit identity
- changed canonical bases become `Conflict`; Discard exposes the latest canonical rows
- metadata, axes, mappings, metric definitions, instances, sources, glyph additions/deletions, and layer payloads merge and save correctly
- parent tombstones cannot resurrect stale child overrides
- recovered directory loading remains payload-lazy
- Save As includes unsaved recovery without mutating its source

## Verification

- `cargo test -p shift-store`
- `cargo test -p shift-workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `LD_PRELOAD=/lib/x86_64-linux-gnu/libsqlite3.so.0 pnpm test` (local Nix Node runtime workaround)
- repository pre-commit suite

This is the Rust storage boundary only. Desktop/utility routing to native Open and recovery lifecycle remains a later stacked PR, so no Electron E2E behavior changes in this slice.

Stacked on #188.