### PR TITLE
Keep tool lifecycle state signals coherent

### DIFF
--- a/apps/desktop/src/renderer/src/lib/tools/docs/DOCS.md
+++ b/apps/desktop/src/renderer/src/lib/tools/docs/DOCS.md
@@ -6,6 +6,8 @@ State machine-based tool system for the Shift font editor: translates pointer/ke
 
 - **Architecture Invariant:** Every tool must call `activate()` to leave `"idle"` state. `BaseTool` skips the behavior loop entirely when `state.type === "idle"`, so a tool that forgets `activate()` will silently ignore all events.
 
+- **Architecture Invariant:** Lifecycle methods mutate tool state through `BaseTool.setState()`, never by assigning `this.state`. The method publishes one coherent value to `state`, `stateCell`, and the editor's active-tool state; direct assignment leaves cursor and editing computations stale.
+
 - **Architecture Invariant:** Behaviors are tried in **array order**; first handler that returns `true` wins. Reordering the `behaviors` array changes tool semantics. **CRITICAL**: placing a broad handler (e.g. `Selection`) before a narrow one (e.g. `ToggleSmooth`) will shadow the narrow handler.
 
 - **Architecture Invariant:** Behaviors are stateless transition rules. All mutable state lives in the tool state union `S` or on `Editor`. Behaviors must not hold state that survives across events unless that resource is cleaned up in `onStateEnter`/`onStateExit`.
@@ -87,7 +89,7 @@ After `#runBehaviors`, if `next !== prev` (reference equality):
 
 1. **Batch** all side effects inside a single reactive `batch()`.
 2. Call `onStateExit` on every behavior (receives `prev`, `next`, a pre-commit context).
-3. Commit: `this.state = next`, `editor.setActiveToolState(next)`.
+3. Commit through `setState(next)`, publishing `state`, `stateCell`, and `editor.setActiveToolState(next)` together.
 4. Call `onStateEnter` on every behavior (receives `prev`, `next`, a post-commit context where `setState` updates `this.state`).
 5. Call `onStateChange(prev, next, event)` if defined on the tool.
 
@@ -131,7 +133,7 @@ All three receive a `Canvas` instance.
    - Set `readonly id: ToolName = "myTool"`.
    - Declare `readonly behaviors: Behavior<MyState>[] = [...]`.
    - Implement `initialState()` returning `{ type: "idle" }`.
-   - Implement `activate()` setting `this.state = { type: "ready" }`.
+   - Implement `activate()` with `this.setState({ type: "ready" })`.
 3. Optionally add `static stateSpec = defineStateDiagram(...)` for compliance testing.
 4. Register in `registerBuiltInTools` (`tools.ts`): `editor.registerTool({ id, create, icon, tooltip, shortcut? })`.
 

--- a/apps/desktop/src/renderer/src/lib/tools/hand/Hand.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/hand/Hand.test.ts
@@ -11,6 +11,20 @@ describe("Hand tool", () => {
     editor.selectTool("hand");
   });
 
