### PR TITLE
Cover edited glyph save and fresh reopen

### DIFF
--- a/apps/desktop/src/renderer/src/lib/workspace/FreshReopen.test.ts
+++ b/apps/desktop/src/renderer/src/lib/workspace/FreshReopen.test.ts
@@ -1,0 +1,109 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { TestEditor } from "@/testing/TestEditor";
+
+function persistedGlyph(editor: TestEditor) {
+  const glyphId = editor.glyphRecord?.id;
+  const layer = editor.requireGlyphLayer();
+
+  return {
+    glyphId,
+    layerId: layer.id,
+    xAdvance: layer.xAdvance,
+    contours: layer.contours.map((contour) => ({
+      id: contour.id,
+      closed: contour.closed,
+      segments: contour.segments().map((segment) => segment.type),
+      points: contour.points.map(({ id, pointType, smooth }) => ({ id, pointType, smooth })),
+    })),
+  };
+}
+
+function persistedPositions(editor: TestEditor) {
+  return editor
+    .requireGlyphLayer()
+    .contours.flatMap((contour) => contour.points.map(({ x, y }) => ({ x, y })));
+}
+
+describe("saved editor outcomes survive a fresh workspace stack", () => {
+  it("reopens authored geometry and continues undoable editing", async () => {
+    const outputRoot = mkdtempSync(join(tmpdir(), "shift-fresh-reopen-"));
+    const savePath = join(outputRoot, "RoundTrip.shift");
+    const original = new TestEditor();
+    await original.startSession();
+    original.selectTool("pen").clickGlyphLocal(100, 100).clickGlyphLocal(300, 100);
+    original.dragScene({
+      down: { x: 500, y: 100 },
+      start: { x: 504, y: 104 },
+      end: { x: 580, y: 180 },
+    });
+    original.setXAdvance(700);
+    await expect(original.font.editCoordinator.state()).resolves.toMatchObject({
+      dirty: true,
+      needsSaveAs: true,
+    });
+    await expect(original.saveAs(savePath)).resolves.toMatchObject({
+      dirty: false,
+      needsSaveAs: false,
+    });
+
+    const firstPoint = original.requireGlyphLayer().allPoints[0];
+    if (!firstPoint) throw new Error("Expected authored point");
+    original.selectTool("select");
+    original.dragScene({
+      down: firstPoint,
+      start: { x: firstPoint.x + 4, y: firstPoint.y },
+      end: { x: firstPoint.x + 40, y: firstPoint.y + 30 },
+    });
+    original.setXAdvance(720);
+    await expect(original.font.editCoordinator.state()).resolves.toMatchObject({ dirty: true });
+    await expect(original.save()).resolves.toMatchObject({ dirty: false });
+    const expected = persistedGlyph(original);
+    const expectedPositions = persistedPositions(original);
+    expect(expected.contours[0]).toMatchObject({
+      closed: false,
+      segments: ["line", "cubic"],
+    });
+    expect(expected.contours[0]?.points.some((point) => point.smooth)).toBe(true);
+    await original.closeSession();
+
+    const reopened = new TestEditor();
+    await reopened.openSession(savePath, "A");
+    await expect(reopened.font.editCoordinator.state()).resolves.toMatchObject({
+      dirty: false,
+      needsSaveAs: false,
+    });
+    expect(persistedGlyph(reopened)).toEqual(expected);
+    const reopenedPositions = persistedPositions(reopened);
+    for (const [index, position] of reopenedPositions.entries()) {
+      expect(position.x).toBeCloseTo(expectedPositions[index]!.x);
+      expect(position.y).toBeCloseTo(expectedPositions[index]!.y);
+    }
+
+    const reopenedPoint = reopened.requireGlyphLayer().allPoints[0];
+    if (!reopenedPoint) throw new Error("Expected reopened point");
+    const savedPosition = reopened.pointPosition(reopenedPoint.id);
+    reopened.selectTool("select");
+    const drag = reopened.dragScene({
+      down: savedPosition,
+      start: { x: savedPosition.x + 4, y: savedPosition.y },
+      end: { x: savedPosition.x + 30, y: savedPosition.y + 20 },
+    });
+    await reopened.settle();
+    const editedPosition = reopened.pointPosition(reopenedPoint.id);
+    expect(editedPosition).toEqual({
+      x: savedPosition.x + drag.delta.x,
+      y: savedPosition.y + drag.delta.y,
+    });
+
+    await reopened.undoAndSettle();
+    expect(reopened.pointPosition(reopenedPoint.id)).toEqual(savedPosition);
+    await reopened.redoAndSettle();
+    expect(reopened.pointPosition(reopenedPoint.id)).toEqual(editedPosition);
+    await reopened.save();
+    await reopened.closeSession();
+    rmSync(outputRoot, { recursive: true, force: true });
+  });
+});

