### PR TITLE
test: replace bounding box editor fake

### DIFF
--- a/apps/desktop/src/renderer/src/lib/tools/docs/DOCS.md
+++ b/apps/desktop/src/renderer/src/lib/tools/docs/DOCS.md
@@ -6,6 +6,8 @@ State machine-based tool system for the Shift font editor: translates pointer/ke
 
 - **Architecture Invariant:** Every tool must call `activate()` to leave `"idle"` state. `BaseTool` skips the behavior loop entirely when `state.type === "idle"`, so a tool that forgets `activate()` will silently ignore all events.
 
+- **Architecture Invariant:** Lifecycle methods mutate tool state through `BaseTool.setState()`, never by assigning `this.state`. The method publishes one coherent value to `state`, `stateCell`, and the editor's active-tool state; direct assignment leaves cursor and editing computations stale.
+
 - **Architecture Invariant:** Behaviors are tried in **array order**; first handler that returns `true` wins. Reordering the `behaviors` array changes tool semantics. **CRITICAL**: placing a broad handler (e.g. `Selection`) before a narrow one (e.g. `ToggleSmooth`) will shadow the narrow handler.
 
 - **Architecture Invariant:** Behaviors are stateless transition rules. All mutable state lives in the tool state union `S` or on `Editor`. Behaviors must not hold state that survives across events unless that resource is cleaned up in `onStateEnter`/`onStateExit`.
@@ -87,7 +89,7 @@ After `#runBehaviors`, if `next !== prev` (reference equality):
 
 1. **Batch** all side effects inside a single reactive `batch()`.
 2. Call `onStateExit` on every behavior (receives `prev`, `next`, a pre-commit context).
-3. Commit: `this.state = next`, `editor.setActiveToolState(next)`.
+3. Commit through `setState(next)`, publishing `state`, `stateCell`, and `editor.setActiveToolState(next)` together.
 4. Call `onStateEnter` on every behavior (receives `prev`, `next`, a post-commit context where `setState` updates `this.state`).
 5. Call `onStateChange(prev, next, event)` if defined on the tool.
 
@@ -131,7 +133,7 @@ All three receive a `Canvas` instance.
    - Set `readonly id: ToolName = "myTool"`.
    - Declare `readonly behaviors: Behavior<MyState>[] = [...]`.
    - Implement `initialState()` returning `{ type: "idle" }`.
-   - Implement `activate()` setting `this.state = { type: "ready" }`.
+   - Implement `activate()` with `this.setState({ type: "ready" })`.
 3. Optionally add `static stateSpec = defineStateDiagram(...)` for compliance testing.
 4. Register in `registerBuiltInTools` (`tools.ts`): `editor.registerTool({ id, create, icon, tooltip, shortcut? })`.
 

--- a/apps/desktop/src/renderer/src/lib/tools/hand/Hand.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/hand/Hand.test.ts
@@ -11,6 +11,20 @@ describe("Hand tool", () => {
     editor.selectTool("hand");
   });
 
