### PR TITLE
Clear dirty when undo reaches the saved revision

### DIFF
--- a/apps/desktop/src/renderer/src/lib/workspace/FreshReopen.test.ts
+++ b/apps/desktop/src/renderer/src/lib/workspace/FreshReopen.test.ts
@@ -28,6 +28,22 @@ function persistedPositions(editor: TestEditor) {
 }
 
 describe("saved editor outcomes survive a fresh workspace stack", () => {
+  it("returns to clean when undo reaches the saved revision", async () => {
+    const outputRoot = mkdtempSync(join(tmpdir(), "shift-saved-revision-"));
+    const editor = new TestEditor();
+    await editor.startSession();
+    await editor.saveAs(join(outputRoot, "SavedRevision.shift"));
+
+    editor.selectTool("pen").clickGlyphLocal(100, 100);
+    await editor.settle();
+    await expect(editor.font.editCoordinator.state()).resolves.toMatchObject({ dirty: true });
+
+    await editor.undoAndSettle();
+    await expect(editor.font.editCoordinator.state()).resolves.toMatchObject({ dirty: false });
+    await editor.closeSession();
+    rmSync(outputRoot, { recursive: true, force: true });
+  });
+
   it("reopens authored geometry and continues undoable editing", async () => {
     const outputRoot = mkdtempSync(join(tmpdir(), "shift-fresh-reopen-"));
     const savePath = join(outputRoot, "RoundTrip.shift");

--- a/crates/shift-store/README.md
+++ b/crates/shift-store/README.md
@@ -18,7 +18,7 @@ Callers use typed APIs from this crate rather than preparing SQL or opening a se
 - Each editable glyph layer is one independently addressable, store-private MessagePack payload identified as `shift.glyph-layer.v1`; the store independently wraps it as `none` or `zstd.v1` without changing authored semantics.
 - Component dependency rows contain only the earned query index: component ID, owner layer ID, base glyph ID, and ordinal.
 - Points, contours, anchors, transforms, guidelines, and layer lib values are canonical only inside the layer BLOB; they are not duplicated as normalized SQL rows.
-- Payload replacement, directory facts, component rows, and workspace revision state commit in one transaction.
+- Payload replacement, directory facts, component rows, monotonic workspace revision, and the workspace-supplied dirty value commit in one transaction.
 
 `ShiftStore::load_font_directory` never reads payload BLOBs. `load_glyph_layer` bounds stored and decoded lengths before fetching and decompressing one payload. `load_glyph_layers` accepts a complete requested set, deduplicates it, and partitions it through the single count- and decoded-byte-aware planner. Each internal batch performs three ordered directory/payload/reference scans for at most 512 layers and 256 MiB decoded bytes, then decompresses and validates with Rayon. Every decoded payload must match its exact declared length and 32-byte BLAKE3 before strict MessagePack decoding. Full-font materialization and workspace acquisition use that same planner; no caller maintains a weaker count-only loop. All payload paths cross-check canonical bytes against relational facts.
 

--- a/crates/shift-store/src/change_set.rs
+++ b/crates/shift-store/src/change_set.rs
@@ -7,13 +7,13 @@ use crate::{
     ShiftStore, StoreError,
     layer::{create_empty_layer_in_tx, rewrite_layer_in_tx, write_layer_in_tx},
     source::SourceKind,
-    workspace_state::mark_workspace_dirty_in_tx,
+    workspace_state::mark_workspace_changed_in_tx,
     write_mode::WriteMode,
 };
 
 impl ShiftStore {
     pub fn apply_change_set(&mut self, change_set: &font::FontChangeSet) -> Result<(), StoreError> {
-        self.apply_change_set_inner(change_set, None)
+        self.apply_change_set_inner(change_set, None, true)
     }
 
     /// Applies relational changes and takes touched layer payloads from the
@@ -23,14 +23,16 @@ impl ShiftStore {
         &mut self,
         change_set: &font::FontChangeSet,
         post_font: &font::Font,
+        dirty: bool,
     ) -> Result<(), StoreError> {
-        self.apply_change_set_inner(change_set, Some(post_font))
+        self.apply_change_set_inner(change_set, Some(post_font), dirty)
     }
 
     fn apply_change_set_inner(
         &mut self,
         change_set: &font::FontChangeSet,
         post_font: Option<&font::Font>,
+        dirty: bool,
     ) -> Result<(), StoreError> {
         let tracks_workspace = self.tracks_workspace();
         let tx = self.conn.transaction()?;
@@ -52,7 +54,7 @@ impl ShiftStore {
             }
         }
         if tracks_workspace {
-            mark_workspace_dirty_in_tx(&tx)?;
+            mark_workspace_changed_in_tx(&tx, dirty)?;
         }
 
         tx.commit()?;

--- a/crates/shift-store/src/layer/tests.rs
+++ b/crates/shift-store/src/layer/tests.rs
@@ -556,7 +556,7 @@ fn post_font_change_set_rewrites_touched_layer_without_decoding_old_payload() {
     let changes = font::FontChangeSet::new(vec![font::FontChange::layer_metrics_changed(&layer)]);
 
     store
-        .apply_change_set_with_font(&changes, &post_font)
+        .apply_change_set_with_font(&changes, &post_font, true)
         .unwrap();
 
     assert_eq!(store.load_glyph_layer(&layer.id()).unwrap(), Some(layer));

--- a/crates/shift-store/src/workspace_state.rs
+++ b/crates/shift-store/src/workspace_state.rs
@@ -420,16 +420,23 @@ impl ShiftStore {
 }
 
 pub(crate) fn mark_workspace_dirty_in_tx(tx: &Transaction<'_>) -> Result<(), StoreError> {
+    mark_workspace_changed_in_tx(tx, true)
+}
+
+pub(crate) fn mark_workspace_changed_in_tx(
+    tx: &Transaction<'_>,
+    dirty: bool,
+) -> Result<(), StoreError> {
     tx.execute(
         "
         UPDATE workspace_state
         SET
-            dirty = 1,
+            dirty = ?1,
             revision = revision + 1,
-            updated_at_ms = ?1
+            updated_at_ms = ?2
         WHERE id = 1
         ",
-        params![now_ms()],
+        params![dirty, now_ms()],
     )?;
     Ok(())
 }

--- a/crates/shift-workspace/docs/DOCS.md
+++ b/crates/shift-workspace/docs/DOCS.md
@@ -17,6 +17,7 @@ Backend runtime object for an open Shift font workspace.
 - **Architecture Invariant:** Metadata ledger entries store complete pre/post snapshots and replay them independently of font metrics.
 - **Architecture Invariant:** Metric-definition ledger state replays before complete source snapshots so source metric IDs are always valid during undo and redo.
 - **Architecture Invariant:** Undo and redo retain at most 100 entries per stack. Extending either stack drops that stack's oldest entry; a fresh apply clears redo.
+- **Architecture Invariant:** Document `dirty` compares the ledger's current history position with its saved position; the durable authored revision remains monotonic and is not an undo cursor. Undo/redo persist their resulting dirty value atomically with replay. A resumed dirty workspace has no reachable saved position because its in-memory ledger does not survive process restart.
 
 ## Codemap
 

--- a/crates/shift-workspace/src/ledger.rs
+++ b/crates/shift-workspace/src/ledger.rs
@@ -18,6 +18,9 @@ use shift_font::{
 /// the stack being extended falls off first; a fresh apply also clears redo.
 const MAX_ENTRIES_PER_STACK: usize = 100;
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct HistoryPosition(u64);
+
 #[derive(Clone)]
 pub enum LedgerStep {
     /// Edits to existing layers; pairs replay by substitution.
@@ -96,6 +99,7 @@ pub struct LayerPair {
 
 #[derive(Clone)]
 pub struct LedgerEntry {
+    position: HistoryPosition,
     pub label: Option<String>,
     pub steps: Vec<LedgerStep>,
 }
@@ -134,17 +138,41 @@ impl LedgerEntry {
     }
 }
 
-#[derive(Default)]
 pub struct Ledger {
     undo: Vec<LedgerEntry>,
     redo: Vec<LedgerEntry>,
+    base_position: HistoryPosition,
+    saved_position: Option<HistoryPosition>,
+    next_position: u64,
+}
+
+impl Default for Ledger {
+    fn default() -> Self {
+        Self::new(false)
+    }
 }
 
 impl Ledger {
+    pub fn new(dirty: bool) -> Self {
+        Self {
+            undo: Vec::new(),
+            redo: Vec::new(),
+            base_position: HistoryPosition::default(),
+            saved_position: (!dirty).then_some(HistoryPosition::default()),
+            next_position: 1,
+        }
+    }
+
     /// Records an applied entry. A fresh apply truncates the redo stack.
-    pub fn push(&mut self, entry: LedgerEntry) {
+    pub fn push(&mut self, label: Option<String>, steps: Vec<LedgerStep>) {
         self.redo.clear();
-        push_bounded(&mut self.undo, entry);
+        let entry = LedgerEntry {
+            position: HistoryPosition(self.next_position),
+            label,
+            steps,
+        };
+        self.next_position += 1;
+        push_undo_bounded(&mut self.undo, entry, &mut self.base_position);
     }
 
     /// Pops the entry to undo; the caller replays its pre states and must
@@ -161,23 +189,52 @@ impl Ledger {
 
     /// Hands a popped undo entry back after a failed replay.
     pub fn restore_undo(&mut self, entry: LedgerEntry) {
-        push_bounded(&mut self.undo, entry);
+        push_undo_bounded(&mut self.undo, entry, &mut self.base_position);
     }
 
     /// Pops the entry to redo; hand back via [`Ledger::record_redone`] after
-    /// the replay durably succeeded, or [`Ledger::restore_redo`] when it
-    /// failed so the step stays available for retry.
+    /// the replay durably succeeded, or [`Ledger::restore_redo`] when it failed
+    /// so the step stays available for retry.
     pub fn pop_redo(&mut self) -> Option<LedgerEntry> {
         self.redo.pop()
     }
 
     pub fn record_redone(&mut self, entry: LedgerEntry) {
-        push_bounded(&mut self.undo, entry);
+        push_undo_bounded(&mut self.undo, entry, &mut self.base_position);
     }
 
     /// Hands a popped redo entry back after a failed replay.
     pub fn restore_redo(&mut self, entry: LedgerEntry) {
         push_bounded(&mut self.redo, entry);
+    }
+
+    pub fn mark_saved(&mut self) {
+        self.saved_position = Some(self.current_position());
+    }
+
+    pub fn is_dirty(&self) -> bool {
+        self.saved_position != Some(self.current_position())
+    }
+
+    pub fn is_entry_dirty(&self, entry: &LedgerEntry) -> bool {
+        self.saved_position != Some(entry.position)
+    }
+
+    fn current_position(&self) -> HistoryPosition {
+        self.undo
+            .last()
+            .map_or(self.base_position, |entry| entry.position)
+    }
+}
+
+fn push_undo_bounded(
+    stack: &mut Vec<LedgerEntry>,
+    entry: LedgerEntry,
+    base_position: &mut HistoryPosition,
+) {
+    stack.push(entry);
+    if stack.len() > MAX_ENTRIES_PER_STACK {
+        *base_position = stack.remove(0).position;
     }
 }
 
@@ -196,7 +253,7 @@ mod tests {
     fn each_stack_drops_its_oldest_entry_independently() {
         let mut ledger = Ledger::default();
         for index in 0..=MAX_ENTRIES_PER_STACK {
-            ledger.push(entry(index));
+            ledger.push(Some(index.to_string()), Vec::new());
         }
         assert_eq!(ledger.undo.len(), MAX_ENTRIES_PER_STACK);
         assert_eq!(ledger.undo[0].label.as_deref(), Some("1"));
@@ -213,16 +270,43 @@ mod tests {
     #[test]
     fn fresh_apply_clears_the_bounded_redo_stack() {
         let mut ledger = Ledger::default();
-        ledger.record_undone(entry(1));
+        ledger.push(Some("1".into()), Vec::new());
+        let entry = ledger.pop_undo().unwrap();
+        ledger.record_undone(entry);
 
-        ledger.push(entry(2));
+        ledger.push(Some("2".into()), Vec::new());
 
         assert!(ledger.redo.is_empty());
         assert_eq!(ledger.undo.len(), 1);
     }
 
+    #[test]
+    fn saved_position_tracks_undo_redo_and_branches() {
+        let mut ledger = Ledger::default();
+        ledger.push(Some("first".into()), Vec::new());
+        ledger.push(Some("saved".into()), Vec::new());
+        ledger.mark_saved();
+        ledger.push(Some("after save".into()), Vec::new());
+        assert!(ledger.is_dirty());
+
+        let after_save = ledger.pop_undo().unwrap();
+        assert!(!ledger.is_dirty());
+        ledger.record_undone(after_save);
+        let after_save = ledger.pop_redo().unwrap();
+        assert!(ledger.is_entry_dirty(&after_save));
+        ledger.record_redone(after_save);
+
+        let after_save = ledger.pop_undo().unwrap();
+        ledger.record_undone(after_save);
+        let saved = ledger.pop_undo().unwrap();
+        ledger.record_undone(saved);
+        ledger.push(Some("branch".into()), Vec::new());
+        assert!(ledger.is_dirty());
+    }
+
     fn entry(index: usize) -> LedgerEntry {
         LedgerEntry {
+            position: HistoryPosition(index as u64),
             label: Some(index.to_string()),
             steps: Vec::new(),
         }

--- a/crates/shift-workspace/src/workspace.rs
+++ b/crates/shift-workspace/src/workspace.rs
@@ -94,12 +94,13 @@ impl FontWorkspace {
         source: WorkspaceSource,
         store: ShiftStore,
         residency: LayerResidency,
+        dirty: bool,
     ) -> Self {
         Self {
             font,
             source,
             store,
-            ledger: Ledger::default(),
+            ledger: Ledger::new(dirty),
             residency,
         }
     }
@@ -120,6 +121,7 @@ impl FontWorkspace {
             WorkspaceSource::Untitled,
             store,
             LayerResidency::default(),
+            false,
         ))
     }
 
@@ -185,7 +187,13 @@ impl FontWorkspace {
         );
         let source = source_from_workspace_state(&state)?;
 
-        Ok(Self::from_store(font, source, store, residency))
+        Ok(Self::from_store(
+            font,
+            source,
+            store,
+            residency,
+            state.dirty,
+        ))
     }
 
     pub fn resume_for_source(
@@ -282,14 +290,14 @@ impl FontWorkspace {
             }
         }
 
-        let outcome = self.commit_edit(|font| {
+        let outcome = self.commit_edit(true, |font| {
             let outcome = font.apply_intents(set)?;
             let changes = outcome.changes.clone();
             Ok((outcome, changes))
         })?;
 
         let steps = self.ledger_steps(&pre, &outcome);
-        self.ledger.push(LedgerEntry { label, steps });
+        self.ledger.push(label, steps);
         Ok(outcome)
     }
 
@@ -492,7 +500,8 @@ impl FontWorkspace {
             return Ok(None);
         };
 
-        match self.replay(&entry, ReplaySide::Pre) {
+        let dirty = self.ledger.is_dirty();
+        match self.replay(&entry, ReplaySide::Pre, dirty) {
             Ok(outcome) => {
                 self.ledger.record_undone(entry);
                 Ok(Some(outcome))
@@ -512,7 +521,8 @@ impl FontWorkspace {
             return Ok(None);
         };
 
-        match self.replay(&entry, ReplaySide::Post) {
+        let dirty = self.ledger.is_entry_dirty(&entry);
+        match self.replay(&entry, ReplaySide::Post, dirty) {
             Ok(outcome) => {
                 self.ledger.record_redone(entry);
                 Ok(Some(outcome))
@@ -528,6 +538,7 @@ impl FontWorkspace {
         &mut self,
         entry: &LedgerEntry,
         side: ReplaySide,
+        dirty: bool,
     ) -> Result<AppliedIntents, WorkspaceError> {
         self.acquire_layers(entry.layer_ids())?;
 
@@ -552,7 +563,7 @@ impl FontWorkspace {
             steps.reverse();
         }
 
-        self.commit_edit(move |font| {
+        self.commit_edit(dirty, move |font| {
             let mut changes = FontChangeSet::default();
             let mut touched: Vec<TouchedLayer> = Vec::new();
 
@@ -639,6 +650,7 @@ impl FontWorkspace {
         &mut self,
         next_font: shift_font::Font,
         change_set: FontChangeSet,
+        dirty: bool,
     ) -> Result<(), WorkspaceError> {
         if let Some(layer_id) = change_set
             .changes
@@ -650,19 +662,19 @@ impl FontWorkspace {
         }
 
         self.store
-            .apply_change_set_with_font(&change_set, &next_font)?;
+            .apply_change_set_with_font(&change_set, &next_font, dirty)?;
         self.font = next_font;
         self.residency.retain_directory_layers(&self.font);
         Ok(())
     }
 
-    fn commit_edit<R, F>(&mut self, edit: F) -> Result<R, WorkspaceError>
+    fn commit_edit<R, F>(&mut self, dirty: bool, edit: F) -> Result<R, WorkspaceError>
     where
         F: FnOnce(&mut shift_font::Font) -> Result<(R, FontChangeSet), WorkspaceError>,
     {
         let mut next_font = self.font.clone();
         let (result, change_set) = edit(&mut next_font)?;
-        self.commit_font(next_font, change_set)?;
+        self.commit_font(next_font, change_set, dirty)?;
 
         Ok(result)
     }
@@ -695,6 +707,7 @@ impl FontWorkspace {
         state.dirty = false;
         state.saved_revision = state.revision;
         self.store.set_workspace_state(state)?;
+        self.ledger.mark_saved();
         Ok(())
     }
 
@@ -736,6 +749,7 @@ impl FontWorkspace {
             },
             store,
             LayerResidency::default(),
+            false,
         ))
     }
 
@@ -784,6 +798,7 @@ impl FontWorkspace {
                     },
                     store,
                     residency,
+                    false,
                 ));
             }
             Err(shift_backends::BackendError::StreamingUnsupported { .. }) => {}
@@ -803,6 +818,7 @@ impl FontWorkspace {
             },
             store,
             LayerResidency::default(),
+            false,
         ))
     }
 

--- a/crates/shift-workspace/tests/workspace_test.rs
+++ b/crates/shift-workspace/tests/workspace_test.rs
@@ -826,6 +826,30 @@ fn resume_package_workspace_can_save_unsaved_store_state() {
 }
 
 #[test]
+fn dirty_follows_saved_undo_position_across_redo_and_branching() {
+    let temp = tempfile::tempdir().unwrap();
+    let store_path = temp.path().join("working.sqlite");
+    let save_path = temp.path().join("SavedFont.shift");
+    let mut workspace = FontWorkspace::create_untitled(&store_path, NewWorkspace::new()).unwrap();
+    create_glyph(&mut workspace, "A", vec![65]);
+    create_glyph(&mut workspace, "B", vec![66]);
+    workspace.save_as(&save_path).unwrap();
+
+    create_glyph(&mut workspace, "C", vec![67]);
+    assert!(workspace.is_dirty().unwrap());
+    workspace.undo().unwrap();
+    assert!(!workspace.is_dirty().unwrap());
+    workspace.redo().unwrap();
+    assert!(workspace.is_dirty().unwrap());
+
+    workspace.undo().unwrap();
+    workspace.undo().unwrap();
+    assert!(workspace.is_dirty().unwrap());
+    create_glyph(&mut workspace, "D", vec![68]);
+    assert!(workspace.is_dirty().unwrap());
+}
+
+#[test]
 fn save_rejects_missing_package_target_without_recreating_it() {
     let temp = tempfile::tempdir().unwrap();
     let store_path = temp.path().join("working.sqlite");


### PR DESCRIPTION
## Summary

- track one private, branch-safe history position per undo entry while keeping the durable workspace revision monotonic
- remember the current history position on save and derive dirty from the current/saved position match
- persist replayed geometry and its resulting dirty value in the same SQLite transaction
- keep resumed dirty workspaces dirty when their in-memory undo ledger no longer exists

## Behavior coverage

- real `TestEditor`: save, edit through Pen, observe dirty, undo to the saved revision, observe clean
- Rust workspace: clean-on-undo, dirty-on-redo, and a new branch before the saved position remains dirty
- ledger unit coverage for saved positions and bounded history

## Validation

- `cargo test -p shift-workspace -p shift-store`
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm format:check`
- `pnpm check-deps`
- `pnpm test:desktop` — 62 files / 579 tests
- `git diff --check`

Stacked on #210.
