### PR TITLE
Replace the bounding-box Editor fake

### DIFF
--- a/apps/desktop/src/renderer/src/lib/tools/select/BoundingBox.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/BoundingBox.test.ts
@@ -1,154 +1,66 @@
-import { describe, it, expect } from "vitest";
-import { type Point2D, type Rect2D } from "@shift/geo";
-import { asPointId } from "@shift/types";
-import type { Editor } from "@/lib/editor/Editor";
-import { signal } from "@/lib/signals";
-import { SELECT_BOUNDING_BOX_STYLE, SelectBoundingBox } from "./BoundingBox";
-import type { Select } from "./Select";
+import { describe, expect, it } from "vitest";
+import type { Point2D, Rect2D } from "@shift/geo";
+import {
+  getHandlePositions,
+  hitTestResize,
+  hitTestRotationZones,
+  SELECT_BOUNDING_BOX_STYLE,
+} from "./BoundingBox";
 
-const createRect = (x: number, y: number, width: number, height: number): Rect2D => ({
-  x,
-  y,
-  width,
-  height,
-  left: x,
-  top: y,
-  right: x + width,
-  bottom: y + height,
-});
+const RECT: Rect2D = {
+  x: 100,
+  y: 100,
+  width: 200,
+  height: 100,
+  left: 100,
+  top: 100,
+  right: 300,
+  bottom: 200,
+};
+const HANDLES = getHandlePositions(
+  RECT,
+  SELECT_BOUNDING_BOX_STYLE.handle.offsetPx,
+  SELECT_BOUNDING_BOX_STYLE.rotationZoneOffsetPx,
+  "down",
+);
+const HIT_RADIUS = SELECT_BOUNDING_BOX_STYLE.hitRadiusPx;
 
