### PR TITLE
Add fluent position edit foundation

### DIFF
--- a/apps/desktop/src/renderer/src/lib/editor/GlyphLayerEditDraft.test.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/GlyphLayerEditDraft.test.ts
@@ -54,7 +54,7 @@ describe("glyph layer edit drafts preserve committed preview bases", () => {
     expect(pointPosition(source(), point.id)).toEqual(start);
   });
 
-  it("discards rule-driven previews that include points outside the initial subject", () => {
+  it("discards rule-driven previews that include points outside the initial targets", () => {
     const [first, second] = source().allPoints;
     const firstStart = pointPosition(source(), first!.id);
     const secondStart = pointPosition(source(), second!.id);

--- a/apps/desktop/src/renderer/src/lib/editor/GlyphLayerEditDraft.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/GlyphLayerEditDraft.ts
@@ -1,11 +1,7 @@
 import type { Point2D } from "@shift/geo";
 import type { GlyphLayer, GlyphLayerPositions } from "@/lib/model/Glyph";
-import {
-  GlyphLayerPositionList,
-  type GlyphLayerPositionSubject,
-} from "@/lib/model/GlyphLayerPositionList";
-
-export type GlyphLayerEditSubject = GlyphLayerPositionSubject;
+import { GlyphLayerPositionList } from "@/lib/model/GlyphLayerPositionList";
+import type { PositionTargets } from "@/types/positionEdit";
 
 /**
  * Preview-backed authored layer position edit.
@@ -16,20 +12,20 @@ export type GlyphLayerEditSubject = GlyphLayerPositionSubject;
  */
 export class GlyphLayerEditDraft {
   readonly glyphLayer: GlyphLayer;
-  readonly subject: GlyphLayerEditSubject;
+  readonly targets: PositionTargets;
 
   #base: GlyphLayerPositionList;
   #preview: GlyphLayerPositionList | null = null;
   #closed = false;
 
-  constructor(glyphLayer: GlyphLayer, subject: GlyphLayerEditSubject) {
+  constructor(glyphLayer: GlyphLayer, targets: PositionTargets) {
     this.glyphLayer = glyphLayer;
 
-    this.subject = {
-      points: subject.points ? [...subject.points] : [],
-      anchors: subject.anchors ? [...subject.anchors] : [],
+    this.targets = {
+      points: targets.points ? [...targets.points] : [],
+      anchors: targets.anchors ? [...targets.anchors] : [],
     };
-    this.#base = GlyphLayerPositionList.fromSubject(glyphLayer, this.subject);
+    this.#base = GlyphLayerPositionList.fromTargetGroups(glyphLayer, this.targets);
   }
 
   get basePositions(): GlyphLayerPositions {

--- a/apps/desktop/src/renderer/src/lib/model/Glyph.ts
+++ b/apps/desktop/src/renderer/src/lib/model/Glyph.ts
@@ -93,6 +93,7 @@ import type { ContourBuffer } from "./ContourBuffer";
 import type { LayerBuffers } from "./LayerBuffers";
 import { LayerIntents } from "@/lib/workspace/LayerIntents";
 import type { WorkspaceEditCoordinator } from "@/lib/workspace/WorkspaceEditCoordinator";
+import { LayerPositions } from "./positions";
 
 export {
   GlyphGeometry,
@@ -337,6 +338,7 @@ class GlyphEditSession {
  * edits also produce workspace intents.
  */
 export class GlyphLayer {
+  readonly positions: LayerPositions;
   readonly #sourceCell: WritableSignal<Source>;
   readonly #edit: GlyphEditSession;
 
@@ -346,6 +348,7 @@ export class GlyphLayer {
       state,
       geometry: state.geometryCell,
     });
+    this.positions = new LayerPositions(this);
   }
 
   get source(): Source {

--- a/apps/desktop/src/renderer/src/lib/model/GlyphLayerPositionList.ts
+++ b/apps/desktop/src/renderer/src/lib/model/GlyphLayerPositionList.ts
@@ -1,12 +1,8 @@
 import { Vec2, type Point2D } from "@shift/geo";
 import type { AnchorId, PointId } from "@shift/types";
 import { Transform } from "@/lib/transform/Transform";
+import type { PositionTargets } from "@/types/positionEdit";
 import type { GlyphLayerPosition, GlyphLayerPositions, GlyphLayerPositionTarget } from "./Glyph";
-
-export interface GlyphLayerPositionSubject {
-  readonly points?: readonly PointId[];
-  readonly anchors?: readonly AnchorId[];
-}
 
 export interface GlyphLayerPositionLookup {
   positionsFor(targets: readonly GlyphLayerPositionTarget[]): GlyphLayerPosition[];
@@ -46,13 +42,13 @@ export class GlyphLayerPositionList {
     return new GlyphLayerPositionList(positions);
   }
 
-  static fromSubject(
+  static fromTargetGroups(
     source: GlyphLayerPositionLookup,
-    subject: GlyphLayerPositionSubject,
+    targets: PositionTargets,
   ): GlyphLayerPositionList {
     return GlyphLayerPositionList.fromTargets(
       source,
-      GlyphLayerPositionList.targetsFromSubject(subject),
+      GlyphLayerPositionList.targetListFromGroups(targets),
     );
   }
 
@@ -63,13 +59,13 @@ export class GlyphLayerPositionList {
     return new GlyphLayerPositionList(source.positionsFor(targets));
   }
 
-  static targetsFromSubject(subject: GlyphLayerPositionSubject): GlyphLayerPositionTarget[] {
+  static targetListFromGroups(groups: PositionTargets): GlyphLayerPositionTarget[] {
     const targets: GlyphLayerPositionTarget[] = [];
-    if (subject.points) {
-      targets.push(...subject.points.map((id) => ({ kind: "point" as const, id })));
+    if (groups.points) {
+      targets.push(...groups.points.map((id) => ({ kind: "point" as const, id })));
     }
-    if (subject.anchors) {
-      targets.push(...subject.anchors.map((id) => ({ kind: "anchor" as const, id })));
+    if (groups.anchors) {
+      targets.push(...groups.anchors.map((id) => ({ kind: "anchor" as const, id })));
     }
 
     return targets;

--- a/apps/desktop/src/renderer/src/lib/model/docs/DOCS.md
+++ b/apps/desktop/src/renderer/src/lib/model/docs/DOCS.md
@@ -16,6 +16,7 @@ Reactive TypeScript font, authored glyph-layer, and derived glyph-view surfaces.
 - **Architecture Invariant:** Rust owns component order, ancestry, attachment selection, and cycle pruning through `GlyphComponents`. TypeScript only resolves current coordinates and composes matrices. Component paths preserve authored occurrence identity; numeric transforms are selected by the occurrence's parent-local `componentIndex`, because compatible exact-source layers may assign different `ComponentId` values to corresponding slots.
 - **Architecture Invariant:** Numeric authored edits flow through the existing `GlyphLayerState` signal graph. Do not add a revision signal, invalidate projections to `null`, or refetch native variation data for point, component-transform, advance, or metric value changes.
 - **Architecture Invariant:** Typed glyph-layer editing methods apply locally representable operations before workspace I/O and queue the matching `FontIntent` through `LayerIntents`. The renderer never reinterprets intent envelopes; Rust remains their sole authoritative interpreter and validator. Each renderer-local `PendingEditId` remains pending until its FIFO echo arrives, and older echoes update a hidden confirmed shadow without replacing newer pending geometry. Rust-only edits remain workspace-driven.
+- **Architecture Invariant:** `GlyphLayer.positions` creates operation-specific fluent edits. Configuration is legal only before the first preview; every preview resolves from one frozen base, writes renderer-local geometry only, and either commits one final position patch or restores the base. Tools may configure these edits but do not own their mechanics.
 - **Architecture Invariant:** `Font.committedFontCell` is an invalidation-only dependency for resources derived from the complete native font, including unloaded glyphs. It carries the stable Font value and notifies after committed echoes or workspace replacement; consumers use `track(...)`, never a revision counter.
 - **Architecture Invariant:** Structural glyph, source, or axis changes rebuild retained native projections behind the workspace FIFO and publish replacements atomically. The previous projection remains usable until its replacement arrives.
 - **Architecture Invariant:** Imported selected-glyph geometry is acquired lazily by stable glyph identity, then retained with its complete component closure until session disposal. External slider coordinates evaluate Rust-compiled `AxisMappingBasis` values synchronously before exact-source matching and projection evaluation. Raw mapping points never enter runtime evaluation; scrubbing is local basis evaluation, never a bridge, filesystem, or projection-acquisition request.
@@ -32,6 +33,7 @@ lib/model/
   Glyph.ts                   -- Glyph, GlyphLayer, internal GlyphRenderModel, root lookup, composed metrics
   ComponentGlyph.ts          -- component and contour occurrence provenance/reactivity
   GlyphLayerState.ts         -- local edit lifecycle and pending confirmation
+  positions/                 -- LayerPositions, MoveEdit/RotateEdit, references and modifiers
   LayerBuffers.ts            -- renderer-owned logical layer records and local operations
   ContourBuffer.ts           -- contour metadata plus packed point coordinates
   AnchorBuffer.ts            -- anchor metadata plus packed coordinates
@@ -61,7 +63,9 @@ hooks/
 ## Key Types
 
 - `Glyph` -- stable, completely loaded renderer domain object containing zero or more authored layers, direct references to its loaded component dependencies, and synchronous location-specific geometry backing.
-- `GlyphLayer` -- editable geometry for one glyph/source pair.
+- `GlyphLayer` -- editable geometry for one glyph/source pair. Its `positions` surface creates fluent movement and rotation edits without exposing sparse patches to future tool integrations.
+- `LayerPositions` -- authored-layer entry point for operation-specific `MoveEdit` and `RotateEdit` values.
+- `MoveEdit` / `RotateEdit` -- per-interaction configuration and lifecycle objects backed by frozen positions and local previews. `DirectionSnap`, `AngleSnap`, `MetricSnap`, `PositionReference`, and `PointRuleConstraint` are attached only where the operation supports them.
 - `LayerBuffers` -- renderer-owned advance, contour, anchor, and component records for one exact authored layer. Its structure and packed wire snapshot are derived outputs.
 - `PackedArray` -- dynamically-sized storage for fixed-width numeric records. Its item width is fixed while capacity grows without imposing a font-format limit.
 - `GlyphProjection` -- generated bridge DTO retained as compact backing: fallback, compatible interpolation, incompatible exact-source shapes, and component identities.

--- a/apps/desktop/src/renderer/src/lib/model/positions/AngleSnap.test.ts
+++ b/apps/desktop/src/renderer/src/lib/model/positions/AngleSnap.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { AngleSnap } from "./AngleSnap";
+
+const degrees = (value: number): number => (value * Math.PI) / 180;
+
+describe("angle snapping keeps interaction direction stable", () => {
+  it("quantizes to the nearest configured increment", () => {
+    const snap = AngleSnap.everyDegrees(15);
+
+    expect(snap.apply(degrees(44))).toBeCloseTo(degrees(45));
+  });
+
+  it("sticks to the previous angle inside the hysteresis threshold", () => {
+    const snap = AngleSnap.everyDegrees(45);
+
+    expect(snap.apply(degrees(2))).toBeCloseTo(0);
+    expect(snap.apply(degrees(17))).toBeCloseTo(0);
+    expect(snap.apply(degrees(24))).toBeCloseTo(degrees(45));
+  });
+
+  it("resets hysteresis while its condition is inactive", () => {
+    let enabled = true;
+    const snap = AngleSnap.everyDegrees(45, { when: () => enabled });
+
+    expect(snap.apply(degrees(2))).toBeCloseTo(0);
+    enabled = false;
+    expect(snap.apply(degrees(44))).toBeNull();
+    enabled = true;
+    expect(snap.apply(degrees(44))).toBeCloseTo(degrees(45));
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/model/positions/AngleSnap.ts
+++ b/apps/desktop/src/renderer/src/lib/model/positions/AngleSnap.ts
@@ -1,0 +1,44 @@
+import type { PositionCondition } from "@/types/positionEdit";
+
+const HYSTERESIS_FACTOR = 0.4;
+
+/** Quantizes scalar rotation angles while preserving the previous snap near boundaries. */
+export class AngleSnap {
+  readonly #increment: number;
+  readonly #when: () => boolean;
+  #previous: number | null = null;
+
+  private constructor(increment: number, condition?: PositionCondition) {
+    this.#increment = increment;
+    this.#when = condition?.when ?? (() => true);
+  }
+
+  static everyDegrees(degrees: number, condition?: PositionCondition): AngleSnap {
+    if (!Number.isFinite(degrees) || degrees <= 0) {
+      throw new Error("Angle snap increment must be a positive finite number");
+    }
+
+    return new AngleSnap((degrees * Math.PI) / 180, condition);
+  }
+
+  apply(angle: number): number | null {
+    if (!this.#when()) {
+      this.#previous = null;
+      return null;
+    }
+
+    if (this.#previous !== null) {
+      const difference = Math.atan2(
+        Math.sin(angle - this.#previous),
+        Math.cos(angle - this.#previous),
+      );
+      if (Math.abs(difference) <= this.#increment * HYSTERESIS_FACTOR) {
+        return this.#previous;
+      }
+    }
+
+    const snapped = Math.round(angle / this.#increment) * this.#increment;
+    this.#previous = snapped;
+    return snapped;
+  }
+}

--- a/apps/desktop/src/renderer/src/lib/model/positions/DirectionSnap.ts
+++ b/apps/desktop/src/renderer/src/lib/model/positions/DirectionSnap.ts
@@ -1,0 +1,27 @@
+import { Vec2, type Point2D } from "@shift/geo";
+import type { PositionCondition } from "@/types/positionEdit";
+import { AngleSnap } from "./AngleSnap";
+
+/** Quantizes a movement vector's direction while preserving its length. */
+export class DirectionSnap {
+  readonly #angle: AngleSnap;
+
+  private constructor(angle: AngleSnap) {
+    this.#angle = angle;
+  }
+
+  static everyDegrees(degrees: number, condition?: PositionCondition): DirectionSnap {
+    return new DirectionSnap(AngleSnap.everyDegrees(degrees, condition));
+  }
+
+  apply(delta: Point2D): Point2D | null {
+    const snappedAngle = this.#angle.apply(Vec2.angle(delta));
+    if (snappedAngle === null) return null;
+
+    const length = Vec2.len(delta);
+    return {
+      x: length * Math.cos(snappedAngle),
+      y: length * Math.sin(snappedAngle),
+    };
+  }
+}

--- a/apps/desktop/src/renderer/src/lib/model/positions/LayerPositions.ts
+++ b/apps/desktop/src/renderer/src/lib/model/positions/LayerPositions.ts
@@ -1,0 +1,22 @@
+import type { Point2D } from "@shift/geo";
+import type { GlyphLayer } from "../Glyph";
+import type { PositionTargets } from "@/types/positionEdit";
+import { MoveEdit } from "./MoveEdit";
+import { RotateEdit } from "./RotateEdit";
+
+/** Operation-specific fluent position edits for one authored glyph layer. */
+export class LayerPositions {
+  readonly #layer: GlyphLayer;
+
+  constructor(layer: GlyphLayer) {
+    this.#layer = layer;
+  }
+
+  move(targets: PositionTargets): MoveEdit {
+    return new MoveEdit(this.#layer, targets);
+  }
+
+  rotate(targets: PositionTargets, origin: Point2D): RotateEdit {
+    return new RotateEdit(this.#layer, targets, origin);
+  }
+}

--- a/apps/desktop/src/renderer/src/lib/model/positions/MetricSnap.test.ts
+++ b/apps/desktop/src/renderer/src/lib/model/positions/MetricSnap.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import type { SourceMetrics } from "@shift/types";
+import { MetricSnap } from "./MetricSnap";
+
+const metrics: SourceMetrics = {
+  unitsPerEm: 1000,
+  metricValues: [],
+  ascender: 800,
+  descender: -200,
+  baseline: 10,
+  xHeight: 500,
+  capHeight: 700,
+};
+
+describe("metric snapping follows authored horizontal metrics", () => {
+  it("returns the nearest metric inside the radius", () => {
+    const snap = MetricSnap.standard(metrics, 8).snap({ x: 40, y: 496 });
+
+    expect(snap?.point).toEqual({ x: 40, y: 500 });
+    expect(snap?.distance).toBe(4);
+    expect(snap?.guides).toEqual([{ kind: "metric", metric: "xHeight", y: 500 }]);
+  });
+
+  it("uses a non-zero authored baseline", () => {
+    const snap = MetricSnap.standard(metrics, 8).snap({ x: 40, y: 4 });
+
+    expect(snap?.point).toEqual({ x: 40, y: 10 });
+    expect(snap?.guides[0]).toEqual({ kind: "metric", metric: "baseline", y: 10 });
+  });
+
+  it("does not fabricate absent optional metrics at zero", () => {
+    const sparse = { ...metrics, xHeight: undefined, capHeight: undefined };
+    const snap = MetricSnap.standard(sparse, 2).snap({ x: 40, y: 0 });
+
+    expect(snap).toBeNull();
+  });
+
+  it("honors its per-frame activation condition", () => {
+    let enabled = false;
+    const snapping = MetricSnap.standard(metrics, 8, { when: () => enabled });
+
+    expect(snapping.snap({ x: 40, y: 496 })).toBeNull();
+    enabled = true;
+    expect(snapping.snap({ x: 40, y: 496 })?.point.y).toBe(500);
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/model/positions/MetricSnap.ts
+++ b/apps/desktop/src/renderer/src/lib/model/positions/MetricSnap.ts
@@ -1,0 +1,86 @@
+import type { Point2D } from "@shift/geo";
+import type { SourceMetrics } from "@shift/types";
+import type {
+  MetricPositionGuide,
+  PositionCondition,
+  PositionSnap,
+  PositionSnapProvider,
+} from "@/types/positionEdit";
+
+/** Snaps a position's Y coordinate to standard source-specific horizontal metrics. */
+export class MetricSnap implements PositionSnapProvider {
+  readonly #guides: readonly MetricPositionGuide[];
+  readonly #radius: number;
+  readonly #when: () => boolean;
+
+  private constructor(
+    guides: readonly MetricPositionGuide[],
+    radius: number,
+    condition?: PositionCondition,
+  ) {
+    this.#guides = guides;
+    this.#radius = radius;
+    this.#when = condition?.when ?? (() => true);
+  }
+
+  static standard(
+    metrics: SourceMetrics,
+    radius: number,
+    condition?: PositionCondition,
+  ): MetricSnap {
+    if (!Number.isFinite(radius) || radius < 0) {
+      throw new Error("Metric snap radius must be a non-negative finite number");
+    }
+
+    const guides: MetricPositionGuide[] = [
+      { kind: "metric", metric: "baseline", y: metrics.baseline },
+      { kind: "metric", metric: "ascender", y: metrics.ascender },
+      { kind: "metric", metric: "descender", y: metrics.descender },
+    ];
+
+    if (metrics.xHeight !== undefined) {
+      guides.push({ kind: "metric", metric: "xHeight", y: metrics.xHeight });
+    }
+    if (metrics.capHeight !== undefined) {
+      guides.push({ kind: "metric", metric: "capHeight", y: metrics.capHeight });
+    }
+
+    return new MetricSnap(uniqueMetricGuides(guides), radius, condition);
+  }
+
+  snap(point: Point2D): PositionSnap | null {
+    if (!this.#when()) return null;
+
+    let best: { guide: MetricPositionGuide; distance: number } | null = null;
+
+    for (const guide of this.#guides) {
+      const distance = Math.abs(point.y - guide.y);
+      if (distance > this.#radius) continue;
+      if (best && best.distance <= distance) continue;
+
+      best = { guide, distance };
+    }
+
+    if (!best) return null;
+
+    return {
+      point: { x: point.x, y: best.guide.y },
+      distance: best.distance,
+      guides: [best.guide],
+    };
+  }
+}
+
+function uniqueMetricGuides(guides: readonly MetricPositionGuide[]): MetricPositionGuide[] {
+  const positions = new Set<number>();
+  const unique: MetricPositionGuide[] = [];
+
+  for (const guide of guides) {
+    if (positions.has(guide.y)) continue;
+
+    positions.add(guide.y);
+    unique.push(guide);
+  }
+
+  return unique;
+}

--- a/apps/desktop/src/renderer/src/lib/model/positions/MoveEdit.ts
+++ b/apps/desktop/src/renderer/src/lib/model/positions/MoveEdit.ts
@@ -1,0 +1,135 @@
+import { Vec2, type Point2D } from "@shift/geo";
+import type { AnchorId } from "@shift/types";
+import type { GlyphLayer } from "../Glyph";
+import { PositionEditDraft } from "./PositionEditDraft";
+import type {
+  PositionEdit,
+  PositionEditPhase,
+  PositionFeedback,
+  PositionGuide,
+  PositionSnapProvider,
+  PositionTargets,
+} from "@/types/positionEdit";
+import { DirectionSnap } from "./DirectionSnap";
+import { PointRuleConstraint } from "./PointRuleConstraint";
+import { PositionReference } from "./PositionReference";
+
+/** Preview-backed movement configured with operation-specific fluent modifiers. */
+export class MoveEdit implements PositionEdit {
+  readonly #layer: GlyphLayer;
+  readonly #draft: PositionEditDraft;
+  readonly #anchorIds: readonly AnchorId[];
+
+  #phase: PositionEditPhase = "configuring";
+  #reference: Point2D | null = null;
+  #directionSnap: DirectionSnap | null = null;
+  #snapProvider: PositionSnapProvider | null = null;
+  #pointRules: PointRuleConstraint | null = null;
+
+  constructor(layer: GlyphLayer, targets: PositionTargets) {
+    this.#layer = layer;
+    this.#draft = new PositionEditDraft(layer, targets);
+    this.#anchorIds = [...(targets.anchors ?? [])];
+  }
+
+  from(reference: PositionReference): this {
+    this.#assertConfiguring();
+
+    const position = reference.resolve(this.#layer);
+    if (!position) throw new Error("Position reference does not exist in this glyph layer");
+
+    this.#reference = position;
+    return this;
+  }
+
+  directionSnappedBy(snap: DirectionSnap): this {
+    this.#assertConfiguring();
+    this.#directionSnap = snap;
+    return this;
+  }
+
+  snappedBy(provider: PositionSnapProvider): this {
+    this.#assertConfiguring();
+    this.#snapProvider = provider;
+    return this;
+  }
+
+  constrainedBy(constraint: PointRuleConstraint): this {
+    this.#assertConfiguring();
+    this.#pointRules = constraint;
+    return this;
+  }
+
+  preview(rawDelta: Point2D): PositionFeedback {
+    if (this.#snapProvider && !this.#reference) {
+      throw new Error("MoveEdit.snappedBy requires an explicit PositionReference");
+    }
+
+    this.#beginPreview();
+
+    let delta = { ...rawDelta };
+    const guides: PositionGuide[] = [];
+    const directionDelta = this.#directionSnap?.apply(delta) ?? null;
+
+    if (directionDelta) {
+      delta = directionDelta;
+      if (this.#reference) {
+        guides.push({
+          kind: "direction",
+          from: this.#reference,
+          to: Vec2.add(this.#reference, delta),
+        });
+      }
+    }
+
+    if (this.#snapProvider && this.#reference) {
+      const snap = this.#snapProvider.snap(Vec2.add(this.#reference, delta));
+      if (snap) {
+        delta = Vec2.sub(snap.point, this.#reference);
+        guides.push(...snap.guides);
+      }
+    }
+
+    if (this.#pointRules) {
+      this.#draft.previewPositionPatch(
+        this.#pointRules.positionsFor(this.#draft.basePositions, this.#anchorIds, delta),
+      );
+    } else {
+      this.#draft.previewTranslate(delta);
+    }
+
+    return { delta, guides };
+  }
+
+  commit(): void {
+    if (this.#phase === "committed" || this.#phase === "discarded") return;
+
+    this.#phase = "committed";
+    this.#draft.commit();
+  }
+
+  discard(): void {
+    if (this.#phase === "committed" || this.#phase === "discarded") return;
+
+    this.#phase = "discarded";
+    this.#draft.discard();
+  }
+
+  #assertConfiguring(): void {
+    if (this.#phase === "configuring") return;
+    throw new Error("Position edit modifiers must be configured before the first preview");
+  }
+
+  #beginPreview(): void {
+    switch (this.#phase) {
+      case "configuring":
+        this.#phase = "previewing";
+        return;
+      case "previewing":
+        return;
+      case "committed":
+      case "discarded":
+        throw new Error("Cannot preview a completed position edit");
+    }
+  }
+}

--- a/apps/desktop/src/renderer/src/lib/model/positions/PointRuleConstraint.ts
+++ b/apps/desktop/src/renderer/src/lib/model/positions/PointRuleConstraint.ts
@@ -1,0 +1,50 @@
+import { Vec2, type Point2D } from "@shift/geo";
+import type { AnchorId, PointId } from "@shift/types";
+import {
+  constrainPreparedDrag,
+  prepareConstrainedDrag,
+  type ConstrainDragGlyph,
+  type PreparedConstrainDrag,
+} from "@shift/rules";
+import type { GlyphLayerPositions } from "../Glyph";
+
+/** Prepared point-neighborhood rules applied after movement snapping. */
+export class PointRuleConstraint {
+  readonly #rules: PreparedConstrainDrag;
+
+  private constructor(rules: PreparedConstrainDrag) {
+    this.#rules = rules;
+  }
+
+  static forSelection(
+    geometry: ConstrainDragGlyph,
+    pointIds: readonly PointId[],
+  ): PointRuleConstraint {
+    return new PointRuleConstraint(prepareConstrainedDrag(geometry, new Set(pointIds)));
+  }
+
+  positionsFor(
+    base: GlyphLayerPositions,
+    anchorIds: readonly AnchorId[],
+    delta: Point2D,
+  ): GlyphLayerPositions {
+    const positions: GlyphLayerPositions[number][] = [];
+    const patch = constrainPreparedDrag(this.#rules, delta, {
+      includeMatchedRules: false,
+    });
+
+    for (const point of patch.pointUpdates) {
+      positions.push({ kind: "point", id: point.id, x: point.x, y: point.y });
+    }
+
+    const anchors = new Set(anchorIds);
+    for (const position of base) {
+      if (position.kind !== "anchor" || !anchors.has(position.id)) continue;
+
+      const next = Vec2.add(position, delta);
+      positions.push({ ...position, x: next.x, y: next.y });
+    }
+
+    return positions;
+  }
+}

--- a/apps/desktop/src/renderer/src/lib/model/positions/PositionEditDraft.ts
+++ b/apps/desktop/src/renderer/src/lib/model/positions/PositionEditDraft.ts
@@ -1,0 +1,55 @@
+import type { Point2D } from "@shift/geo";
+import type { GlyphLayer, GlyphLayerPositions } from "../Glyph";
+import { GlyphLayerPositionList } from "../GlyphLayerPositionList";
+import type { PositionTargets } from "@/types/positionEdit";
+
+/** Model-private frozen base and local preview backing for fluent position edits. */
+export class PositionEditDraft {
+  readonly #layer: GlyphLayer;
+
+  #base: GlyphLayerPositionList;
+  #preview: GlyphLayerPositionList | null = null;
+  #closed = false;
+
+  constructor(layer: GlyphLayer, targets: PositionTargets) {
+    this.#layer = layer;
+    this.#base = GlyphLayerPositionList.fromTargetGroups(layer, targets);
+  }
+
+  get basePositions(): GlyphLayerPositions {
+    return this.#base.positions;
+  }
+
+  previewPositionPatch(positions: GlyphLayerPositions): void {
+    if (this.#closed) return;
+
+    this.#base = this.#base.includeFrom(this.#layer, positions);
+    this.#preview = GlyphLayerPositionList.fromPositions(positions);
+    this.#layer.previewPositionPatch(this.#preview.positions);
+  }
+
+  previewTranslate(delta: Point2D): void {
+    this.previewPositionPatch(this.#base.translate(delta).positions);
+  }
+
+  previewRotate(angle: number, origin: Point2D): void {
+    this.previewPositionPatch(this.#base.rotate(angle, origin).positions);
+  }
+
+  commit(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+
+    if (!this.#preview || this.#preview.positions.length === 0) return;
+    this.#layer.applyPositionPatch(this.#preview.positions);
+  }
+
+  discard(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+
+    if (this.#base.positions.length > 0) {
+      this.#layer.previewPositionPatch(this.#base.positions);
+    }
+  }
+}

--- a/apps/desktop/src/renderer/src/lib/model/positions/PositionEdits.test.ts
+++ b/apps/desktop/src/renderer/src/lib/model/positions/PositionEdits.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { Vec2 } from "@shift/geo";
+import type { PointId } from "@shift/types";
+import { TestEditor } from "@/testing/TestEditor";
+import { AngleSnap } from "./AngleSnap";
+import { DirectionSnap } from "./DirectionSnap";
+import { MetricSnap } from "./MetricSnap";
+import { PointRuleConstraint } from "./PointRuleConstraint";
+import { PositionReference } from "./PositionReference";
+
+// These tests exercise the new model surface directly because Select/Translate
+// intentionally does not consume it in this foundation change.
+describe("fluent position edits preserve one frozen interaction base", () => {
+  let editor: TestEditor;
+  let pointId: PointId;
+
+  beforeEach(async () => {
+    editor = new TestEditor();
+    await editor.startSession();
+    editor.selectTool("pen").clickGlyphLocal(100, 100);
+    await editor.settle();
+    pointId = editor.requireGlyphLayer().allPoints[0]!.id;
+  });
+
+  it("recomputes movement previews from the original position and discards them", () => {
+    const edit = editor.requireGlyphLayer().positions.move({ points: [pointId] });
+
+    edit.preview({ x: 10, y: 0 });
+    edit.preview({ x: 25, y: 0 });
+    expect(editor.pointPosition(pointId)).toEqual({ x: 125, y: 100 });
+
+    edit.discard();
+    expect(editor.pointPosition(pointId)).toEqual({ x: 100, y: 100 });
+  });
+
+  it("commits one preview through the workspace ledger and undoes it", async () => {
+    const edit = editor.requireGlyphLayer().positions.move({ points: [pointId] });
+
+    edit.preview({ x: 25, y: -10 });
+    edit.commit();
+    await editor.settle();
+    expect(editor.pointPosition(pointId)).toEqual({ x: 125, y: 90 });
+
+    await editor.undoAndSettle();
+    expect(editor.pointPosition(pointId)).toEqual({ x: 100, y: 100 });
+  });
+
+  it("applies direction snapping before point rules", () => {
+    const layer = editor.requireGlyphLayer();
+    const edit = layer.positions
+      .move({ points: [pointId] })
+      .from(PositionReference.point(pointId))
+      .directionSnappedBy(DirectionSnap.everyDegrees(45))
+      .constrainedBy(PointRuleConstraint.forSelection(layer.geometry, [pointId]));
+
+    const feedback = edit.preview({ x: 10, y: 6 });
+    const component = Vec2.len({ x: 10, y: 6 }) / Math.sqrt(2);
+
+    expect(feedback.delta.x).toBeCloseTo(component);
+    expect(feedback.delta.y).toBeCloseTo(component);
+    expect(feedback.guides[0]?.kind).toBe("direction");
+    edit.discard();
+  });
+
+  it("snaps the explicit reference to source metrics", () => {
+    const layer = editor.requireGlyphLayer();
+    const metrics = { ...editor.font.metricsForSource(layer.sourceId), xHeight: 500 };
+    const edit = layer.positions
+      .move({ points: [pointId] })
+      .from(PositionReference.point(pointId))
+      .snappedBy(MetricSnap.standard(metrics, 8));
+
+    const feedback = edit.preview({ x: 20, y: 397 });
+
+    expect(feedback.delta).toEqual({ x: 20, y: 400 });
+    expect(editor.pointPosition(pointId)).toEqual({ x: 120, y: 500 });
+    expect(feedback.guides).toEqual([{ kind: "metric", metric: "xHeight", y: 500 }]);
+    edit.discard();
+  });
+
+  it("quantizes rotation independently from movement modifiers", () => {
+    const edit = editor
+      .requireGlyphLayer()
+      .positions.rotate({ points: [pointId] }, { x: 0, y: 0 })
+      .angleSnappedBy(AngleSnap.everyDegrees(15));
+
+    const angle = edit.preview((44 * Math.PI) / 180);
+
+    expect(angle).toBeCloseTo(Math.PI / 4);
+    expect(editor.pointPosition(pointId).x).toBeCloseTo(0);
+    expect(editor.pointPosition(pointId).y).toBeCloseTo(Math.sqrt(20_000));
+    edit.discard();
+  });
+
+  it("rejects configuration after preview and preview after completion", () => {
+    const edit = editor.requireGlyphLayer().positions.move({ points: [pointId] });
+
+    edit.preview({ x: 10, y: 0 });
+    expect(() => edit.from(PositionReference.point(pointId))).toThrow(/before the first preview/);
+
+    edit.discard();
+    expect(() => edit.preview({ x: 20, y: 0 })).toThrow(/completed position edit/);
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/model/positions/PositionReference.ts
+++ b/apps/desktop/src/renderer/src/lib/model/positions/PositionReference.ts
@@ -1,0 +1,34 @@
+import type { Point2D } from "@shift/geo";
+import type { AnchorId, PointId } from "@shift/types";
+import type { GlyphLayer, GlyphLayerPositionTarget } from "../Glyph";
+
+/** Frozen reference used to turn a movement delta into a snappable position. */
+export class PositionReference {
+  readonly #target: GlyphLayerPositionTarget | null;
+  readonly #position: Point2D | null;
+
+  private constructor(target: GlyphLayerPositionTarget | null, position: Point2D | null) {
+    this.#target = target;
+    this.#position = position ? { ...position } : null;
+  }
+
+  static point(pointId: PointId): PositionReference {
+    return new PositionReference({ kind: "point", id: pointId }, null);
+  }
+
+  static anchor(anchorId: AnchorId): PositionReference {
+    return new PositionReference({ kind: "anchor", id: anchorId }, null);
+  }
+
+  static position(position: Point2D): PositionReference {
+    return new PositionReference(null, position);
+  }
+
+  resolve(layer: GlyphLayer): Point2D | null {
+    if (this.#position) return { ...this.#position };
+    if (!this.#target) return null;
+
+    const position = layer.positionsFor([this.#target])[0];
+    return position ? { x: position.x, y: position.y } : null;
+  }
+}

--- a/apps/desktop/src/renderer/src/lib/model/positions/RotateEdit.ts
+++ b/apps/desktop/src/renderer/src/lib/model/positions/RotateEdit.ts
@@ -1,0 +1,65 @@
+import type { Point2D } from "@shift/geo";
+import type { GlyphLayer } from "../Glyph";
+import { PositionEditDraft } from "./PositionEditDraft";
+import type { PositionEdit, PositionEditPhase, PositionTargets } from "@/types/positionEdit";
+import { AngleSnap } from "./AngleSnap";
+
+/** Preview-backed rotation configured with rotation-specific modifiers. */
+export class RotateEdit implements PositionEdit {
+  readonly #draft: PositionEditDraft;
+  readonly #origin: Point2D;
+
+  #phase: PositionEditPhase = "configuring";
+  #angleSnap: AngleSnap | null = null;
+
+  constructor(layer: GlyphLayer, targets: PositionTargets, origin: Point2D) {
+    this.#draft = new PositionEditDraft(layer, targets);
+    this.#origin = { ...origin };
+  }
+
+  angleSnappedBy(snap: AngleSnap): this {
+    this.#assertConfiguring();
+    this.#angleSnap = snap;
+    return this;
+  }
+
+  preview(rawAngle: number): number {
+    this.#beginPreview();
+
+    const angle = this.#angleSnap?.apply(rawAngle) ?? rawAngle;
+    this.#draft.previewRotate(angle, this.#origin);
+    return angle;
+  }
+
+  commit(): void {
+    if (this.#phase === "committed" || this.#phase === "discarded") return;
+
+    this.#phase = "committed";
+    this.#draft.commit();
+  }
+
+  discard(): void {
+    if (this.#phase === "committed" || this.#phase === "discarded") return;
+
+    this.#phase = "discarded";
+    this.#draft.discard();
+  }
+
+  #assertConfiguring(): void {
+    if (this.#phase === "configuring") return;
+    throw new Error("Position edit modifiers must be configured before the first preview");
+  }
+
+  #beginPreview(): void {
+    switch (this.#phase) {
+      case "configuring":
+        this.#phase = "previewing";
+        return;
+      case "previewing":
+        return;
+      case "committed":
+      case "discarded":
+        throw new Error("Cannot preview a completed position edit");
+    }
+  }
+}

--- a/apps/desktop/src/renderer/src/lib/model/positions/index.ts
+++ b/apps/desktop/src/renderer/src/lib/model/positions/index.ts
@@ -1,0 +1,8 @@
+export { AngleSnap } from "./AngleSnap";
+export { DirectionSnap } from "./DirectionSnap";
+export { LayerPositions } from "./LayerPositions";
+export { MetricSnap } from "./MetricSnap";
+export { MoveEdit } from "./MoveEdit";
+export { PointRuleConstraint } from "./PointRuleConstraint";
+export { PositionReference } from "./PositionReference";
+export { RotateEdit } from "./RotateEdit";

--- a/apps/desktop/src/renderer/src/lib/tools/select/behaviors/Translate.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/behaviors/Translate.ts
@@ -83,7 +83,7 @@ export class Translate implements SelectBehavior {
 }
 
 /**
- * A resolved glyph-layer move: the subject point/anchor ids together with the
+ * A resolved glyph-layer move: the target point/anchor ids together with the
  * single authored layer that owns all of them.
  *
  * Construction is where edit scoping happens. Builders resolve identity-only

--- a/apps/desktop/src/renderer/src/types/index.ts
+++ b/apps/desktop/src/renderer/src/types/index.ts
@@ -44,6 +44,17 @@ export type {
   ShiftRecordId,
 } from "./records";
 export type { TextRunRecord } from "./text";
+export type {
+  DirectionPositionGuide,
+  MetricPositionGuide,
+  PositionCondition,
+  PositionEdit,
+  PositionFeedback,
+  PositionGuide,
+  PositionSnap,
+  PositionSnapProvider,
+  PositionTargets,
+} from "./positionEdit";
 export type { WorkspaceApplyStatus, WorkspaceEdit } from "./workspace";
 
 export interface GlyphObjectSegment {

--- a/apps/desktop/src/renderer/src/types/positionEdit.ts
+++ b/apps/desktop/src/renderer/src/types/positionEdit.ts
@@ -1,0 +1,57 @@
+import type { Point2D } from "@shift/geo";
+import type { AnchorId, MetricKind, PointId } from "@shift/types";
+
+/** Point and anchor identities transformed together by one position edit. */
+export interface PositionTargets {
+  readonly points?: readonly PointId[];
+  readonly anchors?: readonly AnchorId[];
+}
+
+/** Shared terminal operations exposed by every fluent position edit. */
+export interface PositionEdit {
+  commit(): void;
+  discard(): void;
+}
+
+/** Internal lifecycle of one configured position edit. */
+export type PositionEditPhase = "configuring" | "previewing" | "committed" | "discarded";
+
+/** Optional activation predicate evaluated for each preview frame. */
+export interface PositionCondition {
+  readonly when: () => boolean;
+}
+
+/** Direction segment emitted while a movement vector is quantized. */
+export interface DirectionPositionGuide {
+  readonly kind: "direction";
+  readonly from: Point2D;
+  readonly to: Point2D;
+}
+
+/** Horizontal metric emitted while a reference position is snapped. */
+export interface MetricPositionGuide {
+  readonly kind: "metric";
+  readonly metric: MetricKind;
+  readonly y: number;
+}
+
+/** Semantic visual guide emitted by a position edit preview. */
+export type PositionGuide = DirectionPositionGuide | MetricPositionGuide;
+
+/** Candidate correction returned by a position snap provider. */
+export interface PositionSnap {
+  readonly point: Point2D;
+  readonly distance: number;
+  readonly guides: readonly PositionGuide[];
+}
+
+/** Source-neutral position snapping contract consumed by MoveEdit. */
+export interface PositionSnapProvider {
+  snap(point: Point2D): PositionSnap | null;
+}
+
+/** Effective movement and visual feedback produced for one preview frame. */
+export interface PositionFeedback {
+  readonly delta: Point2D;
+  readonly guides: readonly PositionGuide[];
+}


### PR DESCRIPTION
## Summary

Foundation for #112.

- add `GlyphLayer.positions` with operation-specific `MoveEdit` and `RotateEdit` values
- add frozen-base preview/commit/discard lifecycle with configuration locked after the first preview
- add `PositionTargets`, explicit `PositionReference` values, direction/angle modifiers, horizontal metric snapping, point-rule constraints, and semantic feedback guides
- keep position edit mechanics model-owned under `lib/model/positions`
- cover angle hysteresis, metric resolution, local preview/discard, workspace commit/undo, modifier order, and lifecycle guards

## Scope

This intentionally does **not** connect the new API to Select, Translate, or Rotate, so it introduces no user-visible snapping behavior yet. Existing tool behavior and `GlyphLayerEditDraft` remain in place for the later integration change.

## Validation

- `pnpm test` — passed
- `pnpm test:desktop src/renderer/src/lib/model/positions/AngleSnap.test.ts src/renderer/src/lib/model/positions/MetricSnap.test.ts src/renderer/src/lib/model/positions/PositionEdits.test.ts src/renderer/src/lib/editor/GlyphLayerEditDraft.test.ts` — 17 passed
- `pnpm typecheck` — passed
- `pnpm format:check` — passed
- `pnpm check-deps` — passed
- `python3 scripts/context-drift-check.py` — completed with the repository's existing unrelated documentation warnings

`pnpm lint:check` is currently blocked before linting source because installed Oxlint 1.58 rejects the existing `oxlint-plugin-eslint` registration as the reserved plugin name `eslint`. No lint configuration is changed in this PR; the commit skipped only that broken hook.
