### PR TITLE
refactor: unify active tool state surface

### DIFF
--- a/apps/desktop/src/renderer/src/components/debug/DebugPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/debug/DebugPanel.tsx
@@ -19,9 +19,8 @@ export function DebugPanel() {
   }, [editor]);
 
   const toolStateRef = useSignalText(() => {
-    const name = editor.getActiveTool();
-    const state = editor.getActiveToolState();
-    return `${name}.${state.type}`;
+    const tool = editor.toolCell.value;
+    return tool ? `${tool.id}.${tool.state.type}` : "none.idle";
   });
 
   const fpsRef = useSignalText(() => {

--- a/apps/desktop/src/renderer/src/components/editor/ToolsPane.tsx
+++ b/apps/desktop/src/renderer/src/components/editor/ToolsPane.tsx
@@ -43,7 +43,7 @@ export const ToolbarIcon: FC<ToolbarIconProps> = ({ Icon, name, tooltip, activeT
 
 export const ToolsPane: FC = () => {
   const editor = useEditor();
-  const activeTool = useSignalState(editor.activeToolCell);
+  const activeTool = useSignalState(editor.toolCell)?.id ?? null;
 
   return (
     <section className="flex flex-col items-center justify-center gap-2">

--- a/apps/desktop/src/renderer/src/components/text/HiddenTextInput.tsx
+++ b/apps/desktop/src/renderer/src/components/text/HiddenTextInput.tsx
@@ -17,7 +17,7 @@ export function TextInput() {
 
   useEffect(() => {
     const fx = effect(() => {
-      setIsTextTool(editor.activeToolCell.value === "text");
+      setIsTextTool(editor.toolCell.value?.id === "text");
     });
     return () => fx.dispose();
   }, [editor]);
@@ -30,7 +30,7 @@ export function TextInput() {
       node.focus();
 
       const handleFocusLost = () => {
-        if (editor.getActiveTool() === "text") {
+        if (editor.toolIf("text")) {
           setTimeout(() => node.focus(), 0);
         }
       };

--- a/apps/desktop/src/renderer/src/lib/editor/Editor.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/Editor.ts
@@ -18,7 +18,7 @@ import { isSegmentId, type SegmentId } from "@shift/glyph-state";
 import type { ExternalAxisLocation } from "@/types/variation";
 import type { Coordinates, NodePoint, ScenePoint } from "@/types/coordinates";
 import { cloneExternalAxisLocation, emptyExternalAxisLocation } from "@/lib/variation/location";
-import type { ToolName, ActiveToolState } from "../tools/core";
+import type { ActiveTool, ToolName } from "../tools/core";
 import { ToolManager } from "../tools/core/ToolManager";
 import { Bounds, Vec2, type Bounds as BoundsType, type Point2D, type Rect2D } from "@shift/geo";
 
@@ -153,8 +153,8 @@ export class Editor {
       shortcut?: string;
     }
   >;
-  #activeTool: Signal<ToolName | null>;
-  #activeToolState: WritableSignal<ActiveToolState>;
+  #tool: Signal<ActiveTool | null>;
+  #dragging: Signal<boolean>;
   #isEditing: Signal<boolean>;
   #selectionBounds: Signal<Rect2D | null>;
 
@@ -243,18 +243,24 @@ export class Editor {
     );
 
     this.#toolMetadata = new Map();
-    this.#activeToolState = signal<ActiveToolState>(
-      { type: "idle" },
-      {
-        name: "editor.tool.state",
-      },
-    );
 
     // TODO: why not make editor extend EventEmitter?
     this.#events = new EventEmitter();
     this.#toolManager = new ToolManager(this);
-    this.#activeTool = computed(() => this.#toolManager.activeToolCell.value?.id ?? null, {
-      name: "editor.tool.active",
+    this.#tool = computed<ActiveTool | null>(
+      () => {
+        const activeTool = this.#toolManager.activeToolCell.value;
+        if (!activeTool) return null;
+
+        return {
+          id: activeTool.id,
+          state: activeTool.stateCell.value,
+        };
+      },
+      { name: "editor.tool" },
+    );
+    this.#dragging = computed(() => this.gesture.cell.value.phase === "dragging", {
+      name: "editor.dragging",
     });
     this.#isEditing = computed(
       () => this.#toolManager.activeToolCell.value?.isEditingCell.value ?? false,
@@ -320,29 +326,37 @@ export class Editor {
     return out;
   }
 
-  public get activeTool(): ToolName | null {
-    return this.#activeTool.peek();
+  /** Returns the current active tool snapshot, or null before a tool is activated. */
+  public get tool(): ActiveTool | null {
+    return this.#tool.peek();
   }
 
-  public get activeToolCell(): Signal<ToolName | null> {
-    return this.#activeTool;
-  }
-
-  // oxlint-disable-next-line shift/no-get-signal-value-method -- retained for upcoming tool refactor
-  public getActiveTool(): ToolName | null {
-    return this.#activeTool.peek();
+  /** Exposes the live active tool identity and state as one reactive value. */
+  public get toolCell(): Signal<ActiveTool | null> {
+    return this.#tool;
   }
 
   /**
-   * Typed as `ActiveToolState` (which is `any`) because each tool defines its
-   * own state shape. Consumers should narrow the type based on `activeTool`.
+   * Returns the active tool narrowed to the requested identity.
+   *
+   * @param id - Tool identity whose current state the caller needs.
+   * @returns The active tool snapshot when its identity matches; otherwise null.
    */
-  public get activeToolState(): ActiveToolState {
-    return this.#activeToolState.peek();
+  public toolIf<Id extends ToolName>(id: Id): ActiveTool<Id> | null {
+    const tool = this.#tool.peek();
+    if (tool?.id !== id) return null;
+
+    return tool as ActiveTool<Id>;
   }
 
-  public get activeToolStateCell(): Signal<ActiveToolState> {
-    return this.#activeToolState;
+  /** Returns whether a pointer drag gesture is currently in flight. */
+  public get isDragging(): boolean {
+    return this.#dragging.peek();
+  }
+
+  /** Exposes the live pointer-drag phase independently of tool state names. */
+  public get draggingCell(): Signal<boolean> {
+    return this.#dragging;
   }
 
   public get isEditing(): boolean {
@@ -351,15 +365,6 @@ export class Editor {
 
   public get isEditingCell(): Signal<boolean> {
     return this.#isEditing;
-  }
-
-  // oxlint-disable-next-line shift/no-get-signal-value-method -- retained for upcoming tool refactor
-  public getActiveToolState(): ActiveToolState {
-    return this.#activeToolState.peek();
-  }
-
-  public setActiveToolState(state: ActiveToolState): void {
-    this.#activeToolState.set(state);
   }
 
   public setActiveTool(toolName: ToolName): void {

--- a/apps/desktop/src/renderer/src/lib/editor/docs/DOCS.md
+++ b/apps/desktop/src/renderer/src/lib/editor/docs/DOCS.md
@@ -26,6 +26,8 @@ Central orchestrator for the canvas-based glyph editing surface, wiring viewport
 
 **Architecture Invariant:** Lifecycle events (`EventEmitter`) are for one-shot imperative actions (`fontLoaded`, `fontSaved`, `destroying`). Continuous state changes use signals. Do not mix the two patterns.
 
+**Architecture Invariant:** `Editor.toolCell` is the public active-tool state surface. It derives `{ id, state }` from the active tool instance and its `stateCell`; consumers use `toolIf(id)` for built-in state narrowing and do not reach through `ToolManager` for active state.
+
 **Architecture Invariant:** Camera and text-layout metrics resolve from the active design location through `Font.metricsAtLocation()`. Exact master locations use authored source values; intermediate locations evaluate the Rust-built source-metric interpolation model.
 
 **Architecture Invariant:** `Selection` is a dumb ordered set of branded object IDs. Mutations go through `select()`, `add()`, `remove()`, and `toggle()`; behavior and live bounds come from resolving those IDs through `Editor.object()`.

--- a/apps/desktop/src/renderer/src/lib/editor/rendering/RenderFrame.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/rendering/RenderFrame.ts
@@ -44,8 +44,7 @@ export class BackgroundLayer extends CanvasItem<BackgroundLayerProps> {
 
   protected props(): BackgroundLayerProps | null {
     this.#editor.camera.trackViewportTransform();
-    this.#editor.activeToolCell.value;
-    this.#editor.activeToolStateCell.value;
+    this.#editor.toolCell.value;
     this.#editor.editing.stateCell.value;
     this.#editor.scene.cell.value;
 
@@ -110,8 +109,7 @@ export class SceneLayer extends CanvasItem<SceneLayerProps> {
     this.#editor.camera.trackViewportTransform();
 
     // TODO: should be track(thing)
-    this.#editor.activeToolCell.value;
-    this.#editor.activeToolStateCell.value;
+    this.#editor.toolCell.value;
     this.#editor.editing.stateCell.value;
     this.#editor.selection.stateCell.value;
     this.#editor.hover.entryCell.value;
@@ -181,10 +179,11 @@ export class OverlayLayer extends CanvasItem<OverlayLayerProps> {
 
   protected props(): OverlayLayerProps {
     this.#editor.camera.trackViewportTransform();
+    const tool = this.#editor.toolCell.value;
 
     return {
-      activeTool: this.#editor.activeToolCell.value,
-      activeToolState: this.#editor.activeToolStateCell.value,
+      activeTool: tool?.id ?? null,
+      activeToolState: tool?.state ?? null,
     };
   }
 

--- a/apps/desktop/src/renderer/src/lib/keyboard/KeyboardRouter.test.ts
+++ b/apps/desktop/src/renderer/src/lib/keyboard/KeyboardRouter.test.ts
@@ -45,7 +45,7 @@ describe("KeyboardRouter", () => {
 
     router = new KeyboardRouter(() => ({
       canvasActive,
-      activeTool: editor.getActiveTool(),
+      activeTool: editor.tool?.id ?? null,
       editor,
       toolManager: editor.toolManager,
     }));
@@ -112,7 +112,7 @@ describe("KeyboardRouter", () => {
       const handled = await router.handleKeyDown(e);
 
       expect(handled).toBe(true);
-      expect(editor.getActiveTool()).toBe("shape");
+      expect(editor.toolIf("shape")?.state).toEqual({ type: "ready" });
     });
 
     it("does not run tool shortcuts outside the canvas context", async () => {
@@ -122,7 +122,7 @@ describe("KeyboardRouter", () => {
       const handled = await router.handleKeyDown(e);
 
       expect(handled).toBe(false);
-      expect(editor.getActiveTool()).toBe("select");
+      expect(editor.toolIf("select")?.state).toEqual({ type: "ready" });
     });
 
     it("does not intercept plain typing while the text tool is active", async () => {
@@ -132,7 +132,7 @@ describe("KeyboardRouter", () => {
       const handled = await router.handleKeyDown(e);
 
       expect(handled).toBe(false);
-      expect(editor.getActiveTool()).toBe("text");
+      expect(editor.toolIf("text")?.state).toEqual({ type: "typing" });
     });
   });
 
@@ -214,13 +214,10 @@ describe("KeyboardRouter", () => {
       const up = createKeyboardEvent({ key: " ", code: "Space" });
 
       await router.handleKeyDown(down);
-      // Temporary tools are tracked as toolManager overrides; activeToolId
-      // reflects the override while primaryToolId stays on the base tool.
-      expect(editor.toolManager.activeToolId).toBe("hand");
-      expect(editor.toolManager.primaryToolId).toBe("select");
+      expect(editor.toolIf("hand")?.state).toEqual({ type: "ready" });
 
       await router.handleKeyUp(up);
-      expect(editor.toolManager.activeToolId).toBe("select");
+      expect(editor.toolIf("select")?.state).toEqual({ type: "ready" });
     });
 
     it("does not activate the hand tool on space while the text tool is active", async () => {
@@ -229,7 +226,7 @@ describe("KeyboardRouter", () => {
 
       await router.handleKeyDown(e);
 
-      expect(editor.getActiveTool()).toBe("text");
+      expect(editor.toolIf("text")?.state).toEqual({ type: "typing" });
     });
   });
 

--- a/apps/desktop/src/renderer/src/lib/signals/docs/DOCS.md
+++ b/apps/desktop/src/renderer/src/lib/signals/docs/DOCS.md
@@ -106,7 +106,7 @@ cd apps/desktop && npm test
 
 ## Related
 
-- `Editor` -- primary consumer; holds `WritableSignal` fields for tool state, cursor, preview mode
+- `Editor` -- primary consumer; derives `toolCell` from the active tool's state cell and owns cursor/view cells
 - `Camera` -- uses `zoomCell`, pan cells, and affine transform cells
 - `Hover` -- uses `targetCell` for hovered editor state
 - `Selection` -- uses `WritableSignal` fields for selected point/anchor/segment state

--- a/apps/desktop/src/renderer/src/lib/tools/core/BaseTool.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/core/BaseTool.test.ts
@@ -78,7 +78,6 @@ describe("BaseTool contract", () => {
       tool.handleEvent(clickEvent);
 
       expect(tool.getState()).toEqual({ type: "clicked" });
-      expect(editor.getActiveToolState()).toEqual({ type: "clicked" });
       expect(tool.stateChanges).toEqual([
         { prev: { type: "ready" }, next: { type: "clicked" }, event: clickEvent },
       ]);

--- a/apps/desktop/src/renderer/src/lib/tools/core/BaseTool.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/core/BaseTool.ts
@@ -147,7 +147,6 @@ export abstract class BaseTool<S extends ToolState, TTool = unknown, Settings = 
   protected setState(next: S): void {
     this.state = next;
     this.#stateCell.set(next);
-    this.editor.setActiveToolState(next);
   }
 
   #runBehaviors(state: S, event: ToolEvent): { state: S; handled: boolean } {

--- a/apps/desktop/src/renderer/src/lib/tools/core/ToolManager.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/core/ToolManager.ts
@@ -64,10 +64,6 @@ export class ToolManager implements ToolSwitchHandler {
     return this.primaryTool?.id ?? null;
   }
 
-  get isDragging(): boolean {
-    return this.editor.gesture.isDragging;
-  }
-
   register(manifest: ToolManifest): void {
     if (typeof manifest.id !== "string" || manifest.id.trim() === "") {
       throw new Error("[ToolManager] Tool id must be a non-empty string");
@@ -98,7 +94,6 @@ export class ToolManager implements ToolSwitchHandler {
     this.primaryTool = nextTool;
     if (this.primaryTool.activate) this.primaryTool.activate();
 
-    this.editor.setActiveToolState(this.primaryTool.getState());
     this.#publishActiveTool();
   }
 
@@ -111,7 +106,6 @@ export class ToolManager implements ToolSwitchHandler {
     this.temporaryOptions = options ?? null;
     this.overrideTool = nextTool;
     if (this.overrideTool.activate) this.overrideTool.activate();
-    this.editor.setActiveToolState(this.overrideTool.getState());
     this.#publishActiveTool();
     if (this.temporaryOptions?.onActivate) this.temporaryOptions.onActivate();
   }
@@ -124,9 +118,6 @@ export class ToolManager implements ToolSwitchHandler {
     if (this.temporaryOptions?.onReturn) this.temporaryOptions.onReturn();
     this.temporaryOptions = null;
 
-    if (this.primaryTool) {
-      this.editor.setActiveToolState(this.primaryTool.getState());
-    }
     this.#publishActiveTool();
   }
 
@@ -307,9 +298,6 @@ export class ToolManager implements ToolSwitchHandler {
     if (this.temporaryOptions?.onReturn) this.temporaryOptions.onReturn();
     this.temporaryOptions = null;
     if (this.primaryTool?.activate) this.primaryTool.activate();
-    if (this.primaryTool) {
-      this.editor.setActiveToolState(this.primaryTool.getState());
-    }
     this.#publishActiveTool();
   }
 

--- a/apps/desktop/src/renderer/src/lib/tools/core/ToolStateMap.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/core/ToolStateMap.ts
@@ -1,4 +1,4 @@
-import type { ToolState } from "./createContext";
+import type { ToolName, ToolState } from "./createContext";
 import type { HandState } from "../hand/types";
 import type { ShapeState } from "../shape/types";
 import type { SelectState } from "../select/types";
@@ -14,4 +14,13 @@ export interface ToolStateMap {
   disabled: ToolState;
 }
 
-export type ActiveToolState = ToolStateMap[keyof ToolStateMap] | ToolState;
+/** Resolves known tool IDs precisely and leaves runtime extension IDs at the base contract. */
+export type ToolStateFor<Id extends ToolName> = Id extends keyof ToolStateMap
+  ? ToolStateMap[Id]
+  : ToolState;
+
+/** Active tool identity paired with the current state published by that tool. */
+export interface ActiveTool<Id extends ToolName = ToolName> {
+  readonly id: Id;
+  readonly state: ToolStateFor<Id>;
+}

--- a/apps/desktop/src/renderer/src/lib/tools/core/index.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/core/index.ts
@@ -21,6 +21,6 @@ export { BaseTool, type ToolState } from "./BaseTool";
 export { ToolManager } from "./ToolManager";
 export { type ToolName, type BuiltInToolId, BUILT_IN_TOOL_IDS } from "./createContext";
 export type { ToolFactory, ToolManifest } from "./ToolManifest";
-export type { ToolStateMap, ActiveToolState } from "./ToolStateMap";
+export type { ActiveTool, ToolStateFor, ToolStateMap } from "./ToolStateMap";
 export { defineStateDiagram, type StateDiagram, type StateTransition } from "./StateDiagram";
 export { createBehavior, type Behavior, type ToolContext } from "./Behavior";

--- a/apps/desktop/src/renderer/src/lib/tools/docs/DOCS.md
+++ b/apps/desktop/src/renderer/src/lib/tools/docs/DOCS.md
@@ -6,7 +6,7 @@ State machine-based tool system for the Shift font editor: translates pointer/ke
 
 - **Architecture Invariant:** Every tool must call `activate()` to leave `"idle"` state. `BaseTool` skips the behavior loop entirely when `state.type === "idle"`, so a tool that forgets `activate()` will silently ignore all events.
 
-- **Architecture Invariant:** Lifecycle methods mutate tool state through `BaseTool.setState()`, never by assigning `this.state`. The method publishes one coherent value to `state`, `stateCell`, and the editor's active-tool state; direct assignment leaves cursor and editing computations stale.
+- **Architecture Invariant:** Lifecycle methods mutate tool state through `BaseTool.setState()`, never by assigning `this.state`. The method publishes one coherent value to `state` and `stateCell`; `Editor.toolCell` pulls the active instance's `stateCell`. Direct assignment leaves editor tool state, cursor, and editing computations stale.
 
 - **Architecture Invariant:** Behaviors are tried in **array order**; first handler that returns `true` wins. Reordering the `behaviors` array changes tool semantics. **CRITICAL**: placing a broad handler (e.g. `Selection`) before a narrow one (e.g. `ToggleSmooth`) will shadow the narrow handler.
 
@@ -51,6 +51,7 @@ tools/
 - `ToolEvent` — discriminated union of semantic events: `pointerMove`, `click`, `doubleClick`, `dragStart`, `drag`, `dragEnd`, `dragCancel`, `keyDown`, `keyUp`, `selectionChanged`. Pointer events include `coords: Coordinates`.
 - `DragStartEvent` / `DragEvent` / `DragEndEvent` — concrete targeted pointer-event contracts used by drag handlers.
 - `ToolManager` — owns the active tool, `GestureDetector`, rAF pointer coalescing, and temporary tool switching.
+- `ActiveTool<Id>` — editor-facing `{ id, state }` snapshot. `Editor.toolIf(id)` narrows built-in state through `ToolStateMap`; runtime IDs fall back to `ToolState`.
 - `GestureDetector` — stateful recognizer: drag threshold, double-click timing. Fed raw `pointerDown`/`Move`/`Up`, emits `ToolEvent[]`.
 - `ToolManifest` — `{ id, create, icon, tooltip, shortcut? }`. Registration descriptor passed to `editor.registerTool`.
 - `StateDiagram` — `{ states, initial, transitions }`. Declarative spec for compliance testing.
@@ -89,7 +90,7 @@ After `#runBehaviors`, if `next !== prev` (reference equality):
 
 1. **Batch** all side effects inside a single reactive `batch()`.
 2. Call `onStateExit` on every behavior (receives `prev`, `next`, a pre-commit context).
-3. Commit through `setState(next)`, publishing `state`, `stateCell`, and `editor.setActiveToolState(next)` together.
+3. Commit through `setState(next)`, publishing `state` and `stateCell` together. `Editor.toolCell` invalidates through its direct dependency on the active tool's `stateCell`.
 4. Call `onStateEnter` on every behavior (receives `prev`, `next`, a post-commit context where `setState` updates `this.state`).
 5. Call `onStateChange(prev, next, event)` if defined on the tool.
 

--- a/apps/desktop/src/renderer/src/lib/tools/hand/Hand.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/hand/Hand.test.ts
@@ -11,18 +11,13 @@ describe("Hand tool", () => {
     editor.selectTool("hand");
   });
 
-  it("publishes ready and idle states through activation and deactivation", () => {
-    const hand = editor.toolManager.activeTool;
-    if (!hand) throw new Error("Expected active Hand tool");
-
-    expect(hand.getState()).toEqual({ type: "ready" });
-    expect(hand.stateCell.value).toEqual({ type: "ready" });
-    expect(editor.getActiveToolState()).toEqual({ type: "ready" });
+  it("publishes lifecycle state through the typed tool surface", () => {
+    expect(editor.toolIf("hand")?.state).toEqual({ type: "ready" });
 
     editor.selectTool("select");
 
-    expect(hand.getState()).toEqual({ type: "idle" });
-    expect(hand.stateCell.value).toEqual({ type: "idle" });
+    expect(editor.toolIf("hand")).toBeNull();
+    expect(editor.toolIf("select")?.state).toEqual({ type: "ready" });
   });
 
   it("drag pans the viewport by the screen delta", () => {
@@ -42,11 +37,12 @@ describe("Hand tool", () => {
     editor.pointerMove(50, 0); // start dragging
     editor.pointerMove(100, 0);
     const panMidDrag = editor.pan;
+    expect(editor.isDragging).toBe(true);
 
     editor.escape();
 
-    const state = editor.getActiveToolState();
-    expect(state.type).toBe("ready");
+    expect(editor.isDragging).toBe(false);
+    expect(editor.toolIf("hand")?.state.type).toBe("ready");
 
     // After cancel, further moves without a new pointerDown must not pan.
     editor.pointerMove(200, 0);

--- a/apps/desktop/src/renderer/src/lib/tools/select/Select.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/Select.ts
@@ -94,14 +94,7 @@ export class Select extends BaseTool<SelectState, Select> {
   override drawOverlay(canvas: Canvas): void {
     // TODO: perhaps there should be a way for tools to turn on/off bounding box
     // rendering without it having to be a commit in the Select Tool
-    const otherToolState = this.editor.getActiveToolState().type;
-    const isMutatingState =
-      this.state.type === "translating" ||
-      this.state.type === "resizing" ||
-      this.state.type === "rotating" ||
-      otherToolState === "bend";
-
-    if (!isMutatingState) {
+    if (!this.isEditing(this.state)) {
       this.boundingBox.draw(canvas);
     }
 

--- a/apps/desktop/src/renderer/src/lib/tools/shape/Shape.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/shape/Shape.test.ts
@@ -14,18 +14,13 @@ describe("Shape tool", () => {
 
   const contours = () => editor.glyphLayer?.geometry.contours ?? [];
 
-  it("publishes ready and idle states through activation and deactivation", () => {
-    const shape = editor.toolManager.activeTool;
-    if (!shape) throw new Error("Expected active Shape tool");
-
-    expect(shape.getState()).toEqual({ type: "ready" });
-    expect(shape.stateCell.value).toEqual({ type: "ready" });
-    expect(editor.getActiveToolState()).toEqual({ type: "ready" });
+  it("publishes lifecycle state through the typed tool surface", () => {
+    expect(editor.toolIf("shape")?.state).toEqual({ type: "ready" });
 
     editor.selectTool("select");
 
-    expect(shape.getState()).toEqual({ type: "idle" });
-    expect(shape.stateCell.value).toEqual({ type: "idle" });
+    expect(editor.toolIf("shape")).toBeNull();
+    expect(editor.toolIf("select")?.state).toEqual({ type: "ready" });
   });
 
   it("drag then release commits a closed 4-point rectangle contour", async () => {
@@ -55,8 +50,7 @@ describe("Shape tool", () => {
     await editor.settle();
 
     expect(contours().length).toBe(contoursBefore);
-    const state = editor.getActiveToolState();
-    expect(state.type).toBe("ready");
+    expect(editor.toolIf("shape")?.state.type).toBe("ready");
   });
 
   it("drag smaller than the 3-unit minimum does not commit", async () => {

--- a/apps/desktop/src/renderer/src/lib/tools/text/Text.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/text/Text.test.ts
@@ -11,19 +11,12 @@ describe("Text tool", () => {
   });
 
   it("publishes typing until Escape returns to Select", () => {
-    const text = editor.toolManager.activeTool;
-    if (!text) throw new Error("Expected active Text tool");
-
-    expect(text.getState()).toEqual({ type: "typing" });
-    expect(text.stateCell.value).toEqual({ type: "typing" });
-    expect(editor.getActiveToolState()).toEqual({ type: "typing" });
+    expect(editor.toolIf("text")?.state).toEqual({ type: "typing" });
     expect(editor.cursor).toBe("text");
 
     editor.escape();
 
-    expect(editor.toolManager.activeToolId).toBe("select");
-    expect(editor.getActiveToolState()).toEqual({ type: "ready" });
-    expect(text.getState()).toEqual({ type: "idle" });
-    expect(text.stateCell.value).toEqual({ type: "idle" });
+    expect(editor.toolIf("text")).toBeNull();
+    expect(editor.toolIf("select")?.state).toEqual({ type: "ready" });
   });
 });

--- a/apps/desktop/src/renderer/src/testing/TestEditor.test.ts
+++ b/apps/desktop/src/renderer/src/testing/TestEditor.test.ts
@@ -13,8 +13,7 @@ describe("TestEditor", () => {
 
   describe("tool activation", () => {
     it("starts with the select tool activated", () => {
-      expect(editor.getActiveTool()).toBe("select");
-      expect(editor.toolManager.activeToolId).toBe("select");
+      expect(editor.toolIf("select")?.state).toEqual({ type: "ready" });
     });
   });
 

--- a/apps/desktop/src/renderer/src/views/Editor.tsx
+++ b/apps/desktop/src/renderer/src/views/Editor.tsx
@@ -75,8 +75,8 @@ export const Editor = () => {
 
     const toolManager = editor.toolManager;
     const keyboardRouter = new KeyboardRouter(() => ({
-      canvasActive: activeZone === "canvas" || toolManager.isDragging,
-      activeTool: editor.getActiveTool(),
+      canvasActive: activeZone === "canvas" || editor.isDragging,
+      activeTool: editor.tool?.id ?? null,
       editor,
       toolManager,
     }));


### PR DESCRIPTION
## Summary

Implements the locked Tool State API direction from the Obsidian ticket.

- replace overlapping active-tool ID/state getters and the public state setter with `tool`, `toolCell`, and typed `toolIf(id)`
- derive editor tool state from the active instance's `stateCell` instead of pushing duplicate state through `Editor`
- preserve open runtime tool IDs: built-ins narrow through `ToolStateMap`; unknown IDs retain the base `ToolState`
- expose gesture dragging through `Editor.isDragging` / `draggingCell` and remove the ToolManager forwarding getter
- migrate renderer, toolbar, text input, keyboard, debug, and tool-state contract consumers
- document the pull-based ownership boundary

## Behavior-test durability check

The five behavior-only tests introduced by the parent PR are unchanged and pass after the refactor. They cover temporary Hand panning, resumed real Pen editing, modifier preservation, override refusal, and lifecycle callbacks without reading ToolManager internals.

## Validation

- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm format:check`
- `pnpm test:desktop` — 58 files / 564 tests
- `pnpm check-deps`

`context-drift-check.py` completed with the repository's 20 existing unrelated documentation warnings.