+  it("publishes ready and idle states through activation and deactivation", () => {
+    const hand = editor.toolManager.activeTool;
+    if (!hand) throw new Error("Expected active Hand tool");
+
+    expect(hand.getState()).toEqual({ type: "ready" });
+    expect(hand.stateCell.value).toEqual({ type: "ready" });
+    expect(editor.getActiveToolState()).toEqual({ type: "ready" });
+
+    editor.selectTool("select");
+
+    expect(hand.getState()).toEqual({ type: "idle" });
+    expect(hand.stateCell.value).toEqual({ type: "idle" });
+  });
+
   it("drag pans the viewport by the screen delta", () => {
     const startPan = editor.pan;
 

--- a/apps/desktop/src/renderer/src/lib/tools/hand/Hand.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/hand/Hand.ts
@@ -24,13 +24,13 @@ export class Hand extends BaseTool<HandState> {
     this.#stashedEditingNodes = [...this.editor.editing.nodeIds];
     this.editor.editing.clear();
 
-    this.state = { type: "ready" };
+    this.setState({ type: "ready" });
   }
 
   override deactivate(): void {
     this.editor.editing.set(this.#stashedEditingNodes);
     this.#stashedEditingNodes = [];
 
-    this.state = { type: "idle" };
+    this.setState({ type: "idle" });
   }
 }

--- a/apps/desktop/src/renderer/src/lib/tools/select/BoundingBox.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/BoundingBox.test.ts
@@ -1,154 +1,66 @@
-import { describe, it, expect } from "vitest";
-import { type Point2D, type Rect2D } from "@shift/geo";
-import { asPointId } from "@shift/types";
-import type { Editor } from "@/lib/editor/Editor";
-import { signal } from "@/lib/signals";
-import { SELECT_BOUNDING_BOX_STYLE, SelectBoundingBox } from "./BoundingBox";
-import type { Select } from "./Select";
+import { describe, expect, it } from "vitest";
+import type { Point2D, Rect2D } from "@shift/geo";
+import {
+  getHandlePositions,
+  hitTestResize,
+  hitTestRotationZones,
+  SELECT_BOUNDING_BOX_STYLE,
+} from "./BoundingBox";
 
-const createRect = (x: number, y: number, width: number, height: number): Rect2D => ({
-  x,
-  y,
-  width,
-  height,
-  left: x,
-  top: y,
-  right: x + width,
-  bottom: y + height,
-});
+const RECT: Rect2D = {
+  x: 100,
+  y: 100,
+  width: 200,
+  height: 100,
+  left: 100,
+  top: 100,
+  right: 300,
+  bottom: 200,
+};
+const HANDLES = getHandlePositions(
+  RECT,
+  SELECT_BOUNDING_BOX_STYLE.handle.offsetPx,
+  SELECT_BOUNDING_BOX_STYLE.rotationZoneOffsetPx,
+  "down",
+);
+const HIT_RADIUS = SELECT_BOUNDING_BOX_STYLE.hitRadiusPx;
 
-function createBoundingBox(rect: Rect2D) {
-  const projectSceneToScreen = (scene: Point2D) => ({ x: scene.x, y: -scene.y });
-  const editor = {
-    selection: {
-      stateCell: signal({
-        ids: [asPointId("point_a"), asPointId("point_b")],
-      }),
-    },
-    selectionBoundsCell: signal(rect),
-    camera: {
-      trackViewportTransform: () => {},
-    },
-    projectSceneToScreen,
-    screenToUpmDistance: (pixels: number) => pixels,
-  } as unknown as Editor;
-  const select = {
-    editor,
-    stateCell: signal({ type: "ready" }),
-  } as unknown as Select;
-
-  const boundingBox = new SelectBoundingBox(select);
-
-  return (scene: Point2D) =>
-    boundingBox.hit({
-      screen: projectSceneToScreen(scene),
-      scene,
-    });
+function resizeHit(point: Point2D) {
+  return hitTestResize(RECT, point, HANDLES, HIT_RADIUS);
 }
 
-describe("SelectBoundingBox.hit", () => {
-  const rect = createRect(100, 100, 200, 100);
-  const hit = createBoundingBox(rect);
-  const handleOffset = SELECT_BOUNDING_BOX_STYLE.handle.offsetPx;
-  const rotationZoneOffset = SELECT_BOUNDING_BOX_STYLE.rotationZoneOffsetPx;
+function rotationHit(point: Point2D) {
+  return hitTestRotationZones(point, HANDLES.rotationZones, HIT_RADIUS);
+}
 
-  describe("resize corner handles", () => {
-    it("detects top-left resize handle", () => {
-      expect(hit({ x: 100 - handleOffset, y: 200 + handleOffset })).toMatchObject({
-        type: "resize",
-        edge: "top-left",
-      });
-    });
-
-    it("detects top-right resize handle", () => {
-      expect(hit({ x: 300 + handleOffset, y: 200 + handleOffset })).toMatchObject({
-        type: "resize",
-        edge: "top-right",
-      });
-    });
-
-    it("detects bottom-left resize handle", () => {
-      expect(hit({ x: 100 - handleOffset, y: 100 - handleOffset })).toMatchObject({
-        type: "resize",
-        edge: "bottom-left",
-      });
-    });
-
-    it("detects bottom-right resize handle", () => {
-      expect(hit({ x: 300 + handleOffset, y: 100 - handleOffset })).toMatchObject({
-        type: "resize",
-        edge: "bottom-right",
-      });
-    });
+describe("bounding-box hit classification", () => {
+  it.each([
+    ["top-left", HANDLES.corners.topLeft],
+    ["top-right", HANDLES.corners.topRight],
+    ["bottom-left", HANDLES.corners.bottomLeft],
+    ["bottom-right", HANDLES.corners.bottomRight],
+    ["top", HANDLES.midpoints.top],
+    ["bottom", HANDLES.midpoints.bottom],
+    ["left", HANDLES.midpoints.left],
+    ["right", HANDLES.midpoints.right],
+  ] as const)("classifies the %s resize target", (edge, point) => {
+    expect(resizeHit(point)).toEqual({ type: "resize", edge });
   });
 
-  describe("resize edges", () => {
-    it("detects the top resize edge away from handles", () => {
-      expect(hit({ x: 150, y: 200 + handleOffset })).toMatchObject({
-        type: "resize",
-        edge: "top",
-      });
-    });
-
-    it("detects the bottom resize edge away from handles", () => {
-      expect(hit({ x: 250, y: 100 - handleOffset })).toMatchObject({
-        type: "resize",
-        edge: "bottom",
-      });
-    });
-
-    it("detects the left resize edge away from handles", () => {
-      expect(hit({ x: 100 - handleOffset, y: 140 })).toMatchObject({
-        type: "resize",
-        edge: "left",
-      });
-    });
-
-    it("detects the right resize edge away from handles", () => {
-      expect(hit({ x: 300 + handleOffset, y: 160 })).toMatchObject({
-        type: "resize",
-        edge: "right",
-      });
-    });
+  it.each([
+    ["top-left", HANDLES.rotationZones.topLeft],
+    ["top-right", HANDLES.rotationZones.topRight],
+    ["bottom-left", HANDLES.rotationZones.bottomLeft],
+    ["bottom-right", HANDLES.rotationZones.bottomRight],
+  ] as const)("classifies the %s rotation target", (corner, point) => {
+    expect(rotationHit(point)).toEqual({ type: "rotate", corner });
   });
 
-  describe("rotation zones", () => {
-    it("detects top-left rotation zone", () => {
-      expect(hit({ x: 100 - rotationZoneOffset, y: 200 + rotationZoneOffset })).toMatchObject({
-        type: "rotate",
-        corner: "top-left",
-      });
-    });
-
-    it("detects top-right rotation zone", () => {
-      expect(hit({ x: 300 + rotationZoneOffset, y: 200 + rotationZoneOffset })).toMatchObject({
-        type: "rotate",
-        corner: "top-right",
-      });
-    });
-
-    it("detects bottom-left rotation zone", () => {
-      expect(hit({ x: 100 - rotationZoneOffset, y: 100 - rotationZoneOffset })).toMatchObject({
-        type: "rotate",
-        corner: "bottom-left",
-      });
-    });
-
-    it("detects bottom-right rotation zone", () => {
-      expect(hit({ x: 300 + rotationZoneOffset, y: 100 - rotationZoneOffset })).toMatchObject({
-        type: "rotate",
-        corner: "bottom-right",
-      });
-    });
-  });
-
-  describe("no hit", () => {
-    it("returns null when clicking inside the bounding box", () => {
-      expect(hit({ x: 200, y: 150 })).toBeNull();
-    });
-
-    it("returns null when clicking far outside the bounding box", () => {
-      expect(hit({ x: 500, y: 500 })).toBeNull();
-    });
+  it.each([
+    ["inside", { x: 200, y: 150 }],
+    ["far outside", { x: 500, y: 500 }],
+  ] as const)("returns no target %s the bounding box", (_description, point) => {
+    expect(resizeHit(point)).toBeNull();
+    expect(rotationHit(point)).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/src/lib/tools/select/BoundingBox.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/BoundingBox.ts
@@ -274,7 +274,7 @@ function getExpandedHandleRect(
   };
 }
 
-function getHandlePositions(
+export function getHandlePositions(
   rect: Rect2D,
   handleOffset: number,
   rotationZoneOffset: number,
@@ -393,7 +393,7 @@ function drawHandle(
   canvas.ctx.restore();
 }
 
-function hitTestRotationZones(
+export function hitTestRotationZones(
   pos: Point2D,
   rotationZones: HandlePositions["rotationZones"],
   hitRadius: number,
@@ -418,7 +418,7 @@ function rectCenter(rect: Rect2D): Point2D {
   return Vec2.midpoint({ x: rect.left, y: rect.top }, { x: rect.right, y: rect.bottom });
 }
 
-function hitTestResize(
+export function hitTestResize(
   rect: Rect2D,
   pos: Point2D,
   handles: HandlePositions,

--- a/apps/desktop/src/renderer/src/lib/tools/shape/Shape.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/shape/Shape.test.ts
@@ -14,6 +14,20 @@ describe("Shape tool", () => {
 
   const contours = () => editor.glyphLayer?.geometry.contours ?? [];
 
+  it("publishes ready and idle states through activation and deactivation", () => {
+    const shape = editor.toolManager.activeTool;
+    if (!shape) throw new Error("Expected active Shape tool");
+
+    expect(shape.getState()).toEqual({ type: "ready" });
+    expect(shape.stateCell.value).toEqual({ type: "ready" });
+    expect(editor.getActiveToolState()).toEqual({ type: "ready" });
+
+    editor.selectTool("select");
+
+    expect(shape.getState()).toEqual({ type: "idle" });
+    expect(shape.stateCell.value).toEqual({ type: "idle" });
+  });
+
   it("drag then release commits a closed 4-point rectangle contour", async () => {
     const contoursBefore = contours().length;
 

--- a/apps/desktop/src/renderer/src/lib/tools/shape/Shape.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/shape/Shape.ts
@@ -44,11 +44,11 @@ export class Shape extends BaseTool<ShapeState> {
   }
 
   override activate(): void {
-    this.state = { type: "ready" };
+    this.setState({ type: "ready" });
   }
 
   override deactivate(): void {
-    this.state = { type: "idle" };
+    this.setState({ type: "idle" });
   }
 
   override drawOverlay(canvas: Canvas): void {

--- a/apps/desktop/src/renderer/src/lib/tools/text/Text.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/Text.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { TestEditor } from "@/testing/TestEditor";
+
+describe("Text tool", () => {
+  let editor: TestEditor;
+
+  beforeEach(async () => {
+    editor = new TestEditor();
+    await editor.startSession();
+    editor.selectTool("text");
+  });
+
+  it("publishes typing until Escape returns to Select", () => {
+    const text = editor.toolManager.activeTool;
+    if (!text) throw new Error("Expected active Text tool");
+
+    expect(text.getState()).toEqual({ type: "typing" });
+    expect(text.stateCell.value).toEqual({ type: "typing" });
+    expect(editor.getActiveToolState()).toEqual({ type: "typing" });
+    expect(editor.cursor).toBe("text");
+
+    editor.escape();
+
+    expect(editor.toolManager.activeToolId).toBe("select");
+    expect(editor.getActiveToolState()).toEqual({ type: "ready" });
+    expect(text.getState()).toEqual({ type: "idle" });
+    expect(text.stateCell.value).toEqual({ type: "idle" });
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/tools/text/Text.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/Text.ts
@@ -17,13 +17,13 @@ export class TextTool extends BaseTool<TextState> {
   }
 
   override activate(): void {
-    this.state = { type: "typing" };
+    this.setState({ type: "typing" });
   }
 
   override deactivate(): void {
     const run = this.editor.textRun;
     run.setCursorVisible(false);
     run.interaction.resume();
-    this.state = { type: "idle" };
+    this.setState({ type: "idle" });
   }
 }


### PR DESCRIPTION
Repairs the coverage stack after #200 was merged into its intermediate parent branch rather than main. Extracts pure bounding-box classifiers while real Select tests continue to cover editor resize and rotation outcomes.