### PR TITLE
test: characterize Select movement and transform outcomes

### DIFF
--- a/apps/desktop/src/renderer/src/lib/tools/select/Select.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/Select.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { isPointId } from "@shift/types";
+import { isPointId, type PointId } from "@shift/types";
 import { TestEditor } from "@/testing/TestEditor";
 import { SELECT_BOUNDING_BOX_STYLE } from "./BoundingBox";
 
@@ -31,6 +31,88 @@ describe("Select tool", () => {
       await editor.click(100, 200);
       await editor.click(9999, 9999);
       expect(editor.selection.hasSelection()).toBe(false);
+    });
+
+    describe("Shift-click selection", () => {
+      let firstId: PointId;
+      let secondId: PointId;
+
+      beforeEach(async () => {
+        const pointIds = await editor.drawOpenContour([
+          { x: 100, y: 100 },
+          { x: 200, y: 200 },
+        ]);
+        if (!pointIds[0] || !pointIds[1]) throw new Error("Expected two points");
+        [firstId, secondId] = pointIds;
+        editor.selectTool("select");
+      });
+
+      it("adds an unselected point without clearing the current selection", async () => {
+        await editor.clickGlyphLocal(100, 100);
+        await editor.clickGlyphLocal(200, 200, { shiftKey: true });
+
+        expect(editor.selection.has(firstId)).toBe(true);
+        expect(editor.selection.has(secondId)).toBe(true);
+        expect(editor.selection.ids).toHaveLength(2);
+      });
+
+      it("removes a selected point while preserving the other selection", async () => {
+        editor.selection.select([firstId, secondId]);
+
+        await editor.clickGlyphLocal(100, 100, { shiftKey: true });
+
+        expect(editor.selection.has(firstId)).toBe(false);
+        expect(editor.selection.has(secondId)).toBe(true);
+        expect(editor.selection.ids).toHaveLength(1);
+      });
+
+      it("preserves the current selection when clicking empty canvas", async () => {
+        editor.selection.select([firstId, secondId]);
+
+        await editor.click(9999, 9999, { shiftKey: true });
+
+        expect(editor.selection.has(firstId)).toBe(true);
+        expect(editor.selection.has(secondId)).toBe(true);
+        expect(editor.selection.ids).toHaveLength(2);
+      });
+
+      it("adds an unselected segment", async () => {
+        const segmentId = editor.requireGlyphLayer().contours[0]?.segments()[0]?.id;
+        if (!segmentId) throw new Error("Expected segment");
+
+        await editor.clickGlyphLocal(150, 150, { shiftKey: true });
+
+        expect(editor.selection.has(segmentId)).toBe(true);
+      });
+
+      it("removes a selected segment", async () => {
+        const segmentId = editor.requireGlyphLayer().contours[0]?.segments()[0]?.id;
+        if (!segmentId) throw new Error("Expected segment");
+        editor.selection.select([segmentId]);
+
+        await editor.clickGlyphLocal(150, 150, { shiftKey: true });
+
+        expect(editor.selection.has(segmentId)).toBe(false);
+      });
+
+      it("adds an unselected anchor", async () => {
+        const anchorId = editor.requireGlyphLayer().addAnchor("top", { x: 300, y: 300 });
+        await editor.settle();
+
+        await editor.clickGlyphLocal(300, 300, { shiftKey: true });
+
+        expect(editor.selection.has(anchorId)).toBe(true);
+      });
+
+      it("removes a selected anchor", async () => {
+        const anchorId = editor.requireGlyphLayer().addAnchor("top", { x: 300, y: 300 });
+        await editor.settle();
+        editor.selection.select([anchorId]);
+
+        await editor.clickGlyphLocal(300, 300, { shiftKey: true });
+
+        expect(editor.selection.has(anchorId)).toBe(false);
+      });
     });
 
     it("drags a selected point", async () => {

--- a/apps/desktop/src/renderer/src/lib/tools/select/SelectMove.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/SelectMove.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { PointId } from "@shift/types";
+import type { GlyphLayer } from "@/lib/model/Glyph";
+import { TestEditor } from "@/testing/TestEditor";
+
+describe("Select movement preserves selected geometry", () => {
+  let editor: TestEditor;
+  let layer: GlyphLayer;
+  let firstId: PointId;
+  let middleId: PointId;
+  let lastId: PointId;
+
+  beforeEach(async () => {
+    editor = new TestEditor();
+    await editor.startSession();
+    [firstId, middleId, lastId] = await editor.drawOpenContour([
+      { x: 100, y: 100 },
+      { x: 150, y: 150 },
+      { x: 200, y: 200 },
+    ]);
+    layer = editor.requireGlyphLayer();
+    editor.selectTool("select");
+  });
+
+  it("moves every point when dragging one point in a multi-point selection", async () => {
+    editor.selection.select([firstId, middleId, lastId]);
+
+    const drag = editor.dragScene({
+      down: editor.pointPosition(middleId),
+      start: { x: 154, y: 150 },
+      end: { x: 190, y: 180 },
+    });
+    await editor.settle();
+
+    expect(editor.pointPosition(firstId)).toEqual({ x: 100 + drag.delta.x, y: 100 + drag.delta.y });
+    expect(editor.pointPosition(middleId)).toEqual({
+      x: 150 + drag.delta.x,
+      y: 150 + drag.delta.y,
+    });
+    expect(editor.pointPosition(lastId)).toEqual({ x: 200 + drag.delta.x, y: 200 + drag.delta.y });
+  });
+
+  it("selects and moves an anchor dragged directly", async () => {
+    const anchorId = layer.addAnchor("top", { x: 300, y: 300 });
+    await editor.settle();
+
+    const drag = editor.dragScene({
+      down: editor.anchorPosition(anchorId),
+      start: { x: 304, y: 300 },
+      end: { x: 330, y: 320 },
+    });
+    await editor.settle();
+
+    expect(editor.selection.has(anchorId)).toBe(true);
+    expect(editor.anchorPosition(anchorId)).toEqual({
+      x: 300 + drag.delta.x,
+      y: 300 + drag.delta.y,
+    });
+  });
+
+  it("moves selected points and anchors together", async () => {
+    const anchorId = layer.addAnchor("top", { x: 300, y: 300 });
+    await editor.settle();
+    editor.selection.select([firstId, middleId, anchorId]);
+
+    const drag = editor.dragScene({
+      down: editor.pointPosition(middleId),
+      start: { x: 154, y: 150 },
+      end: { x: 180, y: 170 },
+    });
+    await editor.settle();
+
+    expect(editor.pointPosition(firstId)).toEqual({ x: 100 + drag.delta.x, y: 100 + drag.delta.y });
+    expect(editor.pointPosition(middleId)).toEqual({
+      x: 150 + drag.delta.x,
+      y: 150 + drag.delta.y,
+    });
+    expect(editor.anchorPosition(anchorId)).toEqual({
+      x: 300 + drag.delta.x,
+      y: 300 + drag.delta.y,
+    });
+  });
+
+  it("moves contour points once when contour and point identities are selected", async () => {
+    const contour = layer.contours[0];
+    if (!contour) throw new Error("Expected contour");
+    editor.selection.select([contour.id, firstId, middleId, lastId]);
+
+    const drag = editor.dragScene({
+      down: editor.pointPosition(middleId),
+      start: { x: 154, y: 150 },
+      end: { x: 180, y: 170 },
+    });
+    await editor.settle();
+
+    expect(editor.pointPosition(firstId)).toEqual({ x: 100 + drag.delta.x, y: 100 + drag.delta.y });
+    expect(editor.pointPosition(middleId)).toEqual({
+      x: 150 + drag.delta.x,
+      y: 150 + drag.delta.y,
+    });
+    expect(editor.pointPosition(lastId)).toEqual({ x: 200 + drag.delta.x, y: 200 + drag.delta.y });
+  });
+
+  it("restores every previewed position when Escape cancels movement", () => {
+    editor.selection.select([firstId, middleId, lastId]);
+    const down = editor.projectSceneToScreen(editor.pointPosition(middleId));
+    const start = editor.projectSceneToScreen({ x: 154, y: 150 });
+    const end = editor.projectSceneToScreen({ x: 190, y: 180 });
+
+    editor.pointerDown(down.x, down.y).pointerMove(start.x, start.y).pointerMove(end.x, end.y);
+    expect(editor.pointPosition(middleId)).not.toEqual({ x: 150, y: 150 });
+    editor.escape();
+
+    expect(editor.pointPosition(firstId)).toEqual({ x: 100, y: 100 });
+    expect(editor.pointPosition(middleId)).toEqual({ x: 150, y: 150 });
+    expect(editor.pointPosition(lastId)).toEqual({ x: 200, y: 200 });
+  });
+
+  it("commits movement as one undoable and redoable edit", async () => {
+    editor.selection.select([firstId, middleId, lastId]);
+    editor.dragScene({
+      down: editor.pointPosition(middleId),
+      start: { x: 154, y: 150 },
+      end: { x: 190, y: 180 },
+    });
+    await editor.settle();
+    const moved = [
+      editor.pointPosition(firstId),
+      editor.pointPosition(middleId),
+      editor.pointPosition(lastId),
+    ];
+
+    await editor.undoAndSettle();
+    expect([
+      editor.pointPosition(firstId),
+      editor.pointPosition(middleId),
+      editor.pointPosition(lastId),
+    ]).toEqual([
+      { x: 100, y: 100 },
+      { x: 150, y: 150 },
+      { x: 200, y: 200 },
+    ]);
+
+    await editor.redoAndSettle();
+    expect([
+      editor.pointPosition(firstId),
+      editor.pointPosition(middleId),
+      editor.pointPosition(lastId),
+    ]).toEqual(moved);
+  });
+
+  it("recomputes each preview from the interaction base", () => {
+    editor.selection.select([firstId]);
+    const down = editor.projectSceneToScreen(editor.pointPosition(firstId));
+    const start = editor.projectSceneToScreen({ x: 104, y: 100 });
+    const first = editor.projectSceneToScreen({ x: 120, y: 100 });
+    const second = editor.projectSceneToScreen({ x: 130, y: 100 });
+
+    editor.pointerDown(down.x, down.y).pointerMove(start.x, start.y).pointerMove(first.x, first.y);
+    const firstPreview = editor.pointPosition(firstId);
+    editor.pointerMove(second.x, second.y);
+    const secondPreview = editor.pointPosition(firstId);
+    editor.escape();
+
+    expect(secondPreview.x - firstPreview.x).toBeCloseTo(10);
+    expect(editor.pointPosition(firstId)).toEqual({ x: 100, y: 100 });
+  });
+
+  it("moves both neighboring handles with a dragged smooth point", async () => {
+    for (const segment of layer.contours[0]?.segments() ?? []) {
+      expect(layer.upgradeLineToCubic(segment.id)).toBe(true);
+    }
+    layer.toggleSmooth(middleId);
+    await editor.settle();
+
+    const cubics = layer.contours[0]?.segments().map((segment) => segment.asCubic()) ?? [];
+    const incoming = cubics.find((segment) => segment?.end.id === middleId);
+    const outgoing = cubics.find((segment) => segment?.start.id === middleId);
+    if (!incoming || !outgoing) throw new Error("Expected cubic neighbors");
+    const incomingBefore = editor.pointPosition(incoming.controlEnd.id);
+    const outgoingBefore = editor.pointPosition(outgoing.controlStart.id);
+
+    const drag = editor.dragScene({
+      down: editor.pointPosition(middleId),
+      start: { x: 154, y: 150 },
+      end: { x: 180, y: 170 },
+    });
+    await editor.settle();
+
+    expect(editor.pointPosition(incoming.controlEnd.id)).toEqual({
+      x: incomingBefore.x + drag.delta.x,
+      y: incomingBefore.y + drag.delta.y,
+    });
+    expect(editor.pointPosition(outgoing.controlStart.id)).toEqual({
+      x: outgoingBefore.x + drag.delta.x,
+      y: outgoingBefore.y + drag.delta.y,
+    });
+  });
+
+  it("does not move geometry before the drag threshold is crossed", async () => {
+    const point = editor.projectSceneToScreen(editor.pointPosition(firstId));
+
+    editor
+      .pointerDown(point.x, point.y)
+      .pointerMove(point.x + 2, point.y)
+      .pointerUp(point.x + 2, point.y);
+    await editor.settle();
+
+    expect(editor.pointPosition(firstId)).toEqual({ x: 100, y: 100 });
+    expect(editor.pointPosition(lastId)).toEqual({ x: 200, y: 200 });
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/tools/select/SelectMove.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/SelectMove.test.ts
@@ -25,12 +25,11 @@ describe("Select movement preserves selected geometry", () => {
   it("moves every point when dragging one point in a multi-point selection", async () => {
     editor.selection.select([firstId, middleId, lastId]);
 
-    const drag = editor.dragScene({
+    const drag = await editor.dragScene({
       down: editor.pointPosition(middleId),
       start: { x: 154, y: 150 },
       end: { x: 190, y: 180 },
     });
-    await editor.settle();
 
     expect(editor.pointPosition(firstId)).toEqual({ x: 100 + drag.delta.x, y: 100 + drag.delta.y });
     expect(editor.pointPosition(middleId)).toEqual({
@@ -44,12 +43,11 @@ describe("Select movement preserves selected geometry", () => {
     const anchorId = layer.addAnchor("top", { x: 300, y: 300 });
     await editor.settle();
 
-    const drag = editor.dragScene({
+    const drag = await editor.dragScene({
       down: editor.anchorPosition(anchorId),
       start: { x: 304, y: 300 },
       end: { x: 330, y: 320 },
     });
-    await editor.settle();
 
     expect(editor.selection.has(anchorId)).toBe(true);
     expect(editor.anchorPosition(anchorId)).toEqual({
@@ -63,12 +61,11 @@ describe("Select movement preserves selected geometry", () => {
     await editor.settle();
     editor.selection.select([firstId, middleId, anchorId]);
 
-    const drag = editor.dragScene({
+    const drag = await editor.dragScene({
       down: editor.pointPosition(middleId),
       start: { x: 154, y: 150 },
       end: { x: 180, y: 170 },
     });
-    await editor.settle();
 
     expect(editor.pointPosition(firstId)).toEqual({ x: 100 + drag.delta.x, y: 100 + drag.delta.y });
     expect(editor.pointPosition(middleId)).toEqual({
@@ -86,12 +83,11 @@ describe("Select movement preserves selected geometry", () => {
     if (!contour) throw new Error("Expected contour");
     editor.selection.select([contour.id, firstId, middleId, lastId]);
 
-    const drag = editor.dragScene({
+    const drag = await editor.dragScene({
       down: editor.pointPosition(middleId),
       start: { x: 154, y: 150 },
       end: { x: 180, y: 170 },
     });
-    await editor.settle();
 
     expect(editor.pointPosition(firstId)).toEqual({ x: 100 + drag.delta.x, y: 100 + drag.delta.y });
     expect(editor.pointPosition(middleId)).toEqual({
@@ -118,19 +114,18 @@ describe("Select movement preserves selected geometry", () => {
 
   it("commits movement as one undoable and redoable edit", async () => {
     editor.selection.select([firstId, middleId, lastId]);
-    editor.dragScene({
+    await editor.dragScene({
       down: editor.pointPosition(middleId),
       start: { x: 154, y: 150 },
       end: { x: 190, y: 180 },
     });
-    await editor.settle();
     const moved = [
       editor.pointPosition(firstId),
       editor.pointPosition(middleId),
       editor.pointPosition(lastId),
     ];
 
-    await editor.undoAndSettle();
+    await editor.undo();
     expect([
       editor.pointPosition(firstId),
       editor.pointPosition(middleId),
@@ -141,7 +136,7 @@ describe("Select movement preserves selected geometry", () => {
       { x: 200, y: 200 },
     ]);
 
-    await editor.redoAndSettle();
+    await editor.redo();
     expect([
       editor.pointPosition(firstId),
       editor.pointPosition(middleId),
@@ -180,12 +175,11 @@ describe("Select movement preserves selected geometry", () => {
     const incomingBefore = editor.pointPosition(incoming.controlEnd.id);
     const outgoingBefore = editor.pointPosition(outgoing.controlStart.id);
 
-    const drag = editor.dragScene({
+    const drag = await editor.dragScene({
       down: editor.pointPosition(middleId),
       start: { x: 154, y: 150 },
       end: { x: 180, y: 170 },
     });
-    await editor.settle();
 
     expect(editor.pointPosition(incoming.controlEnd.id)).toEqual({
       x: incomingBefore.x + drag.delta.x,

--- a/apps/desktop/src/renderer/src/lib/tools/select/SelectNudge.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/SelectNudge.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { PointId } from "@shift/types";
+import { TestEditor } from "@/testing/TestEditor";
+
+describe("Select arrow keys nudge selected points", () => {
+  let editor: TestEditor;
+  let firstId: PointId;
+  let secondId: PointId;
+
+  beforeEach(async () => {
+    editor = new TestEditor();
+    await editor.startSession();
+    [firstId, secondId] = await editor.drawOpenContour([
+      { x: 100, y: 100 },
+      { x: 200, y: 200 },
+    ]);
+    editor.selection.select([firstId]);
+    editor.selectTool("select");
+  });
+
+  it.each([
+    ["ArrowLeft", { x: 99, y: 100 }],
+    ["ArrowRight", { x: 101, y: 100 }],
+    ["ArrowUp", { x: 100, y: 101 }],
+    ["ArrowDown", { x: 100, y: 99 }],
+  ] as const)("moves in the %s direction", async (key, expected) => {
+    editor.keyDown(key);
+    await editor.settle();
+
+    expect(editor.pointPosition(firstId)).toEqual(expected);
+    expect(editor.pointPosition(secondId)).toEqual({ x: 200, y: 200 });
+  });
+
+  it.each([
+    ["the default increment", {}, 1],
+    ["the Shift increment", { shiftKey: true }, 10],
+    ["the accelerator increment", { metaKey: true }, 100],
+  ] as const)("uses %s", async (_description, modifiers, distance) => {
+    editor.keyDown("ArrowRight", modifiers);
+    await editor.settle();
+
+    expect(editor.pointPosition(firstId)).toEqual({ x: 100 + distance, y: 100 });
+  });
+
+  it("moves every selected point by the same increment", async () => {
+    editor.selection.select([firstId, secondId]);
+
+    editor.keyDown("ArrowUp", { shiftKey: true });
+    await editor.settle();
+
+    expect(editor.pointPosition(firstId)).toEqual({ x: 100, y: 110 });
+    expect(editor.pointPosition(secondId)).toEqual({ x: 200, y: 210 });
+  });
+
+  it("commits a nudge as one undoable and redoable edit", async () => {
+    editor.selection.select([firstId, secondId]);
+    editor.keyDown("ArrowRight", { shiftKey: true });
+    await editor.settle();
+    const nudged = [editor.pointPosition(firstId), editor.pointPosition(secondId)];
+
+    await editor.undoAndSettle();
+    expect([editor.pointPosition(firstId), editor.pointPosition(secondId)]).toEqual([
+      { x: 100, y: 100 },
+      { x: 200, y: 200 },
+    ]);
+
+    await editor.redoAndSettle();
+    expect([editor.pointPosition(firstId), editor.pointPosition(secondId)]).toEqual(nudged);
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/tools/select/SelectNudge.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/SelectNudge.test.ts
@@ -24,8 +24,7 @@ describe("Select arrow keys nudge selected points", () => {
     ["ArrowUp", { x: 100, y: 101 }],
     ["ArrowDown", { x: 100, y: 99 }],
   ] as const)("moves in the %s direction", async (key, expected) => {
-    editor.keyDown(key);
-    await editor.settle();
+    await editor.pressKey(key);
 
     expect(editor.pointPosition(firstId)).toEqual(expected);
     expect(editor.pointPosition(secondId)).toEqual({ x: 200, y: 200 });
@@ -36,8 +35,7 @@ describe("Select arrow keys nudge selected points", () => {
     ["the Shift increment", { shiftKey: true }, 10],
     ["the accelerator increment", { metaKey: true }, 100],
   ] as const)("uses %s", async (_description, modifiers, distance) => {
-    editor.keyDown("ArrowRight", modifiers);
-    await editor.settle();
+    await editor.pressKey("ArrowRight", modifiers);
 
     expect(editor.pointPosition(firstId)).toEqual({ x: 100 + distance, y: 100 });
   });
@@ -45,8 +43,7 @@ describe("Select arrow keys nudge selected points", () => {
   it("moves every selected point by the same increment", async () => {
     editor.selection.select([firstId, secondId]);
 
-    editor.keyDown("ArrowUp", { shiftKey: true });
-    await editor.settle();
+    await editor.pressKey("ArrowUp", { shiftKey: true });
 
     expect(editor.pointPosition(firstId)).toEqual({ x: 100, y: 110 });
     expect(editor.pointPosition(secondId)).toEqual({ x: 200, y: 210 });
@@ -54,17 +51,16 @@ describe("Select arrow keys nudge selected points", () => {
 
   it("commits a nudge as one undoable and redoable edit", async () => {
     editor.selection.select([firstId, secondId]);
-    editor.keyDown("ArrowRight", { shiftKey: true });
-    await editor.settle();
+    await editor.pressKey("ArrowRight", { shiftKey: true });
     const nudged = [editor.pointPosition(firstId), editor.pointPosition(secondId)];
 
-    await editor.undoAndSettle();
+    await editor.undo();
     expect([editor.pointPosition(firstId), editor.pointPosition(secondId)]).toEqual([
       { x: 100, y: 100 },
       { x: 200, y: 200 },
     ]);
 
-    await editor.redoAndSettle();
+    await editor.redo();
     expect([editor.pointPosition(firstId), editor.pointPosition(secondId)]).toEqual(nudged);
   });
 });

--- a/apps/desktop/src/renderer/src/lib/tools/select/SelectTransform.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/SelectTransform.test.ts
@@ -1,0 +1,295 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Point2D } from "@shift/geo";
+import type { PointId } from "@shift/types";
+import type { GlyphLayer } from "@/lib/model/Glyph";
+import { TestEditor } from "@/testing/TestEditor";
+import { SELECT_BOUNDING_BOX_STYLE } from "./BoundingBox";
+
+describe("Select bounding-box transforms preserve geometry outcomes", () => {
+  let editor: TestEditor;
+  let layer: GlyphLayer;
+  let firstId: PointId;
+  let secondId: PointId;
+
+  beforeEach(async () => {
+    editor = new TestEditor();
+    await editor.startSession();
+    [firstId, secondId] = await editor.drawOpenContour([
+      { x: 100, y: 100 },
+      { x: 200, y: 200 },
+    ]);
+    layer = editor.requireGlyphLayer();
+    editor.selection.select([firstId, secondId]);
+    editor.selectTool("select");
+  });
+
+  describe("resizing", () => {
+    it("changes only X when dragging the right edge", async () => {
+      const bounds = editor.selectionBounds();
+      if (!bounds) throw new Error("Expected selection bounds");
+
+      editor.dragScene({
+        down: { x: bounds.right, y: (bounds.top + bounds.bottom) / 2 },
+        start: { x: bounds.right + 4, y: (bounds.top + bounds.bottom) / 2 },
+        end: { x: bounds.right + 50, y: (bounds.top + bounds.bottom) / 2 },
+      });
+      await editor.settle();
+
+      expect(editor.pointPosition(firstId)).toEqual({ x: 100, y: 100 });
+      expect(editor.pointPosition(secondId)).toEqual({ x: 250, y: 200 });
+    });
+
+    it("changes only Y when dragging the bottom edge", async () => {
+      const bounds = editor.selectionBounds();
+      if (!bounds) throw new Error("Expected selection bounds");
+
+      editor.dragScene({
+        down: { x: (bounds.left + bounds.right) / 2, y: bounds.bottom },
+        start: { x: (bounds.left + bounds.right) / 2, y: bounds.bottom + 4 },
+        end: { x: (bounds.left + bounds.right) / 2, y: bounds.bottom + 50 },
+      });
+      await editor.settle();
+
+      expect(editor.pointPosition(firstId)).toEqual({ x: 100, y: 100 });
+      expect(editor.pointPosition(secondId)).toEqual({ x: 200, y: 250 });
+    });
+
+    it("resizes both axes from a corner", async () => {
+      const bounds = editor.selectionBounds();
+      if (!bounds) throw new Error("Expected selection bounds");
+
+      editor.dragScene({
+        down: { x: bounds.right, y: bounds.bottom },
+        start: { x: bounds.right + 4, y: bounds.bottom + 4 },
+        end: { x: bounds.right + 50, y: bounds.bottom + 25 },
+      });
+      await editor.settle();
+
+      expect(editor.pointPosition(firstId)).toEqual({ x: 100, y: 100 });
+      expect(editor.pointPosition(secondId)).toEqual({ x: 250, y: 225 });
+    });
+
+    it("uses one scale on both axes for a Shift-corner resize", async () => {
+      const bounds = editor.selectionBounds();
+      if (!bounds) throw new Error("Expected selection bounds");
+
+      editor.dragScene({
+        down: { x: bounds.right, y: bounds.bottom },
+        start: { x: bounds.right + 4, y: bounds.bottom + 4 },
+        end: { x: bounds.right + 100, y: bounds.bottom + 50 },
+        options: { shiftKey: true },
+      });
+      await editor.settle();
+
+      expect(editor.pointPosition(firstId)).toEqual({ x: 100, y: 100 });
+      expect(editor.pointPosition(secondId)).toEqual({ x: 300, y: 300 });
+    });
+
+    it("flips geometry after the dragged edge crosses the fixed edge", async () => {
+      const bounds = editor.selectionBounds();
+      if (!bounds) throw new Error("Expected selection bounds");
+      const centerY = (bounds.top + bounds.bottom) / 2;
+
+      editor.dragScene({
+        down: { x: bounds.right, y: centerY },
+        start: { x: bounds.right + 4, y: centerY },
+        end: { x: 50, y: centerY },
+      });
+      await editor.settle();
+
+      expect(editor.pointPosition(firstId)).toEqual({ x: 100, y: 100 });
+      expect(editor.pointPosition(secondId)).toEqual({ x: 50, y: 200 });
+    });
+
+    it("restores original positions when Escape cancels resize", () => {
+      const bounds = editor.selectionBounds();
+      if (!bounds) throw new Error("Expected selection bounds");
+      const down = editor.projectSceneToScreen({ x: bounds.right, y: bounds.bottom });
+      const start = editor.projectSceneToScreen({ x: bounds.right + 4, y: bounds.bottom + 4 });
+      const end = editor.projectSceneToScreen({ x: bounds.right + 50, y: bounds.bottom + 50 });
+
+      editor.pointerDown(down.x, down.y).pointerMove(start.x, start.y).pointerMove(end.x, end.y);
+      expect(editor.pointPosition(secondId)).not.toEqual({ x: 200, y: 200 });
+      editor.escape();
+
+      expect(editor.pointPosition(firstId)).toEqual({ x: 100, y: 100 });
+      expect(editor.pointPosition(secondId)).toEqual({ x: 200, y: 200 });
+    });
+
+    it("commits resize as one undoable and redoable edit", async () => {
+      const bounds = editor.selectionBounds();
+      if (!bounds) throw new Error("Expected selection bounds");
+      editor.dragScene({
+        down: { x: bounds.right, y: bounds.bottom },
+        start: { x: bounds.right + 4, y: bounds.bottom + 4 },
+        end: { x: bounds.right + 50, y: bounds.bottom + 50 },
+      });
+      await editor.settle();
+      const resized = editor.pointPosition(secondId);
+
+      await editor.undoAndSettle();
+      expect(editor.pointPosition(secondId)).toEqual({ x: 200, y: 200 });
+      await editor.redoAndSettle();
+      expect(editor.pointPosition(secondId)).toEqual(resized);
+    });
+  });
+
+  describe("rotation", () => {
+    function rotateAcrossBottomEdge(): void {
+      const bounds = editor.selectionBounds();
+      if (!bounds) throw new Error("Expected selection bounds");
+      const offset = SELECT_BOUNDING_BOX_STYLE.rotationZoneOffsetPx;
+
+      editor.dragScene({
+        down: { x: bounds.right + offset, y: bounds.bottom + offset },
+        start: { x: bounds.right + offset + 4, y: bounds.bottom + offset + 4 },
+        end: { x: bounds.left - offset, y: bounds.bottom + offset },
+      });
+    }
+
+    it("rotates around the center of the selection", async () => {
+      rotateAcrossBottomEdge();
+      await editor.settle();
+
+      expect(editor.pointPosition(firstId).x).toBeCloseTo(200);
+      expect(editor.pointPosition(firstId).y).toBeCloseTo(100);
+      expect(editor.pointPosition(secondId).x).toBeCloseTo(100);
+      expect(editor.pointPosition(secondId).y).toBeCloseTo(200);
+    });
+
+    it("uses glyph-local geometry when the scene node has a non-zero position", async () => {
+      const node = editor.glyphNode;
+      if (!node) throw new Error("Expected glyph node");
+      editor.scene.updateNode({ id: node.id, position: { x: 400, y: 300 } });
+
+      rotateAcrossBottomEdge();
+      await editor.settle();
+
+      expect(editor.pointPosition(firstId).x).toBeCloseTo(200);
+      expect(editor.pointPosition(firstId).y).toBeCloseTo(100);
+      expect(editor.pointPosition(secondId).x).toBeCloseTo(100);
+      expect(editor.pointPosition(secondId).y).toBeCloseTo(200);
+    });
+
+    it("restores original positions when Escape cancels rotation", () => {
+      const bounds = editor.selectionBounds();
+      if (!bounds) throw new Error("Expected selection bounds");
+      const offset = SELECT_BOUNDING_BOX_STYLE.rotationZoneOffsetPx;
+      const down = editor.projectSceneToScreen({
+        x: bounds.right + offset,
+        y: bounds.bottom + offset,
+      });
+      const start = editor.projectSceneToScreen({
+        x: bounds.right + offset + 4,
+        y: bounds.bottom + offset + 4,
+      });
+      const end = editor.projectSceneToScreen({
+        x: bounds.left - offset,
+        y: bounds.bottom + offset,
+      });
+
+      editor.pointerDown(down.x, down.y).pointerMove(start.x, start.y).pointerMove(end.x, end.y);
+      expect(editor.pointPosition(firstId)).not.toEqual({ x: 100, y: 100 });
+      editor.escape();
+
+      expect(editor.pointPosition(firstId)).toEqual({ x: 100, y: 100 });
+      expect(editor.pointPosition(secondId)).toEqual({ x: 200, y: 200 });
+    });
+
+    it("commits rotation as one undoable and redoable edit", async () => {
+      rotateAcrossBottomEdge();
+      await editor.settle();
+      const rotated = [editor.pointPosition(firstId), editor.pointPosition(secondId)];
+
+      await editor.undoAndSettle();
+      expect([editor.pointPosition(firstId), editor.pointPosition(secondId)]).toEqual([
+        { x: 100, y: 100 },
+        { x: 200, y: 200 },
+      ]);
+
+      await editor.redoAndSettle();
+      expect([editor.pointPosition(firstId), editor.pointPosition(secondId)]).toEqual(rotated);
+    });
+
+    it("rotates selected points and anchors with the same transform", async () => {
+      const anchorId = layer.addAnchor("mark", { x: 125, y: 125 });
+      await editor.settle();
+      editor.selection.select([firstId, secondId, anchorId]);
+
+      rotateAcrossBottomEdge();
+      await editor.settle();
+      const first = editor.pointPosition(firstId);
+      const second = editor.pointPosition(secondId);
+
+      expect(editor.anchorPosition(anchorId).x).toBeCloseTo(first.x + (second.x - first.x) * 0.25);
+      expect(editor.anchorPosition(anchorId).y).toBeCloseTo(first.y + (second.y - first.y) * 0.25);
+    });
+  });
+});
+
+describe("Select curve bending preserves edit lifecycle", () => {
+  let editor: TestEditor;
+  let layer: GlyphLayer;
+  let controlOneId: PointId;
+  let controlTwoId: PointId;
+  let bendPoint: Point2D;
+
+  beforeEach(async () => {
+    editor = new TestEditor();
+    await editor.startSession();
+    await editor.drawOpenContour([
+      { x: 100, y: 200 },
+      { x: 200, y: 200 },
+    ]);
+    layer = editor.requireGlyphLayer();
+    const segment = layer.contours[0]?.segments()[0];
+    if (!segment || !layer.upgradeLineToCubic(segment.id)) throw new Error("Expected cubic");
+    await editor.settle();
+    const cubicSegment = layer.contours[0]?.segments()[0];
+    const cubic = cubicSegment?.asCubic();
+    if (!cubicSegment || !cubic) throw new Error("Expected cubic");
+    controlOneId = cubic.controlStart.id;
+    controlTwoId = cubic.controlEnd.id;
+    bendPoint = cubicSegment.pointAt(0.5);
+    editor.selectTool("select");
+  });
+
+  it("restores both controls when Escape cancels bending", () => {
+    const oneBefore = editor.pointPosition(controlOneId);
+    const twoBefore = editor.pointPosition(controlTwoId);
+    const down = editor.projectSceneToScreen(bendPoint);
+    const start = editor.projectSceneToScreen({ x: bendPoint.x + 4, y: bendPoint.y });
+    const end = editor.projectSceneToScreen({ x: bendPoint.x + 4, y: bendPoint.y + 40 });
+
+    editor.pointerDown(down.x, down.y, { metaKey: true });
+    editor.pointerMove(start.x, start.y, { metaKey: true });
+    editor.pointerMove(end.x, end.y, { metaKey: true });
+    expect(editor.pointPosition(controlOneId)).not.toEqual(oneBefore);
+    editor.escape();
+
+    expect(editor.pointPosition(controlOneId)).toEqual(oneBefore);
+    expect(editor.pointPosition(controlTwoId)).toEqual(twoBefore);
+  });
+
+  it("commits bending as one undoable and redoable edit", async () => {
+    const oneBefore = editor.pointPosition(controlOneId);
+    const twoBefore = editor.pointPosition(controlTwoId);
+    editor.dragScene({
+      down: bendPoint,
+      start: { x: bendPoint.x + 4, y: bendPoint.y },
+      end: { x: bendPoint.x + 4, y: bendPoint.y + 40 },
+      options: { metaKey: true },
+    });
+    await editor.settle();
+    const bent = [editor.pointPosition(controlOneId), editor.pointPosition(controlTwoId)];
+
+    await editor.undoAndSettle();
+    expect([editor.pointPosition(controlOneId), editor.pointPosition(controlTwoId)]).toEqual([
+      oneBefore,
+      twoBefore,
+    ]);
+
+    await editor.redoAndSettle();
+    expect([editor.pointPosition(controlOneId), editor.pointPosition(controlTwoId)]).toEqual(bent);
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/tools/select/SelectTransform.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/SelectTransform.test.ts
@@ -28,12 +28,11 @@ describe("Select bounding-box transforms preserve geometry outcomes", () => {
       const bounds = editor.selectionBounds();
       if (!bounds) throw new Error("Expected selection bounds");
 
-      editor.dragScene({
+      await editor.dragScene({
         down: { x: bounds.right, y: (bounds.top + bounds.bottom) / 2 },
         start: { x: bounds.right + 4, y: (bounds.top + bounds.bottom) / 2 },
         end: { x: bounds.right + 50, y: (bounds.top + bounds.bottom) / 2 },
       });
-      await editor.settle();
 
       expect(editor.pointPosition(firstId)).toEqual({ x: 100, y: 100 });
       expect(editor.pointPosition(secondId)).toEqual({ x: 250, y: 200 });
@@ -43,12 +42,11 @@ describe("Select bounding-box transforms preserve geometry outcomes", () => {
       const bounds = editor.selectionBounds();
       if (!bounds) throw new Error("Expected selection bounds");
 
-      editor.dragScene({
+      await editor.dragScene({
         down: { x: (bounds.left + bounds.right) / 2, y: bounds.bottom },
         start: { x: (bounds.left + bounds.right) / 2, y: bounds.bottom + 4 },
         end: { x: (bounds.left + bounds.right) / 2, y: bounds.bottom + 50 },
       });
-      await editor.settle();
 
       expect(editor.pointPosition(firstId)).toEqual({ x: 100, y: 100 });
       expect(editor.pointPosition(secondId)).toEqual({ x: 200, y: 250 });
@@ -58,12 +56,11 @@ describe("Select bounding-box transforms preserve geometry outcomes", () => {
       const bounds = editor.selectionBounds();
       if (!bounds) throw new Error("Expected selection bounds");
 
-      editor.dragScene({
+      await editor.dragScene({
         down: { x: bounds.right, y: bounds.bottom },
         start: { x: bounds.right + 4, y: bounds.bottom + 4 },
         end: { x: bounds.right + 50, y: bounds.bottom + 25 },
       });
-      await editor.settle();
 
       expect(editor.pointPosition(firstId)).toEqual({ x: 100, y: 100 });
       expect(editor.pointPosition(secondId)).toEqual({ x: 250, y: 225 });
@@ -73,13 +70,12 @@ describe("Select bounding-box transforms preserve geometry outcomes", () => {
       const bounds = editor.selectionBounds();
       if (!bounds) throw new Error("Expected selection bounds");
 
-      editor.dragScene({
+      await editor.dragScene({
         down: { x: bounds.right, y: bounds.bottom },
         start: { x: bounds.right + 4, y: bounds.bottom + 4 },
         end: { x: bounds.right + 100, y: bounds.bottom + 50 },
         options: { shiftKey: true },
       });
-      await editor.settle();
 
       expect(editor.pointPosition(firstId)).toEqual({ x: 100, y: 100 });
       expect(editor.pointPosition(secondId)).toEqual({ x: 300, y: 300 });
@@ -90,12 +86,11 @@ describe("Select bounding-box transforms preserve geometry outcomes", () => {
       if (!bounds) throw new Error("Expected selection bounds");
       const centerY = (bounds.top + bounds.bottom) / 2;
 
-      editor.dragScene({
+      await editor.dragScene({
         down: { x: bounds.right, y: centerY },
         start: { x: bounds.right + 4, y: centerY },
         end: { x: 50, y: centerY },
       });
-      await editor.settle();
 
       expect(editor.pointPosition(firstId)).toEqual({ x: 100, y: 100 });
       expect(editor.pointPosition(secondId)).toEqual({ x: 50, y: 200 });
@@ -119,28 +114,27 @@ describe("Select bounding-box transforms preserve geometry outcomes", () => {
     it("commits resize as one undoable and redoable edit", async () => {
       const bounds = editor.selectionBounds();
       if (!bounds) throw new Error("Expected selection bounds");
-      editor.dragScene({
+      await editor.dragScene({
         down: { x: bounds.right, y: bounds.bottom },
         start: { x: bounds.right + 4, y: bounds.bottom + 4 },
         end: { x: bounds.right + 50, y: bounds.bottom + 50 },
       });
-      await editor.settle();
       const resized = editor.pointPosition(secondId);
 
-      await editor.undoAndSettle();
+      await editor.undo();
       expect(editor.pointPosition(secondId)).toEqual({ x: 200, y: 200 });
-      await editor.redoAndSettle();
+      await editor.redo();
       expect(editor.pointPosition(secondId)).toEqual(resized);
     });
   });
 
   describe("rotation", () => {
-    function rotateAcrossBottomEdge(): void {
+    async function rotateAcrossBottomEdge(): Promise<void> {
       const bounds = editor.selectionBounds();
       if (!bounds) throw new Error("Expected selection bounds");
       const offset = SELECT_BOUNDING_BOX_STYLE.rotationZoneOffsetPx;
 
-      editor.dragScene({
+      await editor.dragScene({
         down: { x: bounds.right + offset, y: bounds.bottom + offset },
         start: { x: bounds.right + offset + 4, y: bounds.bottom + offset + 4 },
         end: { x: bounds.left - offset, y: bounds.bottom + offset },
@@ -148,8 +142,7 @@ describe("Select bounding-box transforms preserve geometry outcomes", () => {
     }
 
     it("rotates around the center of the selection", async () => {
-      rotateAcrossBottomEdge();
-      await editor.settle();
+      await rotateAcrossBottomEdge();
 
       expect(editor.pointPosition(firstId).x).toBeCloseTo(200);
       expect(editor.pointPosition(firstId).y).toBeCloseTo(100);
@@ -162,8 +155,7 @@ describe("Select bounding-box transforms preserve geometry outcomes", () => {
       if (!node) throw new Error("Expected glyph node");
       editor.scene.updateNode({ id: node.id, position: { x: 400, y: 300 } });
 
-      rotateAcrossBottomEdge();
-      await editor.settle();
+      await rotateAcrossBottomEdge();
 
       expect(editor.pointPosition(firstId).x).toBeCloseTo(200);
       expect(editor.pointPosition(firstId).y).toBeCloseTo(100);
@@ -197,17 +189,16 @@ describe("Select bounding-box transforms preserve geometry outcomes", () => {
     });
 
     it("commits rotation as one undoable and redoable edit", async () => {
-      rotateAcrossBottomEdge();
-      await editor.settle();
+      await rotateAcrossBottomEdge();
       const rotated = [editor.pointPosition(firstId), editor.pointPosition(secondId)];
 
-      await editor.undoAndSettle();
+      await editor.undo();
       expect([editor.pointPosition(firstId), editor.pointPosition(secondId)]).toEqual([
         { x: 100, y: 100 },
         { x: 200, y: 200 },
       ]);
 
-      await editor.redoAndSettle();
+      await editor.redo();
       expect([editor.pointPosition(firstId), editor.pointPosition(secondId)]).toEqual(rotated);
     });
 
@@ -216,8 +207,7 @@ describe("Select bounding-box transforms preserve geometry outcomes", () => {
       await editor.settle();
       editor.selection.select([firstId, secondId, anchorId]);
 
-      rotateAcrossBottomEdge();
-      await editor.settle();
+      await rotateAcrossBottomEdge();
       const first = editor.pointPosition(firstId);
       const second = editor.pointPosition(secondId);
 
@@ -274,22 +264,21 @@ describe("Select curve bending preserves edit lifecycle", () => {
   it("commits bending as one undoable and redoable edit", async () => {
     const oneBefore = editor.pointPosition(controlOneId);
     const twoBefore = editor.pointPosition(controlTwoId);
-    editor.dragScene({
+    await editor.dragScene({
       down: bendPoint,
       start: { x: bendPoint.x + 4, y: bendPoint.y },
       end: { x: bendPoint.x + 4, y: bendPoint.y + 40 },
       options: { metaKey: true },
     });
-    await editor.settle();
     const bent = [editor.pointPosition(controlOneId), editor.pointPosition(controlTwoId)];
 
-    await editor.undoAndSettle();
+    await editor.undo();
     expect([editor.pointPosition(controlOneId), editor.pointPosition(controlTwoId)]).toEqual([
       oneBefore,
       twoBefore,
     ]);
 
-    await editor.redoAndSettle();
+    await editor.redo();
     expect([editor.pointPosition(controlOneId), editor.pointPosition(controlTwoId)]).toEqual(bent);
   });
 });

--- a/apps/desktop/src/renderer/src/testing/TestEditor.ts
+++ b/apps/desktop/src/renderer/src/testing/TestEditor.ts
@@ -197,6 +197,7 @@ export class TestEditor extends Editor {
   }
 
   anchorPosition(anchorId: AnchorId): Point2D {
+    this.#assertWorkspaceSettled();
     const anchor = this.requireGlyphLayer().anchor(anchorId);
     if (!anchor) throw new Error("Expected source anchor");
 
@@ -206,8 +207,7 @@ export class TestEditor extends Editor {
   async drawOpenContour(points: readonly Point2D[]): Promise<readonly PointId[]> {
     this.selectTool("pen");
     for (const point of points) {
-      this.clickGlyphLocal(point.x, point.y);
-      await this.settle();
+      await this.clickGlyphLocal(point.x, point.y);
     }
 
     const contour = this.openContour;

--- a/apps/desktop/src/renderer/src/testing/TestEditor.ts
+++ b/apps/desktop/src/renderer/src/testing/TestEditor.ts
@@ -22,6 +22,7 @@ import {
   mintNodeId,
   type GlyphId,
   type GlyphName,
+  type AnchorId,
   type GlyphRecord,
   type PointId,
   type Unicode,
@@ -193,6 +194,26 @@ export class TestEditor extends Editor {
     if (!point) throw new Error("Expected source point");
 
     return { x: point.x, y: point.y };
+  }
+
+  anchorPosition(anchorId: AnchorId): Point2D {
+    const anchor = this.requireGlyphLayer().anchor(anchorId);
+    if (!anchor) throw new Error("Expected source anchor");
+
+    return { x: anchor.x, y: anchor.y };
+  }
+
+  async drawOpenContour(points: readonly Point2D[]): Promise<readonly PointId[]> {
+    this.selectTool("pen");
+    for (const point of points) {
+      this.clickGlyphLocal(point.x, point.y);
+      await this.settle();
+    }
+
+    const contour = this.openContour;
+    if (!contour) throw new Error("Expected open contour");
+
+    return contour.points.map((point) => point.id);
   }
 
   get glyphNode(): GlyphNode | null {


### PR DESCRIPTION
## Summary

- add behavior-level characterization tests for Select movement, including multi-target edits, anchors, contour/point deduplication, cancellation, history, preview recomputation, smooth-point rules, and drag thresholds
- cover Shift-click add/remove outcomes for points, segments, and anchors, plus empty-canvas selection preservation
- add outcome tests for resize, rotate, and curve-bend lifecycle behavior
- add nudge coverage for every direction, modifier increment, multi-point edits, and undo/redo
- extend `TestEditor` with small glyph-fixture and anchor-position helpers

This is the tests-only baseline for #202. It does not change Select production code or assert internal behavior/state names.

The branch is rebased directly on `main` after #215 and #228. High-level editor actions are awaited and return after workspace settlement; raw pointer methods remain available for mid-gesture assertions.

## Validation

- focused Select suites — 4 files / 53 tests passed
- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm format:check`
- temporary mutation checks confirmed failures for skipped preview, first-target-only movement, missing selection replacement, missing commit/discard, bypassed point constraints, and incremental/accumulated preview deltas; all mutations were reverted

## Deliberately excluded

- mixed point/anchor resize, which currently starts marquee selection instead of resize
- release-before-next-frame pointer delivery, whose fix is not on `main`
- interaction cases whose intended behavior remains unresolved
