### PR TITLE
Support replaceable runtime tool contributions

### DIFF
--- a/apps/desktop/src/renderer/src/components/editor/ToolsPane.tsx
+++ b/apps/desktop/src/renderer/src/components/editor/ToolsPane.tsx
@@ -44,12 +44,13 @@ export const ToolbarIcon: FC<ToolbarIconProps> = ({ Icon, name, tooltip, activeT
 export const ToolsPane: FC = () => {
   const editor = useEditor();
   const activeTool = useSignalState(editor.toolCell)?.id ?? null;
+  const toolRegistry = useSignalState(editor.toolRegistryCell);
 
   return (
     <section className="flex flex-col items-center justify-center gap-2">
       <TooltipProvider delayDuration={2000}>
         <div className="flex items-center gap-2 bg-white rounded-lg border-b border-line p-0.5">
-          {Array.from(editor.toolRegistry.entries()).map(([name, { icon, tooltip }]) => (
+          {Array.from(toolRegistry.entries()).map(([name, { icon, tooltip }]) => (
             <ToolbarIcon
               key={name}
               Icon={icon}

--- a/apps/desktop/src/renderer/src/lib/editor/Editor.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/Editor.ts
@@ -18,7 +18,7 @@ import { isSegmentId, type SegmentId } from "@shift/glyph-state";
 import type { ExternalAxisLocation } from "@/types/variation";
 import type { Coordinates, NodePoint, ScenePoint } from "@/types/coordinates";
 import { cloneExternalAxisLocation, emptyExternalAxisLocation } from "@/lib/variation/location";
-import type { ActiveTool, ToolName } from "../tools/core";
+import type { ActiveTool, ToolName, ToolRegistration } from "../tools/core";
 import { ToolManager } from "../tools/core/ToolManager";
 import { Bounds, Vec2, type Bounds as BoundsType, type Point2D, type Rect2D } from "@shift/geo";
 
@@ -145,14 +145,7 @@ export class Editor {
   #renderer: Renderer;
 
   #toolManager: ToolManager;
-  #toolMetadata: Map<
-    ToolName,
-    {
-      icon: React.FC<React.SVGProps<SVGSVGElement>>;
-      tooltip: string;
-      shortcut?: string;
-    }
-  >;
+  #toolRegistry: Signal<ReadonlyMap<ToolName, ToolRegistryItem>>;
   #tool: Signal<ActiveTool | null>;
   #dragging: Signal<boolean>;
   #isEditing: Signal<boolean>;
@@ -242,11 +235,20 @@ export class Editor {
       },
     );
 
-    this.#toolMetadata = new Map();
-
     // TODO: why not make editor extend EventEmitter?
     this.#events = new EventEmitter();
     this.#toolManager = new ToolManager(this);
+    this.#toolRegistry = computed(
+      () => {
+        const registry = new Map<ToolName, ToolRegistryItem>();
+        for (const [id, manifest] of this.#toolManager.manifestsCell.value) {
+          const { icon, tooltip, shortcut } = manifest;
+          registry.set(id, shortcut ? { icon, tooltip, shortcut } : { icon, tooltip });
+        }
+        return registry;
+      },
+      { name: "editor.toolRegistry" },
+    );
     this.#tool = computed<ActiveTool | null>(
       () => {
         const activeTool = this.#toolManager.activeToolCell.value;
@@ -298,32 +300,32 @@ export class Editor {
     );
   }
 
-  public registerTool(descriptor: ToolManifest): void {
-    const { id, icon, tooltip, shortcut } = descriptor;
-    this.#toolMetadata.set(id, shortcut ? { icon, tooltip, shortcut } : { icon, tooltip });
-    this.toolManager.register(descriptor);
+  /**
+   * Installs a tool contribution and returns the handle that owns it.
+   *
+   * @param manifest - Stable identity, metadata, and factory to install.
+   * @returns The handle used to replace or permanently remove the contribution.
+   */
+  public registerTool(manifest: ToolManifest): ToolRegistration {
+    return this.toolManager.register(manifest);
   }
 
   public get toolRegistry(): ReadonlyMap<ToolName, ToolRegistryItem> {
-    const result = new Map<ToolName, ToolRegistryItem>();
-    for (const [name, metadata] of this.#toolMetadata) {
-      result.set(name, {
-        icon: metadata.icon,
-        tooltip: metadata.tooltip,
-        shortcut: metadata.shortcut,
-      });
-    }
-    return result;
+    return this.#toolRegistry.peek();
+  }
+
+  public get toolRegistryCell(): Signal<ReadonlyMap<ToolName, ToolRegistryItem>> {
+    return this.#toolRegistry;
   }
 
   public getToolShortcuts(): ToolShortcutEntry[] {
-    const out: ToolShortcutEntry[] = [];
-    for (const [toolId, metadata] of this.#toolMetadata) {
-      if (metadata.shortcut != null) {
-        out.push({ toolId, shortcut: metadata.shortcut });
+    const shortcuts: ToolShortcutEntry[] = [];
+    for (const [toolId, manifest] of this.#toolManager.manifests) {
+      if (manifest.shortcut != null) {
+        shortcuts.push({ toolId, shortcut: manifest.shortcut });
       }
     }
-    return out;
+    return shortcuts;
   }
 
   /** Returns the current active tool snapshot, or null before a tool is activated. */
@@ -1326,6 +1328,7 @@ export class Editor {
     this.#cursorEffect.dispose();
     this.#cameraMetricsEffect.dispose();
     this.#renderer.destroy();
+    this.#toolManager.dispose();
     this.#events.dispose();
   }
 

--- a/apps/desktop/src/renderer/src/lib/editor/docs/DOCS.md
+++ b/apps/desktop/src/renderer/src/lib/editor/docs/DOCS.md
@@ -28,6 +28,8 @@ Central orchestrator for the canvas-based glyph editing surface, wiring viewport
 
 **Architecture Invariant:** `Editor.toolCell` is the public active-tool state surface. It derives `{ id, state }` from the active tool instance and its `stateCell`; consumers use `toolIf(id)` for built-in state narrowing and do not reach through `ToolManager` for active state.
 
+**Architecture Invariant:** `ToolManager` is authoritative for installed manifests. `Editor.toolRegistryCell` derives reactive toolbar metadata from that collection, and `registerTool()` returns the `ToolRegistration` that exclusively owns replacement and removal of the contributed ID.
+
 **Architecture Invariant:** Camera and text-layout metrics resolve from the active design location through `Font.metricsAtLocation()`. Exact master locations use authored source values; intermediate locations evaluate the Rust-built source-metric interpolation model.
 
 **Architecture Invariant:** `Selection` is a dumb ordered set of branded object IDs. Mutations go through `select()`, `add()`, `remove()`, and `toggle()`; behavior and live bounds come from resolving those IDs through `Editor.object()`.

--- a/apps/desktop/src/renderer/src/lib/tools/core/BaseTool.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/core/BaseTool.test.ts
@@ -4,6 +4,8 @@ import type { ToolEvent } from "./GestureDetector";
 import { makeTestCoordinates, TestEditor } from "@/testing";
 import type { ToolName } from "./createContext";
 import type { Behavior } from "./Behavior";
+import { signal, type Signal } from "@/lib/signals";
+import type { CursorType } from "@/types/editor";
 
 type ContractState = { type: "idle" } | { type: "ready" } | { type: "clicked" };
 
@@ -28,6 +30,25 @@ const ClickBehavior: Behavior<ContractState> = {
  * tests can assert on the full lifecycle payload — what the BaseTool
  * contract promises to downstream tool implementations.
  */
+class DisposableTestTool extends BaseTool<ContractState> {
+  readonly id: ToolName = "disposable-test";
+  readonly behaviors: Behavior<ContractState>[] = [];
+  readonly #cursorSourceCell: Signal<CursorType>;
+
+  constructor(editor: TestEditor, cursorSourceCell: Signal<CursorType>) {
+    super(editor);
+    this.#cursorSourceCell = cursorSourceCell;
+  }
+
+  override getCursor(): CursorType {
+    return this.#cursorSourceCell.value;
+  }
+
+  initialState(): ContractState {
+    return { type: "idle" };
+  }
+}
+
 class ContractTestTool extends BaseTool<ContractState> {
   readonly id: ToolName = "select";
   readonly behaviors: Behavior<ContractState>[] = [ClickBehavior];
@@ -82,6 +103,17 @@ describe("BaseTool contract", () => {
         { prev: { type: "ready" }, next: { type: "clicked" }, event: clickEvent },
       ]);
     });
+  });
+
+  it("permanent disposal severs computed dependencies", () => {
+    const cursorSourceCell = signal<CursorType>({ type: "default" });
+    const disposableTool = new DisposableTestTool(editor, cursorSourceCell);
+    expect(disposableTool.cursorCell.value).toEqual({ type: "default" });
+
+    disposableTool.dispose();
+    cursorSourceCell.set({ type: "text" });
+
+    expect(disposableTool.cursorCell.value).toEqual({ type: "default" });
   });
 
   describe("when state is unchanged (same reference)", () => {

--- a/apps/desktop/src/renderer/src/lib/tools/core/BaseTool.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/core/BaseTool.ts
@@ -101,6 +101,12 @@ export abstract class BaseTool<S extends ToolState, TTool = unknown, Settings = 
   activate?(): void;
   deactivate?(): void;
 
+  /** Permanently severs this instance's reactive dependencies; it cannot be resumed. */
+  dispose(): void {
+    this.cursorCell.dispose();
+    this.isEditingCell.dispose();
+  }
+
   /** @knipclassignore — pure transition API used by tool tests/debugging. */
   transition(state: S, event: ToolEvent): S {
     return this.#runBehaviors(state, event).state;

--- a/apps/desktop/src/renderer/src/lib/tools/core/ToolManager.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/core/ToolManager.test.ts
@@ -1,5 +1,82 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import type { Editor } from "@/lib/editor/Editor";
 import { TestEditor } from "@/testing/TestEditor";
+import { BaseTool } from "./BaseTool";
+import type { Behavior } from "./Behavior";
+import type { ToolManifest } from "./ToolManifest";
+import type { ToolName } from "./createContext";
+
+type RuntimeToolState = { type: "idle" } | { type: "ready" } | { type: "dragging" };
+
+class RuntimeTool extends BaseTool<RuntimeToolState> {
+  readonly id: ToolName;
+  readonly behaviors: Behavior<RuntimeToolState>[];
+
+  constructor(editor: Editor, id: ToolName, version: number) {
+    super(editor);
+    this.id = id;
+    this.behaviors = [
+      {
+        onClick(state, ctx) {
+          if (state.type !== "ready") return false;
+          ctx.editor.setPan({ x: version, y: 0 });
+          return true;
+        },
+        onDragStart(state, ctx) {
+          if (state.type !== "ready") return false;
+          ctx.editor.setPan({ x: version, y: 0 });
+          ctx.setState({ type: "dragging" });
+          return true;
+        },
+        onDrag(state, ctx) {
+          if (state.type !== "dragging") return false;
+          ctx.editor.setPan({ x: version, y: 0 });
+          return true;
+        },
+        onDragEnd(state, ctx) {
+          if (state.type !== "dragging") return false;
+          ctx.setState({ type: "ready" });
+          return true;
+        },
+        onDragCancel(state, ctx) {
+          if (state.type !== "dragging") return false;
+          ctx.editor.setPan({ x: -version, y: 0 });
+          ctx.setState({ type: "ready" });
+          return true;
+        },
+      },
+    ];
+  }
+
+  initialState(): RuntimeToolState {
+    return { type: "idle" };
+  }
+
+  override activate(): void {
+    this.setState({ type: "ready" });
+  }
+
+  override deactivate(): void {
+    this.setState({ type: "idle" });
+  }
+}
+
+const RuntimeIcon: ToolManifest["icon"] = () => null;
+
+function runtimeManifest(
+  version: number,
+  tooltip = `Runtime ${version}`,
+  shortcut?: string,
+): ToolManifest {
+  const manifest = {
+    id: "runtime-test",
+    create: (editor: Editor) => new RuntimeTool(editor, "runtime-test", version),
+    icon: RuntimeIcon,
+    tooltip,
+  };
+
+  return shortcut ? { ...manifest, shortcut } : manifest;
+}
 
 describe("tool selection and temporary overrides", () => {
   let editor: TestEditor;
@@ -77,5 +154,109 @@ describe("tool selection and temporary overrides", () => {
       altKey: false,
       metaKey: false,
     });
+  });
+});
+
+describe("runtime tool contributions", () => {
+  let editor: TestEditor;
+
+  beforeEach(() => {
+    editor = new TestEditor();
+  });
+
+  it("publishes installed, replaced, and removed metadata", () => {
+    const registration = editor.registerTool(runtimeManifest(1, "Runtime One", "r"));
+
+    expect(editor.toolRegistryCell.value.get("runtime-test")?.tooltip).toBe("Runtime One");
+    expect(editor.getToolShortcuts()).toContainEqual({ toolId: "runtime-test", shortcut: "r" });
+
+    registration.replace(runtimeManifest(2, "Runtime Two", "u"));
+
+    expect(editor.toolRegistryCell.value.get("runtime-test")?.tooltip).toBe("Runtime Two");
+    expect(editor.getToolShortcuts()).toContainEqual({ toolId: "runtime-test", shortcut: "u" });
+
+    registration.dispose();
+
+    expect(editor.toolRegistryCell.value.has("runtime-test")).toBe(false);
+  });
+
+  it("rejects duplicate ownership", () => {
+    editor.registerTool(runtimeManifest(1));
+
+    expect(() => editor.registerTool(runtimeManifest(2))).toThrow(
+      "Tool already registered: runtime-test",
+    );
+  });
+
+  it("uses an inactive replacement on first activation", () => {
+    const registration = editor.registerTool(runtimeManifest(1));
+    registration.replace(runtimeManifest(2));
+
+    editor.selectTool("runtime-test").click(0, 0);
+
+    expect(editor.pan.x).toBe(2);
+  });
+
+  it("reconstructs an active idle tool without replacing editor-owned state", async () => {
+    await editor.startSession();
+    const glyphNode = editor.glyphNode;
+    const registration = editor.registerTool(runtimeManifest(1));
+    editor.selectTool("runtime-test").click(0, 0);
+
+    registration.replace(runtimeManifest(2));
+    editor.click(20, 0);
+
+    expect(editor.pan.x).toBe(2);
+    expect(editor.glyphNode).toBe(glyphNode);
+    expect(editor.toolIf("runtime-test")?.state.type).toBe("ready");
+  });
+
+  it("defers active replacement until a drag finishes", () => {
+    const registration = editor.registerTool(runtimeManifest(1));
+    editor.selectTool("runtime-test");
+    editor.pointerDown(0, 0).pointerMove(20, 0);
+
+    registration.replace(runtimeManifest(2));
+    editor.pointerMove(30, 0);
+
+    expect(editor.pan.x).toBe(1);
+
+    editor.pointerUp(30, 0).click(0, 0);
+
+    expect(editor.pan.x).toBe(2);
+  });
+
+  it("cancels an active drag before removing its tool", () => {
+    const registration = editor.registerTool(runtimeManifest(1));
+    editor.selectTool("runtime-test");
+    editor.pointerDown(0, 0).pointerMove(20, 0);
+
+    registration.dispose();
+
+    expect(editor.pan.x).toBe(-1);
+    expect(editor.isDragging).toBe(false);
+    expect(editor.toolIf("select")?.state).toEqual({ type: "ready" });
+  });
+
+  it("replaces a primary tool while a temporary override is active", () => {
+    const registration = editor.registerTool(runtimeManifest(1));
+    editor.selectTool("runtime-test");
+    editor.requestTemporaryTool("hand");
+
+    registration.replace(runtimeManifest(2));
+    editor.returnFromTemporaryTool();
+    editor.click(0, 0);
+
+    expect(editor.pan.x).toBe(2);
+  });
+
+  it("does not let a disposed handle remove a newer owner", () => {
+    const previous = editor.registerTool(runtimeManifest(1));
+    previous.dispose();
+    editor.registerTool(runtimeManifest(2));
+
+    previous.dispose();
+
+    expect(editor.toolRegistryCell.value.has("runtime-test")).toBe(true);
   });
 });

--- a/apps/desktop/src/renderer/src/lib/tools/core/ToolManager.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/core/ToolManager.ts
@@ -12,7 +12,9 @@ import {
 import type { BaseTool } from "./BaseTool";
 import type { Canvas } from "@/lib/editor/rendering/Canvas";
 import type { ToolManifest } from "./ToolManifest";
+import { ToolRegistration } from "./ToolRegistration";
 import { signal, type Signal, type WritableSignal } from "@/lib/signals";
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ToolInstance = BaseTool<any, any, any>;
 
@@ -26,11 +28,14 @@ const DEFAULT_MODIFIERS: Modifiers = {
 
 export class ToolManager implements ToolSwitchHandler {
   private registry = new Map<ToolName, ToolManifest>();
+  private owners = new Map<ToolName, symbol>();
   private primaryTool: ToolInstance | null = null;
   private overrideTool: ToolInstance | null = null;
   readonly #activeTool: WritableSignal<ToolInstance | null>;
+  readonly #manifests: WritableSignal<ReadonlyMap<ToolName, ToolManifest>>;
   private gesture = new GestureDetector();
   private editor: Editor;
+  private pendingReplacements = new Set<ToolName>();
 
   private temporaryOptions: TemporaryToolOptions | null = null;
 
@@ -45,6 +50,9 @@ export class ToolManager implements ToolSwitchHandler {
     this.editor = editor;
     this.#activeTool = signal<ToolInstance | null>(null, {
       name: "toolManager.activeTool",
+    });
+    this.#manifests = signal<ReadonlyMap<ToolName, ToolManifest>>(new Map(), {
+      name: "toolManager.manifests",
     });
   }
 
@@ -64,32 +72,52 @@ export class ToolManager implements ToolSwitchHandler {
     return this.primaryTool?.id ?? null;
   }
 
-  register(manifest: ToolManifest): void {
-    if (typeof manifest.id !== "string" || manifest.id.trim() === "") {
-      throw new Error("[ToolManager] Tool id must be a non-empty string");
-    }
+  get manifests(): ReadonlyMap<ToolName, ToolManifest> {
+    return this.#manifests.peek();
+  }
 
+  get manifestsCell(): Signal<ReadonlyMap<ToolName, ToolManifest>> {
+    return this.#manifests;
+  }
+
+  /**
+   * Installs one tool contribution and returns its ownership handle.
+   *
+   * @param manifest - Stable identity, metadata, and factory to install.
+   * @returns A handle that can replace or permanently remove this contribution.
+   * @throws {Error} when the ID is empty or already owned.
+   */
+  register(manifest: ToolManifest): ToolRegistration {
+    this.#validateManifest(manifest);
     if (this.registry.has(manifest.id)) {
       throw new Error(`[ToolManager] Tool already registered: ${manifest.id}`);
     }
 
+    const owner = Symbol(manifest.id);
     this.registry.set(manifest.id, manifest);
+    this.owners.set(manifest.id, owner);
+    this.#publishManifests();
+
+    return new ToolRegistration(
+      manifest.id,
+      (nextManifest) => this.#replaceRegistration(owner, nextManifest),
+      () => this.#disposeRegistration(owner, manifest.id),
+    );
   }
 
   activate(id: ToolName): void {
-    if (this.overrideTool) {
-      this.releaseOverride();
-    }
-
-    if (this.primaryTool?.deactivate) this.primaryTool.deactivate();
-    this.gesture.reset();
-    this.editor.gesture.reset();
+    if (this.editor.isDragging) this.cancelPointerGesture();
+    if (this.overrideTool) this.#clearOverride();
 
     const nextTool = this.createToolInstance(id);
     if (!nextTool) {
       console.warn(`[ToolManager] Unknown tool: ${id}`);
       return;
     }
+
+    this.#disposePrimary();
+    this.gesture.reset();
+    this.editor.gesture.reset();
 
     this.primaryTool = nextTool;
     if (this.primaryTool.activate) this.primaryTool.activate();
@@ -98,7 +126,7 @@ export class ToolManager implements ToolSwitchHandler {
   }
 
   requestTemporary(toolId: ToolName, options?: TemporaryToolOptions): void {
-    if (this.overrideTool || this.editor.gesture.isDragging) return;
+    if (this.overrideTool || this.editor.isDragging) return;
 
     const nextTool = this.createToolInstance(toolId);
     if (!nextTool) return;
@@ -112,13 +140,9 @@ export class ToolManager implements ToolSwitchHandler {
 
   returnFromTemporary(): void {
     if (!this.overrideTool) return;
+    if (this.editor.isDragging) this.cancelPointerGesture();
 
-    if (this.overrideTool.deactivate) this.overrideTool.deactivate();
-    this.overrideTool = null;
-    if (this.temporaryOptions?.onReturn) this.temporaryOptions.onReturn();
-    this.temporaryOptions = null;
-
-    this.#publishActiveTool();
+    this.#clearOverride();
   }
 
   handlePointerDown(screenPoint: Point2D, modifiers: Modifiers): void {
@@ -154,12 +178,12 @@ export class ToolManager implements ToolSwitchHandler {
   }
 
   /**
-   * Drain any pending pointer-move synchronously.
+   * Drains any pending pointer move synchronously.
    *
-   * `handlePointerMove` normally coalesces calls via `requestAnimationFrame`.
-   * Tests and automation that need the full move pipeline (input state →
-   * gesture → tool event → state signal → cursor effect) to complete before
-   * the next action call this to bypass rAF.
+   * @remarks
+   * Pointer moves normally coalesce through `requestAnimationFrame`. Tests and
+   * automation use this boundary to complete input, gesture, tool-state, and
+   * cursor publication before the next action.
    */
   flushPointerMoves(): void {
     if (this.frameId !== null) {
@@ -196,6 +220,7 @@ export class ToolManager implements ToolSwitchHandler {
     const events = this.gesture.pointerUp(coords, modifiers);
     this.dispatchEvents(events);
     this.editor.gesture.reset();
+    this.#flushPendingReplacements();
   }
 
   cancelPointerGesture(): void {
@@ -205,6 +230,7 @@ export class ToolManager implements ToolSwitchHandler {
     if (wasDragging) {
       this.activeTool?.handleEvent({ type: "dragCancel" });
     }
+    this.#flushPendingReplacements();
   }
 
   handleKeyDown(e: KeyboardEvent): boolean {
@@ -217,9 +243,7 @@ export class ToolManager implements ToolSwitchHandler {
     this.editor.input.setModifiers(modifiers);
 
     if (e.key === "Escape" && this.gesture.isDragging) {
-      this.gesture.reset();
-      this.editor.gesture.reset();
-      this.activeTool?.handleEvent({ type: "dragCancel" });
+      this.cancelPointerGesture();
       return true;
     }
 
@@ -262,6 +286,35 @@ export class ToolManager implements ToolSwitchHandler {
     if (this.activeTool?.drawOverlay) this.activeTool.drawOverlay(canvas);
   }
 
+  /** Permanently disposes every resident instance and installed contribution. */
+  dispose(): void {
+    if (this.editor.isDragging) this.cancelPointerGesture();
+
+    this.#disposeOverride();
+    this.#disposePrimary();
+    this.registry.clear();
+    this.owners.clear();
+    this.pendingReplacements.clear();
+    this.#publishActiveTool();
+    this.#publishManifests();
+  }
+
+  /** @knipclassignore */
+  reset(): void {
+    if (this.editor.isDragging) {
+      this.cancelPointerGesture();
+    } else {
+      this.gesture.reset();
+      this.editor.gesture.reset();
+    }
+
+    if (this.overrideTool) this.#clearOverride();
+  }
+
+  notifySelectionChanged(): void {
+    this.activeTool?.handleEvent({ type: "selectionChanged" });
+  }
+
   private dispatchEvents(events: GestureEvent[]): void {
     for (const event of events) {
       this.activeTool?.handleEvent(this.withPointerTarget(event));
@@ -292,35 +345,134 @@ export class ToolManager implements ToolSwitchHandler {
     }
   }
 
-  private releaseOverride(): void {
-    if (this.overrideTool?.deactivate) this.overrideTool.deactivate();
-    this.overrideTool = null;
-    if (this.temporaryOptions?.onReturn) this.temporaryOptions.onReturn();
-    this.temporaryOptions = null;
-    if (this.primaryTool?.activate) this.primaryTool.activate();
-    this.#publishActiveTool();
-  }
-
-  /** @knipclassignore */
-  reset(): void {
-    this.gesture.reset();
-    this.editor.gesture.reset();
-    if (this.overrideTool) {
-      this.releaseOverride();
-    }
-  }
-
-  notifySelectionChanged(): void {
-    this.activeTool?.handleEvent({ type: "selectionChanged" });
-  }
-
   private createToolInstance(id: ToolName): ToolInstance | null {
     const manifest = this.registry.get(id);
     if (!manifest) return null;
     return manifest.create(this.editor);
   }
 
+  #replaceRegistration(owner: symbol, manifest: ToolManifest): void {
+    this.#assertOwner(owner, manifest.id);
+    this.#validateManifest(manifest);
+    this.registry.set(manifest.id, manifest);
+    this.#publishManifests();
+
+    if (this.activeTool?.id === manifest.id && this.editor.isDragging) {
+      this.pendingReplacements.add(manifest.id);
+      return;
+    }
+
+    this.#replaceResident(manifest.id);
+  }
+
+  #disposeRegistration(owner: symbol, id: ToolName): void {
+    this.#assertOwner(owner, id);
+    this.pendingReplacements.delete(id);
+
+    const removingActive = this.activeTool?.id === id;
+    const removingPrimary = this.primaryTool?.id === id;
+    const removingOverride = this.overrideTool?.id === id;
+
+    if (removingActive && this.editor.isDragging) this.cancelPointerGesture();
+
+    this.registry.delete(id);
+    this.owners.delete(id);
+    this.#publishManifests();
+
+    if (removingOverride) this.#clearOverride();
+    if (removingPrimary) this.#disposePrimary();
+
+    if (removingActive) {
+      const fallbackId = this.#fallbackId();
+      if (fallbackId) {
+        this.activate(fallbackId);
+      } else {
+        this.#publishActiveTool();
+      }
+      return;
+    }
+
+    if (removingPrimary && this.overrideTool) {
+      const fallbackId = this.#fallbackId();
+      this.primaryTool = fallbackId ? this.createToolInstance(fallbackId) : null;
+      if (this.primaryTool?.activate) this.primaryTool.activate();
+    }
+
+    this.#publishActiveTool();
+  }
+
+  #replaceResident(id: ToolName): void {
+    if (this.overrideTool?.id === id) {
+      this.#disposeOverride();
+      this.overrideTool = this.createToolInstance(id);
+      if (this.overrideTool?.activate) this.overrideTool.activate();
+      this.#publishActiveTool();
+      return;
+    }
+
+    if (this.primaryTool?.id !== id) return;
+
+    if (this.primaryTool.deactivate) this.primaryTool.deactivate();
+    this.primaryTool.dispose();
+    this.primaryTool = this.createToolInstance(id);
+    if (this.primaryTool?.activate) this.primaryTool.activate();
+    this.#publishActiveTool();
+  }
+
+  #flushPendingReplacements(): void {
+    if (this.pendingReplacements.size === 0) return;
+
+    const ids = [...this.pendingReplacements];
+    this.pendingReplacements.clear();
+    for (const id of ids) {
+      if (this.registry.has(id)) this.#replaceResident(id);
+    }
+  }
+
+  #clearOverride(): void {
+    this.#disposeOverride();
+    if (this.temporaryOptions?.onReturn) this.temporaryOptions.onReturn();
+    this.temporaryOptions = null;
+    this.#publishActiveTool();
+  }
+
+  #disposeOverride(): void {
+    if (!this.overrideTool) return;
+    if (this.overrideTool.deactivate) this.overrideTool.deactivate();
+    this.overrideTool.dispose();
+    this.overrideTool = null;
+  }
+
+  #disposePrimary(): void {
+    if (!this.primaryTool) return;
+    if (this.primaryTool.deactivate) this.primaryTool.deactivate();
+    this.primaryTool.dispose();
+    this.primaryTool = null;
+  }
+
+  #fallbackId(): ToolName | null {
+    if (this.registry.has("select")) return "select";
+
+    return this.registry.keys().next().value ?? null;
+  }
+
+  #assertOwner(owner: symbol, id: ToolName): void {
+    if (this.owners.get(id) !== owner) {
+      throw new Error(`[ToolManager] Tool registration is no longer current: ${id}`);
+    }
+  }
+
+  #validateManifest(manifest: ToolManifest): void {
+    if (typeof manifest.id !== "string" || manifest.id.trim() === "") {
+      throw new Error("[ToolManager] Tool id must be a non-empty string");
+    }
+  }
+
   #publishActiveTool(): void {
     this.#activeTool.set(this.overrideTool ?? this.primaryTool);
+  }
+
+  #publishManifests(): void {
+    this.#manifests.set(new Map(this.registry));
   }
 }

--- a/apps/desktop/src/renderer/src/lib/tools/core/ToolRegistration.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/core/ToolRegistration.ts
@@ -1,0 +1,44 @@
+import type { ToolManifest } from "./ToolManifest";
+import type { ToolName } from "./createContext";
+
+/** Owns one installed tool contribution until it is permanently removed. */
+export class ToolRegistration {
+  readonly id: ToolName;
+  readonly #replaceRegistration: (manifest: ToolManifest) => void;
+  readonly #disposeRegistration: () => void;
+  #disposed = false;
+
+  /** @internal Constructed only by the tool registry. */
+  constructor(
+    id: ToolName,
+    replaceRegistration: (manifest: ToolManifest) => void,
+    disposeRegistration: () => void,
+  ) {
+    this.id = id;
+    this.#replaceRegistration = replaceRegistration;
+    this.#disposeRegistration = disposeRegistration;
+  }
+
+  /**
+   * Replaces the owned contribution while preserving its stable identity.
+   *
+   * @param manifest - New metadata and factory for this registration's tool ID.
+   * @throws {Error} when the handle was disposed or the manifest changes identity.
+   */
+  replace(manifest: ToolManifest): void {
+    if (this.#disposed) throw new Error(`Tool registration is disposed: ${this.id}`);
+    if (manifest.id !== this.id) {
+      throw new Error(`Tool registration cannot change id from ${this.id} to ${manifest.id}`);
+    }
+
+    this.#replaceRegistration(manifest);
+  }
+
+  /** Permanently removes the owned contribution; repeated disposal is harmless. */
+  dispose(): void {
+    if (this.#disposed) return;
+
+    this.#disposeRegistration();
+    this.#disposed = true;
+  }
+}

--- a/apps/desktop/src/renderer/src/lib/tools/core/index.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/core/index.ts
@@ -21,6 +21,7 @@ export { BaseTool, type ToolState } from "./BaseTool";
 export { ToolManager } from "./ToolManager";
 export { type ToolName, type BuiltInToolId, BUILT_IN_TOOL_IDS } from "./createContext";
 export type { ToolFactory, ToolManifest } from "./ToolManifest";
+export { ToolRegistration } from "./ToolRegistration";
 export type { ActiveTool, ToolStateFor, ToolStateMap } from "./ToolStateMap";
 export { defineStateDiagram, type StateDiagram, type StateTransition } from "./StateDiagram";
 export { createBehavior, type Behavior, type ToolContext } from "./Behavior";

--- a/apps/desktop/src/renderer/src/lib/tools/docs/DOCS.md
+++ b/apps/desktop/src/renderer/src/lib/tools/docs/DOCS.md
@@ -8,6 +8,10 @@ State machine-based tool system for the Shift font editor: translates pointer/ke
 
 - **Architecture Invariant:** Lifecycle methods mutate tool state through `BaseTool.setState()`, never by assigning `this.state`. The method publishes one coherent value to `state` and `stateCell`; `Editor.toolCell` pulls the active instance's `stateCell`. Direct assignment leaves editor tool state, cursor, and editing computations stale.
 
+- **Architecture Invariant:** A temporary override masks the resident primary tool without deactivating or reactivating it. Returning from Hand must preserve tool-local editing scope such as Pen's active open contour. Replacing or removing the primary is a different, permanent transition and calls `deactivate()` followed by `dispose()`.
+
+- **Architecture Invariant:** A `ToolRegistration` exclusively owns one installed ID. Unrelated duplicate IDs are rejected; `replace()` keeps the ownership and selected ID, while `dispose()` is permanent and idempotent. Consumers must retain this handle for runtime update or removal.
+
 - **Architecture Invariant:** Behaviors are tried in **array order**; first handler that returns `true` wins. Reordering the `behaviors` array changes tool semantics. **CRITICAL**: placing a broad handler (e.g. `Selection`) before a narrow one (e.g. `ToggleSmooth`) will shadow the narrow handler.
 
 - **Architecture Invariant:** Behaviors are stateless transition rules. All mutable state lives in the tool state union `S` or on `Editor`. Behaviors must not hold state that survives across events unless that resource is cleaned up in `onStateEnter`/`onStateExit`.
@@ -30,8 +34,9 @@ tools/
     BaseTool.ts          — abstract base class; owns behavior loop and state lifecycle
     Behavior.ts          — Behavior<S> interface and createBehavior helper
     GestureDetector.ts   — pointer+timing -> ToolEvent (click, drag, doubleClick, ...)
-    ToolManager.ts       — tool orchestration, rAF coalescing, temporary tool override
+    ToolManager.ts       — tool orchestration, contribution ownership, replacement
     ToolManifest.ts      — ToolManifest registration descriptor
+    ToolRegistration.ts  — ownership handle for replace/remove lifecycle
     StateDiagram.ts      — defineStateDiagram for declarative tool state specs
     ToolStateMap.ts      — union map of all built-in tool states
     createContext.ts     — ToolName, ToolState, BUILT_IN_TOOL_IDS
@@ -45,15 +50,16 @@ tools/
 
 ## Key Types
 
-- `BaseTool<S, Settings>` — abstract base class all tools extend. Declares `id`, `behaviors`, `initialState`. Optional overrides: `preTransition`, `onStateChange`, `getCursor`, `activate`, `deactivate`, `drawOverlay`, `drawScene`, `drawBackground`.
+- `BaseTool<S, Settings>` — abstract base class all tools extend. Declares `id`, `behaviors`, `initialState`. Optional overrides: `preTransition`, `onStateChange`, `getCursor`, `activate`, `deactivate`, `drawOverlay`, `drawScene`, `drawBackground`. Permanent `dispose()` releases base computed signals after deactivation.
 - `Behavior<S>` — interface with optional per-event handlers (`onClick`, `onDrag`, `onDragStart`, `onDragEnd`, `onDragCancel`, `onPointerMove`, `onDoubleClick`, `onKeyDown`, `onKeyUp`) plus lifecycle hooks (`onStateExit`, `onStateEnter`). Each handler receives `(state, ctx, event)` and returns `boolean` (true = handled).
 - `ToolContext<S>` — `{ editor, getState, setState }`. Passed to behaviors during the event loop and lifecycle hooks.
 - `ToolEvent` — discriminated union of semantic events: `pointerMove`, `click`, `doubleClick`, `dragStart`, `drag`, `dragEnd`, `dragCancel`, `keyDown`, `keyUp`, `selectionChanged`. Pointer events include `coords: Coordinates`.
 - `DragStartEvent` / `DragEvent` / `DragEndEvent` — concrete targeted pointer-event contracts used by drag handlers.
-- `ToolManager` — owns the active tool, `GestureDetector`, rAF pointer coalescing, and temporary tool switching.
+- `ToolManager` — owns installed manifests, resident tool instances, `GestureDetector`, rAF pointer coalescing, replacement, removal, and temporary tool switching.
 - `ActiveTool<Id>` — editor-facing `{ id, state }` snapshot. `Editor.toolIf(id)` narrows built-in state through `ToolStateMap`; runtime IDs fall back to `ToolState`.
 - `GestureDetector` — stateful recognizer: drag threshold, double-click timing. Fed raw `pointerDown`/`Move`/`Up`, emits `ToolEvent[]`.
 - `ToolManifest` — `{ id, create, icon, tooltip, shortcut? }`. Registration descriptor passed to `editor.registerTool`.
+- `ToolRegistration` — exclusive ownership handle returned by `editor.registerTool`; exposes `replace(manifest)` and idempotent `dispose()`.
 - `StateDiagram` — `{ states, initial, transitions }`. Declarative spec for compliance testing.
 - `ToolName` — `string` (not a fixed union; extensible for plugins).
 - `ToolState` — `{ type: string }` base interface for all tool state unions.
@@ -100,7 +106,11 @@ After `#runBehaviors`, if `next !== prev` (reference equality):
 
 ### Temporary tool override
 
-`ToolManager.requestTemporary(toolId, options?)` activates an override tool (e.g. Hand via Space bar). `returnFromTemporary()` restores the primary tool. Blocked during an active drag.
+`ToolManager.requestTemporary(toolId, options?)` activates an override tool (e.g. Hand via Space bar). The primary instance remains resident and unchanged while masked. `returnFromTemporary()` disposes the override and reveals that same primary instance without another lifecycle transition. Requests are blocked during an active drag.
+
+### Runtime contribution lifecycle
+
+`editor.registerTool(manifest)` installs metadata and returns its `ToolRegistration`. `replace()` publishes new metadata immediately. Inactive tools use the new factory on their next activation; resident instances are reconstructed immediately unless they own an active drag, in which case reconstruction waits for `dragEnd` or `dragCancel`. Removing an active contribution cancels its gesture before disposal and falls back to Select when available. `Editor.destroy()` permanently disposes all resident instances and their computed signals.
 
 ### Draft pattern for drag mutations
 

--- a/apps/desktop/src/renderer/src/lib/tools/pen/Pen.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/pen/Pen.test.ts
@@ -130,6 +130,25 @@ describe("Pen tool", () => {
     });
   });
 
+  describe("temporary tool continuity", () => {
+    it("continues the active contour after temporarily panning with Hand", async () => {
+      editor.click(100, 200);
+      await editor.settle();
+      editor.click(300, 200);
+      await editor.settle();
+      const contourId = editor.openContour?.id;
+
+      editor.requestTemporaryTool("hand");
+      editor.returnFromTemporaryTool();
+      editor.click(500, 200);
+      await editor.settle();
+
+      expect(editor.glyphContours).toHaveLength(1);
+      expect(editor.openContour?.id).toBe(contourId);
+      expect(editor.openContour?.points).toHaveLength(3);
+    });
+  });
+
   describe("durability and undo through the workspace", () => {
     it("a click-placed point survives as one undoable ledger entry", async () => {
       editor.click(100, 200);


### PR DESCRIPTION
## Summary

- return an owning `ToolRegistration` from `Editor.registerTool()` and publish one reactive manifest collection
- replace or remove active and inactive tools safely, deferring active replacement through drag completion and cancelling before forced removal
- permanently dispose resident tool computations and preserve editor-owned state across reconstruction
- keep temporary Hand overrides from resetting the masked primary tool's editing scope

## Behavior coverage

Adds real `TestEditor` outcomes for:

- install/replace/remove metadata and shortcuts
- duplicate and stale ownership
- inactive and active replacement
- drag-safe replacement and removal fallback
- replacement beneath a temporary override
- permanent computed disposal
- Pen contour continuity through temporary Hand use

The existing ToolManager outcome tests remain unchanged.

## Validation

- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm format:check`
- `pnpm check-deps`
- `pnpm test:desktop` — 58 files / 574 tests
- `git diff --check`

Stacked on #208.
