### PR TITLE
Fix angle snap hysteresis across boundaries

### DIFF
--- a/apps/desktop/src/renderer/src/lib/model/positions/AngleSnap.test.ts
+++ b/apps/desktop/src/renderer/src/lib/model/positions/AngleSnap.test.ts
@@ -10,12 +10,12 @@ describe("angle snapping keeps interaction direction stable", () => {
     expect(snap.apply(degrees(44))).toBeCloseTo(degrees(45));
   });
 
-  it("sticks to the previous angle inside the hysteresis threshold", () => {
+  it("sticks to the previous angle across the rounding boundary", () => {
     const snap = AngleSnap.everyDegrees(45);
 
-    expect(snap.apply(degrees(2))).toBeCloseTo(0);
-    expect(snap.apply(degrees(17))).toBeCloseTo(0);
     expect(snap.apply(degrees(24))).toBeCloseTo(degrees(45));
+    expect(snap.apply(degrees(21))).toBeCloseTo(degrees(45));
+    expect(snap.apply(degrees(17))).toBeCloseTo(0);
   });
 
   it("resets hysteresis while its condition is inactive", () => {

--- a/apps/desktop/src/renderer/src/lib/model/positions/AngleSnap.ts
+++ b/apps/desktop/src/renderer/src/lib/model/positions/AngleSnap.ts
@@ -1,6 +1,6 @@
 import type { PositionCondition } from "@/types/positionEdit";
 
-const HYSTERESIS_FACTOR = 0.4;
+const HYSTERESIS_FACTOR = 0.6;
 
 /** Quantizes scalar rotation angles while preserving the previous snap near boundaries. */
 export class AngleSnap {


### PR DESCRIPTION
## Summary

Follow-up to #198.

- retain the previous angle snap across the ordinary nearest-angle rounding boundary
- release it after the raw angle exceeds 60% of the configured increment
- test both retention and release while crossing back over a boundary

Without this overlap, the previous 40% threshold was already outside the normal 50% rounding cell and provided no effective hysteresis.

## Validation

- `pnpm test:desktop src/renderer/src/lib/model/positions/AngleSnap.test.ts src/renderer/src/lib/model/positions/PositionEdits.test.ts` — 9 passed
- `pnpm typecheck` — passed
- formatting and commit checks — passed
