### PR TITLE
Typecheck desktop test sources

### DIFF
--- a/apps/desktop/src/renderer/src/components/home/GlyphPreviewLayout.test.ts
+++ b/apps/desktop/src/renderer/src/components/home/GlyphPreviewLayout.test.ts
@@ -1,13 +1,12 @@
 import { describe, expect, it } from "vitest";
-import type { SourceMetrics } from "@shift/types";
+import type { CatalogMetrics } from "@shift/types";
 import { GlyphPreviewLayout } from "./GlyphPreviewLayout";
 
-const METRICS: SourceMetrics = {
+const METRICS: CatalogMetrics = {
   unitsPerEm: 1000,
-  metricValues: [],
   ascender: 800,
   descender: -200,
-  baseline: 0,
+  lineGap: 0,
 };
 
 describe("Glyph preview layout", () => {

--- a/apps/desktop/src/renderer/src/lib/editor/Editor.test.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/Editor.test.ts
@@ -54,15 +54,18 @@ describe("Editor scene bootstrap", () => {
       },
     ]);
 
-    expect(editor.scene.node(left)?.glyphId).toBe(record.id);
-    expect(editor.scene.node(right)?.glyphId).toBe(record.id);
+    const leftNode = editor.scene.node(left);
+    const rightNode = editor.scene.node(right);
+    if (leftNode?.kind !== "glyph" || rightNode?.kind !== "glyph") {
+      throw new Error("Expected two glyph nodes");
+    }
+
+    expect(leftNode.glyphId).toBe(record.id);
+    expect(rightNode.glyphId).toBe(record.id);
     expect(editor.getPointInNodeSpace({ x: 710, y: 20 }, { x: 700, y: 0 })).toEqual({
       x: 10,
       y: 20,
     });
-
-    const rightNode = editor.scene.node(right);
-    if (!rightNode) throw new Error("Expected right glyph node");
 
     editor.scene.updateNode({
       id: rightNode.id,

--- a/apps/desktop/src/renderer/src/lib/model/Font.test.ts
+++ b/apps/desktop/src/renderer/src/lib/model/Font.test.ts
@@ -7,6 +7,7 @@ import {
   mintGlyphId,
   mintLayerId,
   mintSourceId,
+  type Axis,
   type AxisId,
   type GlyphId,
   type GlyphName,
@@ -23,7 +24,9 @@ import { externalAxisLocationFromRecord } from "@/lib/variation/location";
 const SNAPSHOT: WorkspaceSnapshot = {
   documentId: "11111111-2222-3333-4444-555555555555",
   metadata: { familyName: "Untitled Font" },
-  metrics: { unitsPerEm: 2048, ascender: 1638, descender: -410 },
+  metrics: { unitsPerEm: 2048 },
+  metricDefinitions: [],
+  sourceMetricsInterpolation: null,
   glyphs: [
     {
       id: "glyph_A" as GlyphId,
@@ -38,6 +41,7 @@ const SNAPSHOT: WorkspaceSnapshot = {
       id: "source-1" as SourceId,
       name: "Regular",
       location: { values: {} },
+      metricValues: [],
     },
   ],
   axes: [],
@@ -698,7 +702,7 @@ describe("font-level intents make the font variable", () => {
   });
 });
 
-function continuousAxis(axisId: AxisId) {
+function continuousAxis(axisId: AxisId): Axis {
   return {
     id: axisId,
     tag: "wght",

--- a/apps/desktop/src/renderer/src/lib/model/FontStore.test.ts
+++ b/apps/desktop/src/renderer/src/lib/model/FontStore.test.ts
@@ -239,7 +239,9 @@ function snapshot(documentId: string, layerId: LayerId): WorkspaceSnapshot {
   return {
     documentId,
     metadata: { familyName: "Untitled Font" },
-    metrics: { unitsPerEm: 1000, ascender: 800, descender: -200 },
+    metrics: { unitsPerEm: 1000 },
+    metricDefinitions: [],
+    sourceMetricsInterpolation: null,
     glyphs: [
       {
         id: GLYPH_ID,
@@ -254,6 +256,7 @@ function snapshot(documentId: string, layerId: LayerId): WorkspaceSnapshot {
         id: SOURCE_ID,
         name: "Regular",
         location: { values: {} },
+        metricValues: [],
       },
     ],
     axes: [],
@@ -313,7 +316,7 @@ function structure({
         closed: false,
       },
     ],
-    anchors: [{ id: anchorId, x: 50, y: 100 }],
+    anchors: [{ id: anchorId }],
     components: [],
   };
 }

--- a/apps/desktop/src/renderer/src/lib/model/variation.test.ts
+++ b/apps/desktop/src/renderer/src/lib/model/variation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach } from "vitest";
-import type { AxisId, GlyphId, GlyphName, LayerId, Source, Unicode } from "@shift/types";
+import type { Axis, AxisId, GlyphId, GlyphName, LayerId, Source, Unicode } from "@shift/types";
 import {
   mintAxisId,
   mintAxisMappingId,
@@ -171,7 +171,7 @@ async function variableFont(): Promise<{
   return { stack, glyphId, regularLayerId, boldLayerId, bold: updatedBold };
 }
 
-function continuousAxis(axisId: AxisId) {
+function continuousAxis(axisId: AxisId): Axis {
   return {
     id: axisId,
     tag: "wght",

--- a/apps/desktop/src/renderer/src/lib/signals/KeyedCache.test.ts
+++ b/apps/desktop/src/renderer/src/lib/signals/KeyedCache.test.ts
@@ -17,7 +17,7 @@ class CachedValue {
 
 describe("KeyedCache", () => {
   it("reuses cached values when keys are retained", () => {
-    const cache = keyedCache({
+    const cache = keyedCache<Input, string, CachedValue>({
       key: (input) => input.id,
       create: (input) => new CachedValue(input),
     });
@@ -38,7 +38,7 @@ describe("KeyedCache", () => {
   });
 
   it("updates the cached input signal instead of recreating the value", () => {
-    const cache = keyedCache({
+    const cache = keyedCache<Input, string, CachedValue>({
       key: (input) => input.id,
       create: (input) => new CachedValue(input),
     });
@@ -53,7 +53,7 @@ describe("KeyedCache", () => {
 
   it("disposes values whose keys are removed during map", () => {
     const disposed: CachedValue[] = [];
-    const cache = keyedCache({
+    const cache = keyedCache<Input, string, CachedValue>({
       key: (input) => input.id,
       create: (input) => new CachedValue(input),
       dispose: (value) => disposed.push(value),
@@ -71,7 +71,7 @@ describe("KeyedCache", () => {
 
   it("clears cached values", () => {
     const disposed: CachedValue[] = [];
-    const cache = keyedCache({
+    const cache = keyedCache<Input, string, CachedValue>({
       key: (input) => input.id,
       create: (input) => new CachedValue(input),
       dispose: (value) => disposed.push(value),

--- a/apps/desktop/src/renderer/src/lib/tools/core/BaseTool.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/core/BaseTool.test.ts
@@ -7,6 +7,14 @@ import type { Behavior } from "./Behavior";
 
 type ContractState = { type: "idle" } | { type: "ready" } | { type: "clicked" };
 
+const NO_MODIFIERS = {
+  shiftKey: false,
+  altKey: false,
+  metaKey: false,
+  ctrlKey: false,
+  accelKey: false,
+};
+
 const ClickBehavior: Behavior<ContractState> = {
   onClick(state, ctx) {
     if (state.type !== "ready") return false;
@@ -59,12 +67,12 @@ describe("BaseTool contract", () => {
 
   describe("when state changes", () => {
     it("advances tool state and fires onStateChange with prev/next/event", () => {
+      const coords = makeTestCoordinates({ x: 10, y: 10 });
       const clickEvent: ToolEvent = {
         type: "click",
-        point: { x: 10, y: 10 },
-        coords: makeTestCoordinates({ x: 10, y: 10 }),
-        shiftKey: false,
-        altKey: false,
+        coords,
+        target: { kind: "canvas", point: coords.scene },
+        ...NO_MODIFIERS,
       };
 
       tool.handleEvent(clickEvent);
@@ -79,10 +87,12 @@ describe("BaseTool contract", () => {
 
   describe("when state is unchanged (same reference)", () => {
     it("does not fire onStateChange when no behavior matches", () => {
+      const coords = makeTestCoordinates({ x: 10, y: 10 });
       const moveEvent: ToolEvent = {
         type: "pointerMove",
-        point: { x: 10, y: 10 },
-        coords: makeTestCoordinates({ x: 10, y: 10 }),
+        coords,
+        target: { kind: "canvas", point: coords.scene },
+        ...NO_MODIFIERS,
       };
 
       tool.handleEvent(moveEvent);
@@ -92,19 +102,21 @@ describe("BaseTool contract", () => {
     });
 
     it("does not fire onStateChange when transition returns same state after clicked", () => {
+      const clickCoords = makeTestCoordinates({ x: 0, y: 0 });
       tool.handleEvent({
         type: "click",
-        point: { x: 0, y: 0 },
-        coords: makeTestCoordinates({ x: 0, y: 0 }),
-        shiftKey: false,
-        altKey: false,
+        coords: clickCoords,
+        target: { kind: "canvas", point: clickCoords.scene },
+        ...NO_MODIFIERS,
       });
       tool.stateChanges.length = 0;
 
+      const moveCoords = makeTestCoordinates({ x: 5, y: 5 });
       tool.handleEvent({
         type: "pointerMove",
-        point: { x: 5, y: 5 },
-        coords: makeTestCoordinates({ x: 5, y: 5 }),
+        coords: moveCoords,
+        target: { kind: "canvas", point: moveCoords.scene },
+        ...NO_MODIFIERS,
       });
 
       expect(tool.stateChanges).toEqual([]);

--- a/apps/desktop/src/renderer/src/lib/utils/batchRequest.test.ts
+++ b/apps/desktop/src/renderer/src/lib/utils/batchRequest.test.ts
@@ -5,7 +5,7 @@ describe("keyed batch requests", () => {
   it("combines same-turn requests and deduplicates keys", async () => {
     let loadCount = 0;
     let loadedKeys: readonly string[] = [];
-    const request = createBatchRequest(async (keys) => {
+    const request = createBatchRequest<string>(async (keys) => {
       loadCount += 1;
       loadedKeys = keys;
     });

--- a/apps/desktop/src/shared/workspace/PortByteStream.test.ts
+++ b/apps/desktop/src/shared/workspace/PortByteStream.test.ts
@@ -21,7 +21,9 @@ describe("bounded byte delivery over a message port", () => {
 
     const [sent, received] = await Promise.all([
       sender.send(stream([1, 2], [3, 4, 5])),
-      receiver.receive((offset, bytes) => writes.push({ offset, bytes: [...bytes] })),
+      receiver.receive((offset, bytes) => {
+        writes.push({ offset, bytes: [...bytes] });
+      }),
     ]);
 
     expect({ sent, received, writes }).toEqual({
@@ -44,7 +46,9 @@ describe("bounded byte delivery over a message port", () => {
 
     await Promise.all([
       sender.send(stream([1, 2, 3, 4, 5]), undefined, 2),
-      receiver.receive((_offset, bytes) => writes.push([...bytes])),
+      receiver.receive((_offset, bytes) => {
+        writes.push([...bytes]);
+      }),
     ]);
 
     expect(writes).toEqual([[1, 2], [3, 4], [5]]);

--- a/apps/desktop/src/shared/workspace/protocol.ts
+++ b/apps/desktop/src/shared/workspace/protocol.ts
@@ -104,9 +104,9 @@ export type ByteStreamControl =
   | { kind: "cancel"; message: string };
 
 /** Minimal readable-stream contract shared by native and web streams. */
-export interface ByteReadableStream<T> {
-  getReader(): ByteReadableStreamReader<T>;
-}
+export type ByteReadableStream<T> =
+  | { getReader(): ByteReadableStreamReader<T> }
+  | ReadableStream<T>;
 
 export interface ByteReadableStreamReader<T> {
   read(): Promise<{ done: false; value: T } | { done: true; value: undefined }>;

--- a/apps/desktop/tsconfig.build.json
+++ b/apps/desktop/tsconfig.build.json
@@ -1,4 +1,3 @@
 {
-  "extends": "./tsconfig.json",
-  "exclude": ["src/**/*.test.ts"]
+  "extends": "./tsconfig.json"
 }


### PR DESCRIPTION
## Summary
- include desktop `.test.ts` files in the normal package typecheck
- update stale fixtures to current workspace, tool-event, stream, and generated type contracts
- keep existing behavioral assertions intact

## Verification
- `pnpm typecheck`
- `pnpm test:desktop` (57 files, 575 tests)
- `pnpm lint:check`
- `pnpm format:check`