--- a/apps/desktop/src/renderer/src/testing/TestEditor.ts
+++ b/apps/desktop/src/renderer/src/testing/TestEditor.ts
@@ -30,6 +30,7 @@ import type { Contour } from "@shift/glyph-state";
 import type { SystemClipboard } from "@/lib/clipboard";
 import { createWorkspaceStack, type WorkspaceStack } from "./workspaceStack";
 import type { GlyphNode } from "@/types/node";
+import type { WorkspaceDocumentState } from "@shared/workspace/protocol";
 
 const DEFAULT_MODIFIERS = { shiftKey: false, altKey: false, metaKey: false };
 
@@ -75,6 +76,36 @@ export class TestEditor extends Editor {
     if (!record) throw new Error("created glyph did not appear in the font directory");
     this.#placeGlyph(record.id);
     return this;
+  }
+
+  /** Opens a saved package through a fresh workspace stack and places one glyph. */
+  async openSession(sourcePath: string, glyphName: string): Promise<this> {
+    await this.#stack.openWorkspace(sourcePath);
+    this.selectSource(this.font.defaultSource.id);
+
+    const record = this.font.recordForName(glyphName as GlyphName);
+    if (!record) throw new Error(`Opened package has no ${glyphName} glyph`);
+    await this.font.loadGlyph(record.id);
+    this.#placeGlyph(record.id);
+    return this;
+  }
+
+  /** Flushes pending edits, saves to a new target, and adopts it. */
+  saveAs(sourcePath: string): Promise<WorkspaceDocumentState> {
+    return this.#stack.editCoordinator.save(sourcePath);
+  }
+
+  /** Flushes pending edits and saves to the current target. */
+  save(): Promise<WorkspaceDocumentState> {
+    return this.#stack.editCoordinator.save(null);
+  }
+
+  /** Closes the clean workspace and permanently disposes this test stack. */
+  async closeSession(): Promise<void> {
+    await this.settle();
+    await this.#stack.closeWorkspace();
+    this.destroy();
+    this.#stack.dispose();
   }
 
   /** Adds another glyph to the workspace font and loads its local model. */

--- a/apps/desktop/src/renderer/src/testing/workspaceStack.ts
+++ b/apps/desktop/src/renderer/src/testing/workspaceStack.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { MessageChannel, type MessagePort as NodeMessagePort } from "node:worker_threads";
@@ -17,6 +17,8 @@ export type WorkspaceStack = {
   font: Font;
   createWorkspace(): Promise<void>;
   openWorkspace(sourcePath: string): Promise<void>;
+  closeWorkspace(): Promise<void>;
+  dispose(): void;
 };
 
 /**
@@ -74,6 +76,14 @@ export function createWorkspaceStack(): WorkspaceStack {
       }
 
       store.replaceWorkspace(snapshot);
+    },
+    async closeWorkspace(): Promise<void> {
+      await shell.call("workspace.close", { discard: false });
+    },
+    dispose(): void {
+      client.dispose();
+      shell.dispose();
+      rmSync(documentsRoot, { recursive: true, force: true });
     },
   };
 }


### PR DESCRIPTION
## Summary

- extend `TestEditor` with approved save/open/close session boundaries over the real in-process workspace stack
- author a line plus cubic through Pen, change metrics, Save As, transform through Select, and Save again
- close every original owner, open the package through an independent stack, and verify stable glyph/layer/contour/point identities, topology, smooth metadata, coordinates, advance width, and clean document state
- continue editing after reopen and prove undo/redo and another save still work

## Validation

- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm format:check`
- `pnpm test:desktop` — 62 files / 578 tests
- `git diff --check`
