### PR TITLE
Persist glyph-local sources, variants, and variable components

### DIFF
--- a/crates/shift-backends/src/export.rs
+++ b/crates/shift-backends/src/export.rs
@@ -68,6 +68,12 @@ pub enum ExportError {
         source: std::io::Error,
     },
 
+    #[error("TTF export does not support {capability} in glyph {glyph_id}")]
+    UnsupportedAuthoringCapability {
+        glyph_id: shift_font::GlyphId,
+        capability: &'static str,
+    },
+
     #[error("cross-axis mappings are not supported by TTF export yet ({mapping_count} mappings)")]
     UnsupportedCrossAxisMappings { mapping_count: usize },
 
@@ -122,6 +128,7 @@ impl FontExporter {
 
     fn export_ttf(&self, font: &impl FontView, output_path: &Path) -> Result<(), ExportError> {
         ensure_ttf_output_path(output_path)?;
+        ensure_supported_ttf_authoring(font)?;
 
         let temp_dir = tempfile::Builder::new()
             .prefix("shift-export-")
@@ -142,6 +149,53 @@ impl Default for FontExporter {
     fn default() -> Self {
         Self::new()
     }
+}
+
+fn ensure_supported_ttf_authoring(font: &impl FontView) -> Result<(), ExportError> {
+    for glyph in font.glyphs() {
+        let unsupported = if !glyph.axes().is_empty() {
+            Some("glyph-local axes")
+        } else if !glyph.variants().is_empty() {
+            Some("conditional glyph variants")
+        } else if glyph
+            .default_sources()
+            .values()
+            .any(|source| source.base_source_id().is_none() || !source.location().is_empty())
+        {
+            Some("glyph-local source locations")
+        } else {
+            let mut base_source_ids = std::collections::HashSet::new();
+            if glyph
+                .default_sources()
+                .values()
+                .filter_map(|source| source.base_source_id())
+                .any(|source_id| !base_source_ids.insert(source_id))
+            {
+                Some("several glyph sources with one global source base")
+            } else if glyph
+                .layers()
+                .values()
+                .flat_map(|layer| layer.components_iter())
+                .any(|component| {
+                    !component.location().is_empty()
+                        || component.axis_inheritance() != shift_font::AxisInheritance::Parent
+                        || component.condition().is_some()
+                })
+            {
+                Some("variable-component authoring")
+            } else {
+                None
+            }
+        };
+
+        if let Some(capability) = unsupported {
+            return Err(ExportError::UnsupportedAuthoringCapability {
+                glyph_id: glyph.id(),
+                capability,
+            });
+        }
+    }
+    Ok(())
 }
 
 fn compile_ttf(source: ShiftIrSource, build_dir: &Path) -> Result<Vec<u8>, ExportError> {
@@ -181,7 +235,10 @@ fn ensure_ttf_output_path(path: &Path) -> Result<(), ExportError> {
 mod tests {
     use super::*;
     use shift_font::test_support::sample_variable_font;
-    use shift_font::{Axis, AxisMapping, AxisMappingPoint, AxisRole, Font, Location};
+    use shift_font::{
+        Axis, AxisMapping, AxisMappingPoint, AxisRole, Condition, Font, Glyph, GlyphSource,
+        GlyphVariant, Location,
+    };
     use skrifa::{FontRef, MetadataProvider};
 
     #[test]
@@ -238,6 +295,54 @@ mod tests {
             error,
             ExportError::OutputExtensionMismatch { path } if path == output_path
         ));
+    }
+
+    #[test]
+    fn rejects_conditional_variants_before_writing_output() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let output_path = temp_dir.path().join("Dogfood.ttf");
+        let mut font = Font::new();
+        let weight = Axis::weight();
+        let weight_id = weight.id();
+        font.add_axis(weight).unwrap();
+        let source_id = font.default_source_id().unwrap();
+        let mut glyph = Glyph::new("A");
+        let layer_id = glyph.ensure_layer_for_source(source_id.clone()).id();
+        let mut variant = GlyphVariant::new(
+            "Heavy".to_string(),
+            Condition::AxisRange {
+                axis_id: weight_id,
+                minimum: Some(700.0),
+                maximum: None,
+            },
+        );
+        variant.insert_source(GlyphSource::new(
+            "Heavy Regular".to_string(),
+            layer_id,
+            Some(source_id),
+            Location::new(),
+        ));
+        glyph.insert_variant(variant);
+        font.insert_glyph(glyph).unwrap();
+
+        let error = FontExporter::new()
+            .export(
+                &font,
+                FontExportRequest {
+                    path: output_path.clone(),
+                    format: ExportFormat::Ttf,
+                },
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ExportError::UnsupportedAuthoringCapability {
+                capability: "conditional glyph variants",
+                ..
+            }
+        ));
+        assert!(!output_path.exists());
     }
 
     #[test]

--- a/crates/shift-backends/src/formats/designspace/mod.rs
+++ b/crates/shift-backends/src/formats/designspace/mod.rs
@@ -18,7 +18,8 @@ mod tests {
     use crate::traits::{FontReader, FontWriter};
     use shift_font::{
         Axis, AxisKind, AxisLabel, AxisLabelRange, AxisMapping, AxisMappingPoint, Contour,
-        ExternalLocation, Font, Glyph, GlyphLayer, LayerId, Location, NamedInstance, PointType,
+        ExternalLocation, Font, Glyph, GlyphLayer, GlyphSource, LayerId, Location, NamedInstance,
+        PointType,
     };
     use std::fs;
 
@@ -29,8 +30,7 @@ mod tests {
         font.metrics_mut().units_per_em = 1000.0;
 
         let mut glyph = Glyph::with_unicode("o".to_string(), 'o' as u32);
-        let mut layer =
-            GlyphLayer::with_width(LayerId::new(), font.default_source_id().unwrap(), 520.0);
+        let mut layer = GlyphLayer::with_width(LayerId::new(), 520.0);
         let mut contour = Contour::new();
         contour.add_point(100.0, 0.0, PointType::OnCurve, false);
         contour.add_point(420.0, 0.0, PointType::OnCurve, false);
@@ -38,7 +38,15 @@ mod tests {
         contour.add_point(100.0, 500.0, PointType::OnCurve, false);
         contour.close();
         layer.add_contour(contour);
+        let source_id = font.default_source_id().unwrap();
+        let glyph_source = GlyphSource::new(
+            "Regular".to_string(),
+            layer.id(),
+            Some(source_id),
+            Location::new(),
+        );
         glyph.set_layer(layer);
+        glyph.insert_default_source(glyph_source);
         font.insert_glyph(glyph).unwrap();
 
         font

--- a/crates/shift-backends/src/formats/glyphs/conversion.rs
+++ b/crates/shift-backends/src/formats/glyphs/conversion.rs
@@ -6,8 +6,9 @@ use glyphs_reader::{
 };
 use shift_font::{
     Anchor, Axis, AxisMapping, AxisMappingPoint, Component, Contour, DesignLocation,
-    ExternalLocation, FeatureData, Font, Glyph, GlyphId, GlyphLayer, KerningData, KerningPair,
-    KerningSide, LayerId, Location, MetricKind, NamedInstance, Source, SourceId, Transform,
+    ExternalLocation, FeatureData, Font, Glyph, GlyphId, GlyphLayer, GlyphSource, KerningData,
+    KerningPair, KerningSide, LayerId, Location, MetricKind, NamedInstance, Source, SourceId,
+    Transform,
 };
 
 use crate::{
@@ -303,8 +304,7 @@ pub(super) fn convert_glyph(
             continue;
         };
 
-        let mut result_layer =
-            GlyphLayer::with_width(LayerId::new(), source_id, layer.width.into_inner());
+        let mut result_layer = GlyphLayer::with_width(LayerId::new(), layer.width.into_inner());
         for shape in &layer.shapes {
             match shape {
                 Shape::Path(path) => {
@@ -347,7 +347,14 @@ pub(super) fn convert_glyph(
             result_layer.add_anchor(Anchor::new(name, x, y));
         }
 
+        let glyph_source = GlyphSource::new(
+            source_id.to_string(),
+            result_layer.id(),
+            Some(source_id),
+            Location::new(),
+        );
         result.set_layer(result_layer);
+        result.insert_default_source(glyph_source);
     }
 
     Ok(result)

--- a/crates/shift-backends/src/formats/opentype/reader.rs
+++ b/crates/shift-backends/src/formats/opentype/reader.rs
@@ -7,8 +7,8 @@ use crate::{
 };
 use rayon::prelude::*;
 use shift_font::{
-    Contour, ContourId, Font, Glyph, GlyphId as ShiftGlyphId, GlyphLayer, GlyphName, LayerId,
-    PointId, PointType, SourceId,
+    Contour, ContourId, Font, Glyph, GlyphId as ShiftGlyphId, GlyphLayer, GlyphName, GlyphSource,
+    LayerId, Location, PointId, PointType, SourceId,
 };
 use skrifa::{
     outline::{DrawSettings, OutlineGlyphCollection, OutlinePen},
@@ -271,7 +271,6 @@ fn glyph_from_skrifa(
     })?;
     let mut layer = GlyphLayer::with_width(
         LayerId::from_raw(format!("binary{}", record.raw_id.to_u32())),
-        source_id.clone(),
         advance_width as f64,
     );
 
@@ -291,9 +290,16 @@ fn glyph_from_skrifa(
         }
     }
 
+    let glyph_source = GlyphSource::new(
+        source_id.to_string(),
+        layer.id(),
+        Some(source_id.clone()),
+        Location::new(),
+    );
     let mut glyph = Glyph::with_id(record.shift_id.clone(), record.name.clone());
     glyph.set_unicodes(record.unicodes.clone());
     glyph.set_layer(layer);
+    glyph.insert_default_source(glyph_source);
     Ok(glyph)
 }
 

--- a/crates/shift-backends/src/formats/ufo/mod.rs
+++ b/crates/shift-backends/src/formats/ufo/mod.rs
@@ -33,8 +33,21 @@ impl FontWriter for UfoBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use shift_font::{Contour, Glyph, GlyphLayer, LayerId, PointType};
+    use shift_font::{
+        Contour, Glyph, GlyphLayer, GlyphSource, LayerId, Location, PointType, SourceId,
+    };
     use std::fs;
+
+    fn set_source_layer(glyph: &mut Glyph, source_id: SourceId, layer: GlyphLayer) {
+        let glyph_source = GlyphSource::new(
+            source_id.to_string(),
+            layer.id(),
+            Some(source_id),
+            Location::new(),
+        );
+        glyph.set_layer(layer);
+        glyph.insert_default_source(glyph_source);
+    }
 
     fn create_test_font() -> Font {
         let mut font = Font::new();
@@ -45,7 +58,7 @@ mod tests {
         let default_source_id = font.default_source_id().unwrap();
 
         let mut glyph = Glyph::with_unicode("A".to_string(), 65);
-        let mut layer = GlyphLayer::with_width(LayerId::new(), default_source_id, 600.0);
+        let mut layer = GlyphLayer::with_width(LayerId::new(), 600.0);
 
         let mut contour = Contour::new();
         contour.add_point(0.0, 0.0, PointType::OnCurve, false);
@@ -61,7 +74,7 @@ mod tests {
         inner.close();
         layer.add_contour(inner);
 
-        glyph.set_layer(layer);
+        set_source_layer(&mut glyph, default_source_id, layer);
         font.insert_glyph(glyph).unwrap();
 
         font
@@ -124,7 +137,7 @@ mod tests {
         let default_source_id = font.default_source_id().unwrap();
 
         let mut glyph = Glyph::with_unicode("A".to_string(), 0x0041);
-        let mut layer = GlyphLayer::with_width(LayerId::new(), default_source_id, 500.4);
+        let mut layer = GlyphLayer::with_width(LayerId::new(), 500.4);
 
         let mut contour = Contour::new();
         contour.add_point(
@@ -149,7 +162,7 @@ mod tests {
         layer.add_contour(contour);
         layer.add_contour(Contour::new());
 
-        glyph.set_layer(layer);
+        set_source_layer(&mut glyph, default_source_id, layer);
         font.insert_glyph(glyph).unwrap();
 
         let temp_dir = tempfile::tempdir().unwrap();
@@ -220,16 +233,16 @@ mod tests {
 
         for (name, unicode) in [("B", 0x0042_u32), ("C", 0x0043)] {
             let mut glyph = Glyph::with_unicode(name.to_string(), unicode);
-            glyph.set_layer(GlyphLayer::with_width(
-                LayerId::new(),
+            set_source_layer(
+                &mut glyph,
                 default_source_id.clone(),
-                500.0,
-            ));
-            glyph.set_layer(GlyphLayer::with_width(
-                LayerId::new(),
+                GlyphLayer::with_width(LayerId::new(), 500.0),
+            );
+            set_source_layer(
+                &mut glyph,
                 bold_source_id.clone(),
-                550.0,
-            ));
+                GlyphLayer::with_width(LayerId::new(), 550.0),
+            );
             font.insert_glyph(glyph).unwrap();
         }
 
@@ -296,11 +309,11 @@ mod tests {
 
         let bad_name = "A\u{0001}B".to_string();
         let mut glyph = Glyph::with_unicode(bad_name.clone(), 0x0041);
-        glyph.set_layer(GlyphLayer::with_width(
-            LayerId::new(),
+        set_source_layer(
+            &mut glyph,
             default_source_id,
-            600.0,
-        ));
+            GlyphLayer::with_width(LayerId::new(), 600.0),
+        );
         font.insert_glyph(glyph).unwrap();
 
         let temp_dir = tempfile::tempdir().unwrap();
@@ -347,7 +360,7 @@ mod tests {
         let default_source_id = font.default_source_id().unwrap();
 
         let mut glyph = Glyph::with_unicode("A".to_string(), 0x0041);
-        let mut layer = GlyphLayer::with_width(LayerId::new(), default_source_id, 512.5);
+        let mut layer = GlyphLayer::with_width(LayerId::new(), 512.5);
 
         let mut contour = Contour::new();
         contour.add_point(100.5, 33.25, PointType::OnCurve, false);
@@ -357,7 +370,7 @@ mod tests {
         layer.add_contour(contour);
         layer.add_anchor(shift_font::Anchor::new("top".to_string(), 10.75, 720.5));
 
-        glyph.set_layer(layer);
+        set_source_layer(&mut glyph, default_source_id, layer);
         font.insert_glyph(glyph).unwrap();
 
         let temp_dir = tempfile::tempdir().unwrap();

--- a/crates/shift-backends/src/formats/ufo/reader.rs
+++ b/crates/shift-backends/src/formats/ufo/reader.rs
@@ -5,8 +5,7 @@ use crate::traits::FontReader;
 use norad::{Font as NoradFont, Line};
 use shift_font::{
     Anchor, Component, Contour, FeatureData, Font, GlyphId, GlyphLayer, Guideline, KerningData,
-    KerningPair, KerningSide, LayerId, LibData, LibValue, MetricKind, PointType, SourceId,
-    Transform,
+    KerningPair, KerningSide, LayerId, LibData, LibValue, MetricKind, PointType, Transform,
 };
 use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
@@ -187,9 +186,8 @@ impl UfoReader {
     fn convert_layer_geometry(
         norad_glyph: &norad::Glyph,
         layer_id: LayerId,
-        source_id: SourceId,
     ) -> (GlyphLayer, Vec<PendingComponent>) {
-        let mut glyph_layer = GlyphLayer::with_width(layer_id, source_id, norad_glyph.width);
+        let mut glyph_layer = GlyphLayer::with_width(layer_id, norad_glyph.width);
         let mut pending_components = Vec::new();
         if norad_glyph.height != 0.0 {
             glyph_layer.set_height(Some(norad_glyph.height));
@@ -221,11 +219,9 @@ impl UfoReader {
     pub(crate) fn convert_stream_layer(
         norad_glyph: &norad::Glyph,
         layer_id: LayerId,
-        source_id: SourceId,
         glyph_ids: &HashMap<String, GlyphId>,
     ) -> FormatBackendResult<GlyphLayer> {
-        let (mut layer, pending_components) =
-            Self::convert_layer_geometry(norad_glyph, layer_id, source_id);
+        let (mut layer, pending_components) = Self::convert_layer_geometry(norad_glyph, layer_id);
         for pending in pending_components {
             let base_glyph_id = glyph_ids.get(&pending.base_glyph_name).ok_or_else(|| {
                 FormatBackendError::Ufo(format!(

--- a/crates/shift-backends/src/import.rs
+++ b/crates/shift-backends/src/import.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, path::PathBuf};
 
 use rayon::prelude::*;
-use shift_font::{Font, Glyph, GlyphId, GlyphName, LayerId, SourceId};
+use shift_font::{Font, Glyph, GlyphId, GlyphName, GlyphSource, LayerId, Location, SourceId};
 
 use crate::{BackendError, BackendResult, FontFormat, FormatBackendResult, ImportReport};
 
@@ -132,10 +132,16 @@ fn load_glif_glyph(
         let layer = crate::formats::ufo::UfoReader::convert_stream_layer(
             &norad_glyph,
             layer_record.layer_id.clone(),
-            layer_record.source_id.clone(),
             glyph_ids,
         )?;
+        let glyph_source = GlyphSource::new(
+            layer_record.source_id.to_string(),
+            layer.id(),
+            Some(layer_record.source_id.clone()),
+            Location::new(),
+        );
         glyph.set_layer(layer);
+        glyph.insert_default_source(glyph_source);
     }
     Ok(glyph)
 }

--- a/crates/shift-backends/tests/loading.rs
+++ b/crates/shift-backends/tests/loading.rs
@@ -4,7 +4,9 @@ use std::{
 };
 
 use shift_backends::font_loader::FontLoader;
-use shift_font::{Contour, Font, Glyph, GlyphLayer, LayerId, MetricKind, PointType};
+use shift_font::{
+    Contour, Font, Glyph, GlyphLayer, GlyphSource, LayerId, Location, MetricKind, PointType,
+};
 
 fn fixtures_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -99,14 +101,21 @@ fn simple_geometry_font() -> Font {
     let mut font = Font::new();
     let source_id = font.default_source_id().unwrap();
     let mut glyph = Glyph::with_unicode("A".to_string(), 0x0041);
-    let mut layer = GlyphLayer::with_width(LayerId::from_raw("A_regular"), source_id, 640.0);
+    let mut layer = GlyphLayer::with_width(LayerId::from_raw("A_regular"), 640.0);
     let mut contour = Contour::new();
     contour.add_point(100.0, 0.0, PointType::OnCurve, false);
     contour.add_point(320.0, 700.0, PointType::OnCurve, false);
     contour.add_point(540.0, 0.0, PointType::OnCurve, false);
     contour.close();
     layer.add_contour(contour);
+    let glyph_source = GlyphSource::new(
+        "Regular".to_string(),
+        layer.id(),
+        Some(source_id),
+        Location::new(),
+    );
     glyph.set_layer(layer);
+    glyph.insert_default_source(glyph_source);
     font.insert_glyph(glyph).unwrap();
     font
 }
@@ -185,13 +194,14 @@ fn loads_ufo_components_anchors_layers_and_kerning() {
     let source_names: Vec<_> = font.sources().iter().map(|source| source.name()).collect();
     assert!(source_names.contains(&"Regular"));
     assert!(font.sources().len() >= 2);
-    assert!(font
-        .glyphs()
-        .flat_map(|glyph| glyph.layers().values())
-        .all(|layer| font
-            .sources()
-            .iter()
-            .any(|source| source.id() == layer.source_id())));
+    assert!(font.glyphs().all(|glyph| {
+        glyph.default_sources().values().all(|glyph_source| {
+            glyph.layer(glyph_source.layer_id()).is_some()
+                && glyph_source.base_source_id().is_some_and(|source_id| {
+                    font.sources().iter().any(|source| source.id() == source_id)
+                })
+        })
+    }));
 
     assert_eq!(font.kerning().get_kerning("T", "A"), Some(-75.0));
     assert_eq!(font.kerning().get_kerning("V", "A"), Some(-100.0));

--- a/crates/shift-bridge/src/bridge.rs
+++ b/crates/shift-bridge/src/bridge.rs
@@ -1490,13 +1490,16 @@ impl Bridge {
       let projection = font.glyph_projection(&glyph_id)?.as_ref().map(Into::into);
 
       let layers = glyph
-        .layers()
+        .default_sources()
         .values()
-        .map(|layer| layer.as_ref())
-        .map(|layer| GlyphLayerSnapshot {
-          glyph_id: glyph_id.clone(),
-          source_id: layer.source_id(),
-          state: GlyphState::from_layer(layer),
+        .filter_map(|source| {
+          let source_id = source.base_source_id()?;
+          let layer = glyph.layer(source.layer_id())?;
+          Some(GlyphLayerSnapshot {
+            glyph_id: glyph_id.clone(),
+            source_id,
+            state: GlyphState::from_layer(layer),
+          })
         })
         .collect();
 

--- a/crates/shift-cli/src/authoring.rs
+++ b/crates/shift-cli/src/authoring.rs
@@ -299,7 +299,7 @@ fn report_changes(font: &Font, changes: Vec<FontChange>) -> Vec<AuthoringChange>
                 Some(AuthoringChange::GlyphLayerCreated {
                     layer_id: change.layer_id.to_string(),
                     glyph_id: change.glyph_id.to_string(),
-                    source_id: change.source_id.to_string(),
+                    source_id: change.glyph_source.base_source_id()?.to_string(),
                     advance: layer.width(),
                     contour_count: layer.contours().len(),
                     point_count: layer

--- a/crates/shift-cli/src/authoring/glyph.rs
+++ b/crates/shift-cli/src/authoring/glyph.rs
@@ -118,7 +118,7 @@ pub fn copy_layer(args: CopyLayerArgs) -> Result<AuthoringReport> {
     let from_source_id = resolve_source_id(&font, &args.from_source)?;
     let source_id = resolve_source_id(&font, &args.source)?;
     let from_layer_id = font
-        .layer_id_for_glyph_source(glyph_id.clone(), from_source_id.clone())
+        .layer_id_for_source(glyph_id.clone(), from_source_id.clone())
         .ok_or_else(|| {
             miette!(
                 "glyph {:?} has no authored layer at source {:?}",

--- a/crates/shift-cli/src/inspect.rs
+++ b/crates/shift-cli/src/inspect.rs
@@ -24,7 +24,7 @@ mod tests {
     use serde_json::json;
     use shift_font::{
         Axis, AxisId, AxisLabel, AxisLabelId, AxisMapping, AxisMappingPoint, Contour,
-        DesignLocation, ExternalLocation, Font, Glyph, GlyphLayer, LayerId, Location,
+        DesignLocation, ExternalLocation, Font, Glyph, GlyphLayer, GlyphSource, LayerId, Location,
         NamedInstance, NamedInstanceId, Point, Source, SourceId,
     };
     use shift_source::ShiftSourcePackage;
@@ -224,12 +224,19 @@ mod tests {
         font.set_default_source_id(bold_id.clone());
 
         let mut glyph = Glyph::with_unicode("A", 0x41);
-        let mut layer = GlyphLayer::with_width(LayerId::from_raw("A_bold"), bold_id, 600.0);
+        let mut layer = GlyphLayer::with_width(LayerId::from_raw("A_bold"), 600.0);
         layer.add_contour(Contour::from_points(
             vec![Point::on_curve(0.0, 0.0), Point::on_curve(100.0, 0.0)],
             false,
         ));
+        let glyph_source = GlyphSource::new(
+            "Bold".to_string(),
+            layer.id(),
+            Some(bold_id),
+            Location::new(),
+        );
         glyph.set_layer(layer);
+        glyph.insert_default_source(glyph_source);
         font.insert_glyph(glyph).unwrap();
 
         font

--- a/crates/shift-cli/src/inspect/report.rs
+++ b/crates/shift-cli/src/inspect/report.rs
@@ -424,9 +424,17 @@ fn location_values(
 impl GlyphSummary {
     fn from_glyph(glyph: &Glyph, source_names_by_id: &HashMap<SourceId, String>) -> Self {
         let mut layers = glyph
-            .layers()
+            .default_sources()
             .values()
-            .map(|layer| GlyphLayerSummary::from_layer(layer.as_ref(), source_names_by_id))
+            .filter_map(|source| {
+                let source_id = source.base_source_id()?;
+                let layer = glyph.layer(source.layer_id())?;
+                Some(GlyphLayerSummary::from_layer(
+                    layer,
+                    source_id,
+                    source_names_by_id,
+                ))
+            })
             .collect::<Vec<_>>();
         layers.sort_by(|left, right| {
             left.source_id
@@ -449,8 +457,11 @@ impl GlyphSummary {
 }
 
 impl GlyphLayerSummary {
-    fn from_layer(layer: &GlyphLayer, source_names_by_id: &HashMap<SourceId, String>) -> Self {
-        let source_id = layer.source_id();
+    fn from_layer(
+        layer: &GlyphLayer,
+        source_id: SourceId,
+        source_names_by_id: &HashMap<SourceId, String>,
+    ) -> Self {
         let point_count = layer.contours_iter().map(|contour| contour.len()).sum();
 
         Self {

--- a/crates/shift-font/docs/DOCS.md
+++ b/crates/shift-font/docs/DOCS.md
@@ -8,7 +8,7 @@ First-class Rust font object model for Shift.
 - **Architecture Invariant:** Stable IDs are identity. Names, tags, Unicode assignments, and coordinates remain editable authoring values.
 - **Architecture Invariant:** Glyph-structure IDs are font-wide within their entity type. Contours, points, components, anchors, and glyph-layer guidelines are never addressed by a layer-qualified identity.
 - **Architecture Invariant:** Ordered, identity-addressable authoring collections use `EntityList`. Its iteration, equality, and serialization preserve authored order; its private backing container is not part of the model contract.
-- **Architecture Invariant:** Named instances own complete external locations but no source or geometry. Sources own design-space locations.
+- **Architecture Invariant:** Named instances own complete external locations but no source or geometry. Global `Source` values own font design-space locations; ordered `GlyphSource` values bind glyph-local samples to independent geometry layers and optional global-source bases.
 - **Architecture Invariant:** Mapping edits never rewrite external named-instance intent.
 - **Architecture Invariant:** Fontdrasil exclusively constructs variation sample order, supports, and numeric deltas. `shift-font` exposes compiled `VariationBasis` and `AxisMappingBasis` values; TypeScript and transport layers only evaluate or translate them.
 - **Architecture Invariant:** Authored metadata and font metrics are independent. Metadata edits replace the complete metadata snapshot without rewriting metrics.
@@ -40,10 +40,14 @@ crates/shift-font/src/
 - `ExternalLocation` and `DesignLocation` are serde-transparent nominal wrappers around `Location`. Mapping accepts only the former and interpolation/projection accepts only the latter.
 - `NamedInstance` is an explicit named product preset at a complete external location. It owns no source, layer, or compiler representation.
 - `MetricDefinition` gives one metric row stable identity and a standard or custom semantic role.
-- `Source` is an editable designspace position with a name, location, complete metric values, and optional technical metrics.
+- `Source` is an editable font-global designspace position with a name, location, complete metric values, and optional technical metrics.
 - `SourceMetricInterpolation` owns metric identity, optional technical-field participation, variation regions, and delta ordering for source-owned metrics.
-- `Glyph` is a glyph concept identified by `GlyphId`.
-- `GlyphLayer` is authored editable data for one glyph at one source.
+- `Glyph` is a glyph concept identified by `GlyphId`. It owns ordered glyph-local axes, Default glyph sources, conditional variants, and an independent layer map.
+- `GlyphAxis` is a glyph-owned continuous axis. Its `AxisId` shares the font-wide axis identity namespace.
+- `GlyphSource` is a stable sample binding with an optional global-source base, sparse global/local coordinates, and a same-glyph `LayerId`. Several sources may intentionally share a layer; layers may remain unreferenced.
+- `GlyphVariant` is an ordered conditional alternate source set. `Condition` is a validated boolean tree over font axes only.
+- `GlyphLayer` owns geometry only and has no source identity.
+- `Component` may additionally own a sparse child location, `AxisInheritance::{Parent, Font}`, and an optional root-font condition.
 - `LibData` and recursive `LibValue::Dict` use ordered maps so equal domain values serialize deterministically.
 - `GlyphEntityId` gives `FontIndex` one typed set for contour, point, component, anchor, and guideline identity.
 - `VariationBasis` is the source-neutral Fontdrasil output: normalized regions paired with numeric `VariationDelta` vectors.
@@ -63,8 +67,8 @@ crates/shift-font/src/
 Stable IDs are identity. Names and Unicode values are editable metadata.
 
 - `GlyphId` identifies a glyph.
-- `SourceId` identifies a source.
-- `LayerId` identifies a glyph layer: the authored data for one glyph at one source.
+- `SourceId` identifies a font-global source; `GlyphSourceId` identifies one glyph-owned sample binding; `GlyphVariantId` identifies one conditional source set.
+- `LayerId` identifies source-neutral glyph geometry. Source-to-layer membership is represented only by `GlyphSource`.
 - `ContourId`, `PointId`, `ComponentId`, `AnchorId`, and glyph-layer `GuidelineId` identify one authored node anywhere in the font; authoring operations mint them rather than accepting user-chosen values.
 - `AxisMappingId` identifies a font-owned mapping independently of its editable name.
 - `AxisLabelId` identifies an axis value label independently of its editable name or position.
@@ -73,7 +77,7 @@ Stable IDs are identity. Names and Unicode values are editable metadata.
 
 ## How it works
 
-- Own font authoring data structures such as `Font`, `Glyph`, `GlyphLayer`, `Contour`, `Point`, `Source`, and `Axis`.
+- Own font authoring data structures such as `Font`, `Glyph`, `GlyphAxis`, `GlyphSource`, `GlyphVariant`, `Condition`, `GlyphLayer`, `Contour`, `Point`, `Component`, `Source`, and `Axis`.
 - Keep object-level mutation behavior near the objects it mutates.
 - Provide model-native helpers for layer editing, component resolution, variation behavior, axis mapping evaluation, and geometry-derived behavior. `Font::replace_glyph_layers` retains previous layers through cheap `Arc` references, validates a complete hydration/eviction batch into one `HashSet<GlyphEntityId>`, moves that set into the final index, mutates uniquely owned fonts in place, and preserves shared snapshots through copy-on-write.
 - Own canonical glyph, source-metric, and axis-mapping variation-model construction. Fontdrasil constructs every sample order, support region, and delta vector; consumers evaluate the resulting bases without reconstructing them.
@@ -99,7 +103,7 @@ Coordinates, advance width, smooth flags, anchor positions, and component transf
 
 `shift-wire` may translate native bases, source values, and projections into transport DTOs, but it must not rebuild source samples, define value ordering or topology compatibility, or evaluate variation models.
 
-`shift-font` should not perform SQLite persistence or define a durable binary encoding. Durable working-store reads, writes, MessagePack encoding, compression, and compatibility policy belong in `shift-store`.
+`shift-font` should not perform SQLite persistence or define a durable binary encoding. Durable working-store reads, writes, MessagePack encoding, compression, and compatibility policy belong in `shift-store`. Publication boundaries call `Font::validate` to reject invalid source/layer ownership, local-axis collisions, font-axis-only condition violations, missing component bases, and component cycles.
 
 `shift-font` should not own Electron, NAPI, or editor state. The TypeScript editor owns UI interaction, selection, hover, camera, tools, and command history.
 

--- a/crates/shift-font/src/changes.rs
+++ b/crates/shift-font/src/changes.rs
@@ -1,7 +1,7 @@
 use crate::{
     Anchor, AnchorId, Axis, AxisId, AxisMapping, Contour, ContourId, FontMetadata, Glyph, GlyphId,
-    GlyphLayer, GlyphName, LayerId, MetricDefinition, MetricId, MetricValue, NamedInstance, Point,
-    PointId, PointType, Source, SourceId,
+    GlyphLayer, GlyphName, GlyphSource, LayerId, MetricDefinition, MetricId, MetricValue,
+    NamedInstance, Point, PointId, PointType, Source, SourceId,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -134,14 +134,17 @@ impl FontChange {
         })
     }
 
-    pub fn glyph_layer_created(glyph_id: GlyphId, layer: &GlyphLayer) -> Self {
-        Self::GlyphLayerCreated(GlyphLayerCreated::from_layer(glyph_id, layer))
+    pub fn glyph_layer_created(
+        glyph_id: GlyphId,
+        glyph_source: &GlyphSource,
+        layer: &GlyphLayer,
+    ) -> Self {
+        Self::GlyphLayerCreated(GlyphLayerCreated::from_layer(glyph_id, glyph_source, layer))
     }
 
     pub fn glyph_layer_deleted(glyph_id: GlyphId, layer: &GlyphLayer) -> Self {
         Self::GlyphLayerDeleted(GlyphLayerDeleted {
             glyph_id,
-            source_id: layer.source_id(),
             layer_id: layer.id(),
         })
     }
@@ -375,17 +378,17 @@ pub struct GlyphIdentityChanged {
 #[derive(Clone, Debug)]
 pub struct GlyphLayerCreated {
     pub glyph_id: GlyphId,
-    pub source_id: SourceId,
+    pub glyph_source: GlyphSource,
     pub layer_id: LayerId,
     pub width: f64,
     pub height: Option<f64>,
 }
 
 impl GlyphLayerCreated {
-    pub fn from_layer(glyph_id: GlyphId, layer: &GlyphLayer) -> Self {
+    pub fn from_layer(glyph_id: GlyphId, glyph_source: &GlyphSource, layer: &GlyphLayer) -> Self {
         Self {
             glyph_id,
-            source_id: layer.source_id(),
+            glyph_source: glyph_source.clone(),
             layer_id: layer.id(),
             width: layer.width(),
             height: layer.height(),
@@ -396,7 +399,6 @@ impl GlyphLayerCreated {
 #[derive(Clone, Debug)]
 pub struct GlyphLayerDeleted {
     pub glyph_id: GlyphId,
-    pub source_id: SourceId,
     pub layer_id: LayerId,
 }
 

--- a/crates/shift-font/src/composite.rs
+++ b/crates/shift-font/src/composite.rs
@@ -671,8 +671,8 @@ fn compose_transform(outer: Transform, inner: Transform) -> Transform {
 mod tests {
     use super::*;
     use crate::{
-        Anchor, Component, Contour, Font, Glyph, GlyphId, GlyphLayer, LayerId, PointType, SourceId,
-        Transform,
+        Anchor, Component, Contour, Font, Glyph, GlyphId, GlyphLayer, GlyphSource, LayerId,
+        Location, PointType, SourceId, Transform,
     };
 
     fn two_point_contour(x0: f64, y0: f64, x1: f64, y1: f64) -> Contour {
@@ -682,8 +682,19 @@ mod tests {
         contour
     }
 
-    fn test_layer(source_id: SourceId, width: f64) -> GlyphLayer {
-        GlyphLayer::with_width(LayerId::new(), source_id, width)
+    fn test_layer(_source_id: SourceId, width: f64) -> GlyphLayer {
+        GlyphLayer::with_width(LayerId::new(), width)
+    }
+
+    fn set_test_layer(glyph: &mut Glyph, source_id: SourceId, layer: GlyphLayer) {
+        let layer_id = layer.id();
+        glyph.set_layer(layer);
+        glyph.insert_default_source(GlyphSource::new(
+            source_id.to_string(),
+            layer_id,
+            Some(source_id),
+            Location::new(),
+        ));
     }
 
     fn default_layers(font: &Font) -> HashMap<GlyphId, GlyphLayer> {
@@ -706,14 +717,14 @@ mod tests {
         let base_id = base.id();
         let mut base_layer = test_layer(source_id.clone(), 500.0);
         base_layer.add_contour(two_point_contour(0.0, 0.0, 10.0, 10.0));
-        base.set_layer(base_layer);
+        set_test_layer(&mut base, source_id.clone(), base_layer);
         font.insert_glyph(base).unwrap();
 
         let mut composite = Glyph::new("comp".to_string());
         let composite_id = composite.id();
         let mut composite_layer = test_layer(source_id.clone(), 500.0);
         composite_layer.add_component(Component::new(base_id, "base".to_string()));
-        composite.set_layer(composite_layer);
+        set_test_layer(&mut composite, source_id.clone(), composite_layer);
         font.insert_glyph(composite).unwrap();
 
         let resolved =
@@ -730,23 +741,24 @@ mod tests {
 
         let mut base = Glyph::new("base".to_string());
         let base_id = base.id();
-        base.set_layer(test_layer(source_id.clone(), 500.0));
+        let base_layer = test_layer(source_id.clone(), 500.0);
+        set_test_layer(&mut base, source_id.clone(), base_layer);
         font.insert_glyph(base).unwrap();
 
         let mut middle = Glyph::new("middle".to_string());
         let middle_id = middle.id();
         let mut middle_layer = test_layer(source_id.clone(), 500.0);
         let nested_id = middle_layer.add_component(Component::new(base_id, "base".to_string()));
-        middle.set_layer(middle_layer);
+        set_test_layer(&mut middle, source_id.clone(), middle_layer);
         font.insert_glyph(middle).unwrap();
 
         let mut root = Glyph::new("root".to_string());
         let root_id = root.id();
-        let mut root_layer = test_layer(source_id, 500.0);
+        let mut root_layer = test_layer(source_id.clone(), 500.0);
         let first_id =
             root_layer.add_component(Component::new(middle_id.clone(), "middle".to_string()));
         let second_id = root_layer.add_component(Component::new(middle_id, "middle".to_string()));
-        root.set_layer(root_layer);
+        set_test_layer(&mut root, source_id.clone(), root_layer);
         font.insert_glyph(root).unwrap();
 
         let layers = default_layers(&font);
@@ -780,20 +792,20 @@ mod tests {
         let mut a_layer = test_layer(source_id.clone(), 500.0);
         a_layer.add_component(Component::new(b_id.clone(), "B".to_string()));
         a_layer.add_component(Component::new(c_id.clone(), "C".to_string()));
-        a.set_layer(a_layer);
+        set_test_layer(&mut a, source_id.clone(), a_layer);
         font.insert_glyph(a).unwrap();
 
         let mut b = Glyph::with_id(b_id, "B".to_string());
         let mut b_layer = test_layer(source_id.clone(), 500.0);
         b_layer.add_contour(two_point_contour(0.0, 0.0, 20.0, 20.0));
         b_layer.add_component(Component::new(a_id.clone(), "A".to_string()));
-        b.set_layer(b_layer);
+        set_test_layer(&mut b, source_id.clone(), b_layer);
         font.insert_glyph(b).unwrap();
 
         let mut c = Glyph::with_id(c_id, "C".to_string());
         let mut c_layer = test_layer(source_id.clone(), 500.0);
         c_layer.add_contour(two_point_contour(10.0, 0.0, 30.0, 20.0));
-        c.set_layer(c_layer);
+        set_test_layer(&mut c, source_id.clone(), c_layer);
         font.insert_glyph(c).unwrap();
 
         let resolved =
@@ -812,7 +824,7 @@ mod tests {
         let mut base_layer = test_layer(source_id.clone(), 500.0);
         base_layer.add_contour(two_point_contour(0.0, 0.0, 10.0, 0.0));
         base_layer.add_anchor(Anchor::new(Some("top".to_string()), 100.0, 200.0));
-        base.set_layer(base_layer);
+        set_test_layer(&mut base, source_id.clone(), base_layer);
         font.insert_glyph(base).unwrap();
 
         let mut mark = Glyph::new("mark".to_string());
@@ -820,7 +832,7 @@ mod tests {
         let mut mark_layer = test_layer(source_id.clone(), 500.0);
         mark_layer.add_contour(two_point_contour(0.0, 0.0, 10.0, 0.0));
         mark_layer.add_anchor(Anchor::new(Some("_top".to_string()), 5.0, 0.0));
-        mark.set_layer(mark_layer);
+        set_test_layer(&mut mark, source_id.clone(), mark_layer);
         font.insert_glyph(mark).unwrap();
 
         let mut comp = Glyph::new("comp".to_string());
@@ -828,7 +840,7 @@ mod tests {
         let mut comp_layer = test_layer(source_id.clone(), 500.0);
         comp_layer.add_component(Component::new(base_id, "base".to_string()));
         comp_layer.add_component(Component::new(mark_id, "mark".to_string()));
-        comp.set_layer(comp_layer);
+        set_test_layer(&mut comp, source_id.clone(), comp_layer);
         font.insert_glyph(comp).unwrap();
 
         let layers = default_layers(&font);
@@ -864,7 +876,7 @@ mod tests {
         let mut mark_layer = test_layer(source_id.clone(), 500.0);
         mark_layer.add_contour(two_point_contour(0.0, 0.0, 10.0, 0.0));
         mark_layer.add_anchor(Anchor::new(Some("top".to_string()), 5.0, 0.0));
-        mark.set_layer(mark_layer);
+        set_test_layer(&mut mark, source_id.clone(), mark_layer);
         font.insert_glyph(mark).unwrap();
 
         let mut comp = Glyph::new("comp".to_string());
@@ -872,7 +884,7 @@ mod tests {
         let mut comp_layer = test_layer(source_id.clone(), 500.0);
         let matrix = Transform::translate(30.0, 40.0);
         comp_layer.add_component(Component::with_matrix(mark_id, "mark".to_string(), &matrix));
-        comp.set_layer(comp_layer);
+        set_test_layer(&mut comp, source_id.clone(), comp_layer);
         font.insert_glyph(comp).unwrap();
 
         let resolved =
@@ -895,7 +907,7 @@ mod tests {
         let mut base_layer = test_layer(source_id.clone(), 500.0);
         base_layer.add_anchor(Anchor::new(Some("top".to_string()), 100.0, 200.0));
         base_layer.add_contour(two_point_contour(0.0, 0.0, 10.0, 0.0));
-        base.set_layer(base_layer);
+        set_test_layer(&mut base, source_id.clone(), base_layer);
         font.insert_glyph(base).unwrap();
 
         let mut mark = Glyph::new("mark".to_string());
@@ -903,7 +915,7 @@ mod tests {
         let mut mark_layer = test_layer(source_id.clone(), 500.0);
         mark_layer.add_anchor(Anchor::new(Some("top_extra".to_string()), 5.0, 0.0));
         mark_layer.add_contour(two_point_contour(0.0, 0.0, 10.0, 0.0));
-        mark.set_layer(mark_layer);
+        set_test_layer(&mut mark, source_id.clone(), mark_layer);
         font.insert_glyph(mark).unwrap();
 
         let mut comp = Glyph::new("comp".to_string());
@@ -912,7 +924,7 @@ mod tests {
         comp_layer.add_anchor(Anchor::new(Some("parent_top".to_string()), 0.0, 0.0));
         comp_layer.add_component(Component::new(base_id, "base".to_string()));
         comp_layer.add_component(Component::new(mark_id, "mark".to_string()));
-        comp.set_layer(comp_layer);
+        set_test_layer(&mut comp, source_id.clone(), comp_layer);
         font.insert_glyph(comp).unwrap();
 
         let resolved =
@@ -936,7 +948,7 @@ mod tests {
         let mut base_layer = test_layer(source_id.clone(), 500.0);
         base_layer.add_anchor(Anchor::new(Some("top".to_string()), 100.0, 200.0));
         base_layer.add_contour(two_point_contour(0.0, 0.0, 10.0, 0.0));
-        base.set_layer(base_layer);
+        set_test_layer(&mut base, source_id.clone(), base_layer);
         font.insert_glyph(base).unwrap();
 
         let mut mark = Glyph::new("mark".to_string());
@@ -945,7 +957,7 @@ mod tests {
         mark_layer.add_anchor(Anchor::new(Some("_top".to_string()), 5.0, 0.0));
         mark_layer.add_anchor(Anchor::new(Some("top".to_string()), 5.0, 20.0));
         mark_layer.add_contour(two_point_contour(0.0, 0.0, 10.0, 0.0));
-        mark.set_layer(mark_layer);
+        set_test_layer(&mut mark, source_id.clone(), mark_layer);
         font.insert_glyph(mark).unwrap();
 
         let mut comp = Glyph::new("comp".to_string());
@@ -954,7 +966,7 @@ mod tests {
         comp_layer.add_component(Component::new(base_id, "base".to_string()));
         comp_layer.add_component(Component::new(mark_id.clone(), "mark".to_string()));
         comp_layer.add_component(Component::new(mark_id, "mark".to_string()));
-        comp.set_layer(comp_layer);
+        set_test_layer(&mut comp, source_id.clone(), comp_layer);
         font.insert_glyph(comp).unwrap();
 
         let resolved =

--- a/crates/shift-font/src/error.rs
+++ b/crates/shift-font/src/error.rs
@@ -1,6 +1,7 @@
 use crate::{
     AnchorId, AxisId, AxisLabelId, AxisMappingId, ComponentId, ContourId, GlyphId, GlyphName,
-    GuidelineId, LayerId, MetricId, MetricKind, NamedInstanceId, PointId, SourceId,
+    GlyphSourceId, GlyphVariantId, GuidelineId, LayerId, MetricId, MetricKind, NamedInstanceId,
+    PointId, SourceId,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -76,6 +77,24 @@ pub enum CoreError {
     #[error("source id {0} already exists")]
     DuplicateSourceId(SourceId),
 
+    #[error("glyph source id {0} already exists")]
+    DuplicateGlyphSourceId(GlyphSourceId),
+
+    #[error("glyph variant id {0} already exists")]
+    DuplicateGlyphVariantId(GlyphVariantId),
+
+    #[error("glyph source {glyph_source_id} references missing layer {layer_id}")]
+    GlyphSourceLayerNotFound {
+        glyph_source_id: GlyphSourceId,
+        layer_id: LayerId,
+    },
+
+    #[error("layer {layer_id} is referenced by glyph source {glyph_source_id}")]
+    GlyphLayerReferenced {
+        layer_id: LayerId,
+        glyph_source_id: GlyphSourceId,
+    },
+
     #[error("layer {0} not found")]
     LayerNotFound(LayerId),
 
@@ -119,6 +138,9 @@ pub enum CoreError {
 
     #[error("axis tag {0} already exists")]
     DuplicateAxisTag(String),
+
+    #[error("axis id {0} already exists")]
+    DuplicateAxisId(AxisId),
 
     #[error("axis {0} not found")]
     AxisNotFound(AxisId),
@@ -201,6 +223,26 @@ pub enum CoreError {
 
     #[error("cannot delete the last source")]
     CannotDeleteLastSource,
+
+    #[error("{kind} {entity_id} is invalid: {message}")]
+    InvalidAuthoringEntity {
+        kind: &'static str,
+        entity_id: String,
+        message: String,
+    },
+
+    #[error("source {source_id} is used as the base of glyph source {glyph_source_id}")]
+    SourceReferencedByGlyphSource {
+        source_id: SourceId,
+        glyph_source_id: GlyphSourceId,
+    },
+
+    #[error("axis {axis_id} is referenced by {kind} {entity_id}")]
+    AxisReferenced {
+        axis_id: AxisId,
+        kind: &'static str,
+        entity_id: String,
+    },
 }
 
 pub type CoreResult<T> = Result<T, CoreError>;

--- a/crates/shift-font/src/intents.rs
+++ b/crates/shift-font/src/intents.rs
@@ -599,22 +599,25 @@ impl Font {
             return Err(CoreError::CannotDeleteLastSource);
         }
 
-        let layers: Vec<(GlyphId, GlyphLayer)> = self
+        if let Some(glyph_source) = self
             .glyphs()
-            .filter_map(|glyph| {
-                glyph
-                    .layer_for_source(source_id.clone())
-                    .map(|layer| (glyph.id(), layer.clone()))
+            .flat_map(|glyph| {
+                glyph.default_sources().values().chain(
+                    glyph
+                        .variants()
+                        .values()
+                        .flat_map(|variant| variant.sources().values()),
+                )
             })
-            .collect();
-
-        for (glyph_id, layer) in layers {
-            changes.push(FontChange::glyph_layer_deleted(glyph_id, &layer));
-            self.remove_glyph_layer(layer.id())?;
+            .find(|glyph_source| glyph_source.base_source_id().as_ref() == Some(source_id))
+        {
+            return Err(CoreError::SourceReferencedByGlyphSource {
+                source_id: source_id.clone(),
+                glyph_source_id: glyph_source.id(),
+            });
         }
 
-        self.remove_source(source_id.clone())
-            .ok_or_else(|| CoreError::SourceNotFound(source_id.clone()))?;
+        self.remove_source(source_id.clone())?;
         changes.push(FontChange::source_deleted(source_id.clone()));
         Ok(())
     }
@@ -709,7 +712,7 @@ impl Font {
             return Err(CoreError::DuplicateLayerId(layer_id));
         }
         if self
-            .layer_id_for_glyph_source(glyph_id.clone(), source_id.clone())
+            .layer_id_for_source(glyph_id.clone(), source_id.clone())
             .is_some()
         {
             return Err(CoreError::DuplicateGlyphLayer {
@@ -717,10 +720,15 @@ impl Font {
                 source_id,
             });
         }
-        let layer = GlyphLayer::with_width(layer_id.clone(), source_id, self.default_layer_width());
+        let layer = GlyphLayer::with_width(layer_id.clone(), self.default_layer_width());
 
-        self.insert_glyph_layer(glyph_id.clone(), layer.clone())?;
-        changes.push(FontChange::glyph_layer_created(glyph_id, &layer));
+        let glyph_source =
+            self.insert_layer_for_source(glyph_id.clone(), source_id, layer.clone())?;
+        changes.push(FontChange::glyph_layer_created(
+            glyph_id,
+            &glyph_source,
+            &layer,
+        ));
 
         Ok(vec![layer_id])
     }
@@ -733,11 +741,20 @@ impl Font {
         from_layer_id: LayerId,
         changes: &mut FontChangeSet,
     ) -> CoreResult<Vec<LayerId>> {
-        let layer =
-            self.cloned_glyph_layer(layer_id.clone(), glyph_id.clone(), source_id, from_layer_id)?;
+        let layer = self.cloned_glyph_layer(
+            layer_id.clone(),
+            glyph_id.clone(),
+            source_id.clone(),
+            from_layer_id,
+        )?;
 
-        self.insert_glyph_layer(glyph_id.clone(), layer.clone())?;
-        changes.push(FontChange::glyph_layer_created(glyph_id, &layer));
+        let glyph_source =
+            self.insert_layer_for_source(glyph_id.clone(), source_id, layer.clone())?;
+        changes.push(FontChange::glyph_layer_created(
+            glyph_id,
+            &glyph_source,
+            &layer,
+        ));
 
         Ok(vec![layer_id])
     }
@@ -751,12 +768,21 @@ impl Font {
         values: &GlyphInterpolationValues,
         changes: &mut FontChangeSet,
     ) -> CoreResult<Vec<LayerId>> {
-        let mut layer =
-            self.cloned_glyph_layer(layer_id.clone(), glyph_id.clone(), source_id, from_layer_id)?;
+        let mut layer = self.cloned_glyph_layer(
+            layer_id.clone(),
+            glyph_id.clone(),
+            source_id.clone(),
+            from_layer_id,
+        )?;
         layer.apply_interpolation_values(values)?;
 
-        self.insert_glyph_layer(glyph_id.clone(), layer.clone())?;
-        changes.push(FontChange::glyph_layer_created(glyph_id, &layer));
+        let glyph_source =
+            self.insert_layer_for_source(glyph_id.clone(), source_id, layer.clone())?;
+        changes.push(FontChange::glyph_layer_created(
+            glyph_id,
+            &glyph_source,
+            &layer,
+        ));
 
         Ok(vec![layer_id])
     }
@@ -772,7 +798,7 @@ impl Font {
             return Err(CoreError::DuplicateLayerId(layer_id));
         }
         if self
-            .layer_id_for_glyph_source(glyph_id.clone(), source_id.clone())
+            .layer_id_for_source(glyph_id.clone(), source_id.clone())
             .is_some()
         {
             return Err(CoreError::DuplicateGlyphLayer {
@@ -795,7 +821,7 @@ impl Font {
         let source_layer = self
             .layer(from_layer_id.clone())
             .ok_or(CoreError::LayerNotFound(from_layer_id))?;
-        let layer = source_layer.clone_with_fresh_ids(layer_id, source_id);
+        let layer = source_layer.clone_with_fresh_ids(layer_id);
 
         Ok(layer)
     }
@@ -1192,12 +1218,11 @@ mod tests {
     #[test]
     fn intent_set_rejects_contour_identity_used_by_another_layer() {
         let mut font = Font::new();
-        let default_source_id = font.default_source_id().unwrap();
         let contour_id = ContourId::from_raw("shared");
         let glyph_id = GlyphId::new();
         let mut contour = Contour::with_id(contour_id.clone());
         contour.add_point(0.0, 0.0, PointType::OnCurve, false);
-        let mut layer = GlyphLayer::new(LayerId::new(), default_source_id);
+        let mut layer = GlyphLayer::new(LayerId::new());
         layer.add_contour(contour);
         let mut glyph = Glyph::with_id(glyph_id.clone(), "A");
         glyph.set_layer(layer);
@@ -1231,17 +1256,13 @@ mod tests {
     #[test]
     fn materialize_glyph_layer_applies_values_with_fresh_structure_ids() {
         let mut font = Font::new();
-        let default_source_id = font
-            .default_source_id()
-            .expect("new font should have a default source");
         let axis = Axis::weight();
         let axis_id = axis.id();
         font.add_axis(axis).expect("weight axis should be valid");
 
         let glyph_id = GlyphId::new();
         let from_layer_id = LayerId::new();
-        let mut source_layer =
-            GlyphLayer::with_width(from_layer_id.clone(), default_source_id, 500.0);
+        let mut source_layer = GlyphLayer::with_width(from_layer_id.clone(), 500.0);
         let mut contour = Contour::new();
         let source_point_id = contour.add_point(10.0, 20.0, PointType::OnCurve, false);
         source_layer.add_contour(contour);

--- a/crates/shift-font/src/interpolation.rs
+++ b/crates/shift-font/src/interpolation.rs
@@ -391,26 +391,24 @@ fn interpolation_reference_layer(font: &Font, glyph: &crate::Glyph) -> Option<Ar
             .find(|source| source.id() == default_source_id)
             .is_some_and(crate::Source::is_master);
         if default_is_master {
-            if let Some(layer) = glyph
-                .layers()
-                .values()
-                .find(|layer| layer.source_id() == default_source_id)
-            {
-                return Some(layer.clone());
+            if let Some(layer) = glyph.layer_for_source(default_source_id) {
+                return glyph.layers().get(&layer.id()).cloned();
             }
         }
     }
 
     glyph
-        .layers()
+        .default_sources()
         .values()
-        .filter(|layer| {
-            font.sources()
-                .iter()
-                .find(|source| source.id() == layer.source_id())
-                .is_some_and(crate::Source::is_master)
+        .filter(|glyph_source| {
+            glyph_source.base_source_id().is_some_and(|source_id| {
+                font.sources()
+                    .iter()
+                    .find(|source| source.id() == source_id)
+                    .is_some_and(crate::Source::is_master)
+            })
         })
-        .cloned()
+        .filter_map(|glyph_source| glyph.layers().get(&glyph_source.layer_id()).cloned())
         .reduce(|preferred, candidate| {
             if layer_complexity(&candidate) > layer_complexity(&preferred) {
                 candidate

--- a/crates/shift-font/src/interpolation/compatibility.rs
+++ b/crates/shift-font/src/interpolation/compatibility.rs
@@ -212,14 +212,10 @@ fn component_sequence(layer: &GlyphLayer) -> Vec<GlyphId> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Anchor, Component, Contour, LayerId, Point, SourceId};
+    use crate::{Anchor, Component, Contour, LayerId, Point};
 
     fn layer() -> GlyphLayer {
-        let mut layer = GlyphLayer::with_width(
-            LayerId::from_raw("layer"),
-            SourceId::from_raw("source"),
-            600.0,
-        );
+        let mut layer = GlyphLayer::with_width(LayerId::from_raw("layer"), 600.0);
         let mut contour = Contour::from_points(
             vec![
                 Point::on_curve(0.0, 0.0),
@@ -239,10 +235,7 @@ mod tests {
     #[test]
     fn compatible_layers_may_change_interpolated_values_and_metadata() {
         let reference = layer();
-        let mut source = reference.clone_with_fresh_ids(
-            LayerId::from_raw("source-layer"),
-            SourceId::from_raw("other-source"),
-        );
+        let mut source = reference.clone_with_fresh_ids(LayerId::from_raw("source-layer"));
         source.set_width(900.0);
         source.contours_iter_mut().next().unwrap().points_mut()[0].set_position(200.0, 300.0);
         source.contours_iter_mut().next().unwrap().points_mut()[1].set_smooth(false);
@@ -352,10 +345,7 @@ mod tests {
             }]
         );
 
-        let mut component_sequence = GlyphLayer::new(
-            LayerId::from_raw("components"),
-            SourceId::from_raw("other-source"),
-        );
+        let mut component_sequence = GlyphLayer::new(LayerId::from_raw("components"));
         component_sequence.add_contour(reference.contours_iter().next().unwrap().clone());
         component_sequence.add_anchor(reference.anchors()[0].clone());
         component_sequence
@@ -395,10 +385,7 @@ mod tests {
     #[test]
     fn reports_independent_differences_together_in_domain_order() {
         let reference = layer();
-        let source = GlyphLayer::new(
-            LayerId::from_raw("empty-layer"),
-            SourceId::from_raw("other-source"),
-        );
+        let source = GlyphLayer::new(LayerId::from_raw("empty-layer"));
 
         assert_eq!(
             reference

--- a/crates/shift-font/src/ir/component.rs
+++ b/crates/shift-font/src/ir/component.rs
@@ -1,7 +1,15 @@
 use crate::collection::Identified;
 use crate::entity::{ComponentId, GlyphId};
-use crate::GlyphName;
+use crate::{Condition, GlyphName, Location};
 use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AxisInheritance {
+    #[default]
+    Parent,
+    Font,
+}
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Component {
@@ -9,6 +17,9 @@ pub struct Component {
     base_glyph_id: GlyphId,
     base_glyph_name: GlyphName,
     transform: DecomposedTransform,
+    location: Location,
+    axis_inheritance: AxisInheritance,
+    condition: Option<Condition>,
 }
 
 impl Identified for Component {
@@ -216,6 +227,9 @@ impl Component {
             base_glyph_id,
             base_glyph_name: base_glyph_name.into(),
             transform: DecomposedTransform::identity(),
+            location: Location::new(),
+            axis_inheritance: AxisInheritance::Parent,
+            condition: None,
         }
     }
 
@@ -229,6 +243,9 @@ impl Component {
             base_glyph_id,
             base_glyph_name: base_glyph_name.into(),
             transform,
+            location: Location::new(),
+            axis_inheritance: AxisInheritance::Parent,
+            condition: None,
         }
     }
 
@@ -243,6 +260,9 @@ impl Component {
             base_glyph_id,
             base_glyph_name: base_glyph_name.into(),
             transform,
+            location: Location::new(),
+            axis_inheritance: AxisInheritance::Parent,
+            condition: None,
         }
     }
 
@@ -256,6 +276,9 @@ impl Component {
             base_glyph_id,
             base_glyph_name: base_glyph_name.into(),
             transform: DecomposedTransform::from_matrix(matrix),
+            location: Location::new(),
+            axis_inheritance: AxisInheritance::Parent,
+            condition: None,
         }
     }
 
@@ -281,6 +304,30 @@ impl Component {
 
     pub fn set_transform(&mut self, transform: DecomposedTransform) {
         self.transform = transform;
+    }
+
+    pub fn location(&self) -> &Location {
+        &self.location
+    }
+
+    pub fn set_location(&mut self, location: Location) {
+        self.location = location;
+    }
+
+    pub fn axis_inheritance(&self) -> AxisInheritance {
+        self.axis_inheritance
+    }
+
+    pub fn set_axis_inheritance(&mut self, axis_inheritance: AxisInheritance) {
+        self.axis_inheritance = axis_inheritance;
+    }
+
+    pub fn condition(&self) -> Option<&Condition> {
+        self.condition.as_ref()
+    }
+
+    pub fn set_condition(&mut self, condition: Option<Condition>) {
+        self.condition = condition;
     }
 
     pub fn translate(&mut self, dx: f64, dy: f64) {

--- a/crates/shift-font/src/ir/condition.rs
+++ b/crates/shift-font/src/ir/condition.rs
@@ -1,0 +1,29 @@
+use crate::AxisId;
+use serde::{Deserialize, Serialize};
+
+/// A reusable boolean expression over the root font design location.
+///
+/// Axis ranges are inclusive. Semantic validation requires at least one bound
+/// and restricts references to font-owned axes.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(
+    tag = "type",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum Condition {
+    AxisRange {
+        axis_id: AxisId,
+        minimum: Option<f64>,
+        maximum: Option<f64>,
+    },
+    And {
+        conditions: Vec<Condition>,
+    },
+    Or {
+        conditions: Vec<Condition>,
+    },
+    Not {
+        condition: Box<Condition>,
+    },
+}

--- a/crates/shift-font/src/ir/entity.rs
+++ b/crates/shift-font/src/ir/entity.rs
@@ -137,6 +137,8 @@ typed_id!(AnchorId, "anchor");
 typed_id!(GuidelineId, "guideline");
 typed_id!(LayerId, "layer");
 typed_id!(GlyphId, "glyph");
+typed_id!(GlyphSourceId, "glyphSource");
+typed_id!(GlyphVariantId, "glyphVariant");
 typed_id!(SourceId, "source");
 typed_id!(AxisId, "axis");
 typed_id!(AxisLabelId, "axisLabel");

--- a/crates/shift-font/src/ir/font.rs
+++ b/crates/shift-font/src/ir/font.rs
@@ -6,7 +6,7 @@ use crate::entity::{
 };
 use crate::error::{CoreError, CoreResult};
 use crate::features::FeatureData;
-use crate::glyph::{Glyph, GlyphLayer};
+use crate::glyph::{Glyph, GlyphAxis, GlyphLayer, GlyphSource};
 use crate::guideline::Guideline;
 use crate::interpolation::GlyphInterpolationValues;
 use crate::kerning::KerningData;
@@ -15,7 +15,9 @@ use crate::metrics::{FontMetrics, MetricDefinition, MetricKind, MetricValue};
 use crate::named_instance::{validate_named_instances, NamedInstance};
 use crate::source::source_locations_equal;
 use crate::source::Source;
-use crate::{AxisLabelId, GlyphName, NamedInstanceId};
+use crate::{
+    AxisLabelId, Component, Condition, GlyphName, GlyphSourceId, GlyphVariantId, NamedInstanceId,
+};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -124,24 +126,39 @@ struct FontData {
 struct FontIndex {
     glyph_by_name: HashMap<GlyphName, GlyphId>,
     layer_owner: HashMap<LayerId, GlyphId>,
-    layer_by_glyph_source: HashMap<(GlyphId, SourceId), LayerId>,
+    layer_by_glyph_source: HashMap<GlyphSourceId, LayerId>,
+    glyph_source_owner: HashMap<GlyphSourceId, GlyphId>,
+    glyph_variant_owner: HashMap<GlyphVariantId, GlyphId>,
+    glyph_axis_owner: HashMap<AxisId, GlyphId>,
     glyphs_by_unicode: HashMap<u32, Vec<GlyphId>>,
     entity_ids: HashSet<GlyphEntityId>,
 }
 
 impl FontIndex {
-    fn from_glyphs(glyphs: &EntityList<Arc<Glyph>>) -> CoreResult<Self> {
+    fn from_font(axes: &[Axis], glyphs: &EntityList<Arc<Glyph>>) -> CoreResult<Self> {
         let mut index = Self::default();
+        let mut axis_ids = HashSet::new();
+        for axis in axes {
+            if !axis_ids.insert(axis.id()) {
+                return Err(CoreError::DuplicateAxisId(axis.id()));
+            }
+        }
 
         for (glyph_id, glyph) in glyphs.iter() {
-            index.validate_glyph_insert(glyph_id.clone(), glyph)?;
+            index.validate_glyph_insert(glyph_id.clone(), glyph, &axis_ids)?;
             index.insert_glyph(glyph_id.clone(), glyph);
+            axis_ids.extend(glyph.axes().keys().cloned());
         }
 
         Ok(index)
     }
 
-    fn validate_glyph_insert(&self, glyph_id: GlyphId, glyph: &Glyph) -> CoreResult<()> {
+    fn validate_glyph_insert(
+        &self,
+        glyph_id: GlyphId,
+        glyph: &Glyph,
+        font_axis_ids: &HashSet<AxisId>,
+    ) -> CoreResult<()> {
         if glyph_id != glyph.id() {
             return Err(CoreError::MismatchedGlyphId {
                 key: glyph_id,
@@ -153,23 +170,44 @@ impl FontIndex {
             return Err(CoreError::DuplicateGlyphName(glyph.glyph_name().clone()));
         }
 
-        let mut local_sources = HashSet::new();
-        let mut local_entities = HashSet::new();
+        let mut local_axis_ids = HashSet::new();
+        for axis in glyph.axes().values() {
+            if font_axis_ids.contains(&axis.id())
+                || self.glyph_axis_owner.contains_key(&axis.id())
+                || !local_axis_ids.insert(axis.id())
+            {
+                return Err(CoreError::DuplicateAxisId(axis.id()));
+            }
+        }
 
+        let mut local_variant_ids = HashSet::new();
+        for variant in glyph.variants().values() {
+            if self.glyph_variant_owner.contains_key(&variant.id())
+                || !local_variant_ids.insert(variant.id())
+            {
+                return Err(CoreError::DuplicateGlyphVariantId(variant.id()));
+            }
+        }
+
+        let mut local_source_ids = HashSet::new();
+        for source in glyph_sources(glyph) {
+            if self.glyph_source_owner.contains_key(&source.id())
+                || !local_source_ids.insert(source.id())
+            {
+                return Err(CoreError::DuplicateGlyphSourceId(source.id()));
+            }
+            if !glyph.layers().contains_key(&source.layer_id()) {
+                return Err(CoreError::GlyphSourceLayerNotFound {
+                    glyph_source_id: source.id(),
+                    layer_id: source.layer_id(),
+                });
+            }
+        }
+
+        let mut local_entities = HashSet::new();
         for layer in glyph.layers().values().map(Arc::as_ref) {
             if self.layer_owner.contains_key(&layer.id()) {
                 return Err(CoreError::DuplicateLayerId(layer.id()));
-            }
-
-            if self
-                .layer_by_glyph_source
-                .contains_key(&(glyph_id.clone(), layer.source_id()))
-                || !local_sources.insert(layer.source_id())
-            {
-                return Err(CoreError::DuplicateGlyphLayer {
-                    glyph_id: glyph_id.clone(),
-                    source_id: layer.source_id(),
-                });
             }
 
             for entity_id in glyph_entity_ids(layer) {
@@ -183,19 +221,9 @@ impl FontIndex {
         Ok(())
     }
 
-    fn validate_layer_insert(&self, glyph_id: &GlyphId, layer: &GlyphLayer) -> CoreResult<()> {
+    fn validate_layer_insert(&self, layer: &GlyphLayer) -> CoreResult<()> {
         if self.layer_owner.contains_key(&layer.id()) {
             return Err(CoreError::DuplicateLayerId(layer.id()));
-        }
-
-        if self
-            .layer_by_glyph_source
-            .contains_key(&(glyph_id.clone(), layer.source_id()))
-        {
-            return Err(CoreError::DuplicateGlyphLayer {
-                glyph_id: glyph_id.clone(),
-                source_id: layer.source_id(),
-            });
         }
 
         let mut local_entities = HashSet::new();
@@ -232,18 +260,12 @@ impl FontIndex {
     }
 
     fn insert_layer(&mut self, glyph_id: GlyphId, layer: &GlyphLayer) {
-        self.layer_owner.insert(layer.id(), glyph_id.clone());
-        self.layer_by_glyph_source
-            .insert((glyph_id, layer.source_id()), layer.id());
-
+        self.layer_owner.insert(layer.id(), glyph_id);
         self.entity_ids.extend(glyph_entity_ids(layer));
     }
 
-    fn remove_layer(&mut self, glyph_id: GlyphId, layer: &GlyphLayer) {
+    fn remove_layer(&mut self, layer: &GlyphLayer) {
         self.layer_owner.remove(&layer.id());
-        self.layer_by_glyph_source
-            .remove(&(glyph_id, layer.source_id()));
-
         for entity_id in glyph_entity_ids(layer) {
             self.entity_ids.remove(&entity_id);
         }
@@ -260,6 +282,19 @@ impl FontIndex {
                 .push(glyph_id.clone());
         }
 
+        for axis in glyph.axes().values() {
+            self.glyph_axis_owner.insert(axis.id(), glyph_id.clone());
+        }
+        for variant in glyph.variants().values() {
+            self.glyph_variant_owner
+                .insert(variant.id(), glyph_id.clone());
+        }
+        for source in glyph_sources(glyph) {
+            self.glyph_source_owner
+                .insert(source.id(), glyph_id.clone());
+            self.layer_by_glyph_source
+                .insert(source.id(), source.layer_id());
+        }
         for layer in glyph.layers().values().map(Arc::as_ref) {
             self.insert_layer(glyph_id.clone(), layer);
         }
@@ -277,10 +312,29 @@ impl FontIndex {
             }
         }
 
+        for axis in glyph.axes().values() {
+            self.glyph_axis_owner.remove(&axis.id());
+        }
+        for variant in glyph.variants().values() {
+            self.glyph_variant_owner.remove(&variant.id());
+        }
+        for source in glyph_sources(glyph) {
+            self.glyph_source_owner.remove(&source.id());
+            self.layer_by_glyph_source.remove(&source.id());
+        }
         for layer in glyph.layers().values().map(Arc::as_ref) {
-            self.remove_layer(glyph_id.clone(), layer);
+            self.remove_layer(layer);
         }
     }
+}
+
+fn glyph_sources(glyph: &Glyph) -> impl Iterator<Item = &GlyphSource> {
+    glyph.default_sources().values().chain(
+        glyph
+            .variants()
+            .values()
+            .flat_map(|variant| variant.sources().values()),
+    )
 }
 
 fn glyph_entity_ids(layer: &GlyphLayer) -> impl Iterator<Item = GlyphEntityId> + '_ {
@@ -323,12 +377,13 @@ fn duplicate_entity_error(id: GlyphEntityId) -> CoreError {
 
 impl FontState {
     fn from_data(data: FontData) -> CoreResult<Self> {
-        let index = FontIndex::from_glyphs(&data.glyphs)?;
+        validate_font_data(&data)?;
+        let index = FontIndex::from_font(&data.axes, &data.glyphs)?;
         Ok(Self { data, index })
     }
 
     fn rebuild_index(&mut self) -> CoreResult<()> {
-        self.index = FontIndex::from_glyphs(&self.data.glyphs)?;
+        self.index = FontIndex::from_font(&self.data.axes, &self.data.glyphs)?;
         Ok(())
     }
 }
@@ -398,6 +453,13 @@ impl Default for Font {
 impl Font {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Validates the complete authored graph at a publication boundary.
+    pub fn validate(&self) -> CoreResult<()> {
+        validate_font_data(self.data())?;
+        FontIndex::from_font(self.axes(), &self.data().glyphs)?;
+        Ok(())
     }
 
     pub fn empty() -> Self {
@@ -540,6 +602,14 @@ impl Font {
         if self
             .axes()
             .iter()
+            .any(|existing| existing.id() == axis.id())
+            || self.index().glyph_axis_owner.contains_key(&axis.id())
+        {
+            return Err(CoreError::DuplicateAxisId(axis.id()));
+        }
+        if self
+            .axes()
+            .iter()
             .any(|existing| existing.tag() == axis.tag())
         {
             return Err(CoreError::DuplicateAxisTag(axis.tag().to_string()));
@@ -665,6 +735,45 @@ impl Font {
             .iter()
             .position(|axis| axis.id() == axis_id)
             .ok_or_else(|| CoreError::AxisNotFound(axis_id.clone()))?;
+        if let Some((kind, entity_id)) = self.glyphs().find_map(|glyph| {
+            glyph
+                .default_sources()
+                .values()
+                .chain(
+                    glyph
+                        .variants()
+                        .values()
+                        .flat_map(|variant| variant.sources().values()),
+                )
+                .find(|source| source.location().get(&axis_id).is_some())
+                .map(|source| ("glyph source", source.id().to_string()))
+                .or_else(|| {
+                    glyph
+                        .variants()
+                        .values()
+                        .find(|variant| condition_references_axis(variant.condition(), &axis_id))
+                        .map(|variant| ("glyph variant", variant.id().to_string()))
+                })
+                .or_else(|| {
+                    glyph
+                        .layers()
+                        .values()
+                        .flat_map(|layer| layer.components_iter())
+                        .find(|component| {
+                            component.location().get(&axis_id).is_some()
+                                || component.condition().is_some_and(|condition| {
+                                    condition_references_axis(condition, &axis_id)
+                                })
+                        })
+                        .map(|component| ("component", component.id().to_string()))
+                })
+        }) {
+            return Err(CoreError::AxisReferenced {
+                axis_id,
+                kind,
+                entity_id,
+            });
+        }
         let mut axes = self.axes().to_vec();
         let axis = axes.remove(index);
         let mut mappings = self.axis_mappings().to_vec();
@@ -828,21 +937,32 @@ impl Font {
         ))
     }
 
-    /// Removes a source record only; the caller removes the source's glyph
-    /// layers first so the layer index never points at a missing source.
-    pub fn remove_source(&mut self, source_id: SourceId) -> Option<Source> {
+    /// Removes a global source only when no glyph source uses it as a base.
+    pub fn remove_source(&mut self, source_id: SourceId) -> CoreResult<Source> {
+        if let Some(glyph_source) = self
+            .glyphs()
+            .flat_map(glyph_sources)
+            .find(|glyph_source| glyph_source.base_source_id().as_ref() == Some(&source_id))
+        {
+            return Err(CoreError::SourceReferencedByGlyphSource {
+                source_id,
+                glyph_source_id: glyph_source.id(),
+            });
+        }
+
         let data = self.data_mut();
         let index = data
             .sources
             .iter()
-            .position(|source| source.id() == source_id)?;
+            .position(|source| source.id() == source_id)
+            .ok_or_else(|| CoreError::SourceNotFound(source_id.clone()))?;
         let source = data.sources.remove(index);
 
         if data.default_source_id == Some(source_id) {
             data.default_source_id = data.sources.first().map(Source::id);
         }
 
-        Some(source)
+        Ok(source)
     }
 
     pub fn clear_sources(&mut self) {
@@ -900,14 +1020,16 @@ impl Font {
         self.index().layer_owner.get(&layer_id).cloned()
     }
 
-    pub fn layer_id_for_glyph_source(
-        &self,
-        glyph_id: GlyphId,
-        source_id: SourceId,
-    ) -> Option<LayerId> {
+    pub fn layer_id_for_source(&self, glyph_id: GlyphId, source_id: SourceId) -> Option<LayerId> {
+        self.glyph(glyph_id)?
+            .layer_for_source(source_id)
+            .map(GlyphLayer::id)
+    }
+
+    pub fn layer_id_for_glyph_source(&self, glyph_source_id: GlyphSourceId) -> Option<LayerId> {
         self.index()
             .layer_by_glyph_source
-            .get(&(glyph_id, source_id))
+            .get(&glyph_source_id)
             .cloned()
     }
 
@@ -929,8 +1051,9 @@ impl Font {
         if self.data().glyphs.contains(&glyph_id) {
             return Err(CoreError::DuplicateGlyphId(glyph_id));
         }
+        let font_axis_ids = self.axes().iter().map(Axis::id).collect();
         self.index()
-            .validate_glyph_insert(glyph_id.clone(), &glyph)?;
+            .validate_glyph_insert(glyph_id.clone(), &glyph, &font_axis_ids)?;
 
         let state = self.state_mut();
         state.index.insert_glyph(glyph_id.clone(), &glyph);
@@ -1016,15 +1139,32 @@ impl Font {
         Ok(())
     }
 
-    pub fn remove_glyph(&mut self, glyph_id: GlyphId) -> Option<Glyph> {
+    pub fn remove_glyph(&mut self, glyph_id: GlyphId) -> CoreResult<Glyph> {
+        if self.glyph(glyph_id.clone()).is_none() {
+            return Err(CoreError::GlyphNotFound(glyph_id));
+        }
+        if let Some(component) = self
+            .glyphs()
+            .flat_map(|glyph| glyph.layers().values())
+            .flat_map(|layer| layer.components_iter())
+            .find(|component| component.base_glyph_id() == glyph_id)
+        {
+            return Err(CoreError::InvalidAuthoringEntity {
+                kind: "glyph",
+                entity_id: glyph_id.to_string(),
+                message: format!("is referenced by component {}", component.id()),
+            });
+        }
+
         let state = self.state_mut();
         let glyph = state
             .data
             .glyphs
             .shift_remove(&glyph_id)
-            .map(Arc::unwrap_or_clone)?;
+            .map(Arc::unwrap_or_clone)
+            .expect("glyph existence was checked");
         state.index.remove_glyph(glyph_id, &glyph);
-        Some(glyph)
+        Ok(glyph)
     }
 
     pub fn glyph_count(&self) -> usize {
@@ -1057,20 +1197,114 @@ impl Font {
         Ok(())
     }
 
+    pub fn add_glyph_source(
+        &mut self,
+        glyph_id: GlyphId,
+        variant_id: Option<GlyphVariantId>,
+        source: GlyphSource,
+    ) -> CoreResult<()> {
+        if self.index().glyph_source_owner.contains_key(&source.id()) {
+            return Err(CoreError::DuplicateGlyphSourceId(source.id()));
+        }
+
+        let mut state = (*self.state).clone();
+        let glyph = state
+            .data
+            .glyphs
+            .get_mut(&glyph_id)
+            .ok_or_else(|| CoreError::GlyphNotFound(glyph_id.clone()))?;
+        let glyph = Arc::make_mut(glyph);
+        if let Some(variant_id) = variant_id {
+            let variant = glyph.variants_mut().get_mut(&variant_id).ok_or_else(|| {
+                CoreError::InvalidAuthoringEntity {
+                    kind: "glyph variant",
+                    entity_id: variant_id.to_string(),
+                    message: "does not belong to the glyph".to_string(),
+                }
+            })?;
+            variant.insert_source(source);
+        } else {
+            glyph.insert_default_source(source);
+        }
+
+        state.rebuild_index()?;
+        let candidate = Self {
+            state: Arc::new(state),
+        };
+        candidate.validate()?;
+        self.state = candidate.state;
+        Ok(())
+    }
+
+    pub fn remove_glyph_source(
+        &mut self,
+        glyph_source_id: GlyphSourceId,
+    ) -> CoreResult<GlyphSource> {
+        let glyph_id = self
+            .index()
+            .glyph_source_owner
+            .get(&glyph_source_id)
+            .cloned()
+            .ok_or_else(|| CoreError::InvalidAuthoringEntity {
+                kind: "glyph source",
+                entity_id: glyph_source_id.to_string(),
+                message: "does not exist".to_string(),
+            })?;
+
+        let mut state = (*self.state).clone();
+        let glyph = Arc::make_mut(
+            state
+                .data
+                .glyphs
+                .get_mut(&glyph_id)
+                .expect("indexed glyph source owner exists"),
+        );
+        let removed =
+            if let Some(source) = glyph.default_sources_mut().shift_remove(&glyph_source_id) {
+                source
+            } else {
+                glyph
+                    .variants_mut()
+                    .values_mut()
+                    .find_map(|variant| variant.sources_mut().shift_remove(&glyph_source_id))
+                    .expect("indexed glyph source exists in its owner")
+            };
+
+        state.rebuild_index()?;
+        let candidate = Self {
+            state: Arc::new(state),
+        };
+        candidate.validate()?;
+        self.state = candidate.state;
+        Ok(removed)
+    }
+
     pub fn create_glyph_layer(
         &mut self,
         layer_id: LayerId,
         glyph_id: GlyphId,
         source_id: SourceId,
     ) -> CoreResult<()> {
-        if !self.sources().iter().any(|source| source.id() == source_id) {
-            return Err(CoreError::SourceNotFound(source_id));
-        }
-        if self.index().layer_owner.contains_key(&layer_id) {
-            return Err(CoreError::DuplicateLayerId(layer_id));
+        self.insert_layer_for_source(glyph_id, source_id, GlyphLayer::new(layer_id))?;
+        Ok(())
+    }
+
+    pub(crate) fn insert_layer_for_source(
+        &mut self,
+        glyph_id: GlyphId,
+        source_id: SourceId,
+        layer: GlyphLayer,
+    ) -> CoreResult<GlyphSource> {
+        let source = self
+            .sources()
+            .iter()
+            .find(|source| source.id() == source_id)
+            .ok_or_else(|| CoreError::SourceNotFound(source_id.clone()))?;
+        if self.index().layer_owner.contains_key(&layer.id()) {
+            return Err(CoreError::DuplicateLayerId(layer.id()));
         }
         if self
-            .layer_id_for_glyph_source(glyph_id.clone(), source_id.clone())
+            .layer_id_for_source(glyph_id.clone(), source_id.clone())
             .is_some()
         {
             return Err(CoreError::DuplicateGlyphLayer {
@@ -1079,24 +1313,31 @@ impl Font {
             });
         }
 
-        let layer = GlyphLayer::new(layer_id, source_id.clone());
-        self.insert_glyph_layer(glyph_id.clone(), layer)?;
-        Ok(())
+        let glyph_source = GlyphSource::new(
+            source.name().to_string(),
+            layer.id(),
+            Some(source_id),
+            crate::Location::new(),
+        );
+        let mut state = (*self.state).clone();
+        let glyph = state
+            .data
+            .glyphs
+            .get_mut(&glyph_id)
+            .ok_or_else(|| CoreError::GlyphNotFound(glyph_id.clone()))?;
+        let glyph = Arc::make_mut(glyph);
+        glyph.set_layer(layer);
+        glyph.insert_default_source(glyph_source.clone());
+        state.rebuild_index()?;
+        self.state = Arc::new(state);
+        Ok(glyph_source)
     }
 
     pub fn insert_glyph_layer(&mut self, glyph_id: GlyphId, layer: GlyphLayer) -> CoreResult<()> {
-        if !self
-            .sources()
-            .iter()
-            .any(|source| source.id() == layer.source_id())
-        {
-            return Err(CoreError::SourceNotFound(layer.source_id()));
-        }
-
         if self.glyph(glyph_id.clone()).is_none() {
             return Err(CoreError::GlyphNotFound(glyph_id));
         }
-        self.index().validate_layer_insert(&glyph_id, &layer)?;
+        self.index().validate_layer_insert(&layer)?;
 
         let state = self.state_mut();
         let glyph = state
@@ -1163,28 +1404,17 @@ impl Font {
                 .and_then(|glyph| glyph.layers().get(&layer_id))
                 .cloned()
                 .ok_or(CoreError::LayerNotFound(layer_id.clone()))?;
-            if layer.source_id() != previous.source_id() {
-                return Err(CoreError::LayerSourceMismatch {
-                    layer_id,
-                    expected_source_id: previous.source_id(),
-                    actual_source_id: layer.source_id(),
-                });
-            }
             replacements.push((glyph_id, previous, layer));
         }
 
         let replacement_ids = self.index().validate_layer_replacements(&replacements)?;
 
         let state = self.state_mut();
-        for (glyph_id, previous, _) in &replacements {
-            state.index.remove_layer(glyph_id.clone(), previous);
+        for (_, previous, _) in &replacements {
+            state.index.remove_layer(previous);
         }
         for (glyph_id, _, layer) in replacements {
             state.index.layer_owner.insert(layer.id(), glyph_id.clone());
-            state
-                .index
-                .layer_by_glyph_source
-                .insert((glyph_id.clone(), layer.source_id()), layer.id());
             let glyph = state
                 .data
                 .glyphs
@@ -1201,6 +1431,17 @@ impl Font {
         let glyph_id = self
             .glyph_id_by_layer(layer_id.clone())
             .ok_or(CoreError::LayerNotFound(layer_id.clone()))?;
+        if let Some(source) = self
+            .glyph(glyph_id.clone())
+            .into_iter()
+            .flat_map(glyph_sources)
+            .find(|source| source.layer_id() == layer_id)
+        {
+            return Err(CoreError::GlyphLayerReferenced {
+                layer_id,
+                glyph_source_id: source.id(),
+            });
+        }
         let state = self.state_mut();
         let glyph = state
             .data
@@ -1210,7 +1451,7 @@ impl Font {
         let layer = Arc::make_mut(glyph)
             .remove_layer(layer_id.clone())
             .ok_or(CoreError::LayerNotFound(layer_id))?;
-        state.index.remove_layer(glyph_id, &layer);
+        state.index.remove_layer(&layer);
         Ok(layer)
     }
 
@@ -1276,6 +1517,382 @@ impl Font {
 
     pub fn images_mut(&mut self) -> &mut BinaryData {
         &mut self.data_mut().images
+    }
+}
+
+fn validate_font_data(data: &FontData) -> CoreResult<()> {
+    validate_metric_definitions(&data.metric_definitions)?;
+    validate_axis_label_ids(&data.axes)?;
+    validate_axis_mappings(&data.axes, &data.axis_mappings)?;
+    validate_named_instances(&data.named_instances, &data.axes)?;
+
+    let mut axis_ids = HashSet::new();
+    for axis in &data.axes {
+        axis.validate()?;
+        if !axis_ids.insert(axis.id()) {
+            return Err(CoreError::DuplicateAxisId(axis.id()));
+        }
+    }
+
+    let mut source_ids = HashSet::new();
+    for source in &data.sources {
+        if !source_ids.insert(source.id()) {
+            return Err(CoreError::DuplicateSourceId(source.id()));
+        }
+        validate_source(source, &data.sources, &data.axes, &data.metric_definitions)?;
+    }
+    if let Some(default_source_id) = &data.default_source_id {
+        if !source_ids.contains(default_source_id) {
+            return Err(CoreError::SourceNotFound(default_source_id.clone()));
+        }
+    }
+
+    let glyphs = data
+        .glyphs
+        .values()
+        .map(Arc::as_ref)
+        .map(|glyph| (glyph.id(), glyph))
+        .collect::<HashMap<_, _>>();
+    for glyph in glyphs.values() {
+        validate_glyph_authoring(glyph, &data.axes, &source_ids, &glyphs)?;
+    }
+    validate_component_cycles(&glyphs)?;
+
+    Ok(())
+}
+
+fn validate_glyph_authoring(
+    glyph: &Glyph,
+    font_axes: &[Axis],
+    source_ids: &HashSet<SourceId>,
+    glyphs: &HashMap<GlyphId, &Glyph>,
+) -> CoreResult<()> {
+    let mut local_axes = HashMap::new();
+    for axis in glyph.axes().values() {
+        validate_glyph_axis(axis)?;
+        local_axes.insert(axis.id(), axis);
+    }
+
+    for source in glyph.default_sources().values() {
+        validate_glyph_source(glyph, source, font_axes, &local_axes, source_ids)?;
+    }
+    for variant in glyph.variants().values() {
+        if variant.name().trim().is_empty() {
+            return Err(invalid_authoring(
+                "glyph variant",
+                variant.id().to_string(),
+                "name must not be blank",
+            ));
+        }
+        validate_condition(variant.condition(), font_axes, 0)?;
+        if variant.sources().is_empty() {
+            return Err(invalid_authoring(
+                "glyph variant",
+                variant.id().to_string(),
+                "at least one glyph source is required",
+            ));
+        }
+        for source in variant.sources().values() {
+            validate_glyph_source(glyph, source, font_axes, &local_axes, source_ids)?;
+        }
+    }
+
+    for layer in glyph.layers().values() {
+        for component in layer.components_iter() {
+            validate_component(component, font_axes, glyphs)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_glyph_axis(axis: &GlyphAxis) -> CoreResult<()> {
+    if axis.name().trim().is_empty() {
+        return Err(invalid_authoring(
+            "glyph axis",
+            axis.id().to_string(),
+            "name must not be blank",
+        ));
+    }
+    if !axis.minimum().is_finite() || !axis.default().is_finite() || !axis.maximum().is_finite() {
+        return Err(invalid_authoring(
+            "glyph axis",
+            axis.id().to_string(),
+            "range values must be finite",
+        ));
+    }
+    if axis.minimum() > axis.default() || axis.default() > axis.maximum() {
+        return Err(invalid_authoring(
+            "glyph axis",
+            axis.id().to_string(),
+            "expected minimum <= default <= maximum",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_glyph_source(
+    glyph: &Glyph,
+    source: &GlyphSource,
+    font_axes: &[Axis],
+    glyph_axes: &HashMap<AxisId, &GlyphAxis>,
+    source_ids: &HashSet<SourceId>,
+) -> CoreResult<()> {
+    if source.name().trim().is_empty() {
+        return Err(invalid_authoring(
+            "glyph source",
+            source.id().to_string(),
+            "name must not be blank",
+        ));
+    }
+    if !glyph.layers().contains_key(&source.layer_id()) {
+        return Err(CoreError::GlyphSourceLayerNotFound {
+            glyph_source_id: source.id(),
+            layer_id: source.layer_id(),
+        });
+    }
+    if let Some(base_source_id) = source.base_source_id() {
+        if !source_ids.contains(&base_source_id) {
+            return Err(CoreError::SourceNotFound(base_source_id));
+        }
+    }
+
+    for (axis_id, value) in source.location().iter() {
+        if !value.is_finite() {
+            return Err(invalid_authoring(
+                "glyph source",
+                source.id().to_string(),
+                "location values must be finite",
+            ));
+        }
+        let range = font_axes
+            .iter()
+            .find(|axis| axis.id() == *axis_id)
+            .map(|axis| (axis.minimum(), axis.maximum()))
+            .or_else(|| {
+                glyph_axes
+                    .get(axis_id)
+                    .map(|axis| (axis.minimum(), axis.maximum()))
+            });
+        let Some((minimum, maximum)) = range else {
+            return Err(invalid_authoring(
+                "glyph source",
+                source.id().to_string(),
+                format!("location references unknown axis {axis_id}"),
+            ));
+        };
+        if *value < minimum || *value > maximum {
+            return Err(invalid_authoring(
+                "glyph source",
+                source.id().to_string(),
+                format!("location on {axis_id} is outside its authored range"),
+            ));
+        }
+    }
+
+    let _ = glyph;
+    Ok(())
+}
+
+fn validate_component(
+    component: &Component,
+    font_axes: &[Axis],
+    glyphs: &HashMap<GlyphId, &Glyph>,
+) -> CoreResult<()> {
+    let base_glyph_id = component.base_glyph_id();
+    let Some(base_glyph) = glyphs.get(&base_glyph_id) else {
+        return Err(invalid_authoring(
+            "component",
+            component.id().to_string(),
+            format!("references missing glyph {base_glyph_id}"),
+        ));
+    };
+    if component.base_glyph_name() != base_glyph.glyph_name() {
+        return Err(invalid_authoring(
+            "component",
+            component.id().to_string(),
+            "base glyph name cache does not match its stable glyph reference",
+        ));
+    }
+
+    let transform = component.transform();
+    if [
+        transform.translate_x,
+        transform.translate_y,
+        transform.rotation,
+        transform.scale_x,
+        transform.scale_y,
+        transform.skew_x,
+        transform.skew_y,
+        transform.t_center_x,
+        transform.t_center_y,
+    ]
+    .iter()
+    .any(|value| !value.is_finite())
+    {
+        return Err(invalid_authoring(
+            "component",
+            component.id().to_string(),
+            "transform values must be finite",
+        ));
+    }
+
+    for (axis_id, value) in component.location().iter() {
+        if !value.is_finite() {
+            return Err(invalid_authoring(
+                "component",
+                component.id().to_string(),
+                "location values must be finite",
+            ));
+        }
+        let known = font_axes.iter().any(|axis| axis.id() == *axis_id)
+            || base_glyph.axis(axis_id.clone()).is_some();
+        if !known {
+            return Err(invalid_authoring(
+                "component",
+                component.id().to_string(),
+                format!("location references unsupported axis {axis_id}"),
+            ));
+        }
+    }
+    if let Some(condition) = component.condition() {
+        validate_condition(condition, font_axes, 0)?;
+    }
+    Ok(())
+}
+
+fn condition_references_axis(condition: &Condition, axis_id: &AxisId) -> bool {
+    match condition {
+        Condition::AxisRange {
+            axis_id: condition_axis_id,
+            ..
+        } => condition_axis_id == axis_id,
+        Condition::And { conditions } | Condition::Or { conditions } => conditions
+            .iter()
+            .any(|condition| condition_references_axis(condition, axis_id)),
+        Condition::Not { condition } => condition_references_axis(condition, axis_id),
+    }
+}
+
+fn validate_condition(condition: &Condition, font_axes: &[Axis], depth: usize) -> CoreResult<()> {
+    if depth >= 64 {
+        return Err(invalid_authoring(
+            "condition",
+            "tree",
+            "nesting exceeds 64 levels",
+        ));
+    }
+
+    match condition {
+        Condition::AxisRange {
+            axis_id,
+            minimum,
+            maximum,
+        } => {
+            if minimum.is_none() && maximum.is_none() {
+                return Err(invalid_authoring(
+                    "condition",
+                    axis_id.to_string(),
+                    "axis range requires at least one bound",
+                ));
+            }
+            if !font_axes.iter().any(|axis| axis.id() == *axis_id) {
+                return Err(invalid_authoring(
+                    "condition",
+                    axis_id.to_string(),
+                    "axis ranges may reference font axes only",
+                ));
+            }
+            if minimum.is_some_and(|value| !value.is_finite())
+                || maximum.is_some_and(|value| !value.is_finite())
+            {
+                return Err(invalid_authoring(
+                    "condition",
+                    axis_id.to_string(),
+                    "axis range bounds must be finite",
+                ));
+            }
+            if let (Some(minimum), Some(maximum)) = (minimum, maximum) {
+                if minimum > maximum {
+                    return Err(invalid_authoring(
+                        "condition",
+                        axis_id.to_string(),
+                        "minimum must not exceed maximum",
+                    ));
+                }
+            }
+        }
+        Condition::And { conditions } | Condition::Or { conditions } => {
+            if conditions.is_empty() {
+                return Err(invalid_authoring(
+                    "condition",
+                    "group",
+                    "boolean groups must not be empty",
+                ));
+            }
+            for condition in conditions {
+                validate_condition(condition, font_axes, depth + 1)?;
+            }
+        }
+        Condition::Not { condition } => {
+            validate_condition(condition, font_axes, depth + 1)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_component_cycles(glyphs: &HashMap<GlyphId, &Glyph>) -> CoreResult<()> {
+    fn visit(
+        glyph_id: &GlyphId,
+        glyphs: &HashMap<GlyphId, &Glyph>,
+        visiting: &mut HashSet<GlyphId>,
+        visited: &mut HashSet<GlyphId>,
+    ) -> CoreResult<()> {
+        if visited.contains(glyph_id) {
+            return Ok(());
+        }
+        if !visiting.insert(glyph_id.clone()) {
+            return Err(invalid_authoring(
+                "component graph",
+                glyph_id.to_string(),
+                "component references form a cycle",
+            ));
+        }
+
+        let glyph = glyphs
+            .get(glyph_id)
+            .expect("component validation established every glyph reference");
+        for base_glyph_id in glyph
+            .layers()
+            .values()
+            .flat_map(|layer| layer.components_iter())
+            .map(Component::base_glyph_id)
+        {
+            visit(&base_glyph_id, glyphs, visiting, visited)?;
+        }
+
+        visiting.remove(glyph_id);
+        visited.insert(glyph_id.clone());
+        Ok(())
+    }
+
+    let mut visiting = HashSet::new();
+    let mut visited = HashSet::new();
+    for glyph_id in glyphs.keys() {
+        visit(glyph_id, glyphs, &mut visiting, &mut visited)?;
+    }
+    Ok(())
+}
+
+fn invalid_authoring(
+    kind: &'static str,
+    entity_id: impl Into<String>,
+    message: impl Into<String>,
+) -> CoreError {
+    CoreError::InvalidAuthoringEntity {
+        kind,
+        entity_id: entity_id.into(),
+        message: message.into(),
     }
 }
 
@@ -1456,11 +2073,22 @@ mod tests {
     use super::*;
     use crate::{
         test_support::sample_font, Anchor, AxisMappingPoint, AxisRole, Component, ComponentId,
-        Contour, ContourId, ExternalLocation, GlyphLayer, GuidelineId, LayerId, Location, PointId,
-        PointType,
+        Contour, ContourId, ExternalLocation, GlyphLayer, GlyphVariant, GuidelineId, LayerId,
+        Location, PointId, PointType,
     };
     use std::sync::Arc;
     use std::time::{Duration, Instant};
+
+    fn set_test_layer(glyph: &mut Glyph, source_id: SourceId, layer: GlyphLayer) {
+        let layer_id = layer.id();
+        glyph.set_layer(layer);
+        glyph.insert_default_source(GlyphSource::new(
+            source_id.to_string(),
+            layer_id,
+            Some(source_id),
+            Location::new(),
+        ));
+    }
 
     #[derive(Clone, Copy)]
     struct PerfFontMark {
@@ -1482,11 +2110,7 @@ mod tests {
 
         for glyph_index in 0..mark.glyphs {
             let mut glyph = Glyph::with_unicode(format!("g{glyph_index:05}"), glyph_index as u32);
-            let mut layer = GlyphLayer::with_width(
-                LayerId::new(),
-                source_id.clone(),
-                500.0 + glyph_index as f64,
-            );
+            let mut layer = GlyphLayer::with_width(LayerId::new(), 500.0 + glyph_index as f64);
 
             for contour_index in 0..mark.contours_per_glyph {
                 let mut contour = Contour::new();
@@ -1501,7 +2125,7 @@ mod tests {
                 layer.add_contour(contour);
             }
 
-            glyph.set_layer(layer);
+            set_test_layer(&mut glyph, source_id.clone(), layer);
             font.insert_glyph(glyph).unwrap();
         }
 
@@ -1516,18 +2140,18 @@ mod tests {
 
         let mut first_contour = Contour::with_id(contour_id.clone());
         first_contour.add_point(0.0, 0.0, PointType::OnCurve, false);
-        let mut first_layer = GlyphLayer::new(LayerId::new(), source_id.clone());
+        let mut first_layer = GlyphLayer::new(LayerId::new());
         first_layer.add_contour(first_contour);
         let mut first_glyph = Glyph::new("A");
-        first_glyph.set_layer(first_layer);
+        set_test_layer(&mut first_glyph, source_id.clone(), first_layer);
         font.insert_glyph(first_glyph).unwrap();
 
         let mut second_contour = Contour::with_id(contour_id.clone());
         second_contour.add_point(100.0, 100.0, PointType::OnCurve, false);
-        let mut second_layer = GlyphLayer::new(LayerId::new(), source_id);
+        let mut second_layer = GlyphLayer::new(LayerId::new());
         second_layer.add_contour(second_contour);
         let mut second_glyph = Glyph::new("B");
-        second_glyph.set_layer(second_layer);
+        set_test_layer(&mut second_glyph, source_id.clone(), second_layer);
 
         assert!(matches!(
             font.insert_glyph(second_glyph),
@@ -1727,11 +2351,11 @@ mod tests {
     #[test]
     fn font_glyph_operations() {
         let mut font = Font::new();
+        let source_id = font.default_source_id().unwrap();
         let mut glyph = Glyph::with_unicode("A".to_string(), 65);
-        let layer =
-            GlyphLayer::with_width(LayerId::new(), font.default_source_id().unwrap(), 600.0);
+        let layer = GlyphLayer::with_width(LayerId::new(), 600.0);
         let layer_id = layer.id();
-        glyph.set_layer(layer);
+        set_test_layer(&mut glyph, source_id, layer);
 
         let glyph_id = font.insert_glyph(glyph).unwrap();
 
@@ -1744,7 +2368,7 @@ mod tests {
             Some(glyph_id.clone())
         );
         assert_eq!(
-            font.layer_id_for_glyph_source(glyph_id.clone(), font.default_source_id().unwrap()),
+            font.layer_id_for_source(glyph_id.clone(), font.default_source_id().unwrap()),
             Some(layer_id.clone())
         );
         assert_eq!(
@@ -1759,29 +2383,27 @@ mod tests {
     fn glyph_layer_batch_replacement_is_atomic() {
         let mut font = Font::new();
         let source_id = font.default_source_id().unwrap();
-        let first_layer = GlyphLayer::with_width(LayerId::new(), source_id.clone(), 500.0);
+        let first_layer = GlyphLayer::with_width(LayerId::new(), 500.0);
         let first_layer_id = first_layer.id();
         let mut first_glyph = Glyph::new("A");
-        first_glyph.set_layer(first_layer);
+        set_test_layer(&mut first_glyph, source_id.clone(), first_layer);
         font.insert_glyph(first_glyph).unwrap();
 
-        let second_layer = GlyphLayer::with_width(LayerId::new(), source_id.clone(), 600.0);
+        let second_layer = GlyphLayer::with_width(LayerId::new(), 600.0);
         let second_layer_id = second_layer.id();
         let mut second_glyph = Glyph::new("B");
-        second_glyph.set_layer(second_layer);
+        set_test_layer(&mut second_glyph, source_id.clone(), second_layer);
         font.insert_glyph(second_glyph).unwrap();
 
         let contour_id = ContourId::new();
         let mut first_contour = Contour::with_id(contour_id.clone());
         first_contour.add_point(0.0, 0.0, PointType::OnCurve, false);
-        let mut first_replacement =
-            GlyphLayer::with_width(first_layer_id.clone(), source_id.clone(), 700.0);
+        let mut first_replacement = GlyphLayer::with_width(first_layer_id.clone(), 700.0);
         first_replacement.add_contour(first_contour);
 
         let mut second_contour = Contour::with_id(contour_id.clone());
         second_contour.add_point(10.0, 10.0, PointType::OnCurve, false);
-        let mut second_replacement =
-            GlyphLayer::with_width(second_layer_id.clone(), source_id.clone(), 800.0);
+        let mut second_replacement = GlyphLayer::with_width(second_layer_id.clone(), 800.0);
         second_replacement.add_contour(second_contour);
 
         assert!(matches!(
@@ -1792,8 +2414,8 @@ mod tests {
         assert_eq!(font.layer(second_layer_id.clone()).unwrap().width(), 600.0);
 
         font.replace_glyph_layers(vec![
-            GlyphLayer::with_width(first_layer_id.clone(), source_id.clone(), 700.0),
-            GlyphLayer::with_width(second_layer_id.clone(), source_id, 800.0),
+            GlyphLayer::with_width(first_layer_id.clone(), 700.0),
+            GlyphLayer::with_width(second_layer_id.clone(), 800.0),
         ])
         .unwrap();
         assert_eq!(font.layer(first_layer_id).unwrap().width(), 700.0);
@@ -1810,7 +2432,7 @@ mod tests {
         let component_id = ComponentId::new();
         let mut contour = Contour::with_id(contour_id.clone());
         contour.add_point_with_id(point_id.clone(), 10.0, 20.0, PointType::OnCurve, false);
-        let mut layer = GlyphLayer::with_width(LayerId::new(), source_id, 500.0);
+        let mut layer = GlyphLayer::with_width(LayerId::new(), 500.0);
         layer.add_contour(contour);
         layer.add_anchor(Anchor::with_id(
             anchor_id.clone(),
@@ -1826,7 +2448,7 @@ mod tests {
         ));
         let layer_id = layer.id();
         let mut glyph = Glyph::new("A");
-        glyph.set_layer(layer);
+        set_test_layer(&mut glyph, source_id.clone(), layer);
         font.insert_glyph(glyph).unwrap();
 
         let snapshot = font.clone();
@@ -1883,7 +2505,7 @@ mod tests {
         let base_glyph_id = GlyphId::new();
         let mut contour = Contour::with_id(contour_id.clone());
         contour.add_point_with_id(point_id.clone(), 0.0, 0.0, PointType::OnCurve, false);
-        let mut first_layer = GlyphLayer::with_width(LayerId::new(), source_id.clone(), 500.0);
+        let mut first_layer = GlyphLayer::with_width(LayerId::new(), 500.0);
         first_layer.add_contour(contour);
         first_layer.add_component(Component::with_id(
             component_id.clone(),
@@ -1907,13 +2529,13 @@ mod tests {
         ));
         let first_layer_id = first_layer.id();
         let mut first_glyph = Glyph::new("A");
-        first_glyph.set_layer(first_layer);
+        set_test_layer(&mut first_glyph, source_id.clone(), first_layer);
         font.insert_glyph(first_glyph).unwrap();
 
-        let second_layer = GlyphLayer::with_width(LayerId::new(), source_id.clone(), 600.0);
+        let second_layer = GlyphLayer::with_width(LayerId::new(), 600.0);
         let second_layer_id = second_layer.id();
         let mut second_glyph = Glyph::new("B");
-        second_glyph.set_layer(second_layer);
+        set_test_layer(&mut second_glyph, source_id.clone(), second_layer);
         font.insert_glyph(second_glyph).unwrap();
 
         let snapshot = font.clone();
@@ -1938,16 +2560,14 @@ mod tests {
             PointType::OnCurve,
             false,
         );
-        let mut conflicting_layer =
-            GlyphLayer::with_width(second_layer_id.clone(), source_id.clone(), 800.0);
+        let mut conflicting_layer = GlyphLayer::with_width(second_layer_id.clone(), 800.0);
         conflicting_layer.add_contour(conflicting_contour);
         assert!(matches!(
             font.replace_glyph_layers(vec![conflicting_layer]),
             Err(CoreError::DuplicatePointId(id)) if id == point_id
         ));
 
-        let mut conflicting_layer =
-            GlyphLayer::with_width(second_layer_id.clone(), source_id.clone(), 800.0);
+        let mut conflicting_layer = GlyphLayer::with_width(second_layer_id.clone(), 800.0);
         conflicting_layer.add_component(Component::with_id(
             component_id.clone(),
             base_glyph_id.clone(),
@@ -1959,16 +2579,14 @@ mod tests {
             Err(CoreError::DuplicateComponentId(id)) if id == component_id
         ));
 
-        let mut conflicting_layer =
-            GlyphLayer::with_width(second_layer_id.clone(), source_id.clone(), 800.0);
+        let mut conflicting_layer = GlyphLayer::with_width(second_layer_id.clone(), 800.0);
         conflicting_layer.add_anchor(Anchor::with_id(anchor_id.clone(), None, 10.0, 10.0));
         assert!(matches!(
             font.replace_glyph_layers(vec![conflicting_layer]),
             Err(CoreError::DuplicateAnchorId(id)) if id == anchor_id
         ));
 
-        let mut conflicting_layer =
-            GlyphLayer::with_width(second_layer_id.clone(), source_id.clone(), 800.0);
+        let mut conflicting_layer = GlyphLayer::with_width(second_layer_id.clone(), 800.0);
         conflicting_layer.add_guideline(Guideline::with_id(
             guideline_id.clone(),
             Some(10.0),
@@ -1983,7 +2601,7 @@ mod tests {
         ));
         assert_eq!(font.layer(second_layer_id.clone()).unwrap().width(), 600.0);
 
-        let emptied = GlyphLayer::with_width(first_layer_id, source_id.clone(), 700.0);
+        let emptied = GlyphLayer::with_width(first_layer_id, 700.0);
         let mut transferred_contour = Contour::with_id(contour_id.clone());
         transferred_contour.add_point_with_id(
             point_id.clone(),
@@ -1992,7 +2610,7 @@ mod tests {
             PointType::OnCurve,
             false,
         );
-        let mut transferred = GlyphLayer::with_width(second_layer_id.clone(), source_id, 800.0);
+        let mut transferred = GlyphLayer::with_width(second_layer_id.clone(), 800.0);
         transferred.add_contour(transferred_contour);
         transferred.add_component(Component::with_id(
             component_id,
@@ -2025,7 +2643,7 @@ mod tests {
         let glyph_id = font.insert_glyph(glyph).unwrap();
 
         let taken = font.remove_glyph(glyph_id.clone());
-        assert!(taken.is_some());
+        assert!(taken.is_ok());
         assert_eq!(font.glyph_count(), 0);
         assert_eq!(font.glyph_id_by_name("A"), None);
 
@@ -2089,9 +2707,9 @@ mod tests {
         let mut font = Font::new();
         let source_id = font.default_source_id().unwrap();
         let mut glyph = Glyph::with_unicode("A", 0x41);
-        let layer = GlyphLayer::new(LayerId::new(), source_id.clone());
+        let layer = GlyphLayer::new(LayerId::new());
         let layer_id = layer.id();
-        glyph.set_layer(layer);
+        set_test_layer(&mut glyph, source_id.clone(), layer);
         let glyph_id = font.insert_glyph(glyph).unwrap();
 
         let json = serde_json::to_string(&font).unwrap();
@@ -2103,7 +2721,7 @@ mod tests {
             Some(glyph_id.clone())
         );
         assert_eq!(
-            decoded.layer_id_for_glyph_source(glyph_id.clone(), source_id.clone()),
+            decoded.layer_id_for_source(glyph_id.clone(), source_id.clone()),
             Some(layer_id.clone())
         );
         assert_eq!(
@@ -2168,49 +2786,148 @@ mod tests {
     }
 
     #[test]
-    fn layer_indexes_update_after_layer_removal() {
+    fn layer_indexes_update_after_unreferenced_layer_removal() {
         let mut font = Font::new();
-        let source_id = font.default_source_id().unwrap();
         let glyph_id = font.insert_glyph(Glyph::new("A")).unwrap();
         let layer_id = LayerId::new();
-        font.create_glyph_layer(layer_id.clone(), glyph_id.clone(), source_id.clone())
+        font.insert_glyph_layer(glyph_id.clone(), GlyphLayer::new(layer_id.clone()))
             .unwrap();
 
         assert_eq!(
             font.glyph_id_by_layer(layer_id.clone()),
             Some(glyph_id.clone())
         );
-        assert_eq!(
-            font.layer_id_for_glyph_source(glyph_id.clone(), source_id.clone()),
-            Some(layer_id.clone())
-        );
 
         font.remove_glyph_layer(layer_id.clone()).unwrap();
 
-        assert_eq!(font.glyph_id_by_layer(layer_id.clone()), None);
-        assert_eq!(
-            font.layer_id_for_glyph_source(glyph_id.clone(), source_id.clone()),
-            None
-        );
+        assert_eq!(font.glyph_id_by_layer(layer_id), None);
     }
 
     #[test]
-    fn index_validation_rejects_duplicate_layers_for_one_glyph_source() {
+    fn index_validation_rejects_duplicate_glyph_source_ids() {
+        let glyph_source_id = GlyphSourceId::new();
         let source_id = SourceId::new();
-        let mut glyph = Glyph::new("A");
-        glyph.set_layer(GlyphLayer::new(LayerId::new(), source_id.clone()));
-        glyph.set_layer(GlyphLayer::new(LayerId::new(), source_id.clone()));
         let mut glyphs = EntityList::new();
-        glyphs.insert(Arc::new(glyph));
+        for name in ["A", "B"] {
+            let mut glyph = Glyph::new(name);
+            let layer = GlyphLayer::new(LayerId::new());
+            let layer_id = layer.id();
+            glyph.set_layer(layer);
+            glyph.insert_default_source(GlyphSource::with_id(
+                glyph_source_id.clone(),
+                name.to_string(),
+                layer_id,
+                Some(source_id.clone()),
+                Location::new(),
+            ));
+            glyphs.insert(Arc::new(glyph));
+        }
 
-        let error = FontIndex::from_glyphs(&glyphs).unwrap_err();
+        let error = FontIndex::from_font(&[], &glyphs).unwrap_err();
 
         assert!(matches!(
             error,
-            CoreError::DuplicateGlyphLayer {
-                glyph_id: _,
-                source_id: source
-            } if source == source_id
+            CoreError::DuplicateGlyphSourceId(id) if id == glyph_source_id
+        ));
+    }
+
+    #[test]
+    fn conditions_reject_glyph_local_axis_references() {
+        let mut font = Font::new();
+        let source_id = font.default_source_id().unwrap();
+        let local_axis_id = AxisId::from_raw("local");
+        let layer = GlyphLayer::new(LayerId::new());
+        let mut glyph = Glyph::new("A");
+        glyph.insert_axis(GlyphAxis::with_id(
+            local_axis_id.clone(),
+            "Local".to_string(),
+            0.0,
+            0.0,
+            1.0,
+        ));
+        glyph.set_layer(layer.clone());
+        glyph.insert_default_source(GlyphSource::new(
+            "Default".to_string(),
+            layer.id(),
+            Some(source_id.clone()),
+            Location::new(),
+        ));
+        let mut variant = GlyphVariant::new(
+            "Invalid".to_string(),
+            Condition::AxisRange {
+                axis_id: local_axis_id,
+                minimum: Some(0.5),
+                maximum: None,
+            },
+        );
+        variant.insert_source(GlyphSource::new(
+            "Variant".to_string(),
+            layer.id(),
+            Some(source_id),
+            Location::new(),
+        ));
+        glyph.insert_variant(variant);
+        font.insert_glyph(glyph).unwrap();
+
+        assert!(matches!(
+            font.validate(),
+            Err(CoreError::InvalidAuthoringEntity {
+                kind: "condition",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn deletion_rejects_live_glyph_source_and_component_references() {
+        let mut font = Font::new();
+        let source_id = font.default_source_id().unwrap();
+        let base_id = font.insert_glyph(Glyph::new("base")).unwrap();
+        let mut parent = Glyph::new("parent");
+        let mut layer = GlyphLayer::new(LayerId::new());
+        layer.add_component(Component::new(base_id.clone(), "base"));
+        parent.set_layer(layer);
+        font.insert_glyph(parent).unwrap();
+
+        assert!(matches!(
+            font.remove_glyph(base_id),
+            Err(CoreError::InvalidAuthoringEntity { kind: "glyph", .. })
+        ));
+
+        let glyph_id = font.insert_glyph(Glyph::new("sourced")).unwrap();
+        font.create_glyph_layer(LayerId::new(), glyph_id, source_id.clone())
+            .unwrap();
+        assert!(matches!(
+            font.remove_source(source_id.clone()),
+            Err(CoreError::SourceReferencedByGlyphSource {
+                source_id: actual,
+                ..
+            }) if actual == source_id
+        ));
+    }
+
+    #[test]
+    fn validation_rejects_component_cycles() {
+        let first_id = GlyphId::from_raw("first");
+        let second_id = GlyphId::from_raw("second");
+        let mut first = Glyph::with_id(first_id.clone(), "first");
+        let mut first_layer = GlyphLayer::new(LayerId::new());
+        first_layer.add_component(Component::new(second_id.clone(), "second"));
+        first.set_layer(first_layer);
+        let mut second = Glyph::with_id(second_id.clone(), "second");
+        let mut second_layer = GlyphLayer::new(LayerId::new());
+        second_layer.add_component(Component::new(first_id, "first"));
+        second.set_layer(second_layer);
+        let mut font = Font::new();
+        font.insert_glyph(first).unwrap();
+        font.insert_glyph(second).unwrap();
+
+        assert!(matches!(
+            font.validate(),
+            Err(CoreError::InvalidAuthoringEntity {
+                kind: "component graph",
+                ..
+            })
         ));
     }
 
@@ -2314,7 +3031,7 @@ mod tests {
         let default_source_id = font.default_source_id().unwrap();
         let glyph_id = font.glyph_id_by_name("g00000").unwrap();
         let layer_id = font
-            .layer_id_for_glyph_source(glyph_id.clone(), default_source_id.clone())
+            .layer_id_for_source(glyph_id.clone(), default_source_id.clone())
             .unwrap();
         let other_glyph_id = font.glyph_id_by_name("g00001").unwrap();
         let start = Instant::now();
@@ -2421,11 +3138,10 @@ mod tests {
         };
         let mut font = synthetic_point_heavy_font(mark);
         let glyph_id = font.glyph_id_by_name("g00000").unwrap();
-        let source_id = font.add_source(Source::new("Bold".to_string(), DesignLocation::new()));
         let start = Instant::now();
 
         let layer_id = LayerId::new();
-        font.create_glyph_layer(layer_id.clone(), glyph_id.clone(), source_id.clone())
+        font.insert_glyph_layer(glyph_id, GlyphLayer::new(layer_id.clone()))
             .unwrap();
         let removed = font.remove_glyph_layer(layer_id.clone()).unwrap();
 
@@ -2433,10 +3149,6 @@ mod tests {
 
         assert_eq!(removed.id(), layer_id);
         assert_eq!(font.glyph_id_by_layer(layer_id.clone()), None);
-        assert_eq!(
-            font.layer_id_for_glyph_source(glyph_id.clone(), source_id.clone()),
-            None
-        );
         print_perf_mark("create/remove layer and rebuild indexes", mark, elapsed);
         assert!(
             elapsed < Duration::from_secs(1),

--- a/crates/shift-font/src/ir/glyph.rs
+++ b/crates/shift-font/src/ir/glyph.rs
@@ -3,21 +3,210 @@ use crate::collection::{EntityList, Identified};
 use crate::component::Component;
 use crate::contour::Contour;
 use crate::entity::{
-    AnchorId, ComponentId, ContourId, GlyphId, GuidelineId, LayerId, PointId, SourceId,
+    AnchorId, AxisId, ComponentId, ContourId, GlyphId, GlyphSourceId, GlyphVariantId, GuidelineId,
+    LayerId, PointId, SourceId,
 };
 use crate::guideline::Guideline;
 use crate::lib_data::LibData;
 use crate::point::Point;
-use crate::GlyphName;
+use crate::{Condition, GlyphName, Location};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct GlyphAxis {
+    id: AxisId,
+    name: String,
+    minimum: f64,
+    default: f64,
+    maximum: f64,
+}
+
+impl Identified for GlyphAxis {
+    type Id = AxisId;
+
+    fn id(&self) -> Self::Id {
+        GlyphAxis::id(self)
+    }
+}
+
+impl GlyphAxis {
+    pub fn new(name: String, minimum: f64, default: f64, maximum: f64) -> Self {
+        Self::with_id(AxisId::new(), name, minimum, default, maximum)
+    }
+
+    pub fn with_id(id: AxisId, name: String, minimum: f64, default: f64, maximum: f64) -> Self {
+        Self {
+            id,
+            name,
+            minimum,
+            default,
+            maximum,
+        }
+    }
+
+    pub fn id(&self) -> AxisId {
+        self.id.clone()
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn minimum(&self) -> f64 {
+        self.minimum
+    }
+
+    pub fn default(&self) -> f64 {
+        self.default
+    }
+
+    pub fn maximum(&self) -> f64 {
+        self.maximum
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct GlyphSource {
+    id: GlyphSourceId,
+    name: String,
+    layer_id: LayerId,
+    base_source_id: Option<SourceId>,
+    location: Location,
+}
+
+impl Identified for GlyphSource {
+    type Id = GlyphSourceId;
+
+    fn id(&self) -> Self::Id {
+        GlyphSource::id(self)
+    }
+}
+
+impl GlyphSource {
+    pub fn new(
+        name: String,
+        layer_id: LayerId,
+        base_source_id: Option<SourceId>,
+        location: Location,
+    ) -> Self {
+        Self::with_id(
+            GlyphSourceId::new(),
+            name,
+            layer_id,
+            base_source_id,
+            location,
+        )
+    }
+
+    pub fn with_id(
+        id: GlyphSourceId,
+        name: String,
+        layer_id: LayerId,
+        base_source_id: Option<SourceId>,
+        location: Location,
+    ) -> Self {
+        Self {
+            id,
+            name,
+            layer_id,
+            base_source_id,
+            location,
+        }
+    }
+
+    pub fn id(&self) -> GlyphSourceId {
+        self.id.clone()
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn layer_id(&self) -> LayerId {
+        self.layer_id.clone()
+    }
+
+    pub fn base_source_id(&self) -> Option<SourceId> {
+        self.base_source_id.clone()
+    }
+
+    pub fn location(&self) -> &Location {
+        &self.location
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct GlyphVariant {
+    id: GlyphVariantId,
+    name: String,
+    condition: Condition,
+    sources: EntityList<GlyphSource>,
+}
+
+impl Identified for GlyphVariant {
+    type Id = GlyphVariantId;
+
+    fn id(&self) -> Self::Id {
+        GlyphVariant::id(self)
+    }
+}
+
+impl GlyphVariant {
+    pub fn new(name: String, condition: Condition) -> Self {
+        Self::with_id(GlyphVariantId::new(), name, condition)
+    }
+
+    pub fn with_id(id: GlyphVariantId, name: String, condition: Condition) -> Self {
+        Self {
+            id,
+            name,
+            condition,
+            sources: EntityList::new(),
+        }
+    }
+
+    pub fn id(&self) -> GlyphVariantId {
+        self.id.clone()
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn condition(&self) -> &Condition {
+        &self.condition
+    }
+
+    pub fn sources(&self) -> &EntityList<GlyphSource> {
+        &self.sources
+    }
+
+    pub(crate) fn sources_mut(&mut self) -> &mut EntityList<GlyphSource> {
+        &mut self.sources
+    }
+
+    pub fn source(&self, id: GlyphSourceId) -> Option<&GlyphSource> {
+        self.sources.get(&id)
+    }
+
+    pub fn insert_source(&mut self, source: GlyphSource) -> Option<GlyphSource> {
+        self.sources.insert(source)
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Glyph {
     id: GlyphId,
     name: GlyphName,
     unicodes: Vec<u32>,
+    #[serde(default)]
+    axes: EntityList<GlyphAxis>,
+    #[serde(default)]
+    default_sources: EntityList<GlyphSource>,
+    #[serde(default)]
+    variants: EntityList<GlyphVariant>,
     layers: HashMap<LayerId, Arc<GlyphLayer>>,
     lib: LibData,
 }
@@ -33,7 +222,6 @@ impl Identified for Glyph {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GlyphLayer {
     id: LayerId,
-    source_id: SourceId,
     width: f64,
     height: Option<f64>,
     contours: EntityList<Contour>,
@@ -44,10 +232,9 @@ pub struct GlyphLayer {
 }
 
 impl GlyphLayer {
-    pub fn new(id: LayerId, source_id: SourceId) -> Self {
+    pub fn new(id: LayerId) -> Self {
         Self {
             id,
-            source_id,
             width: 0.0,
             height: None,
             contours: EntityList::new(),
@@ -58,10 +245,10 @@ impl GlyphLayer {
         }
     }
 
-    pub fn with_width(id: LayerId, source_id: SourceId, width: f64) -> Self {
+    pub fn with_width(id: LayerId, width: f64) -> Self {
         Self {
             width,
-            ..Self::new(id, source_id)
+            ..Self::new(id)
         }
     }
 
@@ -69,19 +256,14 @@ impl GlyphLayer {
         self.id.clone()
     }
 
-    pub fn source_id(&self) -> SourceId {
-        self.source_id.clone()
-    }
-
-    pub fn clone_with_identity(&self, id: LayerId, source_id: SourceId) -> Self {
+    pub fn clone_with_identity(&self, id: LayerId) -> Self {
         let mut layer = self.clone();
         layer.id = id;
-        layer.source_id = source_id;
         layer
     }
 
-    pub fn clone_with_fresh_ids(&self, id: LayerId, source_id: SourceId) -> Self {
-        let mut layer = Self::with_width(id, source_id, self.width);
+    pub fn clone_with_fresh_ids(&self, id: LayerId) -> Self {
+        let mut layer = Self::with_width(id, self.width);
         layer.height = self.height;
         layer.lib = self.lib.clone();
 
@@ -105,11 +287,15 @@ impl GlyphLayer {
         }
 
         for component in self.components_iter() {
-            layer.add_component(Component::with_transform(
+            let mut cloned = Component::with_transform(
                 component.base_glyph_id(),
                 component.base_glyph_name().clone(),
                 *component.transform(),
-            ));
+            );
+            cloned.set_location(component.location().clone());
+            cloned.set_axis_inheritance(component.axis_inheritance());
+            cloned.set_condition(component.condition().cloned());
+            layer.add_component(cloned);
         }
 
         for anchor in self.anchors_iter() {
@@ -305,6 +491,9 @@ impl Glyph {
             id,
             name: name.into(),
             unicodes: Vec::new(),
+            axes: EntityList::new(),
+            default_sources: EntityList::new(),
+            variants: EntityList::new(),
             layers: HashMap::new(),
             lib: LibData::new(),
         }
@@ -315,6 +504,9 @@ impl Glyph {
             id: GlyphId::new(),
             name: name.into(),
             unicodes: vec![unicode],
+            axes: EntityList::new(),
+            default_sources: EntityList::new(),
+            variants: EntityList::new(),
             layers: HashMap::new(),
             lib: LibData::new(),
         }
@@ -358,6 +550,59 @@ impl Glyph {
         self.unicodes = unicodes;
     }
 
+    pub fn axes(&self) -> &EntityList<GlyphAxis> {
+        &self.axes
+    }
+
+    pub fn axis(&self, id: AxisId) -> Option<&GlyphAxis> {
+        self.axes.get(&id)
+    }
+
+    pub fn default_sources(&self) -> &EntityList<GlyphSource> {
+        &self.default_sources
+    }
+
+    pub(crate) fn default_sources_mut(&mut self) -> &mut EntityList<GlyphSource> {
+        &mut self.default_sources
+    }
+
+    pub fn source(&self, id: GlyphSourceId) -> Option<&GlyphSource> {
+        self.default_sources.get(&id).or_else(|| {
+            self.variants
+                .values()
+                .find_map(|variant| variant.source(id.clone()))
+        })
+    }
+
+    pub fn variants(&self) -> &EntityList<GlyphVariant> {
+        &self.variants
+    }
+
+    pub(crate) fn variants_mut(&mut self) -> &mut EntityList<GlyphVariant> {
+        &mut self.variants
+    }
+
+    pub fn variant(&self, id: GlyphVariantId) -> Option<&GlyphVariant> {
+        self.variants.get(&id)
+    }
+
+    pub fn insert_axis(&mut self, axis: GlyphAxis) -> Option<GlyphAxis> {
+        self.axes.insert(axis)
+    }
+
+    pub fn insert_default_source(&mut self, source: GlyphSource) -> Option<GlyphSource> {
+        self.default_sources.insert(source)
+    }
+
+    pub fn insert_variant(&mut self, variant: GlyphVariant) -> Option<GlyphVariant> {
+        self.variants.insert(variant)
+    }
+
+    pub fn layer_for_glyph_source(&self, glyph_source_id: GlyphSourceId) -> Option<&GlyphLayer> {
+        let layer_id = self.source(glyph_source_id)?.layer_id();
+        self.layer(layer_id)
+    }
+
     pub fn layers(&self) -> &HashMap<LayerId, Arc<GlyphLayer>> {
         &self.layers
     }
@@ -372,17 +617,27 @@ impl Glyph {
 
     pub fn ensure_layer_for_source(&mut self, source_id: SourceId) -> &mut GlyphLayer {
         if let Some(layer_id) = self
-            .layers
+            .default_sources
             .values()
-            .find(|layer| layer.source_id() == source_id)
-            .map(|layer| layer.id())
+            .find(|source| source.base_source_id().as_ref() == Some(&source_id))
+            .map(GlyphSource::layer_id)
         {
-            return self.layer_mut(layer_id).expect("layer id came from glyph");
+            return self
+                .layer_mut(layer_id)
+                .expect("glyph source layer belongs to glyph");
         }
 
-        let layer = GlyphLayer::new(LayerId::new(), source_id);
-        let layer_id = layer.id();
-        self.layers.insert(layer_id.clone(), Arc::new(layer));
+        let layer_id = LayerId::new();
+        self.layers.insert(
+            layer_id.clone(),
+            Arc::new(GlyphLayer::new(layer_id.clone())),
+        );
+        self.default_sources.insert(GlyphSource::new(
+            source_id.to_string(),
+            layer_id.clone(),
+            Some(source_id),
+            Location::new(),
+        ));
         self.layer_mut(layer_id).expect("layer was just inserted")
     }
 
@@ -394,18 +649,26 @@ impl Glyph {
         self.layers.insert(layer.id(), layer);
     }
 
+    /// Returns the first Default glyph-source layer based on a global source.
+    ///
+    /// Several glyph sources may intentionally share one global base. Stable
+    /// glyph-source lookup should be used when that distinction matters.
     pub fn layer_for_source(&self, source_id: SourceId) -> Option<&GlyphLayer> {
-        self.layers
+        let layer_id = self
+            .default_sources
             .values()
-            .find(|layer| layer.source_id() == source_id)
-            .map(Arc::as_ref)
+            .find(|source| source.base_source_id().as_ref() == Some(&source_id))?
+            .layer_id();
+        self.layer(layer_id)
     }
 
     pub fn layer_for_source_mut(&mut self, source_id: SourceId) -> Option<&mut GlyphLayer> {
-        self.layers
-            .values_mut()
-            .find(|layer| layer.source_id() == source_id)
-            .map(Arc::make_mut)
+        let layer_id = self
+            .default_sources
+            .values()
+            .find(|source| source.base_source_id().as_ref() == Some(&source_id))?
+            .layer_id();
+        self.layer_mut(layer_id)
     }
 
     pub fn remove_layer(&mut self, id: LayerId) -> Option<GlyphLayer> {
@@ -453,20 +716,10 @@ mod tests {
     #[test]
     fn cloned_glyph_shares_layers_until_one_layer_is_mutated() {
         let mut glyph = Glyph::new("A".to_string());
-        let first_source_id = SourceId::new();
-        let second_source_id = SourceId::new();
         let first_layer_id = LayerId::new();
         let second_layer_id = LayerId::new();
-        glyph.set_layer(GlyphLayer::with_width(
-            first_layer_id.clone(),
-            first_source_id.clone(),
-            500.0,
-        ));
-        glyph.set_layer(GlyphLayer::with_width(
-            second_layer_id.clone(),
-            second_source_id.clone(),
-            600.0,
-        ));
+        glyph.set_layer(GlyphLayer::with_width(first_layer_id.clone(), 500.0));
+        glyph.set_layer(GlyphLayer::with_width(second_layer_id.clone(), 600.0));
         let snapshot = glyph.clone();
 
         glyph
@@ -491,7 +744,7 @@ mod tests {
 
     #[test]
     fn glyph_layer_contours() {
-        let mut layer = GlyphLayer::with_width(LayerId::new(), SourceId::new(), 500.0);
+        let mut layer = GlyphLayer::with_width(LayerId::new(), 500.0);
         assert!(layer.is_empty());
 
         let contour = Contour::new();
@@ -503,7 +756,7 @@ mod tests {
 
     #[test]
     fn glyph_layer_anchors_are_ordered() {
-        let mut layer = GlyphLayer::new(LayerId::new(), SourceId::new());
+        let mut layer = GlyphLayer::new(LayerId::new());
         let a1 = layer.add_anchor(Anchor::new(Some("top".to_string()), 10.0, 20.0));
         let a2 = layer.add_anchor(Anchor::new(Some("bottom".to_string()), 30.0, 40.0));
 

--- a/crates/shift-font/src/ir/mod.rs
+++ b/crates/shift-font/src/ir/mod.rs
@@ -4,6 +4,7 @@ pub mod binary_data;
 pub mod boolean;
 pub mod collection;
 pub mod component;
+pub mod condition;
 pub mod contour;
 pub mod entity;
 pub mod features;
@@ -27,15 +28,17 @@ pub use axis::{
 };
 pub use binary_data::BinaryData;
 pub use boolean::{boolean, BooleanOp};
-pub use component::{Component, DecomposedTransform, Transform};
+pub use component::{AxisInheritance, Component, DecomposedTransform, Transform};
+pub use condition::Condition;
 pub use contour::{Contour, Contours};
 pub use entity::{
     AnchorId, AxisId, AxisLabelId, AxisMappingId, ComponentId, ContourId, EntityId, GlyphEntityId,
-    GlyphId, GuidelineId, LayerId, MetricId, NamedInstanceId, PointId, SourceId,
+    GlyphId, GlyphSourceId, GlyphVariantId, GuidelineId, LayerId, MetricId, NamedInstanceId,
+    PointId, SourceId,
 };
 pub use features::FeatureData;
 pub use font::{Font, FontMetadata};
-pub use glyph::{Glyph, GlyphLayer};
+pub use glyph::{Glyph, GlyphAxis, GlyphLayer, GlyphSource, GlyphVariant};
 pub use glyph_name::{GlyphName, GlyphNameError};
 pub use guideline::{Guideline, GuidelineOrientation};
 pub use kerning::{KerningData, KerningPair, KerningSide};

--- a/crates/shift-font/src/layer_edit.rs
+++ b/crates/shift-font/src/layer_edit.rs
@@ -546,10 +546,10 @@ impl GlyphLayer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Anchor, Component, GlyphId, LayerId, SourceId};
+    use crate::{Anchor, Component, GlyphId, LayerId};
 
     fn create_session() -> GlyphLayer {
-        GlyphLayer::with_width(LayerId::new(), SourceId::new(), 500.0)
+        GlyphLayer::with_width(LayerId::new(), 500.0)
     }
 
     fn session_with_contour() -> (GlyphLayer, ContourId) {

--- a/crates/shift-font/src/lib.rs
+++ b/crates/shift-font/src/lib.rs
@@ -47,8 +47,8 @@ pub use intents::*;
 pub use interpolation::*;
 pub use ir::*;
 pub use ir::{
-    anchor, axis, boolean, collection, component, contour, entity, features, font, glyph,
-    glyph_name, guideline, kerning, lib_data, metrics, named_instance, point, segment, source,
-    variation,
+    anchor, axis, boolean, collection, component, condition, contour, entity, features, font,
+    glyph, glyph_name, guideline, kerning, lib_data, metrics, named_instance, point, segment,
+    source, variation,
 };
 pub use projection::*;

--- a/crates/shift-font/src/projection.rs
+++ b/crates/shift-font/src/projection.rs
@@ -60,6 +60,7 @@ pub struct GlyphProjectionSet {
 
 #[derive(Clone, Debug, PartialEq)]
 struct GlyphLayerProjection {
+    fallback_source_id: SourceId,
     fallback: Arc<GlyphLayer>,
     interpolation: Option<GlyphInterpolation>,
     exact_source_shapes: Vec<GlyphSourceShape>,
@@ -74,7 +75,7 @@ impl GlyphLayerProjection {
     ) -> CoreResult<GlyphLayer> {
         let exact_source_id = exact_source_id(location, axes, sources);
         if let Some(source_id) = exact_source_id {
-            if source_id == self.fallback.source_id() {
+            if source_id == self.fallback_source_id {
                 return Ok(self.fallback.as_ref().clone());
             }
 
@@ -223,10 +224,13 @@ impl Font {
         let interpolation = self.glyph_interpolation_with_bases(glyph_id, interpolation_bases)?;
         let fallback = interpolation
             .as_ref()
-            .and_then(|interpolation| glyph.layers().get(&interpolation.reference_layer().id()))
-            .cloned()
+            .and_then(|interpolation| {
+                let layer = glyph.layers().get(&interpolation.reference_layer().id())?;
+                let source_id = source_id_for_layer(self, glyph, layer.id())?;
+                Some((source_id, layer.clone()))
+            })
             .or_else(|| fallback_layer(self, glyph));
-        let Some(fallback) = fallback else {
+        let Some((fallback_source_id, fallback)) = fallback else {
             return Ok(None);
         };
         let exact_source_shapes = self
@@ -235,9 +239,8 @@ impl Font {
             .filter(|source| source.is_master())
             .filter_map(|source| {
                 let layer = glyph
-                    .layers()
-                    .values()
-                    .find(|layer| layer.source_id() == source.id())?
+                    .layer_for_source(source.id())
+                    .and_then(|layer| glyph.layers().get(&layer.id()))?
                     .clone();
                 if layer.id() == fallback.id() {
                     return None;
@@ -259,6 +262,7 @@ impl Font {
             .collect();
 
         Ok(Some(Arc::new(GlyphLayerProjection {
+            fallback_source_id,
             fallback,
             interpolation,
             exact_source_shapes,
@@ -363,7 +367,7 @@ impl Font {
         layers: Arc<GlyphLayerProjection>,
         projections: &HashMap<GlyphId, Option<Arc<GlyphLayerProjection>>>,
     ) -> CoreResult<GlyphProjection> {
-        let fallback_source_id = layers.fallback.source_id();
+        let fallback_source_id = layers.fallback_source_id.clone();
         let components =
             self.structural_components(glyph_id, &layers, projections, &fallback_source_id)?;
 
@@ -675,26 +679,45 @@ fn component_base_glyph_ids(
         })
 }
 
-fn fallback_layer(font: &Font, glyph: &Glyph) -> Option<Arc<GlyphLayer>> {
+fn fallback_layer(font: &Font, glyph: &Glyph) -> Option<(SourceId, Arc<GlyphLayer>)> {
     if let Some(default_source_id) = font.default_source_id() {
         let is_master = source_for_id(font, &default_source_id).is_some_and(Source::is_master);
         if is_master {
-            if let Some(layer) = glyph
-                .layers()
-                .values()
-                .find(|layer| layer.source_id() == default_source_id)
-            {
-                return Some(layer.clone());
+            if let Some(layer) = glyph.layer_for_source(default_source_id.clone()) {
+                return glyph
+                    .layers()
+                    .get(&layer.id())
+                    .cloned()
+                    .map(|layer| (default_source_id, layer));
             }
         }
     }
 
     glyph
-        .layers()
+        .default_sources()
         .values()
-        .filter(|layer| source_for_id(font, &layer.source_id()).is_some_and(Source::is_master))
-        .max_by_key(|layer| layer.contours().len() + layer.components().len())
-        .cloned()
+        .filter_map(|glyph_source| {
+            let source_id = glyph_source.base_source_id()?;
+            if !source_for_id(font, &source_id).is_some_and(Source::is_master) {
+                return None;
+            }
+            let layer = glyph.layers().get(&glyph_source.layer_id())?.clone();
+            Some((source_id, layer))
+        })
+        .max_by_key(|(_, layer)| layer.contours().len() + layer.components().len())
+}
+
+fn source_id_for_layer(font: &Font, glyph: &Glyph, layer_id: crate::LayerId) -> Option<SourceId> {
+    glyph
+        .default_sources()
+        .values()
+        .find(|glyph_source| {
+            glyph_source.layer_id() == layer_id
+                && glyph_source.base_source_id().is_some_and(|source_id| {
+                    source_for_id(font, &source_id).is_some_and(Source::is_master)
+                })
+        })
+        .and_then(|glyph_source| glyph_source.base_source_id())
 }
 
 fn source_for_id<'a>(font: &'a Font, source_id: &SourceId) -> Option<&'a Source> {
@@ -720,7 +743,7 @@ mod tests {
     use crate::test_support::sample_variable_font;
     use crate::{
         Anchor, Axis, AxisId, Component, Contour, CoreError, DesignLocation, Font, Glyph, GlyphId,
-        GlyphLayer, LayerId, PointType, Source, SourceId, Transform,
+        GlyphLayer, GlyphSource, LayerId, Location, PointType, Source, SourceId, Transform,
     };
 
     fn variable_font() -> (Font, AxisId, SourceId, SourceId, SourceId) {
@@ -753,13 +776,24 @@ mod tests {
         location
     }
 
-    fn line_layer(source_id: SourceId, x: f64) -> GlyphLayer {
-        let mut layer = GlyphLayer::with_width(LayerId::new(), source_id, 200.0);
+    fn line_layer(_source_id: SourceId, x: f64) -> GlyphLayer {
+        let mut layer = GlyphLayer::with_width(LayerId::new(), 200.0);
         let mut contour = Contour::new();
         contour.add_point(x, 0.0, PointType::OnCurve, false);
         contour.add_point(x + 10.0, 0.0, PointType::OnCurve, false);
         layer.add_contour(contour);
         layer
+    }
+
+    fn set_test_layer(glyph: &mut Glyph, source_id: SourceId, layer: GlyphLayer) {
+        let layer_id = layer.id();
+        glyph.set_layer(layer);
+        glyph.insert_default_source(GlyphSource::new(
+            source_id.to_string(),
+            layer_id,
+            Some(source_id),
+            Location::new(),
+        ));
     }
 
     #[test]
@@ -774,9 +808,9 @@ mod tests {
 
         for root_id in &root_ids {
             let mut root = Glyph::with_id(root_id.clone(), root_id.to_string());
-            let mut layer = GlyphLayer::with_width(LayerId::new(), source_id.clone(), 700.0);
+            let mut layer = GlyphLayer::with_width(LayerId::new(), 700.0);
             layer.add_component(Component::new(child_id.clone(), "A"));
-            root.set_layer(layer);
+            set_test_layer(&mut root, source_id.clone(), layer);
             font.insert_glyph(root).unwrap();
         }
 
@@ -851,15 +885,16 @@ mod tests {
         let (mut font, axis_id, _light_id, regular_id, bold_id) = variable_font();
         let child_id = GlyphId::from_raw("diaeresis");
         let mut child = Glyph::with_id(child_id.clone(), "diaeresis");
-        child.set_layer(line_layer(regular_id.clone(), 20.0));
+        let child_layer = line_layer(regular_id.clone(), 20.0);
+        set_test_layer(&mut child, regular_id.clone(), child_layer);
         font.insert_glyph(child).unwrap();
 
         let root_id = GlyphId::from_raw("Adieresis");
         let mut root = Glyph::with_id(root_id.clone(), "Adieresis");
         for source_id in [regular_id, bold_id] {
-            let mut layer = GlyphLayer::with_width(LayerId::new(), source_id, 500.0);
+            let mut layer = GlyphLayer::with_width(LayerId::new(), 500.0);
             layer.add_component(Component::new(child_id.clone(), "diaeresis"));
-            root.set_layer(layer);
+            set_test_layer(&mut root, source_id, layer);
         }
         font.insert_glyph(root).unwrap();
 
@@ -878,8 +913,10 @@ mod tests {
         let (mut font, axis_id, light_id, regular_id, bold_id) = variable_font();
         let child_id = GlyphId::from_raw("diaeresis");
         let mut child = Glyph::with_id(child_id.clone(), "diaeresis");
-        child.set_layer(line_layer(light_id, 0.0));
-        child.set_layer(line_layer(bold_id, 80.0));
+        let light_layer = line_layer(light_id.clone(), 0.0);
+        set_test_layer(&mut child, light_id, light_layer);
+        let bold_layer = line_layer(bold_id.clone(), 80.0);
+        set_test_layer(&mut child, bold_id, bold_layer);
         font.insert_glyph(child).unwrap();
 
         let weights = font
@@ -893,9 +930,9 @@ mod tests {
 
         let root_id = GlyphId::from_raw("Adieresis");
         let mut root = Glyph::with_id(root_id.clone(), "Adieresis");
-        let mut root_layer = GlyphLayer::with_width(LayerId::new(), regular_id, 500.0);
+        let mut root_layer = GlyphLayer::with_width(LayerId::new(), 500.0);
         root_layer.add_component(Component::new(child_id, "diaeresis"));
-        root.set_layer(root_layer);
+        set_test_layer(&mut root, regular_id, root_layer);
         font.insert_glyph(root).unwrap();
 
         let glyph = font
@@ -915,9 +952,9 @@ mod tests {
         let missing_id = GlyphId::from_raw("missing");
         let root_id = GlyphId::from_raw("root");
         let mut root = Glyph::with_id(root_id.clone(), "root");
-        let mut root_layer = GlyphLayer::with_width(LayerId::new(), source_id, 500.0);
+        let mut root_layer = GlyphLayer::with_width(LayerId::new(), 500.0);
         root_layer.add_component(Component::new(missing_id.clone(), "missing"));
-        root.set_layer(root_layer);
+        set_test_layer(&mut root, source_id, root_layer);
         font.insert_glyph(root).unwrap();
 
         let error = font.glyph_projection(&root_id).unwrap_err();
@@ -936,14 +973,15 @@ mod tests {
         let layer_source_id = font.add_source(Source::layer("background".to_string()));
         let child_id = GlyphId::from_raw("child");
         let mut child = Glyph::with_id(child_id.clone(), "child");
-        child.set_layer(line_layer(layer_source_id, 20.0));
+        let child_layer = line_layer(layer_source_id.clone(), 20.0);
+        set_test_layer(&mut child, layer_source_id, child_layer);
         font.insert_glyph(child).unwrap();
 
         let root_id = GlyphId::from_raw("root");
         let mut root = Glyph::with_id(root_id.clone(), "root");
-        let mut root_layer = GlyphLayer::with_width(LayerId::new(), master_id, 500.0);
+        let mut root_layer = GlyphLayer::with_width(LayerId::new(), 500.0);
         root_layer.add_component(Component::new(child_id.clone(), "child"));
-        root.set_layer(root_layer);
+        set_test_layer(&mut root, master_id, root_layer);
         font.insert_glyph(root).unwrap();
 
         let error = font.glyph_projection(&root_id).unwrap_err();
@@ -967,20 +1005,18 @@ mod tests {
             .unwrap()
             .clone();
         let reference_layer_id = font
-            .layer_id_for_glyph_source(glyph_id.clone(), reference_source_id.clone())
+            .layer_id_for_source(glyph_id.clone(), reference_source_id.clone())
             .unwrap();
         let bold_layer_id = font
-            .layer_id_for_glyph_source(glyph_id.clone(), bold_source.id())
+            .layer_id_for_source(glyph_id.clone(), bold_source.id())
             .unwrap();
         let c_id = GlyphId::from_raw("C");
         let caron_id = GlyphId::from_raw("caron.cap");
         for (component_glyph_id, name) in [(c_id.clone(), "C"), (caron_id.clone(), "caron.cap")] {
             let mut component_glyph = Glyph::with_id(component_glyph_id, name);
-            component_glyph.set_layer(GlyphLayer::with_width(
-                LayerId::new(),
-                reference_source_id.clone(),
-                500.0,
-            ));
+            component_glyph
+                .ensure_layer_for_source(reference_source_id.clone())
+                .set_width(500.0);
             font.insert_glyph(component_glyph).unwrap();
         }
         let reference_layer = font.layer_mut(reference_layer_id).unwrap();
@@ -1027,16 +1063,17 @@ mod tests {
             (regular_id.clone(), 40.0),
             (bold_id.clone(), 80.0),
         ] {
-            base.set_layer(line_layer(source_id, x));
+            let layer = line_layer(source_id.clone(), x);
+            set_test_layer(&mut base, source_id, layer);
         }
         font.insert_glyph(base).unwrap();
 
         let root_id = GlyphId::from_raw("Aacute");
         let mut root = Glyph::with_id(root_id.clone(), "Aacute");
         for (source_id, x) in [(light_id, 0.0), (regular_id, 40.0), (bold_id, 80.0)] {
-            let mut layer = line_layer(source_id, x);
+            let mut layer = line_layer(source_id.clone(), x);
             layer.add_component(Component::new(base_id.clone(), "A"));
-            root.set_layer(layer);
+            set_test_layer(&mut root, source_id, layer);
         }
         font.insert_glyph(root).unwrap();
 
@@ -1060,16 +1097,19 @@ mod tests {
         let (mut font, _axis_id, _light_id, regular_id, bold_id) = variable_font();
         let base_id = GlyphId::from_raw("A");
         let mut base = Glyph::with_id(base_id.clone(), "A");
-        base.set_layer(line_layer(regular_id.clone(), 0.0));
-        base.set_layer(line_layer(bold_id.clone(), 80.0));
+        let regular_layer = line_layer(regular_id.clone(), 0.0);
+        set_test_layer(&mut base, regular_id.clone(), regular_layer);
+        let bold_layer = line_layer(bold_id.clone(), 80.0);
+        set_test_layer(&mut base, bold_id.clone(), bold_layer);
         font.insert_glyph(base).unwrap();
 
         let root_id = GlyphId::from_raw("Aacute");
         let mut root = Glyph::with_id(root_id.clone(), "Aacute");
-        let mut composed = GlyphLayer::with_width(LayerId::new(), regular_id, 500.0);
+        let mut composed = GlyphLayer::with_width(LayerId::new(), 500.0);
         composed.add_component(Component::new(base_id.clone(), "A"));
-        root.set_layer(composed);
-        root.set_layer(line_layer(bold_id.clone(), 80.0));
+        set_test_layer(&mut root, regular_id, composed);
+        let bold_layer = line_layer(bold_id.clone(), 80.0);
+        set_test_layer(&mut root, bold_id.clone(), bold_layer);
         font.insert_glyph(root).unwrap();
 
         let projection = font.glyph_projection(&root_id).unwrap().unwrap();
@@ -1094,15 +1134,17 @@ mod tests {
         let (mut font, _axis_id, light_id, regular_id, bold_id) = variable_font();
         let base_id = GlyphId::from_raw("diaeresis");
         let mut base = Glyph::with_id(base_id.clone(), "diaeresis");
-        base.set_layer(line_layer(light_id, 0.0));
-        base.set_layer(line_layer(bold_id, 80.0));
+        let light_layer = line_layer(light_id.clone(), 0.0);
+        set_test_layer(&mut base, light_id, light_layer);
+        let bold_layer = line_layer(bold_id.clone(), 80.0);
+        set_test_layer(&mut base, bold_id, bold_layer);
         font.insert_glyph(base).unwrap();
 
         let root_id = GlyphId::from_raw("Adieresis");
         let mut root = Glyph::with_id(root_id.clone(), "Adieresis");
-        let mut layer = GlyphLayer::with_width(LayerId::new(), regular_id, 500.0);
+        let mut layer = GlyphLayer::with_width(LayerId::new(), 500.0);
         layer.add_component(Component::new(base_id.clone(), "diaeresis"));
-        root.set_layer(layer);
+        set_test_layer(&mut root, regular_id, layer);
         font.insert_glyph(root).unwrap();
 
         let projection = font.glyph_projection(&root_id).unwrap().unwrap();
@@ -1116,21 +1158,22 @@ mod tests {
         let (mut font, _axis_id, _light_id, regular_id, _bold_id) = variable_font();
         let acute_id = GlyphId::from_raw("acute");
         let mut acute = Glyph::with_id(acute_id.clone(), "acute");
-        acute.set_layer(line_layer(regular_id.clone(), 0.0));
+        let acute_layer = line_layer(regular_id.clone(), 0.0);
+        set_test_layer(&mut acute, regular_id.clone(), acute_layer);
         font.insert_glyph(acute).unwrap();
 
         let acutecomb_id = GlyphId::from_raw("acutecomb");
         let mut acutecomb = Glyph::with_id(acutecomb_id.clone(), "acutecomb");
-        let mut acutecomb_layer = GlyphLayer::with_width(LayerId::new(), regular_id.clone(), 0.0);
+        let mut acutecomb_layer = GlyphLayer::with_width(LayerId::new(), 0.0);
         acutecomb_layer.add_component(Component::new(acute_id.clone(), "acute"));
-        acutecomb.set_layer(acutecomb_layer);
+        set_test_layer(&mut acutecomb, regular_id.clone(), acutecomb_layer);
         font.insert_glyph(acutecomb).unwrap();
 
         let root_id = GlyphId::from_raw("Aacute");
         let mut root = Glyph::with_id(root_id.clone(), "Aacute");
-        let mut root_layer = line_layer(regular_id, 40.0);
+        let mut root_layer = line_layer(regular_id.clone(), 40.0);
         root_layer.add_component(Component::new(acutecomb_id.clone(), "acutecomb"));
-        root.set_layer(root_layer);
+        set_test_layer(&mut root, regular_id, root_layer);
         font.insert_glyph(root).unwrap();
 
         let projection = font.glyph_projection(&root_id).unwrap().unwrap();
@@ -1156,22 +1199,22 @@ mod tests {
         let mut base = Glyph::with_id(base_id.clone(), "A");
         let mut base_layer = line_layer(regular_id.clone(), 0.0);
         base_layer.add_anchor(Anchor::new(Some("top".to_string()), 100.0, 200.0));
-        base.set_layer(base_layer);
+        set_test_layer(&mut base, regular_id.clone(), base_layer);
         font.insert_glyph(base).unwrap();
 
         let mark_id = GlyphId::from_raw("acutecomb");
         let mut mark = Glyph::with_id(mark_id.clone(), "acutecomb");
         let mut mark_layer = line_layer(regular_id.clone(), 0.0);
         mark_layer.add_anchor(Anchor::new(Some("_top".to_string()), 5.0, 0.0));
-        mark.set_layer(mark_layer);
+        set_test_layer(&mut mark, regular_id.clone(), mark_layer);
         font.insert_glyph(mark).unwrap();
 
         let root_id = GlyphId::from_raw("Aacute");
         let mut root = Glyph::with_id(root_id.clone(), "Aacute");
-        let mut root_layer = GlyphLayer::with_width(LayerId::new(), regular_id, 500.0);
+        let mut root_layer = GlyphLayer::with_width(LayerId::new(), 500.0);
         root_layer.add_component(Component::new(base_id, "A"));
         root_layer.add_component(Component::new(mark_id, "acutecomb"));
-        root.set_layer(root_layer);
+        set_test_layer(&mut root, regular_id, root_layer);
         font.insert_glyph(root).unwrap();
 
         let projection = font.glyph_projection(&root_id).unwrap().unwrap();
@@ -1195,7 +1238,8 @@ mod tests {
         let source_id = font.default_source_id().unwrap();
         let blank_id = GlyphId::from_raw("blank");
         let mut blank = Glyph::with_id(blank_id.clone(), "blank");
-        blank.set_layer(GlyphLayer::with_width(LayerId::new(), source_id, 420.0));
+        let blank_layer = GlyphLayer::with_width(LayerId::new(), 420.0);
+        set_test_layer(&mut blank, source_id, blank_layer);
         font.insert_glyph(blank).unwrap();
 
         let glyphs = font
@@ -1219,23 +1263,23 @@ mod tests {
         let source_id = font.default_source_id().unwrap();
         let base_id = GlyphId::from_raw("base");
         let mut base = Glyph::with_id(base_id.clone(), "base");
-        let mut base_layer = GlyphLayer::with_width(LayerId::new(), source_id.clone(), 200.0);
+        let mut base_layer = GlyphLayer::with_width(LayerId::new(), 200.0);
         let mut contour = Contour::new();
         contour.add_point(0.0, 0.0, PointType::OnCurve, false);
         contour.add_point(10.0, 10.0, PointType::OnCurve, false);
         base_layer.add_contour(contour);
-        base.set_layer(base_layer);
+        set_test_layer(&mut base, source_id.clone(), base_layer);
         font.insert_glyph(base).unwrap();
 
         let root_id = GlyphId::from_raw("root");
         let mut root = Glyph::with_id(root_id.clone(), "root");
-        let mut root_layer = GlyphLayer::with_width(LayerId::new(), source_id, 500.0);
+        let mut root_layer = GlyphLayer::with_width(LayerId::new(), 500.0);
         root_layer.add_component(Component::with_matrix(
             base_id,
             "base",
             &Transform::translate(50.0, 20.0),
         ));
-        root.set_layer(root_layer);
+        set_test_layer(&mut root, source_id, root_layer);
         font.insert_glyph(root).unwrap();
 
         let glyph = font

--- a/crates/shift-font/src/test_support.rs
+++ b/crates/shift-font/src/test_support.rs
@@ -3,9 +3,9 @@
 use crate::{
     Anchor, AnchorId, Axis, AxisId, AxisLabel, AxisLabelId, AxisLabelRange, AxisMapping,
     AxisMappingPoint, AxisRole, Component, ComponentId, Contour, ContourId, DecomposedTransform,
-    DesignLocation, ExternalLocation, Font, Glyph, GlyphId, GlyphLayer, Guideline, GuidelineId,
-    KerningPair, KerningSide, LayerId, LibValue, Location, MetricKind, MetricValue, NamedInstance,
-    NamedInstanceId, Point, PointId, PointType, Source, SourceId,
+    DesignLocation, ExternalLocation, Font, Glyph, GlyphId, GlyphLayer, GlyphSource, GlyphSourceId,
+    Guideline, GuidelineId, KerningPair, KerningSide, LayerId, LibValue, Location, MetricKind,
+    MetricValue, NamedInstance, NamedInstanceId, Point, PointId, PointType, Source, SourceId,
 };
 use std::collections::BTreeMap;
 
@@ -217,19 +217,19 @@ pub fn sample_font() -> Font {
 
     let acute_id = GlyphId::from_raw("acute");
     let mut acute = Glyph::with_id(acute_id.clone(), "acute");
-    acute.set_layer(GlyphLayer::with_width(
-        LayerId::from_raw("acute_regular"),
+    set_layer_for_source(
+        &mut acute,
         regular_id.clone(),
-        200.0,
-    ));
+        "Regular",
+        GlyphLayer::with_width(LayerId::from_raw("acute_regular"), 200.0),
+    );
     font.insert_glyph(acute).unwrap();
 
     let glyph_id = GlyphId::from_raw("A");
     let mut glyph = Glyph::with_id(glyph_id, "A");
     glyph.set_unicodes(vec![0x0041, 0x00C1]);
 
-    let mut regular_layer =
-        GlyphLayer::with_width(LayerId::from_raw("A_regular"), regular_id, 600.0);
+    let mut regular_layer = GlyphLayer::with_width(LayerId::from_raw("A_regular"), 600.0);
     regular_layer.set_height(Some(700.0));
     let mut contour = Contour::with_id(ContourId::from_raw("A_outer"));
     contour.push_point(Point::new(
@@ -298,9 +298,9 @@ pub fn sample_font() -> Font {
     regular_layer
         .lib_mut()
         .set("com.shift.layer".to_string(), LibValue::Integer(42));
-    glyph.set_layer(regular_layer);
+    set_layer_for_source(&mut glyph, regular_id, "Regular", regular_layer);
 
-    let mut bold_layer = GlyphLayer::with_width(LayerId::from_raw("A_bold"), bold_id, 650.0);
+    let mut bold_layer = GlyphLayer::with_width(LayerId::from_raw("A_bold"), 650.0);
     bold_layer.set_height(Some(720.0));
     let mut bold_contour = Contour::with_id(ContourId::from_raw("A_bold_outer"));
     bold_contour.push_point(Point::new(
@@ -318,7 +318,7 @@ pub fn sample_font() -> Font {
         false,
     ));
     bold_layer.add_contour(bold_contour);
-    glyph.set_layer(bold_layer);
+    set_layer_for_source(&mut glyph, bold_id, "Bold", bold_layer);
     glyph
         .lib_mut()
         .set("com.shift.glyph".to_string(), LibValue::Boolean(true));
@@ -422,8 +422,18 @@ pub fn sample_variable_font() -> Font {
     ));
 
     let mut glyph = Glyph::with_unicode("A".to_string(), 0x0041);
-    glyph.set_layer(triangle_layer(default_source_id, 600.0, 300.0));
-    glyph.set_layer(triangle_layer(bold_source_id, 800.0, 380.0));
+    set_layer_for_source(
+        &mut glyph,
+        default_source_id,
+        "Regular",
+        triangle_layer(600.0, 300.0),
+    );
+    set_layer_for_source(
+        &mut glyph,
+        bold_source_id,
+        "Bold",
+        triangle_layer(800.0, 380.0),
+    );
     font.insert_glyph(glyph).unwrap();
     font
 }
@@ -473,8 +483,25 @@ fn mapping_point(axis: &Axis, user: f64, design: f64) -> AxisMappingPoint {
     }
 }
 
-fn triangle_layer(source_id: SourceId, width: f64, apex_x: f64) -> GlyphLayer {
-    let mut layer = GlyphLayer::with_width(LayerId::new(), source_id, width);
+fn set_layer_for_source(
+    glyph: &mut Glyph,
+    source_id: SourceId,
+    source_name: &str,
+    layer: GlyphLayer,
+) {
+    let layer_id = layer.id();
+    glyph.set_layer(layer);
+    glyph.insert_default_source(GlyphSource::with_id(
+        GlyphSourceId::from_raw(layer_id.as_str()),
+        source_name.to_string(),
+        layer_id,
+        Some(source_id),
+        Location::new(),
+    ));
+}
+
+fn triangle_layer(width: f64, apex_x: f64) -> GlyphLayer {
+    let mut layer = GlyphLayer::with_width(LayerId::new(), width);
     let mut contour = Contour::new();
     contour.add_point(100.0, 0.0, PointType::OnCurve, false);
     contour.add_point(apex_x, 700.0, PointType::OnCurve, false);

--- a/crates/shift-slug/src/authored/component.rs
+++ b/crates/shift-slug/src/authored/component.rs
@@ -482,12 +482,22 @@ fn fallback_bounds(
     projection: &GlyphProjection,
     resolved_sources: &mut HashMap<SourceId, ResolvedGlyph>,
 ) -> Result<Bounds, AuthoredSlugError> {
+    let fallback_source_id = font
+        .glyph(projection.glyph_id())
+        .and_then(|glyph| {
+            glyph
+                .default_sources()
+                .values()
+                .find(|source| source.layer_id() == projection.fallback().id())
+        })
+        .and_then(|source| source.base_source_id())
+        .ok_or(AuthoredSlugError::MissingInterpolationSources)?;
     let resolved = resolved_source_glyph(
         resolved_sources,
         font,
         projection_set,
         projection,
-        &projection.fallback().source_id(),
+        &fallback_source_id,
     )?;
     let curves = curves_from_resolved_contours(resolved.contours())?;
     let mut curves = curves.into_iter();

--- a/crates/shift-slug/tests/authored_model.rs
+++ b/crates/shift-slug/tests/authored_model.rs
@@ -2,7 +2,7 @@ use shift_backends::font_loader::FontLoader;
 use shift_font::{
     test_support::{sample_font, sample_variable_font},
     Anchor, Component, Contour, DecomposedTransform, DesignLocation, Glyph, GlyphId, GlyphLayer,
-    InterpolationBasis, LayerId, PointType, SourceId,
+    GlyphSource, InterpolationBasis, LayerId, Location, PointType, SourceId,
 };
 use shift_slug::{
     add_authored_component_projection_glyph, add_authored_glyph,
@@ -321,14 +321,18 @@ fn component_model_resolves_varying_decomposed_transform() {
     let layers = font
         .glyph(glyph_id.clone())
         .unwrap()
-        .layers()
+        .default_sources()
         .values()
-        .map(|layer| (layer.id(), layer.source_id()))
+        .filter_map(|source| Some((source.layer_id(), source.base_source_id()?)))
         .collect::<Vec<_>>();
     let grandchild_id = GlyphId::from_raw("component-grandchild");
     let mut grandchild = Glyph::with_id(grandchild_id.clone(), "component-grandchild");
     for (_, source_id) in &layers {
-        grandchild.set_layer(triangle_layer_for_source_shifted(source_id.clone(), 25.0));
+        set_source_layer(
+            &mut grandchild,
+            source_id.clone(),
+            triangle_layer_for_source_shifted(source_id.clone(), 25.0),
+        );
     }
     font.insert_glyph(grandchild).unwrap();
 
@@ -348,7 +352,7 @@ fn component_model_resolves_varying_decomposed_transform() {
                 ..DecomposedTransform::identity()
             },
         ));
-        child.set_layer(layer);
+        set_source_layer(&mut child, source_id.clone(), layer);
     }
     font.insert_glyph(child).unwrap();
 
@@ -421,9 +425,9 @@ fn component_model_resolves_variable_anchor_attachment() {
         .glyphs_by_unicode(0x41)
         .next()
         .unwrap()
-        .layers()
+        .default_sources()
         .values()
-        .map(|layer| layer.source_id())
+        .filter_map(|source| source.base_source_id())
         .collect::<Vec<_>>();
 
     let base_id = GlyphId::from_raw("attachment-base");
@@ -435,7 +439,7 @@ fn component_model_resolves_variable_anchor_attachment() {
             100.0 + 80.0 * source_index as f64,
             200.0 + 40.0 * source_index as f64,
         ));
-        base.set_layer(layer);
+        set_source_layer(&mut base, source_id.clone(), layer);
     }
     font.insert_glyph(base).unwrap();
 
@@ -448,17 +452,17 @@ fn component_model_resolves_variable_anchor_attachment() {
             5.0 + 10.0 * source_index as f64,
             10.0 + 5.0 * source_index as f64,
         ));
-        mark.set_layer(layer);
+        set_source_layer(&mut mark, source_id.clone(), layer);
     }
     font.insert_glyph(mark).unwrap();
 
     let root_id = GlyphId::from_raw("attachment-root");
     let mut root = Glyph::with_id(root_id.clone(), "attachment-root");
     for source_id in &source_ids {
-        let mut layer = GlyphLayer::with_width(LayerId::new(), source_id.clone(), 500.0);
+        let mut layer = GlyphLayer::with_width(LayerId::new(), 500.0);
         layer.add_component(Component::new(base_id.clone(), "attachment-base"));
         layer.add_component(Component::new(mark_id.clone(), "attachment-mark"));
-        root.set_layer(layer);
+        set_source_layer(&mut root, source_id.clone(), layer);
     }
     font.insert_glyph(root).unwrap();
 
@@ -503,9 +507,9 @@ fn component_model_accepts_a_component_specific_interpolation_basis() {
     let root_source_ids = font
         .glyph(root_id.clone())
         .unwrap()
-        .layers()
+        .default_sources()
         .values()
-        .map(|layer| layer.source_id())
+        .filter_map(|source| source.base_source_id())
         .collect::<Vec<_>>();
     let medium_source_id = font
         .sources()
@@ -524,10 +528,9 @@ fn component_model_accepts_a_component_specific_interpolation_basis() {
     .into_iter()
     .enumerate()
     {
-        child.set_layer(triangle_layer_for_source_shifted(
-            source_id,
-            source_index as f64 * 30.0,
-        ));
+        let layer =
+            triangle_layer_for_source_shifted(source_id.clone(), source_index as f64 * 30.0);
+        set_source_layer(&mut child, source_id, layer);
     }
     font.insert_glyph(child).unwrap();
 
@@ -705,7 +708,7 @@ fn authored_projection_reports_unimplemented_product_semantics() {
 }
 
 fn cubic_layer() -> GlyphLayer {
-    let mut layer = GlyphLayer::new(LayerId::new(), SourceId::new());
+    let mut layer = GlyphLayer::new(LayerId::new());
     let mut contour = Contour::new();
     contour.add_point(0.0, 0.0, PointType::OnCurve, false);
     contour.add_point(33.0, 0.0, PointType::OffCurve, false);
@@ -713,6 +716,17 @@ fn cubic_layer() -> GlyphLayer {
     contour.add_point(100.0, 0.0, PointType::OnCurve, false);
     layer.add_contour(contour);
     layer
+}
+
+fn set_source_layer(glyph: &mut Glyph, source_id: SourceId, layer: GlyphLayer) {
+    let glyph_source = GlyphSource::new(
+        source_id.to_string(),
+        layer.id(),
+        Some(source_id),
+        Location::new(),
+    );
+    glyph.set_layer(layer);
+    glyph.insert_default_source(glyph_source);
 }
 
 fn triangle_layer() -> GlyphLayer {
@@ -723,8 +737,8 @@ fn triangle_layer_for_source(source_id: SourceId) -> GlyphLayer {
     triangle_layer_for_source_shifted(source_id, 0.0)
 }
 
-fn triangle_layer_for_source_shifted(source_id: SourceId, shift: f64) -> GlyphLayer {
-    let mut layer = GlyphLayer::new(LayerId::new(), source_id);
+fn triangle_layer_for_source_shifted(_source_id: SourceId, shift: f64) -> GlyphLayer {
+    let mut layer = GlyphLayer::new(LayerId::new());
     let mut contour = Contour::new();
     contour.add_point(shift, 0.0, PointType::OnCurve, false);
     contour.add_point(50.0 + shift, 100.0, PointType::OnCurve, false);

--- a/crates/shift-slug/tests/component_gpu.rs
+++ b/crates/shift-slug/tests/component_gpu.rs
@@ -4,7 +4,8 @@ use std::sync::mpsc;
 
 use shift_font::{
     test_support::sample_variable_font, Anchor, Component, Contour, DecomposedTransform,
-    DesignLocation, Glyph, GlyphId, GlyphLayer, LayerId, PointType,
+    DesignLocation, Glyph, GlyphId, GlyphLayer, GlyphSource, LayerId, Location, PointType,
+    SourceId,
 };
 use shift_slug::{
     add_authored_glyph_with_weight_sets, pack_render_instances, pack_variable_params,
@@ -278,9 +279,9 @@ fn component_font() -> (shift_font::Font, GlyphId) {
     let layers = font
         .glyph(root_id.clone())
         .unwrap()
-        .layers()
+        .default_sources()
         .values()
-        .map(|layer| (layer.id(), layer.source_id()))
+        .filter_map(|source| Some((source.layer_id(), source.base_source_id()?)))
         .collect::<Vec<_>>();
 
     let base_id = GlyphId::from_raw("gpu-component-base");
@@ -294,7 +295,7 @@ fn component_font() -> (shift_font::Font, GlyphId) {
             100.0 + source_index as f64 * 60.0,
             180.0 + source_index as f64 * 30.0,
         ));
-        base.set_layer(base_layer);
+        set_source_layer(&mut base, source_id.clone(), base_layer);
 
         let mut mark_layer = triangle_layer(source_id.clone(), source_index as f64 * 5.0);
         mark_layer.add_anchor(Anchor::new(
@@ -302,7 +303,7 @@ fn component_font() -> (shift_font::Font, GlyphId) {
             10.0 + source_index as f64 * 5.0,
             5.0 + source_index as f64 * 2.0,
         ));
-        mark.set_layer(mark_layer);
+        set_source_layer(&mut mark, source_id.clone(), mark_layer);
     }
     font.insert_glyph(base).unwrap();
     font.insert_glyph(mark).unwrap();
@@ -329,8 +330,19 @@ fn component_font() -> (shift_font::Font, GlyphId) {
     (font, root_id)
 }
 
-fn triangle_layer(source_id: shift_font::SourceId, shift: f64) -> GlyphLayer {
-    let mut layer = GlyphLayer::with_width(LayerId::new(), source_id, 500.0);
+fn set_source_layer(glyph: &mut Glyph, source_id: SourceId, layer: GlyphLayer) {
+    let glyph_source = GlyphSource::new(
+        source_id.to_string(),
+        layer.id(),
+        Some(source_id),
+        Location::new(),
+    );
+    glyph.set_layer(layer);
+    glyph.insert_default_source(glyph_source);
+}
+
+fn triangle_layer(_source_id: SourceId, shift: f64) -> GlyphLayer {
+    let mut layer = GlyphLayer::with_width(LayerId::new(), 500.0);
     let mut contour = Contour::new();
     contour.add_point(shift, 0.0, PointType::OnCurve, false);
     contour.add_point(50.0 + shift, 100.0, PointType::OnCurve, false);

--- a/crates/shift-source/src/package.rs
+++ b/crates/shift-source/src/package.rs
@@ -9,12 +9,12 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 use shift_font::{
-    Anchor, Axis, AxisId, AxisKind, AxisLabel, AxisLabelId, AxisLabelRange, AxisMapping,
-    AxisMappingId, AxisMappingPoint, AxisRole, Component, Contour, DecomposedTransform,
-    DesignLocation, ExternalLocation, FeatureData, Font, FontMetadata, FontMetrics, Glyph,
-    GlyphLayer, GlyphName, Guideline, KerningData, KerningPair, KerningSide, LibData, LibValue,
-    Location, MetricDefinition, MetricId, MetricKind, MetricValue, NamedInstance, NamedInstanceId,
-    Point, PointType, Source, SourceId, SourceRole,
+    Anchor, Axis, AxisId, AxisInheritance, AxisKind, AxisLabel, AxisLabelId, AxisLabelRange,
+    AxisMapping, AxisMappingId, AxisMappingPoint, AxisRole, Component, Contour,
+    DecomposedTransform, DesignLocation, ExternalLocation, FeatureData, Font, FontMetadata,
+    FontMetrics, Glyph, GlyphLayer, GlyphName, GlyphSource, GlyphSourceId, Guideline, KerningData,
+    KerningPair, KerningSide, LibData, LibValue, Location, MetricDefinition, MetricId, MetricKind,
+    MetricValue, NamedInstance, NamedInstanceId, Point, PointType, Source, SourceId, SourceRole,
 };
 use zip::{CompressionMethod, ZipArchive, ZipWriter, result::ZipError, write::SimpleFileOptions};
 
@@ -657,10 +657,83 @@ enum LibValueDoc {
     Uid(u64),
 }
 
+fn legacy_source_id_for_layer(
+    glyph: &Glyph,
+    layer_id: &shift_font::LayerId,
+) -> Result<SourceId, SourcePackageError> {
+    glyph
+        .default_sources()
+        .values()
+        .find(|source| source.layer_id() == *layer_id)
+        .and_then(|source| source.base_source_id())
+        .ok_or_else(|| {
+            SourcePackageError::UnsupportedFormat(format!(
+                "layer {layer_id} has no representable global source binding"
+            ))
+        })
+}
+
+fn ensure_legacy_source_shape(font: &Font) -> Result<(), SourcePackageError> {
+    for glyph in font.glyphs() {
+        if !glyph.axes().is_empty() || !glyph.variants().is_empty() {
+            return Err(SourcePackageError::UnsupportedFormat(format!(
+                "glyph {} uses glyph-local axes or variants",
+                glyph.id()
+            )));
+        }
+
+        let mut referenced_layers = HashSet::new();
+        for source in glyph.default_sources().values() {
+            if source.base_source_id().is_none() || !source.location().is_empty() {
+                return Err(SourcePackageError::UnsupportedFormat(format!(
+                    "glyph source {} cannot be represented by source package v1",
+                    source.id()
+                )));
+            }
+            if !referenced_layers.insert(source.layer_id()) {
+                return Err(SourcePackageError::UnsupportedFormat(format!(
+                    "layer {} is shared by several glyph sources",
+                    source.layer_id()
+                )));
+            }
+        }
+        if referenced_layers.len() != glyph.layers().len()
+            || referenced_layers
+                .iter()
+                .any(|layer_id| glyph.layer(layer_id.clone()).is_none())
+        {
+            return Err(SourcePackageError::UnsupportedFormat(format!(
+                "glyph {} has {} layers but {} distinct representable glyph-source bindings",
+                glyph.id(),
+                glyph.layers().len(),
+                referenced_layers.len(),
+            )));
+        }
+
+        for component in glyph
+            .layers()
+            .values()
+            .flat_map(|layer| layer.components_iter())
+        {
+            if !component.location().is_empty()
+                || component.axis_inheritance() != AxisInheritance::Parent
+                || component.condition().is_some()
+            {
+                return Err(SourcePackageError::UnsupportedFormat(format!(
+                    "component {} uses variable-component authoring",
+                    component.id()
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
 pub fn font_to_tree(
     package_id: &PackageId,
     font: &Font,
 ) -> Result<PackageTree, SourcePackageError> {
+    ensure_legacy_source_shape(font)?;
     let manifest = ManifestDoc {
         format: FORMAT_ID.to_string(),
         schema_version: SCHEMA_VERSION,
@@ -728,7 +801,7 @@ pub fn font_to_tree(
         tree.push(json_entry(KERNING_FILE, &KerningDoc::from_font(font)?)?);
     }
 
-    if let Some(lib_module_doc) = LibModuleDoc::from_font(font) {
+    if let Some(lib_module_doc) = LibModuleDoc::from_font(font)? {
         tree.push(json_entry(LIB_MODULE_FILE, &lib_module_doc)?);
     }
 
@@ -901,7 +974,7 @@ pub fn tree_to_font(tree: PackageTree) -> Result<Font, SourcePackageError> {
 
     for (_, glyph_doc) in ordered_glyph_docs {
         validate_glyph_component_references(&glyph_doc, &glyph_names_by_id)?;
-        let mut glyph = Glyph::try_from(glyph_doc)?;
+        let mut glyph = glyph_doc.into_glyph(font.sources())?;
         if let Some(module_doc) = &mut lib_module_doc {
             apply_lib_module_to_glyph(&mut glyph, module_doc)?;
         }
@@ -1435,24 +1508,23 @@ fn apply_lib_module_to_glyph(
             });
         }
 
+        let expected_source_id = legacy_source_id_for_layer(glyph, &layer_id)?;
+        if layer_doc.source_id != expected_source_id.to_string() {
+            return Err(SourcePackageError::InvalidModule {
+                path: LIB_MODULE_FILE.to_string(),
+                message: format!(
+                    "layer lib source {:?} does not match glyph source base {:?}",
+                    layer_doc.source_id, expected_source_id
+                ),
+            });
+        }
+
         let layer = glyph.layer_mut(layer_id.clone()).ok_or_else(|| {
             SourcePackageError::DanglingReference {
                 field: "lib layer",
                 id: layer_id.to_string(),
             }
         })?;
-
-        if layer_doc.source_id != layer.source_id().to_string() {
-            return Err(SourcePackageError::InvalidModule {
-                path: LIB_MODULE_FILE.to_string(),
-                message: format!(
-                    "layer lib source {:?} does not match layer source {:?}",
-                    layer_doc.source_id,
-                    layer.source_id()
-                ),
-            });
-        }
-
         *layer.lib_mut() = lib_from_doc(layer_doc.lib)?;
     }
 
@@ -1499,7 +1571,7 @@ fn lib_from_doc(doc: BTreeMap<String, LibValueDoc>) -> Result<LibData, SourcePac
 }
 
 impl LibModuleDoc {
-    fn from_font(font: &Font) -> Option<Self> {
+    fn from_font(font: &Font) -> Result<Option<Self>, SourcePackageError> {
         let font_lib = lib_to_doc(font.lib());
         let mut sources = BTreeMap::new();
         let mut glyphs = BTreeMap::new();
@@ -1540,7 +1612,7 @@ impl LibModuleDoc {
                     LayerLibDoc {
                         glyph_id: glyph.id().to_string(),
                         glyph_name: glyph.name().to_string(),
-                        source_id: layer.source_id().to_string(),
+                        source_id: legacy_source_id_for_layer(glyph, &layer.id())?.to_string(),
                         lib: lib_to_doc(layer.lib()),
                     },
                 );
@@ -1548,10 +1620,10 @@ impl LibModuleDoc {
         }
 
         if font_lib.is_empty() && sources.is_empty() && glyphs.is_empty() && layers.is_empty() {
-            return None;
+            return Ok(None);
         }
 
-        Some(Self {
+        Ok(Some(Self {
             owner: LIB_MODULE_OWNER.to_string(),
             module: LIB_MODULE_NAME.to_string(),
             schema_version: LIB_MODULE_SCHEMA_VERSION,
@@ -1559,7 +1631,7 @@ impl LibModuleDoc {
             sources,
             glyphs,
             layers,
-        })
+        }))
     }
 }
 
@@ -2339,11 +2411,20 @@ impl TryFrom<SourceDoc> for Source {
 impl GlyphDoc {
     fn from_glyph(font: &Font, glyph: &Glyph) -> Result<Self, SourcePackageError> {
         let mut layers = BTreeMap::new();
-        for layer in glyph.layers().values() {
-            layers.insert(
-                layer.source_id().to_string(),
-                LayerDoc::from_layer(font, layer.as_ref())?,
-            );
+        for source in glyph.default_sources().values() {
+            let source_id = source.base_source_id().ok_or_else(|| {
+                SourcePackageError::UnsupportedFormat(format!(
+                    "glyph source {} has no global source base",
+                    source.id()
+                ))
+            })?;
+            let layer = glyph.layer(source.layer_id()).ok_or_else(|| {
+                SourcePackageError::DanglingReference {
+                    field: "glyph source layer",
+                    id: source.layer_id().to_string(),
+                }
+            })?;
+            layers.insert(source_id.to_string(), LayerDoc::from_layer(font, layer)?);
         }
 
         Ok(Self {
@@ -2359,22 +2440,52 @@ impl GlyphDoc {
     }
 }
 
-impl TryFrom<GlyphDoc> for Glyph {
-    type Error = SourcePackageError;
-
-    fn try_from(doc: GlyphDoc) -> Result<Self, Self::Error> {
-        let glyph_name = GlyphName::new(doc.name.clone())
-            .map_err(|_| SourcePackageError::InvalidGlyphName(doc.name.clone()))?;
-        let mut glyph = Glyph::with_id(parse_id("glyph", &doc.id)?, glyph_name);
+impl GlyphDoc {
+    fn into_glyph(self, sources: &[Source]) -> Result<Glyph, SourcePackageError> {
+        let glyph_name = GlyphName::new(self.name.clone())
+            .map_err(|_| SourcePackageError::InvalidGlyphName(self.name.clone()))?;
+        let mut glyph = Glyph::with_id(parse_id("glyph", &self.id)?, glyph_name);
         glyph.set_unicodes(
-            doc.unicodes
+            self.unicodes
                 .iter()
                 .map(|value| unicode_from_hex(value))
                 .collect::<Result<Vec<_>, _>>()?,
         );
 
-        for (source_id, layer_doc) in doc.layers {
-            glyph.set_layer(layer_doc.into_layer(parse_id("source", &source_id)?)?);
+        let mut layers = self
+            .layers
+            .into_iter()
+            .map(|(source_id, layer_doc)| {
+                let base_source_id = parse_id("source", &source_id)?;
+                let source_order = sources
+                    .iter()
+                    .position(|source| source.id() == base_source_id)
+                    .ok_or_else(|| SourcePackageError::DanglingReference {
+                        field: "glyph layer source",
+                        id: base_source_id.to_string(),
+                    })?;
+                Ok((source_order, base_source_id, layer_doc))
+            })
+            .collect::<Result<Vec<_>, SourcePackageError>>()?;
+        layers.sort_by_key(|(source_order, _, _)| *source_order);
+
+        for (_, base_source_id, layer_doc) in layers {
+            let source_name = sources
+                .iter()
+                .find(|source| source.id() == base_source_id)
+                .expect("source order established the source")
+                .name()
+                .to_string();
+            let layer = layer_doc.into_layer()?;
+            let glyph_source = GlyphSource::with_id(
+                GlyphSourceId::from_raw(layer.id().as_str()),
+                source_name,
+                layer.id(),
+                Some(base_source_id),
+                Location::new(),
+            );
+            glyph.set_layer(layer);
+            glyph.insert_default_source(glyph_source);
         }
 
         Ok(glyph)
@@ -2407,10 +2518,9 @@ impl LayerDoc {
         })
     }
 
-    fn into_layer(self, source_id: SourceId) -> Result<GlyphLayer, SourcePackageError> {
+    fn into_layer(self) -> Result<GlyphLayer, SourcePackageError> {
         let mut layer = GlyphLayer::with_width(
             parse_id("layer", &self.id)?,
-            source_id,
             ensure_finite("glyph.layers[].advance", self.advance)?,
         );
         layer.set_height(ensure_optional_finite(

--- a/crates/shift-source/tests/package_test.rs
+++ b/crates/shift-source/tests/package_test.rs
@@ -1,8 +1,8 @@
 use std::fs::{self, File};
 
 use shift_font::{
-    Axis, AxisId, DesignLocation, Font, KerningPair, LibValue, Source, SourceId, SourceRole,
-    test_support::sample_font,
+    Axis, AxisId, DesignLocation, Font, Glyph, GlyphAxis, KerningPair, LibValue, Source, SourceId,
+    SourceRole, test_support::sample_font,
 };
 use shift_source::{
     AXES_FILE, AXIS_MAPPINGS_FILE, DATA_DIR, FEATURES_FILE, FONT_FILE, FONTINFO_MODULE_FILE,
@@ -356,6 +356,24 @@ fn rejects_non_finite_metric_values_before_json_serialization() {
         error,
         SourcePackageError::NonFiniteNumber { field } if field.contains("metricValues")
     ));
+}
+
+#[test]
+fn source_package_v1_rejects_glyph_local_authoring_explicitly() {
+    let mut font = Font::new();
+    let mut glyph = Glyph::new("A");
+    glyph.insert_axis(GlyphAxis::with_id(
+        AxisId::from_raw("local"),
+        "Local".to_string(),
+        0.0,
+        0.0,
+        1.0,
+    ));
+    font.insert_glyph(glyph).unwrap();
+
+    let error = font_to_tree(&test_package_id(), &font).unwrap_err();
+
+    assert!(matches!(error, SourcePackageError::UnsupportedFormat(_)));
 }
 
 #[test]

--- a/crates/shift-store/README.md
+++ b/crates/shift-store/README.md
@@ -30,8 +30,9 @@ Recovery states are `Clean`, `Dirty`, `SavePending`, and `Conflict`:
 
 ## Storage boundary
 
-- Font metadata and the glyph/layer directory remain relational and load eagerly. Layer rows reference their glyph rather than duplicating its editable name.
-- Each editable glyph layer is one independently addressable, store-private MessagePack payload identified as `shift.glyph-layer.v1`; the store independently wraps it as `none` or `zstd.v1` without changing authored semantics.
+- Font metadata and the glyph/layer directory remain relational and load eagerly. `glyph_axes`, `glyph_variants`, `glyph_sources`, and `glyph_source_locations` preserve ordered glyph-local designspaces independently from geometry; nullable `glyph_sources.variant_id` distinguishes Default membership from one variant.
+- `glyph_layers` contains only glyph ownership and metrics. A source row references a same-glyph layer, several sources may share one layer, and unreferenced backup/background layers remain canonical.
+- Each editable glyph layer is one independently addressable, store-private MessagePack payload identified as `shift.glyph-layer.v2`; the store independently wraps it as `none` or `zstd.v1` without changing authored semantics.
 - Component dependency rows contain only the earned query index: component ID, owner layer ID, base glyph ID, and ordinal.
 - Points, contours, anchors, transforms, guidelines, and layer lib values are canonical only inside the layer BLOB; they are not duplicated as normalized SQL rows.
 - Payload replacement, directory facts, component rows, and workspace revision state commit in one transaction.
@@ -42,7 +43,7 @@ Recovery states are `Clean`, `Dirty`, `SavePending`, and `Conflict`:
 
 `glyph_layer_payloads` stores `inner_format`, `compression`, `stored_byte_length`,
 `decoded_byte_length`, `decoded_blake3`, and `payload`. `inner_format` remains
-`shift.glyph-layer.v1`. Its bytes are `rmp-serde`'s compact serialization of `GlyphLayer`; struct field order and enum Serde attributes are format-bearing and require a new identifier if changed. Compression is either `none` or `zstd.v1`; `zstd.v1` means one complete independent Zstandard frame with no dictionary. Level 1 is the current write policy, not a decoding
+`shift.glyph-layer.v2`. Its bytes are `rmp-serde`'s compact serialization of source-neutral `GlyphLayer`; component location, axis inheritance, and condition fields are part of that payload. Struct field order and enum Serde attributes are format-bearing and require a new identifier if changed. Compression is either `none` or `zstd.v1`; `zstd.v1` means one complete independent Zstandard frame with no dictionary. Level 1 is the current write policy, not a decoding
 requirement. Writers retain compressed bytes only when they are smaller than the canonical input.
 
 `decoded_blake3` is the 32-byte BLAKE3 of the exact canonical bytes. Reads bound both lengths before
@@ -58,7 +59,7 @@ only then invoke strict MessagePack decoding. A layer replacement may move betwe
 
 ## Preservation and export gate
 
-Canonical SQLite publication must preserve the complete `shift-font::Font`, not a projection chosen for one exporter. The kitchen-sink canonical-document test covers metadata, metrics, axes and mappings, named instances, sources, kerning, features, libs, binary data, guidelines, glyph layers, components, anchors, and stable authored identities through SQLite equality. UFO and Designspace exports must materialize that complete canonical state and use their dedicated writers. Any concept the target format cannot represent requires an explicit export diagnostic; no exporter may silently narrow the canonical document or route through another authoring format.
+Canonical SQLite publication must preserve the complete `shift-font::Font`, not a projection chosen for one exporter. The kitchen-sink and glyph-local canonical-document tests cover metadata, metrics, axes and mappings, named instances, global and glyph-local sources, conditional variants, shared and unreferenced layers, variable-component fields, kerning, features, libs, binary data, guidelines, anchors, and stable authored identities through SQLite equality. UFO and Designspace exports must materialize that complete canonical state and use their dedicated writers. Any concept the target format cannot represent requires an explicit export diagnostic; no exporter may silently narrow the canonical document or route through another authoring format.
 
 ## Schema policy
 

--- a/crates/shift-store/src/change_set.rs
+++ b/crates/shift-store/src/change_set.rs
@@ -51,6 +51,7 @@ impl ShiftStore {
         let tracks_workspace = self.tracks_workspace();
         let tx = self.conn.transaction()?;
         let mut touched_layer_ids = HashSet::new();
+        let mut touched_glyph_ids = HashSet::new();
 
         for change in &change_set.changes {
             if post_font.is_none() || !post_font_supersedes_incremental_layer_write(change) {
@@ -59,11 +60,28 @@ impl ShiftStore {
             if let Some(layer_id) = change.layer_id() {
                 touched_layer_ids.insert(layer_id.clone());
             }
+            match change {
+                font::FontChange::GlyphCreated(change) => {
+                    touched_glyph_ids.insert(change.glyph_id.clone());
+                }
+                font::FontChange::GlyphLayerCreated(change) => {
+                    touched_glyph_ids.insert(change.glyph_id.clone());
+                }
+                font::FontChange::GlyphLayerDeleted(change) => {
+                    touched_glyph_ids.insert(change.glyph_id.clone());
+                }
+                _ => {}
+            }
         }
         if let Some(post_font) = post_font {
             for layer_id in touched_layer_ids {
                 if let Some(layer) = post_font.layer(layer_id) {
                     rewrite_layer_in_tx(&tx, layer)?;
+                }
+            }
+            for glyph_id in touched_glyph_ids {
+                if let Some(glyph) = post_font.glyph(glyph_id) {
+                    replace_glyph_authoring_in_tx(&tx, glyph)?;
                 }
             }
         }
@@ -76,6 +94,7 @@ impl ShiftStore {
     }
 
     pub fn replace_font_state(&mut self, font: &font::Font) -> Result<(), StoreError> {
+        font.validate()?;
         let tx = self.conn.transaction()?;
         replace_font_header_in_tx(&tx, font)?;
 
@@ -102,6 +121,10 @@ pub(crate) fn replace_font_header_in_tx(
     tx.execute("DELETE FROM feature_text", [])?;
     tx.execute("DELETE FROM font_guidelines", [])?;
     tx.execute("DELETE FROM glyph_components", [])?;
+    tx.execute("DELETE FROM glyph_source_locations", [])?;
+    tx.execute("DELETE FROM glyph_sources", [])?;
+    tx.execute("DELETE FROM glyph_variants", [])?;
+    tx.execute("DELETE FROM glyph_axes", [])?;
     tx.execute("DELETE FROM glyph_layer_payloads", [])?;
     tx.execute("DELETE FROM glyph_layers", [])?;
     tx.execute("DELETE FROM glyph_unicodes", [])?;
@@ -183,6 +206,105 @@ pub(crate) fn write_glyph_in_tx(
 
     for layer in glyph.layers().values().map(|layer| layer.as_ref()) {
         write_layer_in_tx(tx, &glyph.id(), layer)?;
+    }
+    replace_glyph_authoring_in_tx(tx, glyph)
+}
+
+pub(crate) fn replace_glyph_authoring_in_tx(
+    tx: &Transaction<'_>,
+    glyph: &font::Glyph,
+) -> Result<(), StoreError> {
+    tx.execute(
+        "DELETE FROM glyph_source_locations
+         WHERE glyph_source_id IN (SELECT id FROM glyph_sources WHERE glyph_id = ?1)",
+        [glyph.id().to_string()],
+    )?;
+    tx.execute(
+        "DELETE FROM glyph_sources WHERE glyph_id = ?1",
+        [glyph.id().to_string()],
+    )?;
+    tx.execute(
+        "DELETE FROM glyph_variants WHERE glyph_id = ?1",
+        [glyph.id().to_string()],
+    )?;
+    tx.execute(
+        "DELETE FROM glyph_axes WHERE glyph_id = ?1",
+        [glyph.id().to_string()],
+    )?;
+
+    for (order_index, axis) in glyph.axes().values().enumerate() {
+        tx.execute(
+            "INSERT INTO glyph_axes
+             (id, glyph_id, name, min_value, default_value, max_value, order_index)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                axis.id().to_string(),
+                glyph.id().to_string(),
+                axis.name(),
+                axis.minimum(),
+                axis.default(),
+                axis.maximum(),
+                order_index as i64,
+            ],
+        )?;
+    }
+
+    for (order_index, source) in glyph.default_sources().values().enumerate() {
+        insert_glyph_source(tx, &glyph.id(), None, source, order_index as i64)?;
+    }
+    for (variant_order, variant) in glyph.variants().values().enumerate() {
+        tx.execute(
+            "INSERT INTO glyph_variants
+             (id, glyph_id, name, condition_json, order_index)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                variant.id().to_string(),
+                glyph.id().to_string(),
+                variant.name(),
+                serde_json::to_string(variant.condition())?,
+                variant_order as i64,
+            ],
+        )?;
+        for (source_order, source) in variant.sources().values().enumerate() {
+            insert_glyph_source(
+                tx,
+                &glyph.id(),
+                Some(&variant.id()),
+                source,
+                source_order as i64,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn insert_glyph_source(
+    tx: &Transaction<'_>,
+    glyph_id: &font::GlyphId,
+    variant_id: Option<&font::GlyphVariantId>,
+    source: &font::GlyphSource,
+    order_index: i64,
+) -> Result<(), StoreError> {
+    tx.execute(
+        "INSERT INTO glyph_sources
+         (id, glyph_id, variant_id, name, layer_id, base_source_id, order_index)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
+            source.id().to_string(),
+            glyph_id.to_string(),
+            variant_id.map(ToString::to_string),
+            source.name(),
+            source.layer_id().to_string(),
+            source.base_source_id().map(|id| id.to_string()),
+            order_index,
+        ],
+    )?;
+    for (axis_id, value) in source.location().iter() {
+        tx.execute(
+            "INSERT INTO glyph_source_locations (glyph_source_id, axis_id, value)
+             VALUES (?1, ?2, ?3)",
+            params![source.id().to_string(), axis_id.to_string(), value],
+        )?;
     }
     Ok(())
 }
@@ -364,12 +486,16 @@ fn apply_change(tx: &Transaction<'_>, change: &font::FontChange) -> Result<(), S
         font::FontChange::GlyphLayerCreated(change) => create_empty_layer_in_tx(
             tx,
             &change.glyph_id,
+            &change.glyph_source,
             change.layer_id.clone(),
-            change.source_id.clone(),
             change.width,
             change.height,
         ),
         font::FontChange::GlyphLayerDeleted(change) => {
+            tx.execute(
+                "DELETE FROM glyph_sources WHERE layer_id = ?1",
+                [layer_row_id(&change.layer_id)],
+            )?;
             let rows_changed = tx.execute(
                 "DELETE FROM glyph_layers WHERE id = ?1",
                 [layer_row_id(&change.layer_id)],

--- a/crates/shift-store/src/font_state.rs
+++ b/crates/shift-store/src/font_state.rs
@@ -59,6 +59,7 @@ impl ShiftStore {
         }
 
         *font.kerning_mut() = load_kerning(&self.conn)?;
+        font.validate()?;
 
         Ok(font)
     }
@@ -362,21 +363,137 @@ fn load_glyphs(
         }
     }
 
+    let mut glyph_axes: HashMap<font::GlyphId, Vec<font::GlyphAxis>> = HashMap::new();
+    {
+        let mut stmt = conn.prepare(
+            "SELECT id, glyph_id, name, min_value, default_value, max_value
+             FROM glyph_axes
+             ORDER BY glyph_id, order_index, id",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok((
+                font::GlyphId::from_raw(row.get::<_, String>(1)?),
+                font::GlyphAxis::with_id(
+                    font::AxisId::from_raw(row.get::<_, String>(0)?),
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                ),
+            ))
+        })?;
+        for row in rows {
+            let (glyph_id, axis) = row?;
+            glyph_axes.entry(glyph_id).or_default().push(axis);
+        }
+    }
+
+    let mut variants: HashMap<font::GlyphId, Vec<font::GlyphVariant>> = HashMap::new();
+    let mut variant_owners: HashMap<font::GlyphVariantId, font::GlyphId> = HashMap::new();
+    {
+        let mut stmt = conn.prepare(
+            "SELECT id, glyph_id, name, condition_json
+             FROM glyph_variants
+             ORDER BY glyph_id, order_index, id",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            let condition_json = row.get::<_, String>(3)?;
+            let condition = serde_json::from_str(&condition_json).map_err(json_column_error)?;
+            Ok((
+                font::GlyphId::from_raw(row.get::<_, String>(1)?),
+                font::GlyphVariant::with_id(
+                    font::GlyphVariantId::from_raw(row.get::<_, String>(0)?),
+                    row.get(2)?,
+                    condition,
+                ),
+            ))
+        })?;
+        for row in rows {
+            let (glyph_id, variant) = row?;
+            variant_owners.insert(variant.id(), glyph_id.clone());
+            variants.entry(glyph_id).or_default().push(variant);
+        }
+    }
+
+    let mut glyph_source_locations: HashMap<font::GlyphSourceId, font::Location> = HashMap::new();
+    {
+        let mut stmt = conn.prepare(
+            "SELECT glyph_source_id, axis_id, value
+             FROM glyph_source_locations
+             ORDER BY glyph_source_id, axis_id",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok((
+                font::GlyphSourceId::from_raw(row.get::<_, String>(0)?),
+                font::AxisId::from_raw(row.get::<_, String>(1)?),
+                row.get::<_, f64>(2)?,
+            ))
+        })?;
+        for row in rows {
+            let (glyph_source_id, axis_id, value) = row?;
+            glyph_source_locations
+                .entry(glyph_source_id)
+                .or_default()
+                .set(axis_id, value);
+        }
+    }
+
+    let mut default_sources: HashMap<font::GlyphId, Vec<font::GlyphSource>> = HashMap::new();
+    let mut variant_sources: HashMap<font::GlyphVariantId, Vec<font::GlyphSource>> = HashMap::new();
+    {
+        let mut stmt = conn.prepare(
+            "SELECT id, glyph_id, variant_id, name, layer_id, base_source_id
+             FROM glyph_sources
+             ORDER BY glyph_id, variant_id, order_index, id",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            let glyph_source_id = font::GlyphSourceId::from_raw(row.get::<_, String>(0)?);
+            let location = glyph_source_locations
+                .remove(&glyph_source_id)
+                .unwrap_or_default();
+            Ok((
+                font::GlyphId::from_raw(row.get::<_, String>(1)?),
+                row.get::<_, Option<String>>(2)?
+                    .map(font::GlyphVariantId::from_raw),
+                font::GlyphSource::with_id(
+                    glyph_source_id,
+                    row.get(3)?,
+                    font::LayerId::from_raw(row.get::<_, String>(4)?),
+                    row.get::<_, Option<String>>(5)?
+                        .map(font::SourceId::from_raw),
+                    location,
+                ),
+            ))
+        })?;
+        for row in rows {
+            let (glyph_id, variant_id, source) = row?;
+            if let Some(variant_id) = variant_id {
+                if variant_owners.get(&variant_id) != Some(&glyph_id) {
+                    return Err(StoreError::InvalidDocument(format!(
+                        "glyph source {} and variant {} have different glyph owners",
+                        source.id(),
+                        variant_id
+                    )));
+                }
+                variant_sources.entry(variant_id).or_default().push(source);
+            } else {
+                default_sources.entry(glyph_id).or_default().push(source);
+            }
+        }
+    }
+
     let layer_rows = {
         let mut stmt = conn.prepare(
-            "
-            SELECT id, glyph_id, source_id, width, height
-            FROM glyph_layers
-            ORDER BY glyph_id, source_id, id
-            ",
+            "SELECT id, glyph_id, width, height
+             FROM glyph_layers
+             ORDER BY glyph_id, id",
         )?;
         stmt.query_map([], |row| {
             Ok((
                 font::LayerId::from_raw(row.get::<_, String>(0)?),
                 font::GlyphId::from_raw(row.get::<_, String>(1)?),
-                font::SourceId::from_raw(row.get::<_, String>(2)?),
-                row.get::<_, f64>(3)?,
-                row.get::<_, Option<f64>>(4)?,
+                row.get::<_, f64>(2)?,
+                row.get::<_, Option<f64>>(3)?,
             ))
         })?
         .collect::<Result<Vec<_>, _>>()?
@@ -385,7 +502,7 @@ fn load_glyphs(
     if include_layer_payloads {
         let layer_ids = layer_rows
             .iter()
-            .map(|(layer_id, _, _, _, _)| layer_id.clone())
+            .map(|(layer_id, _, _, _)| layer_id.clone())
             .collect::<Vec<_>>();
         for layer in crate::layer::load_glyph_layers_from_conn(conn, &layer_ids)? {
             loaded_layers.insert(layer.id(), layer);
@@ -393,7 +510,7 @@ fn load_glyphs(
     }
 
     let mut layers: HashMap<font::GlyphId, Vec<font::GlyphLayer>> = HashMap::new();
-    for (layer_id, glyph_id, source_id, width, height) in layer_rows {
+    for (layer_id, glyph_id, width, height) in layer_rows {
         let layer = if include_layer_payloads {
             loaded_layers
                 .remove(&layer_id)
@@ -402,7 +519,7 @@ fn load_glyphs(
                     id: layer_id.to_string(),
                 })?
         } else {
-            let mut layer = font::GlyphLayer::with_width(layer_id, source_id, width);
+            let mut layer = font::GlyphLayer::with_width(layer_id, width);
             layer.set_height(height);
             layer
         };
@@ -421,8 +538,20 @@ fn load_glyphs(
                 .collect(),
         );
         *glyph.lib_mut() = font::LibData::from_map(libs.remove(&glyph_id).unwrap_or_default());
+        for axis in glyph_axes.remove(&glyph_id).unwrap_or_default() {
+            glyph.insert_axis(axis);
+        }
         for layer in layers.remove(&glyph_id).unwrap_or_default() {
             glyph.set_layer(layer);
+        }
+        for source in default_sources.remove(&glyph_id).unwrap_or_default() {
+            glyph.insert_default_source(source);
+        }
+        for mut variant in variants.remove(&glyph_id).unwrap_or_default() {
+            for source in variant_sources.remove(&variant.id()).unwrap_or_default() {
+                variant.insert_source(source);
+            }
+            glyph.insert_variant(variant);
         }
         glyphs.push(glyph);
     }

--- a/crates/shift-store/src/import_writer.rs
+++ b/crates/shift-store/src/import_writer.rs
@@ -6,7 +6,9 @@ use shift_font as font;
 
 use crate::{
     GlyphWriteBatch, LayerBatchTiming, ShiftStore, StoreError,
-    change_set::{replace_font_header_in_tx, write_glyph_directory_in_tx},
+    change_set::{
+        replace_font_header_in_tx, replace_glyph_authoring_in_tx, write_glyph_directory_in_tx,
+    },
     layer::{StoredLayerPayload, compress_layer, encode_layer, store_stored_layer_in_tx},
     schema::{defer_import_indexes, restore_import_indexes},
     types::{EncodedGlyphLayers, PackedGlyph},
@@ -120,6 +122,7 @@ impl FontImportWriter<'_> {
                 })?;
             store_stored_layer_in_tx(&self.tx, &glyph.id(), layer, stored, WriteMode::Insert)?;
         }
+        replace_glyph_authoring_in_tx(&self.tx, glyph)?;
         self.next_glyph_order += 1;
         Ok(())
     }
@@ -165,10 +168,14 @@ fn compress_glyph_layers(
 mod tests {
     use super::*;
 
-    const DEFERRED_INDEXES: [&str; 4] = [
+    const DEFERRED_INDEXES: [&str; 8] = [
         "glyphs_name_idx",
+        "glyph_axes_glyph_id_idx",
+        "glyph_variants_glyph_id_idx",
         "glyph_layers_glyph_id_idx",
-        "glyph_layers_source_id_idx",
+        "glyph_sources_glyph_id_idx",
+        "glyph_sources_layer_id_idx",
+        "glyph_sources_base_source_id_idx",
         "glyph_components_base_glyph_id_idx",
     ];
 

--- a/crates/shift-store/src/layer/directory.rs
+++ b/crates/shift-store/src/layer/directory.rs
@@ -13,7 +13,7 @@ const MAX_LAYER_PAYLOAD_BYTES_SQL: i64 = MAX_LAYER_PAYLOAD_BYTES as i64;
 pub struct GlyphLayerDirectoryEntry {
     pub layer_id: font::LayerId,
     pub glyph_id: font::GlyphId,
-    pub source_id: font::SourceId,
+    pub source_id: Option<font::SourceId>,
     pub name: Option<font::GlyphName>,
     pub width: f64,
     pub height: Option<f64>,
@@ -25,12 +25,20 @@ impl ShiftStore {
     pub fn list_glyph_layer_directory(&self) -> Result<Vec<GlyphLayerDirectoryEntry>, StoreError> {
         let mut stmt = self.conn.prepare(
             "
-            SELECT l.id, l.glyph_id, l.source_id, g.name, l.width, l.height,
+            SELECT l.id, l.glyph_id,
+                   (SELECT gs.base_source_id
+                    FROM glyph_sources AS gs
+                    WHERE gs.layer_id = l.id
+                      AND gs.variant_id IS NULL
+                      AND gs.base_source_id IS NOT NULL
+                    ORDER BY gs.order_index, gs.id
+                    LIMIT 1) AS source_id,
+                   g.name, l.width, l.height,
                    p.stored_byte_length, p.decoded_byte_length
             FROM glyph_layers AS l
             JOIN glyphs AS g ON g.id = l.glyph_id
             JOIN glyph_layer_payloads AS p ON p.layer_id = l.id
-            ORDER BY l.glyph_id, l.source_id, l.id
+            ORDER BY l.glyph_id, l.id
             ",
         )?;
         let rows = stmt.query_map([], map_directory_row)?;
@@ -40,7 +48,6 @@ impl ShiftStore {
 
 pub(super) struct DirectoryFacts {
     pub(super) layer_id: String,
-    pub(super) source_id: String,
     pub(super) width: f64,
     pub(super) height: Option<f64>,
     inner_format: String,
@@ -117,29 +124,25 @@ impl DirectoryFacts {
 pub(super) fn map_directory_facts_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<DirectoryFacts> {
     Ok(DirectoryFacts {
         layer_id: row.get(0)?,
-        source_id: row.get(1)?,
-        width: row.get(2)?,
-        height: row.get(3)?,
-        inner_format: row.get(4)?,
-        compression: row.get(5)?,
-        stored_byte_length: row.get(6)?,
-        decoded_byte_length: row.get(7)?,
-        decoded_blake3: row.get(8)?,
-        actual_stored_byte_length: row.get(9)?,
+        width: row.get(1)?,
+        height: row.get(2)?,
+        inner_format: row.get(3)?,
+        compression: row.get(4)?,
+        stored_byte_length: row.get(5)?,
+        decoded_byte_length: row.get(6)?,
+        decoded_blake3: row.get(7)?,
+        actual_stored_byte_length: row.get(8)?,
     })
 }
 
 pub(super) fn validate_directory_facts(
     expected_id: &font::LayerId,
-    expected_source_id: &str,
     expected_width: f64,
     expected_height: Option<f64>,
     layer: &font::GlyphLayer,
 ) -> Result<(), StoreError> {
     let detail = if layer.id() != *expected_id {
         Some(format!("payload id is {}", layer.id()))
-    } else if layer.source_id().as_str() != expected_source_id {
-        Some(format!("payload source id is {}", layer.source_id()))
     } else if layer.width().to_bits() != expected_width.to_bits() {
         Some("payload width differs from directory width".to_string())
     } else if !same_optional_f64(layer.height(), expected_height) {
@@ -162,7 +165,9 @@ fn map_directory_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<GlyphLayerDire
     Ok(GlyphLayerDirectoryEntry {
         layer_id: font::LayerId::from_raw(row.get::<_, String>(0)?),
         glyph_id: font::GlyphId::from_raw(row.get::<_, String>(1)?),
-        source_id: font::SourceId::from_raw(row.get::<_, String>(2)?),
+        source_id: row
+            .get::<_, Option<String>>(2)?
+            .map(font::SourceId::from_raw),
         name: row.get::<_, Option<String>>(3)?.map(font::GlyphName::from),
         width: row.get(4)?,
         height: row.get(5)?,

--- a/crates/shift-store/src/layer/format.rs
+++ b/crates/shift-store/src/layer/format.rs
@@ -6,7 +6,7 @@ use shift_font::{self as font, GlyphEntityId, LibValue};
 use super::check_layer_length;
 use crate::StoreError;
 
-pub const GLYPH_LAYER_FORMAT: &str = "shift.glyph-layer.v1";
+pub const GLYPH_LAYER_FORMAT: &str = "shift.glyph-layer.v2";
 const MAX_NESTING_DEPTH: usize = 64;
 const MAX_LIB_VALUES: usize = 1_000_000;
 
@@ -266,7 +266,6 @@ mod tests {
     fn invalid_ids_and_non_finite_values_are_rejected() {
         let invalid_id = rmp_serde::to_vec(&(
             "wrong",
-            "source_test",
             0.0_f64,
             None::<f64>,
             Vec::<font::Contour>::new(),
@@ -280,7 +279,6 @@ mod tests {
 
         let non_finite = rmp_serde::to_vec(&(
             "layer_test",
-            "source_test",
             f64::NAN,
             None::<f64>,
             Vec::<font::Contour>::new(),
@@ -314,10 +312,7 @@ mod tests {
             font::PointType::OnCurve,
             false,
         ));
-        let mut layer = font::GlyphLayer::new(
-            font::LayerId::from_raw("test"),
-            font::SourceId::from_raw("test"),
-        );
+        let mut layer = font::GlyphLayer::new(font::LayerId::from_raw("test"));
         layer.add_contour(contour);
 
         assert!(matches!(

--- a/crates/shift-store/src/layer/load.rs
+++ b/crates/shift-store/src/layer/load.rs
@@ -42,7 +42,7 @@ pub(crate) fn load_glyph_layer_from_conn(
 ) -> Result<Option<font::GlyphLayer>, StoreError> {
     let mut directory_stmt = conn.prepare_cached(
         "
-        SELECT l.id, l.source_id, l.width, l.height,
+        SELECT l.id, l.width, l.height,
                p.inner_format, p.compression,
                p.stored_byte_length, p.decoded_byte_length, p.decoded_blake3,
                length(p.payload)
@@ -87,13 +87,7 @@ pub(crate) fn load_glyph_layer_from_conn(
         })?;
     let decoded = decompress_layer(facts.layer_id.as_str(), facts.stored_layer(payload)?)?;
     let layer = decode_layer(&decoded)?;
-    validate_directory_facts(
-        layer_id,
-        &facts.source_id,
-        facts.width,
-        facts.height,
-        &layer,
-    )?;
+    validate_directory_facts(layer_id, facts.width, facts.height, &layer)?;
     validate_component_index(conn, &layer)?;
     Ok(Some(layer))
 }
@@ -195,7 +189,7 @@ pub(super) fn load_glyph_layer_batch_from_conn(
     let placeholders = (0..keys.len()).map(|_| "?").collect::<Vec<_>>().join(",");
     let directory_sql = format!(
         "
-        SELECT l.id, l.source_id, l.width, l.height,
+        SELECT l.id, l.width, l.height,
                p.inner_format, p.compression,
                p.stored_byte_length, p.decoded_byte_length, p.decoded_blake3,
                length(p.payload)
@@ -292,13 +286,7 @@ pub(super) fn load_glyph_layer_batch_from_conn(
             let decoded = decompress_layer(layer_id.as_str(), facts.stored_layer(payload)?)?;
             let layer = decode_layer(&decoded)?;
             let expected_id = font::LayerId::from_raw(layer_id.clone());
-            validate_directory_facts(
-                &expected_id,
-                &facts.source_id,
-                facts.width,
-                facts.height,
-                &layer,
-            )?;
+            validate_directory_facts(&expected_id, facts.width, facts.height, &layer)?;
             Ok((layer_id, layer))
         })
         .collect::<Result<Vec<_>, StoreError>>()?;

--- a/crates/shift-store/src/layer/tests.rs
+++ b/crates/shift-store/src/layer/tests.rs
@@ -33,13 +33,6 @@ fn sqlite_payload_preserves_canonical_bytes() {
     store
         .conn
         .execute(
-            "INSERT INTO sources (id, name, kind, order_index) VALUES (?1, 'Golden', 'master', 0)",
-            [layer.source_id().to_string()],
-        )
-        .unwrap();
-    store
-        .conn
-        .execute(
             "INSERT INTO glyphs (id, name, order_index) VALUES (?1, ?2, 0)",
             params![glyph_id.to_string(), glyph_name.as_str()],
         )
@@ -100,12 +93,10 @@ fn bounded_batch_load_matches_complete_font_layers() {
 #[test]
 fn requested_layers_load_across_multiple_count_bounded_batches() {
     let mut font = font::Font::new();
-    let source_id = font.default_source_id().unwrap();
     let mut layer_ids = Vec::new();
     for index in 0..=MAX_LAYER_READ_BATCH_COUNT {
         let layer = font::GlyphLayer::with_width(
             font::LayerId::from_raw(format!("layer_{index:04}")),
-            source_id.clone(),
             index as f64,
         );
         layer_ids.push(layer.id());
@@ -609,22 +600,14 @@ fn abandoned_font_stream_rolls_back_header_and_glyphs() {
 fn cjk_scale_directory_open_is_payload_independent() {
     const GLYPH_COUNT: usize = 65_536;
     let mut store = ShiftStore::open_memory_for_test().unwrap();
-    let source_id = font::SourceId::from_raw("cjk").to_string();
-    store
-        .conn
-        .execute(
-            "INSERT INTO sources (id, name, kind, order_index) VALUES (?1, 'CJK', 'master', 0)",
-            [&source_id],
-        )
-        .unwrap();
     let tx = store.conn.transaction().unwrap();
     {
         let mut glyph_stmt = tx
             .prepare("INSERT INTO glyphs (id, name, order_index) VALUES (?1, ?2, ?3)")
             .unwrap();
         let mut layer_stmt = tx
-                .prepare("INSERT INTO glyph_layers (id, glyph_id, source_id, width, height) VALUES (?1, ?2, ?3, 1000, NULL)")
-                .unwrap();
+            .prepare("INSERT INTO glyph_layers (id, glyph_id, width, height) VALUES (?1, ?2, 1000, NULL)")
+            .unwrap();
         let mut payload_stmt = tx
             .prepare(
                 "INSERT INTO glyph_layer_payloads (
@@ -640,9 +623,7 @@ fn cjk_scale_directory_open_is_payload_independent() {
             glyph_stmt
                 .execute(params![glyph_id, name, index as i64])
                 .unwrap();
-            layer_stmt
-                .execute(params![layer_id, glyph_id, source_id])
-                .unwrap();
+            layer_stmt.execute(params![layer_id, glyph_id]).unwrap();
             payload_stmt
                 .execute(params![layer_id, GLYPH_LAYER_FORMAT])
                 .unwrap();

--- a/crates/shift-store/src/layer/write.rs
+++ b/crates/shift-store/src/layer/write.rs
@@ -59,15 +59,14 @@ pub(crate) fn store_stored_layer_in_tx(
     let decoded_byte_length = encoded_len(stored.decoded_byte_length)?;
     let layer_sql = match mode {
         WriteMode::Insert => {
-            "INSERT INTO glyph_layers (id, glyph_id, source_id, width, height) VALUES (?1, ?2, ?3, ?4, ?5)"
+            "INSERT INTO glyph_layers (id, glyph_id, width, height) VALUES (?1, ?2, ?3, ?4)"
         }
         WriteMode::Upsert => {
             "
-            INSERT INTO glyph_layers (id, glyph_id, source_id, width, height)
-            VALUES (?1, ?2, ?3, ?4, ?5)
+            INSERT INTO glyph_layers (id, glyph_id, width, height)
+            VALUES (?1, ?2, ?3, ?4)
             ON CONFLICT(id) DO UPDATE SET
                 glyph_id = excluded.glyph_id,
-                source_id = excluded.source_id,
                 width = excluded.width,
                 height = excluded.height
             "
@@ -76,7 +75,6 @@ pub(crate) fn store_stored_layer_in_tx(
     tx.prepare_cached(layer_sql)?.execute(params![
         layer.id().to_string(),
         glyph_id.to_string(),
-        layer.source_id().to_string(),
         layer.width(),
         layer.height(),
     ])?;
@@ -137,14 +135,43 @@ pub(crate) fn rewrite_layer_in_tx(
 pub(crate) fn create_empty_layer_in_tx(
     tx: &Transaction<'_>,
     glyph_id: &font::GlyphId,
+    glyph_source: &font::GlyphSource,
     layer_id: font::LayerId,
-    source_id: font::SourceId,
     width: f64,
     height: Option<f64>,
 ) -> Result<(), StoreError> {
-    let mut layer = font::GlyphLayer::with_width(layer_id, source_id, width);
+    let mut layer = font::GlyphLayer::with_width(layer_id, width);
     layer.set_height(height);
-    write_layer_in_tx(tx, glyph_id, &layer)
+    write_layer_in_tx(tx, glyph_id, &layer)?;
+
+    let order_index: i64 = tx.query_row(
+        "SELECT COALESCE(MAX(order_index) + 1, 0)
+         FROM glyph_sources
+         WHERE glyph_id = ?1 AND variant_id IS NULL",
+        [glyph_id.to_string()],
+        |row| row.get(0),
+    )?;
+    tx.execute(
+        "INSERT INTO glyph_sources (
+            id, glyph_id, variant_id, name, layer_id, base_source_id, order_index
+         ) VALUES (?1, ?2, NULL, ?3, ?4, ?5, ?6)",
+        params![
+            glyph_source.id().to_string(),
+            glyph_id.to_string(),
+            glyph_source.name(),
+            glyph_source.layer_id().to_string(),
+            glyph_source.base_source_id().map(|id| id.to_string()),
+            order_index,
+        ],
+    )?;
+    for (axis_id, value) in glyph_source.location().iter() {
+        tx.execute(
+            "INSERT INTO glyph_source_locations (glyph_source_id, axis_id, value)
+             VALUES (?1, ?2, ?3)",
+            params![glyph_source.id().to_string(), axis_id.to_string(), value],
+        )?;
+    }
+    Ok(())
 }
 
 fn write_component_index(

--- a/crates/shift-store/src/recovery/catalog.rs
+++ b/crates/shift-store/src/recovery/catalog.rs
@@ -110,6 +110,16 @@ pub(super) const SOURCES: RecoveryTable =
     RecoveryTable::overlay_rows("sources", Some("source"), SOURCE_BASE_FALLBACK_COLUMNS);
 pub(super) const GLYPHS: RecoveryTable =
     RecoveryTable::overlay_rows("glyphs", Some("glyph"), NO_BASE_FALLBACK_COLUMNS);
+pub(super) const GLYPH_AXES: RecoveryTable =
+    RecoveryTable::replace_collection("glyph_axes", Some("glyph_id"), false);
+pub(super) const GLYPH_VARIANTS: RecoveryTable =
+    RecoveryTable::replace_collection("glyph_variants", Some("glyph_id"), true);
+pub(super) const GLYPH_LAYERS: RecoveryTable =
+    RecoveryTable::overlay_rows("glyph_layers", Some("layer"), NO_BASE_FALLBACK_COLUMNS);
+pub(super) const GLYPH_SOURCES: RecoveryTable =
+    RecoveryTable::replace_collection("glyph_sources", Some("glyph_id"), true);
+pub(super) const GLYPH_SOURCE_LOCATIONS: RecoveryTable =
+    RecoveryTable::replace_collection("glyph_source_locations", Some("glyph_source_id"), false);
 pub(super) const GLYPH_UNICODES: RecoveryTable =
     RecoveryTable::replace_collection("glyph_unicodes", Some("glyph_id"), false);
 pub(super) const FONT_GUIDELINES: RecoveryTable = RecoveryTable::canonical_only("font_guidelines");
@@ -130,8 +140,6 @@ pub(super) const SOURCE_LIB: RecoveryTable =
 pub(super) const GLYPH_LIB: RecoveryTable =
     RecoveryTable::replace_collection("glyph_lib", Some("glyph_id"), false);
 pub(super) const FONT_BINARIES: RecoveryTable = RecoveryTable::canonical_only("font_binaries");
-pub(super) const GLYPH_LAYERS: RecoveryTable =
-    RecoveryTable::overlay_rows("glyph_layers", Some("layer"), NO_BASE_FALLBACK_COLUMNS);
 pub(super) const GLYPH_LAYER_PAYLOADS: RecoveryTable =
     RecoveryTable::overlay_rows("glyph_layer_payloads", None, NO_BASE_FALLBACK_COLUMNS);
 pub(super) const GLYPH_COMPONENTS: RecoveryTable =
@@ -147,6 +155,11 @@ const RECOVERY_TABLES: &[RecoveryTable] = &[
     NAMED_INSTANCES,
     SOURCES,
     GLYPHS,
+    GLYPH_AXES,
+    GLYPH_VARIANTS,
+    GLYPH_LAYERS,
+    GLYPH_SOURCES,
+    GLYPH_SOURCE_LOCATIONS,
     GLYPH_UNICODES,
     FONT_GUIDELINES,
     SOURCE_LOCATIONS,
@@ -160,7 +173,6 @@ const RECOVERY_TABLES: &[RecoveryTable] = &[
     SOURCE_LIB,
     GLYPH_LIB,
     FONT_BINARIES,
-    GLYPH_LAYERS,
     GLYPH_LAYER_PAYLOADS,
     GLYPH_COMPONENTS,
     DOCUMENT_METADATA,

--- a/crates/shift-store/src/recovery/patch.rs
+++ b/crates/shift-store/src/recovery/patch.rs
@@ -6,7 +6,8 @@ use shift_font as font;
 use super::{
     RecoveryOverlay, RecoveryState,
     catalog::{
-        AXES, AXIS_MAPPINGS, GLYPH_COMPONENTS, GLYPH_LAYERS, GLYPH_LIB, GLYPH_UNICODES, GLYPHS,
+        AXES, AXIS_MAPPINGS, GLYPH_AXES, GLYPH_COMPONENTS, GLYPH_LAYERS, GLYPH_LIB,
+        GLYPH_SOURCE_LOCATIONS, GLYPH_SOURCES, GLYPH_UNICODES, GLYPH_VARIANTS, GLYPHS,
         METRIC_DEFINITIONS, NAMED_INSTANCES, RecoveryTable, SOURCE_LIB, SOURCE_LOCATIONS,
         SOURCE_METRIC_VALUES, SOURCES,
     },
@@ -14,9 +15,9 @@ use super::{
 use crate::{
     FontInfo, StoreError,
     change_set::{
-        replace_axis_mappings, replace_metric_definitions, replace_named_instances,
-        upsert_axis_with_order, upsert_font_info, write_glyph_directory_in_tx,
-        write_source_snapshot_in_tx,
+        replace_axis_mappings, replace_glyph_authoring_in_tx, replace_metric_definitions,
+        replace_named_instances, upsert_axis_with_order, upsert_font_info,
+        write_glyph_directory_in_tx, write_source_snapshot_in_tx,
     },
     layer::write_layer_in_tx,
     write_mode::WriteMode,
@@ -51,6 +52,7 @@ impl RecoveryOverlay {
         let mut source_ids = HashSet::new();
         let mut glyph_ids = HashSet::new();
         let mut layer_ids = HashSet::new();
+        let mut authoring_glyph_ids = HashSet::new();
 
         for change in &change_set.changes {
             match change {
@@ -84,6 +86,10 @@ impl RecoveryOverlay {
                 }
                 font::FontChange::GlyphIdentityChanged(change) => {
                     glyph_ids.insert(change.glyph_id.clone());
+                }
+                font::FontChange::GlyphLayerCreated(change) => {
+                    authoring_glyph_ids.insert(change.glyph_id.clone());
+                    layer_ids.insert(change.layer_id.clone());
                 }
                 _ => {
                     if let Some(layer_id) = change.layer_id() {
@@ -176,6 +182,24 @@ impl RecoveryOverlay {
             } else {
                 delete_layer_override(&tx, &layer_id)?;
                 mark_tombstone(&tx, GLYPH_LAYERS, layer_id.as_str())?;
+            }
+        }
+
+        for glyph_id in authoring_glyph_ids {
+            let Some(glyph) = post_font.glyph(glyph_id.clone()) else {
+                continue;
+            };
+            replace_glyph_authoring_in_tx(&tx, glyph)?;
+            mark_replaced(&tx, GLYPH_AXES, glyph_id.as_str())?;
+            mark_replaced(&tx, GLYPH_VARIANTS, glyph_id.as_str())?;
+            mark_replaced(&tx, GLYPH_SOURCES, glyph_id.as_str())?;
+            for source in glyph.default_sources().values().chain(
+                glyph
+                    .variants()
+                    .values()
+                    .flat_map(|variant| variant.sources().values()),
+            ) {
+                mark_replaced(&tx, GLYPH_SOURCE_LOCATIONS, source.id().as_str())?;
             }
         }
 

--- a/crates/shift-store/src/schema.rs
+++ b/crates/shift-store/src/schema.rs
@@ -4,15 +4,23 @@ use crate::StoreError;
 
 const DEFER_IMPORT_INDEXES: &str = r#"
 DROP INDEX IF EXISTS glyphs_name_idx;
+DROP INDEX IF EXISTS glyph_axes_glyph_id_idx;
+DROP INDEX IF EXISTS glyph_variants_glyph_id_idx;
 DROP INDEX IF EXISTS glyph_layers_glyph_id_idx;
-DROP INDEX IF EXISTS glyph_layers_source_id_idx;
+DROP INDEX IF EXISTS glyph_sources_glyph_id_idx;
+DROP INDEX IF EXISTS glyph_sources_layer_id_idx;
+DROP INDEX IF EXISTS glyph_sources_base_source_id_idx;
 DROP INDEX IF EXISTS glyph_components_base_glyph_id_idx;
 "#;
 
 const RESTORE_IMPORT_INDEXES: &str = r#"
 CREATE INDEX glyphs_name_idx ON glyphs(name);
+CREATE INDEX glyph_axes_glyph_id_idx ON glyph_axes(glyph_id);
+CREATE INDEX glyph_variants_glyph_id_idx ON glyph_variants(glyph_id);
 CREATE INDEX glyph_layers_glyph_id_idx ON glyph_layers(glyph_id);
-CREATE INDEX glyph_layers_source_id_idx ON glyph_layers(source_id);
+CREATE INDEX glyph_sources_glyph_id_idx ON glyph_sources(glyph_id);
+CREATE INDEX glyph_sources_layer_id_idx ON glyph_sources(layer_id);
+CREATE INDEX glyph_sources_base_source_id_idx ON glyph_sources(base_source_id);
 CREATE INDEX glyph_components_base_glyph_id_idx ON glyph_components(base_glyph_id);
 "#;
 
@@ -108,21 +116,87 @@ CREATE TABLE IF NOT EXISTS glyph_unicodes (
     FOREIGN KEY (glyph_id) REFERENCES glyphs(id) ON DELETE CASCADE
 );
 
+CREATE TABLE IF NOT EXISTS glyph_axes (
+    id TEXT PRIMARY KEY,
+    glyph_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    min_value REAL NOT NULL,
+    default_value REAL NOT NULL,
+    max_value REAL NOT NULL,
+    order_index INTEGER NOT NULL,
+    FOREIGN KEY (glyph_id) REFERENCES glyphs(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS glyph_axes_glyph_order_unique
+ON glyph_axes(glyph_id, order_index);
+
+CREATE INDEX IF NOT EXISTS glyph_axes_glyph_id_idx
+ON glyph_axes(glyph_id);
+
+CREATE TABLE IF NOT EXISTS glyph_variants (
+    id TEXT PRIMARY KEY,
+    glyph_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    condition_json TEXT NOT NULL,
+    order_index INTEGER NOT NULL,
+    FOREIGN KEY (glyph_id) REFERENCES glyphs(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS glyph_variants_glyph_order_unique
+ON glyph_variants(glyph_id, order_index);
+
+CREATE INDEX IF NOT EXISTS glyph_variants_glyph_id_idx
+ON glyph_variants(glyph_id);
+
 CREATE TABLE IF NOT EXISTS glyph_layers (
     id TEXT PRIMARY KEY,
     glyph_id TEXT NOT NULL,
-    source_id TEXT NOT NULL,
     width REAL NOT NULL DEFAULT 0,
     height REAL,
-    FOREIGN KEY (glyph_id) REFERENCES glyphs(id) ON DELETE CASCADE,
-    FOREIGN KEY (source_id) REFERENCES sources(id) ON DELETE CASCADE
+    FOREIGN KEY (glyph_id) REFERENCES glyphs(id) ON DELETE CASCADE
 );
 
 CREATE INDEX IF NOT EXISTS glyph_layers_glyph_id_idx
 ON glyph_layers(glyph_id);
 
-CREATE INDEX IF NOT EXISTS glyph_layers_source_id_idx
-ON glyph_layers(source_id);
+CREATE TABLE IF NOT EXISTS glyph_sources (
+    id TEXT PRIMARY KEY,
+    glyph_id TEXT NOT NULL,
+    variant_id TEXT,
+    name TEXT NOT NULL,
+    layer_id TEXT NOT NULL,
+    base_source_id TEXT,
+    order_index INTEGER NOT NULL,
+    FOREIGN KEY (glyph_id) REFERENCES glyphs(id) ON DELETE CASCADE,
+    FOREIGN KEY (variant_id) REFERENCES glyph_variants(id) ON DELETE CASCADE,
+    FOREIGN KEY (layer_id) REFERENCES glyph_layers(id),
+    FOREIGN KEY (base_source_id) REFERENCES sources(id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS glyph_sources_default_order_unique
+ON glyph_sources(glyph_id, order_index)
+WHERE variant_id IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS glyph_sources_variant_order_unique
+ON glyph_sources(variant_id, order_index)
+WHERE variant_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS glyph_sources_glyph_id_idx
+ON glyph_sources(glyph_id);
+
+CREATE INDEX IF NOT EXISTS glyph_sources_layer_id_idx
+ON glyph_sources(layer_id);
+
+CREATE INDEX IF NOT EXISTS glyph_sources_base_source_id_idx
+ON glyph_sources(base_source_id);
+
+CREATE TABLE IF NOT EXISTS glyph_source_locations (
+    glyph_source_id TEXT NOT NULL,
+    axis_id TEXT NOT NULL,
+    value REAL NOT NULL,
+    PRIMARY KEY (glyph_source_id, axis_id),
+    FOREIGN KEY (glyph_source_id) REFERENCES glyph_sources(id) ON DELETE CASCADE
+);
 
 CREATE TABLE IF NOT EXISTS glyph_layer_payloads (
     layer_id TEXT PRIMARY KEY,

--- a/crates/shift-store/tests/recovery_patch_test.rs
+++ b/crates/shift-store/tests/recovery_patch_test.rs
@@ -83,7 +83,7 @@ fn recovery_overlay_reopens_and_saves_semantic_directory_changes() {
 
     let mut post = original.clone();
     post.metadata_mut().family_name = Some("Recovered Sans".to_string());
-    let deleted_glyph_id = shift_font::GlyphId::from_raw("acute");
+    let deleted_glyph_id = shift_font::GlyphId::from_raw("A");
     post.remove_glyph(deleted_glyph_id.clone())
         .expect("sample glyph");
     let weight_id = shift_font::AxisId::from_raw("weight");
@@ -252,17 +252,44 @@ fn recovery_overlay_adds_a_new_glyph_and_layer_without_copying_the_directory() {
     let layer_id = shift_font::LayerId::from_raw("B_regular");
     let mut glyph = shift_font::Glyph::with_id(glyph_id.clone(), "B");
     glyph.set_unicodes(vec![0x42]);
-    let layer = shift_font::GlyphLayer::with_width(
+    glyph.insert_axis(shift_font::GlyphAxis::with_id(
+        shift_font::AxisId::from_raw("B-width"),
+        "B Width".to_string(),
+        0.0,
+        50.0,
+        100.0,
+    ));
+    let layer = shift_font::GlyphLayer::with_width(layer_id.clone(), 620.0);
+    let glyph_source = shift_font::GlyphSource::new(
+        "Regular".to_string(),
         layer_id.clone(),
-        shift_font::SourceId::from_raw("regular"),
-        620.0,
+        Some(shift_font::SourceId::from_raw("regular")),
+        shift_font::Location::new(),
     );
     glyph.set_layer(layer.clone());
+    glyph.insert_default_source(glyph_source.clone());
+    let mut variant = shift_font::GlyphVariant::with_id(
+        shift_font::GlyphVariantId::from_raw("B-heavy"),
+        "Heavy".to_string(),
+        shift_font::Condition::AxisRange {
+            axis_id: shift_font::AxisId::from_raw("weight"),
+            minimum: Some(700.0),
+            maximum: None,
+        },
+    );
+    variant.insert_source(shift_font::GlyphSource::with_id(
+        shift_font::GlyphSourceId::from_raw("B-heavy"),
+        "Heavy Regular".to_string(),
+        layer_id.clone(),
+        Some(shift_font::SourceId::from_raw("regular")),
+        shift_font::Location::new(),
+    ));
+    glyph.insert_variant(variant);
     let mut post = original;
     post.insert_glyph(glyph.clone()).expect("insert glyph");
     let changes = shift_font::FontChangeSet::new(vec![
         shift_font::FontChange::glyph_created(&glyph),
-        shift_font::FontChange::glyph_layer_created(glyph_id.clone(), &layer),
+        shift_font::FontChange::glyph_layer_created(glyph_id.clone(), &glyph_source, &layer),
     ]);
 
     let mut document = ShiftStore::open_document_with_recovery(&document_path, &recovery_path)
@@ -272,6 +299,11 @@ fn recovery_overlay_adds_a_new_glyph_and_layer_without_copying_the_directory() {
         .unwrap();
     let directory = document.load_font_directory().unwrap();
     assert_eq!(directory.glyph_count(), post.glyph_count());
+    assert_eq!(directory.glyph(glyph_id.clone()).unwrap().axes().len(), 1);
+    assert_eq!(
+        directory.glyph(glyph_id.clone()).unwrap().variants().len(),
+        1
+    );
     assert_eq!(
         directory
             .glyph(glyph_id)

--- a/crates/shift-store/tests/store_test.rs
+++ b/crates/shift-store/tests/store_test.rs
@@ -291,7 +291,10 @@ fn creates_and_reads_glyph_layer() {
         .expect("glyph layer should exist");
 
     assert_eq!(layer.glyph_id.as_str(), glyph_id.as_str());
-    assert_eq!(layer.source_id.as_str(), source_id.as_str());
+    assert_eq!(
+        layer.source_id.as_ref().unwrap().as_str(),
+        source_id.as_str()
+    );
     assert_eq!(layer.name.as_ref().map(|name| name.as_str()), Some("A"));
 }
 
@@ -299,17 +302,13 @@ fn creates_and_reads_glyph_layer() {
 fn glyph_layer_requires_existing_glyph_and_source() {
     let mut store = ShiftStore::open_memory_for_test().expect("memory store should open");
 
-    let layer = shift_font::GlyphLayer::with_width(
-        shift_font::LayerId::from_raw("layer-A-regular"),
-        shift_font::SourceId::from_raw("source-missing"),
-        0.0,
-    );
-    let result = store.apply_change_set(&shift_font::FontChangeSet::new(vec![
-        shift_font::FontChange::glyph_layer_created(
+    let layer =
+        shift_font::GlyphLayer::with_width(shift_font::LayerId::from_raw("layer-A-regular"), 0.0);
+    let result =
+        store.apply_change_set(&shift_font::FontChangeSet::new(vec![glyph_layer_created(
             shift_font::GlyphId::from_raw("glyph-missing"),
             &layer,
-        ),
-    ]));
+        )]));
 
     assert!(result.is_err());
 }
@@ -330,7 +329,10 @@ fn lists_glyph_layers_for_glyph() {
 
     assert_eq!(layers.len(), 1);
     assert_eq!(layers[0].layer_id, layer_id);
-    assert_eq!(layers[0].source_id.as_str(), source_id.as_str());
+    assert_eq!(
+        layers[0].source_id.as_ref().unwrap().as_str(),
+        source_id.as_str()
+    );
 }
 
 #[test]
@@ -358,11 +360,8 @@ fn creates_and_reads_glyph_component() {
 #[test]
 fn glyph_component_replacement_requires_existing_layer() {
     let mut store = ShiftStore::open_memory_for_test().expect("memory store should open");
-    let mut layer = shift_font::GlyphLayer::with_width(
-        shift_font::LayerId::from_raw("layer-missing"),
-        shift_font::SourceId::from_raw("source-missing"),
-        0.0,
-    );
+    let mut layer =
+        shift_font::GlyphLayer::with_width(shift_font::LayerId::from_raw("layer-missing"), 0.0);
     layer.add_component(shift_font::Component::with_id(
         shift_font::ComponentId::from_raw("component-A-missing"),
         shift_font::GlyphId::from_raw("glyph-missing"),
@@ -402,14 +401,13 @@ fn applies_glyph_identity_change_set() {
     let glyph = shift_font::Glyph::with_unicode("A", 65);
     let glyph_id = glyph.id();
     let source_id = shift_font::SourceId::new();
-    let layer =
-        shift_font::GlyphLayer::with_width(shift_font::LayerId::new(), source_id.clone(), 500.0);
+    let layer = shift_font::GlyphLayer::with_width(shift_font::LayerId::new(), 500.0);
     create_regular_source_with_id(&mut store, source_id);
 
     store
         .apply_change_set(&shift_font::FontChangeSet::new(vec![
             shift_font::FontChange::GlyphCreated(shift_font::GlyphCreated::from(&glyph)),
-            shift_font::FontChange::glyph_layer_created(glyph.id(), &layer),
+            glyph_layer_created(glyph.id(), &layer),
             shift_font::FontChange::GlyphIdentityChanged(shift_font::GlyphIdentityChanged {
                 glyph_id: glyph_id.clone(),
                 from_name: shift_font::GlyphName::from("A"),
@@ -476,14 +474,13 @@ fn applies_glyph_delete_change_set_and_cascades_layers() {
     let glyph = shift_font::Glyph::with_unicode("A", 65);
     let glyph_id = glyph.id();
     let source_id = shift_font::SourceId::new();
-    let layer =
-        shift_font::GlyphLayer::with_width(shift_font::LayerId::new(), source_id.clone(), 500.0);
+    let layer = shift_font::GlyphLayer::with_width(shift_font::LayerId::new(), 500.0);
     create_regular_source_with_id(&mut store, source_id);
 
     store
         .apply_change_set(&shift_font::FontChangeSet::new(vec![
             shift_font::FontChange::glyph_created(&glyph),
-            shift_font::FontChange::glyph_layer_created(glyph.id(), &layer),
+            glyph_layer_created(glyph.id(), &layer),
             shift_font::FontChange::glyph_deleted(glyph.id()),
         ]))
         .expect("change set should apply");
@@ -510,12 +507,11 @@ fn applies_glyph_delete_change_set_and_cascades_layers() {
 fn applies_layer_metrics_and_contour_point_changes() {
     let mut store = ShiftStore::open_memory_for_test().expect("memory store should open");
     let (glyph, layer, contour, point_id) = store_layer_with_contour();
-    create_regular_source_with_id(&mut store, layer.source_id());
 
     store
         .apply_change_set(&shift_font::FontChangeSet::new(vec![
             shift_font::FontChange::glyph_created(&glyph),
-            shift_font::FontChange::glyph_layer_created(glyph.id(), &layer),
+            glyph_layer_created(glyph.id(), &layer),
             shift_font::FontChange::LayerMetricsChanged(shift_font::LayerMetricsChanged {
                 layer_id: layer.id(),
                 width: 720.0,
@@ -557,14 +553,13 @@ fn applies_layer_metrics_and_contour_point_changes() {
 fn applies_layer_geometry_replacement() {
     let mut store = ShiftStore::open_memory_for_test().expect("memory store should open");
     let (glyph, layer, first_contour, _) = store_layer_with_contour();
-    create_regular_source_with_id(&mut store, layer.source_id());
-    let mut replacement = shift_font::GlyphLayer::with_width(layer.id(), layer.source_id(), 500.0);
+    let mut replacement = shift_font::GlyphLayer::with_width(layer.id(), 500.0);
     replacement.add_contour(contour_with_point(10.0, 20.0));
 
     store
         .apply_change_set(&shift_font::FontChangeSet::new(vec![
             shift_font::FontChange::glyph_created(&glyph),
-            shift_font::FontChange::glyph_layer_created(glyph.id(), &layer),
+            glyph_layer_created(glyph.id(), &layer),
             shift_font::FontChange::ContourAdded(shift_font::ContourAdded {
                 layer_id: layer.id(),
                 contour: first_contour,
@@ -593,7 +588,6 @@ fn applies_layer_geometry_replacement() {
 fn layer_geometry_replacement_round_trips_anchors() {
     let mut store = ShiftStore::open_memory_for_test().expect("memory store should open");
     let (glyph, layer, anchor_id) = store_layer_with_anchor();
-    create_regular_source_with_id(&mut store, layer.source_id());
 
     store
         .apply_change_set(&anchored_layer_change_set(&glyph, &layer))
@@ -615,7 +609,6 @@ fn layer_geometry_replacement_round_trips_anchors() {
 fn applies_anchor_position_changes() {
     let mut store = ShiftStore::open_memory_for_test().expect("memory store should open");
     let (glyph, layer, anchor_id) = store_layer_with_anchor();
-    create_regular_source_with_id(&mut store, layer.source_id());
     store
         .apply_change_set(&anchored_layer_change_set(&glyph, &layer))
         .expect("change set should apply");
@@ -645,7 +638,6 @@ fn applies_anchor_position_changes() {
 fn rejects_anchor_position_change_for_missing_anchor_row() {
     let mut store = ShiftStore::open_memory_for_test().expect("memory store should open");
     let (glyph, layer, _) = store_layer_with_anchor();
-    create_regular_source_with_id(&mut store, layer.source_id());
     store
         .apply_change_set(&anchored_layer_change_set(&glyph, &layer))
         .expect("change set should apply");
@@ -677,7 +669,6 @@ fn reopen_preserves_layer_anchors() {
 
     {
         let mut store = ShiftStore::open(&path).expect("open");
-        create_regular_source_with_id(&mut store, layer.source_id());
         store
             .apply_change_set(&anchored_layer_change_set(&glyph, &layer))
             .expect("change set should apply");
@@ -702,12 +693,11 @@ fn reopen_preserves_layer_anchors() {
 fn rejects_incremental_change_for_missing_point_row() {
     let mut store = ShiftStore::open_memory_for_test().expect("memory store should open");
     let (glyph, layer, _, _) = store_layer_with_contour();
-    create_regular_source_with_id(&mut store, layer.source_id());
     let missing_point_id = shift_font::PointId::new();
 
     let result = store.apply_change_set(&shift_font::FontChangeSet::new(vec![
         shift_font::FontChange::glyph_created(&glyph),
-        shift_font::FontChange::glyph_layer_created(glyph.id(), &layer),
+        glyph_layer_created(glyph.id(), &layer),
         shift_font::FontChange::PointPositionsChanged(shift_font::PointPositionsChanged {
             layer_id: layer.id(),
             points: vec![shift_font::PointPosition {
@@ -834,16 +824,19 @@ fn create_default_glyph_layer(
     glyph_id: &GlyphId,
     source_id: &SourceId,
 ) -> shift_font::LayerId {
-    let layer = shift_font::GlyphLayer::with_width(
-        shift_font::LayerId::from_raw("A-regular"),
-        shift_font::SourceId::from_raw(source_id.as_str()),
-        0.0,
+    let layer = shift_font::GlyphLayer::with_width(shift_font::LayerId::from_raw("A-regular"), 0.0);
+    let glyph_source = shift_font::GlyphSource::new(
+        "Regular".to_string(),
+        layer.id(),
+        Some(shift_font::SourceId::from_raw(source_id.as_str())),
+        shift_font::Location::new(),
     );
 
     store
         .apply_change_set(&shift_font::FontChangeSet::new(vec![
             shift_font::FontChange::glyph_layer_created(
                 shift_font::GlyphId::from_raw(glyph_id.as_str()),
+                &glyph_source,
                 &layer,
             ),
         ]))
@@ -931,8 +924,7 @@ fn store_layer_with_contour() -> (
     shift_font::PointId,
 ) {
     let glyph = shift_font::Glyph::with_unicode("A", 65);
-    let source_id = shift_font::SourceId::new();
-    let layer = shift_font::GlyphLayer::with_width(shift_font::LayerId::new(), source_id, 500.0);
+    let layer = shift_font::GlyphLayer::with_width(shift_font::LayerId::new(), 500.0);
     let contour = contour_with_point(10.0, 20.0);
     let point_id = contour.points()[0].id();
 
@@ -950,9 +942,7 @@ fn store_layer_with_anchor() -> (
     shift_font::AnchorId,
 ) {
     let glyph = shift_font::Glyph::with_unicode("A", 65);
-    let source_id = shift_font::SourceId::new();
-    let mut layer =
-        shift_font::GlyphLayer::with_width(shift_font::LayerId::new(), source_id, 500.0);
+    let mut layer = shift_font::GlyphLayer::with_width(shift_font::LayerId::new(), 500.0);
     let anchor_id = layer.add_anchor(shift_font::Anchor::new(
         Some("top".to_string()),
         250.0,
@@ -962,13 +952,26 @@ fn store_layer_with_anchor() -> (
     (glyph, layer, anchor_id)
 }
 
+fn glyph_layer_created(
+    glyph_id: shift_font::GlyphId,
+    layer: &shift_font::GlyphLayer,
+) -> shift_font::FontChange {
+    let source = shift_font::GlyphSource::new(
+        "Default".to_string(),
+        layer.id(),
+        None,
+        shift_font::Location::new(),
+    );
+    shift_font::FontChange::glyph_layer_created(glyph_id, &source, layer)
+}
+
 fn anchored_layer_change_set(
     glyph: &shift_font::Glyph,
     layer: &shift_font::GlyphLayer,
 ) -> shift_font::FontChangeSet {
     shift_font::FontChangeSet::new(vec![
         shift_font::FontChange::glyph_created(glyph),
-        shift_font::FontChange::glyph_layer_created(glyph.id(), layer),
+        glyph_layer_created(glyph.id(), layer),
         shift_font::FontChange::layer_geometry_replaced(layer),
     ])
 }
@@ -1441,6 +1444,145 @@ fn replace_and_load_font_state_preserves_whole_font() {
 }
 
 #[test]
+fn canonical_round_trip_preserves_glyph_local_authoring_and_variable_components() {
+    let mut font = shift_font::Font::new();
+    let weight = shift_font::Axis::weight();
+    let weight_id = weight.id();
+    font.add_axis(weight).unwrap();
+    let regular_id = font.default_source_id().unwrap();
+    let mut bold_location = shift_font::DesignLocation::new();
+    bold_location.set(weight_id.clone(), 800.0);
+    let bold_id = font.add_source(shift_font::Source::new("Bold".to_string(), bold_location));
+
+    let part_id = shift_font::GlyphId::from_raw("part");
+    let part_axis_id = shift_font::AxisId::from_raw("part-width");
+    let part_regular_layer =
+        shift_font::GlyphLayer::with_width(shift_font::LayerId::from_raw("part-regular"), 200.0);
+    let part_bold_layer =
+        shift_font::GlyphLayer::with_width(shift_font::LayerId::from_raw("part-bold"), 240.0);
+    let mut part = shift_font::Glyph::with_id(part_id.clone(), "part");
+    part.insert_axis(shift_font::GlyphAxis::with_id(
+        part_axis_id.clone(),
+        "Part Width".to_string(),
+        0.0,
+        50.0,
+        100.0,
+    ));
+    part.set_layer(part_regular_layer.clone());
+    part.set_layer(part_bold_layer.clone());
+    let mut part_regular_location = shift_font::Location::new();
+    part_regular_location.set(part_axis_id.clone(), 0.0);
+    part.insert_default_source(shift_font::GlyphSource::with_id(
+        shift_font::GlyphSourceId::from_raw("part-regular"),
+        "Regular Narrow".to_string(),
+        part_regular_layer.id(),
+        Some(regular_id.clone()),
+        part_regular_location,
+    ));
+    let mut part_bold_location = shift_font::Location::new();
+    part_bold_location.set(part_axis_id.clone(), 100.0);
+    part.insert_default_source(shift_font::GlyphSource::with_id(
+        shift_font::GlyphSourceId::from_raw("part-bold"),
+        "Bold Wide".to_string(),
+        part_bold_layer.id(),
+        Some(bold_id.clone()),
+        part_bold_location,
+    ));
+    font.insert_glyph(part).unwrap();
+
+    let glyph_id = shift_font::GlyphId::from_raw("A-local");
+    let shared_layer_id = shift_font::LayerId::from_raw("A-shared");
+    let heavy_layer_id = shift_font::LayerId::from_raw("A-heavy");
+    let backup_layer_id = shift_font::LayerId::from_raw("A-backup");
+    let mut shared_layer = shift_font::GlyphLayer::with_width(shared_layer_id.clone(), 600.0);
+    let mut component = shift_font::Component::with_id(
+        shift_font::ComponentId::from_raw("A-part"),
+        part_id,
+        "part",
+        shift_font::DecomposedTransform::identity(),
+    );
+    let mut component_location = shift_font::Location::new();
+    component_location.set(part_axis_id, 75.0);
+    component.set_location(component_location);
+    component.set_axis_inheritance(shift_font::AxisInheritance::Font);
+    component.set_condition(Some(shift_font::Condition::AxisRange {
+        axis_id: weight_id.clone(),
+        minimum: None,
+        maximum: Some(600.0),
+    }));
+    shared_layer.add_component(component);
+
+    let mut glyph = shift_font::Glyph::with_id(glyph_id, "A.local");
+    glyph.set_layer(shared_layer);
+    glyph.set_layer(shift_font::GlyphLayer::with_width(
+        heavy_layer_id.clone(),
+        640.0,
+    ));
+    glyph.set_layer(shift_font::GlyphLayer::with_width(backup_layer_id, 610.0));
+    glyph.insert_default_source(shift_font::GlyphSource::with_id(
+        shift_font::GlyphSourceId::from_raw("A-default"),
+        "Default Regular".to_string(),
+        shared_layer_id.clone(),
+        Some(regular_id.clone()),
+        shift_font::Location::new(),
+    ));
+    let mut variant = shift_font::GlyphVariant::with_id(
+        shift_font::GlyphVariantId::from_raw("A-heavy"),
+        "Heavy".to_string(),
+        shift_font::Condition::AxisRange {
+            axis_id: weight_id,
+            minimum: Some(700.0),
+            maximum: None,
+        },
+    );
+    variant.insert_source(shift_font::GlyphSource::with_id(
+        shift_font::GlyphSourceId::from_raw("A-heavy-regular"),
+        "Heavy Regular".to_string(),
+        shared_layer_id.clone(),
+        Some(regular_id),
+        shift_font::Location::new(),
+    ));
+    variant.insert_source(shift_font::GlyphSource::with_id(
+        shift_font::GlyphSourceId::from_raw("A-heavy-bold"),
+        "Heavy Bold".to_string(),
+        heavy_layer_id,
+        Some(bold_id),
+        shift_font::Location::new(),
+    ));
+    glyph.insert_variant(variant);
+    font.insert_glyph(glyph).unwrap();
+    font.validate().unwrap();
+
+    let mut store = ShiftStore::open_memory_for_test().unwrap();
+    store.replace_font_state(&font).unwrap();
+
+    let directory = store.load_font_directory().unwrap();
+    let directory_glyph = directory.glyph_by_name("A.local").unwrap();
+    assert_eq!(directory_glyph.variants().len(), 1);
+    assert_eq!(directory_glyph.default_sources().len(), 1);
+    assert_eq!(directory_glyph.layers().len(), 3);
+    assert!(
+        directory_glyph
+            .layers()
+            .values()
+            .all(|layer| layer.components().is_empty())
+    );
+
+    let loaded = store.load_font_state().unwrap();
+    assert_eq!(loaded, font);
+    assert_eq!(
+        loaded
+            .glyph_by_name("A.local")
+            .unwrap()
+            .layer(shared_layer_id)
+            .unwrap()
+            .components()
+            .len(),
+        1
+    );
+}
+
+#[test]
 fn refuses_stores_from_newer_schema_versions() {
     let path = temp_store_path("future");
 
@@ -1460,14 +1602,16 @@ fn refuses_stores_from_newer_schema_versions() {
 fn replace_and_load_font_state_preserves_source_roles_and_layer_names() {
     let mut store = ShiftStore::open_memory_for_test().expect("memory store should open");
 
-    let mut font = shift_font::Font::new();
+    let mut font = shift_font::Font::empty();
     let mut medium = shift_font::Source::with_filename(
         "Medium".to_string(),
         shift_font::DesignLocation::new(),
         "Family-Bold.ufo".to_string(),
     );
     medium.set_layer_name(Some("Medium".to_string()));
+    let medium_id = medium.id();
     font.add_source(medium);
+    font.set_default_source_id(medium_id);
     font.add_source(shift_font::Source::layer("background".to_string()));
 
     store.replace_font_state(&font).expect("replace font state");

--- a/crates/shift-wire/src/lib.rs
+++ b/crates/shift-wire/src/lib.rs
@@ -354,9 +354,9 @@ impl From<&IrGlyph> for GlyphRecord {
         component_base_glyph_ids.sort();
         component_base_glyph_ids.dedup();
         let mut layers: Vec<_> = glyph
-            .layers()
+            .default_sources()
             .values()
-            .map(|layer| GlyphLayerRecord::from(layer.as_ref()))
+            .filter_map(GlyphLayerRecord::from_glyph_source)
             .collect();
         layers.sort_by(|a, b| {
             a.source_id
@@ -382,12 +382,12 @@ pub struct GlyphLayerRecord {
     pub source_id: SourceId,
 }
 
-impl From<&GlyphLayer> for GlyphLayerRecord {
-    fn from(layer: &GlyphLayer) -> Self {
-        Self {
-            id: layer.id(),
-            source_id: layer.source_id(),
-        }
+impl GlyphLayerRecord {
+    fn from_glyph_source(source: &shift_font::GlyphSource) -> Option<Self> {
+        Some(Self {
+            id: source.layer_id(),
+            source_id: source.base_source_id()?,
+        })
     }
 }
 

--- a/crates/shift-wire/src/state.rs
+++ b/crates/shift-wire/src/state.rs
@@ -11,11 +11,11 @@ use shift_font::{
 
 pub fn layer_from_state(
     layer_id: LayerId,
-    source_id: SourceId,
+    _source_id: SourceId,
     structure: &GlyphStructure,
     values: &[GlyphValue],
 ) -> CoreResult<GlyphLayer> {
-    let mut layer = GlyphLayer::new(layer_id, source_id);
+    let mut layer = GlyphLayer::new(layer_id);
     apply_state_to_layer(&mut layer, structure, values)?;
     Ok(layer)
 }
@@ -103,7 +103,7 @@ mod tests {
     use shift_font::{Anchor, Component, DecomposedTransform, GlyphId, LayerId, SourceId};
 
     fn sample_layer() -> GlyphLayer {
-        let mut layer = GlyphLayer::with_width(LayerId::new(), SourceId::new(), 500.0);
+        let mut layer = GlyphLayer::with_width(LayerId::new(), 500.0);
 
         let mut contour = IrContour::with_id(ContourId::from_raw(10));
         contour.add_point_with_id(PointId::from_raw(20), 1.0, 2.0, IrPointType::OnCurve, false);
@@ -157,13 +157,12 @@ mod tests {
         let structure = GlyphStructure::from(&layer);
         let restored = layer_from_state(
             layer.id(),
-            layer.source_id(),
+            SourceId::from_raw("test"),
             &structure,
             &values_from_layer(&layer),
         )?;
 
         assert_eq!(restored.id(), layer.id());
-        assert_eq!(restored.source_id(), layer.source_id());
         assert_eq!(restored.width(), 500.0);
 
         let contour = restored.contour(ContourId::from_raw(10)).unwrap();
@@ -195,7 +194,7 @@ mod tests {
 
     #[test]
     fn glyph_structure_preserves_component_order() {
-        let mut layer = GlyphLayer::new(LayerId::new(), SourceId::new());
+        let mut layer = GlyphLayer::new(LayerId::new());
         layer.add_component(Component::with_id(
             ComponentId::from_raw(200),
             GlyphId::from_raw("later"),

--- a/crates/shift-workspace/src/ledger.rs
+++ b/crates/shift-workspace/src/ledger.rs
@@ -10,7 +10,7 @@
 use std::sync::Arc;
 
 use shift_font::{
-    Axis, AxisMapping, FontMetadata, Glyph, GlyphId, GlyphLayer, GlyphName, LayerId,
+    Axis, AxisMapping, FontMetadata, Glyph, GlyphId, GlyphLayer, GlyphName, GlyphSource, LayerId,
     MetricDefinition, NamedInstance, Source, SourceId,
 };
 
@@ -63,11 +63,11 @@ pub enum LedgerStep {
         pre: Option<Source>,
         post: Option<Source>,
     },
-    /// Independent glyph-layer existence for sparse source authoring.
+    /// Independent glyph-source and layer existence for sparse source authoring.
     GlyphLayer {
         glyph_id: GlyphId,
-        pre: Option<Box<GlyphLayer>>,
-        post: Option<Box<GlyphLayer>>,
+        pre: Option<(GlyphSource, Box<GlyphLayer>)>,
+        post: Option<(GlyphSource, Box<GlyphLayer>)>,
     },
     /// Glyph rename / unicode reassignment. Both sides always exist; the
     /// glyph and its layers are untouched.
@@ -120,7 +120,7 @@ impl LedgerEntry {
                 LedgerStep::GlyphLayer { pre, post, .. } => pre
                     .iter()
                     .chain(post.iter())
-                    .map(|layer| layer.id())
+                    .map(|(_, layer)| layer.id())
                     .collect(),
                 LedgerStep::FontMetadata { .. }
                 | LedgerStep::Axis { .. }

--- a/crates/shift-workspace/src/workspace.rs
+++ b/crates/shift-workspace/src/workspace.rs
@@ -10,8 +10,8 @@ use shift_backends::{
 };
 use shift_font::{
     AppliedIntents, Axis, AxisId, FontChange, FontChangeSet, FontIntent, FontIntentSet,
-    FontMetadata, Glyph, GlyphId, GlyphLayer, LayerId, MetricDefinition, NamedInstance, Source,
-    SourceId, TouchedLayer, error::CoreError,
+    FontMetadata, Glyph, GlyphId, GlyphLayer, GlyphSource, LayerId, Location, MetricDefinition,
+    NamedInstance, Source, SourceId, TouchedLayer, error::CoreError,
 };
 use shift_source::ShiftSourcePackage;
 use shift_store::{
@@ -353,7 +353,7 @@ impl FontWorkspace {
                     .and_then(|glyph| glyph.layers().get(layer_id))
                     .cloned()
             {
-                pre.layers.push(PreLayer { glyph_id, layer });
+                pre.layers.push(PreLayer { layer });
             }
         }
 
@@ -501,7 +501,7 @@ impl FontWorkspace {
                     steps.push(LedgerStep::GlyphLayer {
                         glyph_id: change.glyph_id.clone(),
                         pre: None,
-                        post: Some(Box::new(layer.clone())),
+                        post: Some((change.glyph_source.clone(), Box::new(layer.clone()))),
                     });
                 }
                 FontChange::GlyphLayerDeleted(change) => {
@@ -510,13 +510,7 @@ impl FontWorkspace {
                     }
                     steps.push(LedgerStep::GlyphLayer {
                         glyph_id: change.glyph_id.clone(),
-                        pre: pre
-                            .layers
-                            .iter()
-                            .find(|pre| {
-                                pre.glyph_id == change.glyph_id && pre.layer.id() == change.layer_id
-                            })
-                            .map(|pre| Box::new(pre.layer.as_ref().clone())),
+                        pre: None,
                         post: None,
                     });
                 }
@@ -680,8 +674,8 @@ impl FontWorkspace {
                         replay_glyph_layer(
                             font,
                             glyph_id,
-                            from.map(|layer| *layer),
-                            to.map(|layer| *layer),
+                            from.map(|(source, layer)| (source, *layer)),
+                            to.map(|(source, layer)| (source, *layer)),
                             &mut changes,
                             &mut touched,
                         )?;
@@ -954,8 +948,7 @@ impl FontWorkspace {
                 if self.residency.is_unloaded(&layer.id()) || !seen_layer_ids.insert(layer.id()) {
                     continue;
                 }
-                let mut placeholder =
-                    GlyphLayer::with_width(layer.id(), layer.source_id(), layer.width());
+                let mut placeholder = GlyphLayer::with_width(layer.id(), layer.width());
                 placeholder.set_height(layer.height());
                 placeholders.push(placeholder);
                 evicted.push(layer.id());
@@ -1074,7 +1067,6 @@ impl FontWorkspace {
 
 #[derive(Clone)]
 struct PreLayer {
-    glyph_id: GlyphId,
     layer: Arc<GlyphLayer>,
 }
 
@@ -1145,24 +1137,6 @@ fn capture_font_level_pre_state(
                     .find(|source| source.id() == *source_id)
             {
                 pre.sources.push(source.clone());
-            }
-
-            for glyph in font.glyphs() {
-                let Some(layer) = glyph
-                    .layers()
-                    .values()
-                    .find(|layer| layer.source_id() == *source_id)
-                    .cloned()
-                else {
-                    continue;
-                };
-                if pre.layers.iter().any(|pre| pre.layer.id() == layer.id()) {
-                    continue;
-                }
-                pre.layers.push(PreLayer {
-                    glyph_id: glyph.id(),
-                    layer,
-                });
             }
         }
         FontIntent::UpdateAxis { axis } => {
@@ -1263,8 +1237,7 @@ fn replay_glyph(
     touched: &mut Vec<TouchedLayer>,
 ) -> Result<(), WorkspaceError> {
     if let Some(glyph) = from {
-        font.remove_glyph(glyph.id())
-            .ok_or(CoreError::GlyphNotFound(glyph.id()))?;
+        font.remove_glyph(glyph.id())?;
         changes.push(FontChange::glyph_deleted(glyph.id()));
     }
 
@@ -1273,7 +1246,30 @@ fn replay_glyph(
         changes.push(FontChange::glyph_created(&glyph));
 
         for layer in glyph.layers().values() {
-            changes.push(FontChange::glyph_layer_created(glyph.id(), layer.as_ref()));
+            let glyph_source = glyph
+                .default_sources()
+                .values()
+                .chain(
+                    glyph
+                        .variants()
+                        .values()
+                        .flat_map(|variant| variant.sources().values()),
+                )
+                .find(|source| source.layer_id() == layer.id())
+                .cloned()
+                .unwrap_or_else(|| {
+                    GlyphSource::new(
+                        "Unreferenced layer".to_string(),
+                        layer.id(),
+                        None,
+                        Location::new(),
+                    )
+                });
+            changes.push(FontChange::glyph_layer_created(
+                glyph.id(),
+                &glyph_source,
+                layer.as_ref(),
+            ));
             touched.push(TouchedLayer {
                 layer: layer.clone(),
                 structural: true,
@@ -1415,8 +1411,7 @@ fn replay_source(
     }
 
     if let Some(source) = from {
-        font.remove_source(source.id())
-            .ok_or(CoreError::SourceNotFound(source.id()))?;
+        font.remove_source(source.id())?;
         changes.push(FontChange::source_deleted(source.id()));
     }
 
@@ -1431,19 +1426,21 @@ fn replay_source(
 fn replay_glyph_layer(
     font: &mut shift_font::Font,
     glyph_id: GlyphId,
-    from: Option<GlyphLayer>,
-    to: Option<GlyphLayer>,
+    from: Option<(GlyphSource, GlyphLayer)>,
+    to: Option<(GlyphSource, GlyphLayer)>,
     changes: &mut FontChangeSet,
     touched: &mut Vec<TouchedLayer>,
 ) -> Result<(), WorkspaceError> {
-    if let Some(layer) = from {
+    if let Some((source, layer)) = from {
+        font.remove_glyph_source(source.id())?;
         font.remove_glyph_layer(layer.id())?;
         changes.push(FontChange::glyph_layer_deleted(glyph_id.clone(), &layer));
     }
 
-    if let Some(layer) = to {
-        changes.push(FontChange::glyph_layer_created(glyph_id.clone(), &layer));
-        font.insert_glyph_layer(glyph_id, layer.clone())?;
+    if let Some((source, layer)) = to {
+        font.insert_glyph_layer(glyph_id.clone(), layer.clone())?;
+        font.add_glyph_source(glyph_id.clone(), None, source.clone())?;
+        changes.push(FontChange::glyph_layer_created(glyph_id, &source, &layer));
         touched.push(TouchedLayer {
             layer: Arc::new(layer),
             structural: true,

--- a/crates/shift-workspace/tests/workspace_test.rs
+++ b/crates/shift-workspace/tests/workspace_test.rs
@@ -2,8 +2,9 @@ use std::{fs, path::PathBuf};
 
 use shift_font::{
     AnchorId, AnchorSeed, Axis, AxisId, BooleanOp, ContourId, DesignLocation, ExternalLocation,
-    Font, FontChange, FontIntent, FontIntentSet, Glyph, GlyphId, GlyphLayer, GlyphName, LayerId,
-    NamedInstance, NamedInstanceId, PointId, PointSeed, PointType, SourceId, error::CoreError,
+    Font, FontChange, FontIntent, FontIntentSet, Glyph, GlyphId, GlyphLayer, GlyphName,
+    GlyphSource, LayerId, Location, NamedInstance, NamedInstanceId, PointId, PointSeed, PointType,
+    SourceId, error::CoreError,
 };
 use shift_source::ShiftSourcePackage;
 use shift_store::ShiftStore;
@@ -566,11 +567,18 @@ fn failed_streaming_import_removes_staging_and_preserves_the_destination() {
     let store_path = temp.path().join("existing.sqlite");
     let mut font = Font::new();
     let mut glyph = Glyph::new("A");
-    let mut layer = GlyphLayer::new(LayerId::new(), font.default_source_id().unwrap());
+    let mut layer = GlyphLayer::new(LayerId::new());
     let mut contour = shift_font::Contour::new();
     contour.add_point(0.0, 0.0, PointType::OnCurve, false);
     layer.add_contour(contour);
+    let glyph_source = GlyphSource::new(
+        "Regular".to_string(),
+        layer.id(),
+        font.default_source_id(),
+        Location::new(),
+    );
     glyph.set_layer(layer);
+    glyph.insert_default_source(glyph_source);
     font.insert_glyph(glyph).unwrap();
     shift_backends::font_loader::FontLoader::new()
         .write_font(&font, source_path.to_str().unwrap())
@@ -1142,7 +1150,7 @@ fn create_glyph_layer_undo_redo_removes_and_restores_sparse_layer() {
     assert_eq!(
         workspace
             .font()
-            .layer_id_for_glyph_source(glyph_id.clone(), source_id.clone()),
+            .layer_id_for_source(glyph_id.clone(), source_id.clone()),
         Some(layer_id.clone())
     );
 
@@ -1156,7 +1164,7 @@ fn create_glyph_layer_undo_redo_removes_and_restores_sparse_layer() {
     assert_eq!(
         workspace
             .font()
-            .layer_id_for_glyph_source(glyph_id.clone(), source_id.clone()),
+            .layer_id_for_source(glyph_id.clone(), source_id.clone()),
         None
     );
 
@@ -1166,9 +1174,7 @@ fn create_glyph_layer_undo_redo_removes_and_restores_sparse_layer() {
         .expect("createGlyphLayer should redo");
     assert_eq!(redone.layers.len(), 1);
     assert_eq!(
-        workspace
-            .font()
-            .layer_id_for_glyph_source(glyph_id, source_id),
+        workspace.font().layer_id_for_source(glyph_id, source_id),
         Some(layer_id)
     );
 }
@@ -1189,12 +1195,11 @@ fn create_glyph_layer_initializes_width_from_font_upm() {
 }
 
 #[test]
-fn delete_source_undo_redo_removes_and_restores_existing_sparse_layers() {
+fn delete_source_rejects_an_existing_glyph_source_base_atomically() {
     let temp = tempfile::tempdir().unwrap();
     let store_path = temp.path().join("working.sqlite");
     let mut workspace = FontWorkspace::create_untitled(&store_path, NewWorkspace::new()).unwrap();
-    let glyph_a = create_glyph(&mut workspace, "A", vec![65]);
-    let glyph_b = create_glyph(&mut workspace, "B", vec![66]);
+    let glyph_id = create_glyph(&mut workspace, "A", vec![65]);
     let source_id = SourceId::from_raw("source_alt");
     let axis_id = create_weight_axis(&mut workspace);
 
@@ -1210,18 +1215,12 @@ fn delete_source_undo_redo_removes_and_restores_existing_sparse_layers() {
             Some("Create Source".to_string()),
         )
         .unwrap();
-    let layer_id = create_glyph_layer(&mut workspace, glyph_a.clone(), source_id.clone());
+    let layer_id = create_glyph_layer(&mut workspace, glyph_id, source_id.clone());
     workspace
         .apply(set_x_advance_intents(layer_id.clone(), 640.0), None)
         .unwrap();
-    assert_eq!(
-        workspace
-            .font()
-            .layer_id_for_glyph_source(glyph_b.clone(), source_id.clone()),
-        None
-    );
 
-    workspace
+    let error = workspace
         .apply(
             FontIntentSet {
                 intents: vec![FontIntent::DeleteSource {
@@ -1230,23 +1229,16 @@ fn delete_source_undo_redo_removes_and_restores_existing_sparse_layers() {
             },
             Some("Delete Source".to_string()),
         )
-        .unwrap();
+        .err()
+        .expect("a glyph-source base must block global source deletion");
 
-    assert!(
-        workspace
-            .font()
-            .sources()
-            .iter()
-            .all(|source| source.id() != source_id)
-    );
-    assert!(workspace.font().layer(layer_id.clone()).is_none());
-
-    let undone = workspace.undo().unwrap().expect("deleteSource should undo");
-    assert!(undone
-        .changes
-        .changes
-        .iter()
-        .any(|change| matches!(change, FontChange::SourceCreated(change) if change.source_id == source_id)));
+    assert!(matches!(
+        error,
+        WorkspaceError::Font(CoreError::SourceReferencedByGlyphSource {
+            source_id: actual,
+            ..
+        }) if actual == source_id
+    ));
     assert!(
         workspace
             .font()
@@ -1254,31 +1246,7 @@ fn delete_source_undo_redo_removes_and_restores_existing_sparse_layers() {
             .iter()
             .any(|source| source.id() == source_id)
     );
-    assert_eq!(
-        workspace.font().layer(layer_id.clone()).unwrap().width(),
-        640.0
-    );
-    assert_eq!(
-        workspace
-            .font()
-            .layer_id_for_glyph_source(glyph_b, source_id.clone()),
-        None
-    );
-
-    let redone = workspace.redo().unwrap().expect("deleteSource should redo");
-    assert!(redone
-        .changes
-        .changes
-        .iter()
-        .any(|change| matches!(change, FontChange::GlyphLayerDeleted(change) if change.layer_id == layer_id)));
-    assert!(
-        workspace
-            .font()
-            .sources()
-            .iter()
-            .all(|source| source.id() != source_id)
-    );
-    assert!(workspace.font().layer(layer_id).is_none());
+    assert_eq!(workspace.font().layer(layer_id).unwrap().width(), 640.0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add the approved native `GlyphAxis`, `GlyphSource`, `GlyphVariant`, `Condition`, and component authoring fields
- make `GlyphLayer` source-neutral and validate font-wide ownership, references, conditions, and component cycles
- update the unreleased SQLite v1 baseline with glyph-local authoring tables and `shift.glyph-layer.v2`
- preserve the model through canonical documents, lazy directory loads, bounded payload acquisition, streaming import, and sparse recovery
- reject unsupported legacy source-package and TTF output explicitly instead of flattening canonical intent

## Scope

This is the native model/persistence PR. It does not add bridge DTOs, UI, Glyphs semantic import, or compiler lowering for these concepts. Existing bridge/import consumers receive only compatibility migrations for the source-neutral layer model.

## Tests

- full repository pre-commit suite
- `cargo test --workspace --exclude shift-bridge --no-fail-fast` (bridge Rust test binaries require a Node N-API host)
- `cargo clippy --workspace --all-targets -- -D warnings`
- canonical advanced-authoring round trip, lazy directory, sparse recovery/save, shared/unreferenced layer, validation/deletion, payload-v2, and unsupported-export coverage