-function createBoundingBox(rect: Rect2D) {
-  const projectSceneToScreen = (scene: Point2D) => ({ x: scene.x, y: -scene.y });
-  const editor = {
-    selection: {
-      stateCell: signal({
-        ids: [asPointId("point_a"), asPointId("point_b")],
-      }),
-    },
-    selectionBoundsCell: signal(rect),
-    camera: {
-      trackViewportTransform: () => {},
-    },
-    projectSceneToScreen,
-    screenToUpmDistance: (pixels: number) => pixels,
-  } as unknown as Editor;
-  const select = {
-    editor,
-    stateCell: signal({ type: "ready" }),
-  } as unknown as Select;
-
-  const boundingBox = new SelectBoundingBox(select);
-
-  return (scene: Point2D) =>
-    boundingBox.hit({
-      screen: projectSceneToScreen(scene),
-      scene,
-    });
+function resizeHit(point: Point2D) {
+  return hitTestResize(RECT, point, HANDLES, HIT_RADIUS);
 }
 
-describe("SelectBoundingBox.hit", () => {
-  const rect = createRect(100, 100, 200, 100);
-  const hit = createBoundingBox(rect);
-  const handleOffset = SELECT_BOUNDING_BOX_STYLE.handle.offsetPx;
-  const rotationZoneOffset = SELECT_BOUNDING_BOX_STYLE.rotationZoneOffsetPx;
+function rotationHit(point: Point2D) {
+  return hitTestRotationZones(point, HANDLES.rotationZones, HIT_RADIUS);
+}
 
-  describe("resize corner handles", () => {
-    it("detects top-left resize handle", () => {
-      expect(hit({ x: 100 - handleOffset, y: 200 + handleOffset })).toMatchObject({
-        type: "resize",
-        edge: "top-left",
-      });
-    });
-
-    it("detects top-right resize handle", () => {
-      expect(hit({ x: 300 + handleOffset, y: 200 + handleOffset })).toMatchObject({
-        type: "resize",
-        edge: "top-right",
-      });
-    });
-
-    it("detects bottom-left resize handle", () => {
-      expect(hit({ x: 100 - handleOffset, y: 100 - handleOffset })).toMatchObject({
-        type: "resize",
-        edge: "bottom-left",
-      });
-    });
-
-    it("detects bottom-right resize handle", () => {
-      expect(hit({ x: 300 + handleOffset, y: 100 - handleOffset })).toMatchObject({
-        type: "resize",
-        edge: "bottom-right",
-      });
-    });
+describe("bounding-box hit classification", () => {
+  it.each([
+    ["top-left", HANDLES.corners.topLeft],
+    ["top-right", HANDLES.corners.topRight],
+    ["bottom-left", HANDLES.corners.bottomLeft],
+    ["bottom-right", HANDLES.corners.bottomRight],
+    ["top", HANDLES.midpoints.top],
+    ["bottom", HANDLES.midpoints.bottom],
+    ["left", HANDLES.midpoints.left],
+    ["right", HANDLES.midpoints.right],
+  ] as const)("classifies the %s resize target", (edge, point) => {
+    expect(resizeHit(point)).toEqual({ type: "resize", edge });
   });
 
-  describe("resize edges", () => {
-    it("detects the top resize edge away from handles", () => {
-      expect(hit({ x: 150, y: 200 + handleOffset })).toMatchObject({
-        type: "resize",
-        edge: "top",
-      });
-    });
-
-    it("detects the bottom resize edge away from handles", () => {
-      expect(hit({ x: 250, y: 100 - handleOffset })).toMatchObject({
-        type: "resize",
-        edge: "bottom",
-      });
-    });
-
-    it("detects the left resize edge away from handles", () => {
-      expect(hit({ x: 100 - handleOffset, y: 140 })).toMatchObject({
-        type: "resize",
-        edge: "left",
-      });
-    });
-
-    it("detects the right resize edge away from handles", () => {
-      expect(hit({ x: 300 + handleOffset, y: 160 })).toMatchObject({
-        type: "resize",
-        edge: "right",
-      });
-    });
+  it.each([
+    ["top-left", HANDLES.rotationZones.topLeft],
+    ["top-right", HANDLES.rotationZones.topRight],
+    ["bottom-left", HANDLES.rotationZones.bottomLeft],
+    ["bottom-right", HANDLES.rotationZones.bottomRight],
+  ] as const)("classifies the %s rotation target", (corner, point) => {
+    expect(rotationHit(point)).toEqual({ type: "rotate", corner });
   });
 
-  describe("rotation zones", () => {
-    it("detects top-left rotation zone", () => {
-      expect(hit({ x: 100 - rotationZoneOffset, y: 200 + rotationZoneOffset })).toMatchObject({
-        type: "rotate",
-        corner: "top-left",
-      });
-    });
-
-    it("detects top-right rotation zone", () => {
-      expect(hit({ x: 300 + rotationZoneOffset, y: 200 + rotationZoneOffset })).toMatchObject({
-        type: "rotate",
-        corner: "top-right",
-      });
-    });
-
-    it("detects bottom-left rotation zone", () => {
-      expect(hit({ x: 100 - rotationZoneOffset, y: 100 - rotationZoneOffset })).toMatchObject({
-        type: "rotate",
-        corner: "bottom-left",
-      });
-    });
-
-    it("detects bottom-right rotation zone", () => {
-      expect(hit({ x: 300 + rotationZoneOffset, y: 100 - rotationZoneOffset })).toMatchObject({
-        type: "rotate",
-        corner: "bottom-right",
-      });
-    });
-  });
-
-  describe("no hit", () => {
-    it("returns null when clicking inside the bounding box", () => {
-      expect(hit({ x: 200, y: 150 })).toBeNull();
-    });
-
-    it("returns null when clicking far outside the bounding box", () => {
-      expect(hit({ x: 500, y: 500 })).toBeNull();
-    });
+  it.each([
+    ["inside", { x: 200, y: 150 }],
+    ["far outside", { x: 500, y: 500 }],
+  ] as const)("returns no target %s the bounding box", (_description, point) => {
+    expect(resizeHit(point)).toBeNull();
+    expect(rotationHit(point)).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/src/lib/tools/select/BoundingBox.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/BoundingBox.ts
@@ -274,7 +274,7 @@ function getExpandedHandleRect(
   };
 }
 
-function getHandlePositions(
+export function getHandlePositions(
   rect: Rect2D,
   handleOffset: number,
   rotationZoneOffset: number,
@@ -393,7 +393,7 @@ function drawHandle(
   canvas.ctx.restore();
 }
 
-function hitTestRotationZones(
+export function hitTestRotationZones(
   pos: Point2D,
   rotationZones: HandlePositions["rotationZones"],
   hitRadius: number,
@@ -418,7 +418,7 @@ function rectCenter(rect: Rect2D): Point2D {
   return Vec2.midpoint({ x: rect.left, y: rect.top }, { x: rect.right, y: rect.bottom });
 }
 
-function hitTestResize(
+export function hitTestResize(
   rect: Rect2D,
   pos: Point2D,
   handles: HandlePositions,


### PR DESCRIPTION
## Summary
- remove the partial `Editor`/`Select` objects from bounding-box tests
- exercise the existing resize and rotation classifiers as pure behavior
- retain real resize and rotation outcomes in `Select.test.ts` through `TestEditor`

## Stack
- depends on #199

## Verification
- `pnpm test:desktop src/renderer/src/lib/tools/select/BoundingBox.test.ts src/renderer/src/lib/tools/select/Select.test.ts`
- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm format:check`