+  it("publishes ready and idle states through activation and deactivation", () => {
+    const hand = editor.toolManager.activeTool;
+    if (!hand) throw new Error("Expected active Hand tool");
+
+    expect(hand.getState()).toEqual({ type: "ready" });
+    expect(hand.stateCell.value).toEqual({ type: "ready" });
+    expect(editor.getActiveToolState()).toEqual({ type: "ready" });
+
+    editor.selectTool("select");
+
+    expect(hand.getState()).toEqual({ type: "idle" });
+    expect(hand.stateCell.value).toEqual({ type: "idle" });
+  });
+
   it("drag pans the viewport by the screen delta", () => {
     const startPan = editor.pan;
 

--- a/apps/desktop/src/renderer/src/lib/tools/hand/Hand.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/hand/Hand.ts
@@ -24,13 +24,13 @@ export class Hand extends BaseTool<HandState> {
     this.#stashedEditingNodes = [...this.editor.editing.nodeIds];
     this.editor.editing.clear();
 
-    this.state = { type: "ready" };
+    this.setState({ type: "ready" });
   }
 
   override deactivate(): void {
     this.editor.editing.set(this.#stashedEditingNodes);
     this.#stashedEditingNodes = [];
 
-    this.state = { type: "idle" };
+    this.setState({ type: "idle" });
   }
 }

--- a/apps/desktop/src/renderer/src/lib/tools/shape/Shape.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/shape/Shape.test.ts
@@ -14,6 +14,20 @@ describe("Shape tool", () => {
 
   const contours = () => editor.glyphLayer?.geometry.contours ?? [];
 
+  it("publishes ready and idle states through activation and deactivation", () => {
+    const shape = editor.toolManager.activeTool;
+    if (!shape) throw new Error("Expected active Shape tool");
+
+    expect(shape.getState()).toEqual({ type: "ready" });
+    expect(shape.stateCell.value).toEqual({ type: "ready" });
+    expect(editor.getActiveToolState()).toEqual({ type: "ready" });
+
+    editor.selectTool("select");
+
+    expect(shape.getState()).toEqual({ type: "idle" });
+    expect(shape.stateCell.value).toEqual({ type: "idle" });
+  });
+
   it("drag then release commits a closed 4-point rectangle contour", async () => {
     const contoursBefore = contours().length;
 

--- a/apps/desktop/src/renderer/src/lib/tools/shape/Shape.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/shape/Shape.ts
@@ -44,11 +44,11 @@ export class Shape extends BaseTool<ShapeState> {
   }
 
   override activate(): void {
-    this.state = { type: "ready" };
+    this.setState({ type: "ready" });
   }
 
   override deactivate(): void {
-    this.state = { type: "idle" };
+    this.setState({ type: "idle" });
   }
 
   override drawOverlay(canvas: Canvas): void {

--- a/apps/desktop/src/renderer/src/lib/tools/text/Text.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/Text.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { TestEditor } from "@/testing/TestEditor";
+
+describe("Text tool", () => {
+  let editor: TestEditor;
+
+  beforeEach(async () => {
+    editor = new TestEditor();
+    await editor.startSession();
+    editor.selectTool("text");
+  });
+
+  it("publishes typing until Escape returns to Select", () => {
+    const text = editor.toolManager.activeTool;
+    if (!text) throw new Error("Expected active Text tool");
+
+    expect(text.getState()).toEqual({ type: "typing" });
+    expect(text.stateCell.value).toEqual({ type: "typing" });
+    expect(editor.getActiveToolState()).toEqual({ type: "typing" });
+    expect(editor.cursor).toBe("text");
+
+    editor.escape();
+
+    expect(editor.toolManager.activeToolId).toBe("select");
+    expect(editor.getActiveToolState()).toEqual({ type: "ready" });
+    expect(text.getState()).toEqual({ type: "idle" });
+    expect(text.stateCell.value).toEqual({ type: "idle" });
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/tools/text/Text.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/Text.ts
@@ -17,13 +17,13 @@ export class TextTool extends BaseTool<TextState> {
   }
 
   override activate(): void {
-    this.state = { type: "typing" };
+    this.setState({ type: "typing" });
   }
 
   override deactivate(): void {
     const run = this.editor.textRun;
     run.setCursorVisible(false);
     run.interaction.resume();
-    this.state = { type: "idle" };
+    this.setState({ type: "idle" });
   }
 }


### PR DESCRIPTION
## Summary
- route Hand, Shape, and Text activation/deactivation through `BaseTool.setState()`
- protect lifecycle state, state signal, editor state, and Text cursor outcomes through `TestEditor`
- document `setState()` as the canonical lifecycle mutation boundary

## State contract
- Hand and Shape: `idle -> ready`, then `ready -> idle` on deactivation
- Text: `idle -> typing`, then Escape switches to Select and leaves Text `idle`
- existing drag/cancel semantics are unchanged

## Stack
- depends on #200 (and #199)

## Verification
- `pnpm test:desktop` (58 files, 578 tests)
- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm format:check`
- `python3 scripts/context-drift-check.py` still reports the repository's 22 pre-existing documentation warnings; no tools-doc warning
