### PR TITLE
Make awaited editor actions settle workspace edits

### DIFF
--- a/apps/desktop/src/renderer/src/lib/editor/Editor.test.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/Editor.test.ts
@@ -77,12 +77,9 @@ describe("Editor scene bootstrap", () => {
 
   it("resolves authored points through the ownership index and keeps their bounds live", async () => {
     editor.selectTool("pen");
-    editor.clickGlyphLocal(0, 0);
-    await editor.settle();
-    editor.clickGlyphLocal(100, 0);
-    await editor.settle();
-    editor.clickGlyphLocal(100, 100);
-    await editor.settle();
+    await editor.clickGlyphLocal(0, 0);
+    await editor.clickGlyphLocal(100, 0);
+    await editor.clickGlyphLocal(100, 100);
 
     const layer = editor.requireGlyphLayer();
     const point = layer.allPoints[0];
@@ -107,12 +104,9 @@ describe("Editor scene bootstrap", () => {
 
   it("creates and selects a source by materializing the opened glyph", async () => {
     editor.selectTool("pen");
-    editor.clickGlyphLocal(0, 0);
-    await editor.settle();
-    editor.clickGlyphLocal(100, 0);
-    await editor.settle();
-    editor.clickGlyphLocal(100, 100);
-    await editor.settle();
+    await editor.clickGlyphLocal(0, 0);
+    await editor.clickGlyphLocal(100, 0);
+    await editor.clickGlyphLocal(100, 100);
 
     const node = editor.glyphNode;
     if (!node) throw new Error("Expected opened glyph node");
@@ -163,10 +157,8 @@ describe("Editor scene bootstrap", () => {
 
   it("materializes the opened glyph when selecting a sparse source", async () => {
     editor.selectTool("pen");
-    editor.clickGlyphLocal(0, 0);
-    await editor.settle();
-    editor.clickGlyphLocal(100, 0);
-    await editor.settle();
+    await editor.clickGlyphLocal(0, 0);
+    await editor.clickGlyphLocal(100, 0);
 
     const node = editor.glyphNode;
     if (!node) throw new Error("Expected opened glyph node");
@@ -223,12 +215,9 @@ describe("Editor renderer commands", () => {
     editor = new TestEditor();
     await editor.startSession();
     editor.selectTool("pen");
-    editor.click(0, 0);
-    await editor.settle();
-    editor.click(100, 0);
-    await editor.settle();
-    editor.click(200, 0);
-    await editor.settle();
+    await editor.click(0, 0);
+    await editor.click(100, 0);
+    await editor.click(200, 0);
   });
 
   it("reverses the contour implied by selected points", async () => {

--- a/apps/desktop/src/renderer/src/lib/editor/Editor.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/Editor.ts
@@ -888,13 +888,13 @@ export class Editor {
     return this.#camera;
   }
 
-  public undo() {
+  public async undo(): Promise<void> {
     // One undo authority: the workspace ledger (state-pair replay).
-    void this.font.editCoordinator.undo();
+    await this.font.editCoordinator.undo();
   }
 
-  public redo() {
-    void this.font.editCoordinator.redo();
+  public async redo(): Promise<void> {
+    await this.font.editCoordinator.redo();
   }
 
   /**
@@ -1252,11 +1252,12 @@ export class Editor {
       selection.layer.removePoints(selection.pointIds);
     });
     this.selection.clear();
+    await this.font.editCoordinator.settled();
 
     return true;
   }
 
-  public deleteSelection(): boolean {
+  public async deleteSelection(): Promise<boolean> {
     const selection = this.#pointSelectionFromIds(this.selection.ids);
     if (!selection || selection.pointIds.length === 0) return false;
 
@@ -1264,6 +1265,7 @@ export class Editor {
       selection.layer.removePoints(selection.pointIds);
     });
     this.selection.clear();
+    await this.font.editCoordinator.settled();
 
     return true;
   }
@@ -1284,6 +1286,7 @@ export class Editor {
         if (!inserted) return false;
 
         this.selection.select(inserted);
+        await this.font.editCoordinator.settled();
         return true;
       }
 

--- a/apps/desktop/src/renderer/src/lib/editor/GlyphLayerEditDraft.test.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/GlyphLayerEditDraft.test.ts
@@ -30,10 +30,8 @@ describe("glyph layer edit drafts preserve committed preview bases", () => {
     editor = new TestEditor();
     await editor.startSession();
     editor.selectTool("pen");
-    editor.clickGlyphLocal(100, 100);
-    await editor.settle();
-    editor.clickGlyphLocal(300, 200);
-    await editor.settle();
+    await editor.clickGlyphLocal(100, 100);
+    await editor.clickGlyphLocal(300, 200);
   });
 
   const source = () => editor.glyphLayer!;
@@ -50,7 +48,7 @@ describe("glyph layer edit drafts preserve committed preview bases", () => {
     await editor.settle();
     expect(pointPosition(source(), point.id)).toEqual({ x: start.x + 25, y: start.y - 10 });
 
-    await editor.undoAndSettle();
+    await editor.undo();
     expect(pointPosition(source(), point.id)).toEqual(start);
   });
 

--- a/apps/desktop/src/renderer/src/lib/keyboard/KeyboardRouter.test.ts
+++ b/apps/desktop/src/renderer/src/lib/keyboard/KeyboardRouter.test.ts
@@ -139,14 +139,10 @@ describe("KeyboardRouter", () => {
   describe("clipboard shortcuts", () => {
     beforeEach(async () => {
       editor.selectTool("pen");
-      editor.click(100, 100);
-      await editor.settle();
-      editor.click(200, 100);
-      await editor.settle();
-      editor.click(200, 200);
-      await editor.settle();
-      editor.click(100, 200);
-      await editor.settle();
+      await editor.click(100, 100);
+      await editor.click(200, 100);
+      await editor.click(200, 200);
+      await editor.click(100, 200);
       editor.selectTool("select");
       editor.selectAll();
     });
@@ -158,7 +154,6 @@ describe("KeyboardRouter", () => {
       const e = createKeyboardEvent({ key: "v", ctrlKey: true });
 
       const handled = await router.handleKeyDown(e);
-      await editor.settle();
 
       expect(handled).toBe(true);
       expect(editor.pointCount).toBeGreaterThan(pointsBefore);
@@ -171,7 +166,6 @@ describe("KeyboardRouter", () => {
       const e = createKeyboardEvent({ key: "v", metaKey: true });
 
       await router.handleKeyDown(e);
-      await editor.settle();
 
       expect(editor.pointCount).toBe(pointsBefore);
     });
@@ -190,17 +184,14 @@ describe("KeyboardRouter", () => {
   describe("delete key", () => {
     it("deletes the current canvas selection", async () => {
       editor.selectTool("pen");
-      editor.click(100, 100);
-      await editor.settle();
-      editor.click(200, 100);
-      await editor.settle();
+      await editor.click(100, 100);
+      await editor.click(200, 100);
       editor.selectTool("select");
       editor.selectAll();
 
       const handled = await router.handleKeyDown(
         createKeyboardEvent({ key: "Delete", code: "Delete" }),
       );
-      await editor.settle();
 
       expect(handled).toBe(true);
       expect(editor.pointCount).toBe(0);

--- a/apps/desktop/src/renderer/src/lib/keyboard/keymaps.ts
+++ b/apps/desktop/src/renderer/src/lib/keyboard/keymaps.ts
@@ -33,8 +33,8 @@ export function createGlobalKeyDownBindings(): KeyBinding[] {
       id: "global.undo",
       preventDefault: true,
       match: (event) => matchChord(event, { key: "z", primaryModifier: true, shiftKey: false }),
-      run: (ctx) => {
-        ctx.editor.undo();
+      run: async (ctx) => {
+        await ctx.editor.undo();
         return true;
       },
     },
@@ -42,8 +42,8 @@ export function createGlobalKeyDownBindings(): KeyBinding[] {
       id: "global.redo",
       preventDefault: true,
       match: (event) => matchChord(event, { key: "z", primaryModifier: true, shiftKey: true }),
-      run: (ctx) => {
-        ctx.editor.redo();
+      run: async (ctx) => {
+        await ctx.editor.redo();
         return true;
       },
     },

--- a/apps/desktop/src/renderer/src/lib/keyboard/types.ts
+++ b/apps/desktop/src/renderer/src/lib/keyboard/types.ts
@@ -8,9 +8,9 @@ export interface KeyboardEditorActions {
   copy(): Promise<boolean>;
   cut(): Promise<boolean>;
   paste(): Promise<boolean>;
-  deleteSelection(): boolean;
-  undo(): void;
-  redo(): void;
+  deleteSelection(): Promise<boolean>;
+  undo(): Promise<void>;
+  redo(): Promise<void>;
   selectAll(): void;
   setActiveTool(toolName: ToolName): void;
   getToolShortcuts(): ToolShortcutEntry[];

--- a/apps/desktop/src/renderer/src/lib/model/Glyph.test.ts
+++ b/apps/desktop/src/renderer/src/lib/model/Glyph.test.ts
@@ -295,7 +295,7 @@ describe("anchors edit through the workspace", () => {
     expect(layer.point(pointId)).toMatchObject({ x: 10, y: 20 });
     expect(layer.anchor(anchorId)).toMatchObject({ x: 300, y: 650 });
 
-    await editor.undoAndSettle();
+    await editor.undo();
     expect(layer.point(pointId)).toMatchObject({ x: 0, y: 0 });
     expect(layer.anchor(anchorId)).toMatchObject({ x: 250, y: 700 });
   });
@@ -305,10 +305,10 @@ describe("anchors edit through the workspace", () => {
     await editor.settle();
     expect(layer.anchors.length).toBe(1);
 
-    await editor.undoAndSettle();
+    await editor.undo();
     expect(layer.anchors.length).toBe(0);
 
-    await editor.redoAndSettle();
+    await editor.redo();
     expect(layer.anchor(anchorId)).toMatchObject({ x: 100, y: 100 });
   });
 

--- a/apps/desktop/src/renderer/src/lib/model/GlyphLayerGeometry.test.ts
+++ b/apps/desktop/src/renderer/src/lib/model/GlyphLayerGeometry.test.ts
@@ -9,10 +9,8 @@ describe("GlyphLayer point movement", () => {
     editor = new TestEditor();
     await editor.startSession();
     editor.selectTool("pen");
-    editor.clickGlyphLocal(10, 20);
-    await editor.settle();
-    editor.clickGlyphLocal(30, 40);
-    await editor.settle();
+    await editor.clickGlyphLocal(10, 20);
+    await editor.clickGlyphLocal(30, 40);
   });
 
   const layer = () => editor.glyphLayer!;
@@ -32,7 +30,7 @@ describe("GlyphLayer point movement", () => {
     layer().movePoints(ids, { x: 5, y: -10 });
     await editor.settle();
 
-    await editor.undoAndSettle();
+    await editor.undo();
     expect(layer().allPoints.map(({ x, y }) => ({ x, y }))).toEqual([
       { x: 10, y: 20 },
       { x: 30, y: 40 },
@@ -57,8 +55,7 @@ describe("GlyphLayer.toggleSmooth", () => {
     editor = new TestEditor();
     await editor.startSession();
     editor.selectTool("pen");
-    editor.click(100, 200);
-    await editor.settle();
+    await editor.click(100, 200);
   });
 
   const layer = () => editor.glyphLayer!;
@@ -79,7 +76,7 @@ describe("GlyphLayer.toggleSmooth", () => {
     await editor.settle();
     expect(layer().point(pointId)?.smooth).toBe(true);
 
-    await editor.undoAndSettle();
+    await editor.undo();
     expect(layer().point(pointId)?.smooth).toBe(false);
   });
 });
@@ -91,12 +88,9 @@ describe("GlyphLayer.reverseContour", () => {
     editor = new TestEditor();
     await editor.startSession();
     editor.selectTool("pen");
-    editor.click(0, 0);
-    await editor.settle();
-    editor.click(100, 0);
-    await editor.settle();
-    editor.click(200, 0);
-    await editor.settle();
+    await editor.click(0, 0);
+    await editor.click(100, 0);
+    await editor.click(200, 0);
   });
 
   const layer = () => editor.glyphLayer!;
@@ -115,7 +109,7 @@ describe("GlyphLayer.reverseContour", () => {
     layer().reverseContour(layer().contours[0]!.id);
     await editor.settle();
 
-    await editor.undoAndSettle();
+    await editor.undo();
     expect(layer().contours[0]!.points.map(({ x }) => x)).toEqual([0, 100, 200]);
   });
 });
@@ -133,10 +127,8 @@ describe("GlyphLayer.splitSegment", () => {
 
   describe("line segment", () => {
     beforeEach(async () => {
-      editor.clickGlyphLocal(0, 0);
-      await editor.settle();
-      editor.clickGlyphLocal(100, 0);
-      await editor.settle();
+      await editor.clickGlyphLocal(0, 0);
+      await editor.clickGlyphLocal(100, 0);
     });
 
     it("inserts a single on-curve point at t=0.5", async () => {
@@ -157,16 +149,14 @@ describe("GlyphLayer.splitSegment", () => {
       await editor.settle();
       expect(layer().allPoints.length).toBe(3);
 
-      await editor.undoAndSettle();
+      await editor.undo();
       expect(layer().allPoints.length).toBe(2);
     });
   });
 
   it("inserts the point at the parametric position for t=0.25", async () => {
-    editor.clickGlyphLocal(0, 0);
-    await editor.settle();
-    editor.clickGlyphLocal(100, 100);
-    await editor.settle();
+    await editor.clickGlyphLocal(0, 0);
+    await editor.clickGlyphLocal(100, 100);
 
     const segment = layer().contours[0]!.segments()[0]!;
     const splitId = layer().splitSegment(segment.id, 0.25);
@@ -208,7 +198,7 @@ describe("GlyphLayer.splitSegment", () => {
       await editor.settle();
       expect(layer().allPoints.length).toBe(7);
 
-      await editor.undoAndSettle();
+      await editor.undo();
       expect(layer().allPoints.length).toBe(4);
       expect(layer().point(c1)).toMatchObject({ x: 25, y: 100 });
       expect(layer().point(c2)).toMatchObject({ x: 75, y: 100 });
@@ -223,10 +213,8 @@ describe("GlyphLayer.upgradeLineToCubic", () => {
     editor = new TestEditor();
     await editor.startSession();
     editor.selectTool("pen");
-    editor.clickGlyphLocal(0, 0);
-    await editor.settle();
-    editor.clickGlyphLocal(90, 30);
-    await editor.settle();
+    await editor.clickGlyphLocal(0, 0);
+    await editor.clickGlyphLocal(90, 30);
   });
 
   const layer = () => editor.glyphLayer!;
@@ -253,7 +241,7 @@ describe("GlyphLayer.upgradeLineToCubic", () => {
     await editor.settle();
     expect(layer().allPoints.length).toBe(4);
 
-    await editor.undoAndSettle();
+    await editor.undo();
     expect(layer().allPoints.length).toBe(2);
     expect(layer().contours[0]!.segments()[0]!.type).toBe("line");
   });
@@ -267,10 +255,8 @@ describe("GlyphLayer metrics", () => {
     editor = new TestEditor();
     await editor.startSession();
     editor.selectTool("pen");
-    editor.clickGlyphLocal(100, 200);
-    await editor.settle();
-    editor.clickGlyphLocal(150, 200);
-    await editor.settle();
+    await editor.clickGlyphLocal(100, 200);
+    await editor.clickGlyphLocal(150, 200);
     initialAdvance = editor.glyphLayer!.xAdvance;
   });
 
@@ -288,7 +274,7 @@ describe("GlyphLayer metrics", () => {
       layer().setXAdvance(530);
       await editor.settle();
 
-      await editor.undoAndSettle();
+      await editor.undo();
       expect(layer().xAdvance).toBe(initialAdvance);
     });
   });
@@ -329,7 +315,7 @@ describe("GlyphLayer metrics", () => {
       layer().setLeftSidebearing(nextLeftSidebearing);
       await editor.settle();
 
-      await editor.undoAndSettle();
+      await editor.undo();
       expect(layer().xAdvance).toBe(initialAdvance);
       expect(layer().point(pointId)).toMatchObject({ x: point.x, y: point.y });
     });

--- a/apps/desktop/src/renderer/src/lib/model/positions/PositionEdits.test.ts
+++ b/apps/desktop/src/renderer/src/lib/model/positions/PositionEdits.test.ts
@@ -17,8 +17,8 @@ describe("fluent position edits preserve one frozen interaction base", () => {
   beforeEach(async () => {
     editor = new TestEditor();
     await editor.startSession();
-    editor.selectTool("pen").clickGlyphLocal(100, 100);
-    await editor.settle();
+    editor.selectTool("pen");
+    await editor.clickGlyphLocal(100, 100);
     pointId = editor.requireGlyphLayer().allPoints[0]!.id;
   });
 
@@ -41,7 +41,7 @@ describe("fluent position edits preserve one frozen interaction base", () => {
     await editor.settle();
     expect(editor.pointPosition(pointId)).toEqual({ x: 125, y: 90 });
 
-    await editor.undoAndSettle();
+    await editor.undo();
     expect(editor.pointPosition(pointId)).toEqual({ x: 100, y: 100 });
   });
 

--- a/apps/desktop/src/renderer/src/lib/tools/core/ToolManager.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/core/ToolManager.test.ts
@@ -103,8 +103,7 @@ describe("tool selection and temporary overrides", () => {
     editor.requestTemporaryTool("hand");
     editor.pointerDown(0, 0).pointerMove(50, 30).pointerMove(120, 80).pointerUp(120, 80);
     editor.returnFromTemporaryTool();
-    editor.clickGlyphLocal(100, 100);
-    await editor.settle();
+    await editor.clickGlyphLocal(100, 100);
 
     expect(editor.pan).toEqual({ x: 120, y: 80 });
     expect(editor.cursor).toBe(penCursor);

--- a/apps/desktop/src/renderer/src/lib/tools/pen/Pen.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/pen/Pen.test.ts
@@ -18,8 +18,7 @@ describe("Pen tool", () => {
 
   describe("point creation", () => {
     it("adds a point on click", async () => {
-      editor.click(100, 200);
-      await editor.settle();
+      await editor.click(100, 200);
 
       const contour = editor.openContour;
       expect(contour?.points.length).toBe(1);
@@ -28,10 +27,8 @@ describe("Pen tool", () => {
 
   describe("creating segments", () => {
     it("adding two points creates a line segment", async () => {
-      editor.click(100, 200);
-      await editor.settle();
-      editor.click(300, 200);
-      await editor.settle();
+      await editor.click(100, 200);
+      await editor.click(300, 200);
 
       const segment = editor.openContour?.segments()[0];
 
@@ -39,12 +36,9 @@ describe("Pen tool", () => {
     });
 
     it("adding three points creates two line segments", async () => {
-      editor.click(100, 200);
-      await editor.settle();
-      editor.click(300, 200);
-      await editor.settle();
-      editor.click(500, 200);
-      await editor.settle();
+      await editor.click(100, 200);
+      await editor.click(300, 200);
+      await editor.click(500, 200);
 
       const contour = editor.openContour;
       expect(contour?.segments().length).toBe(2);
@@ -54,15 +48,11 @@ describe("Pen tool", () => {
     });
 
     it("clicking the first point closes the contour and ends the stroke", async () => {
-      editor.click(100, 200);
-      await editor.settle();
-      editor.click(300, 200);
-      await editor.settle();
-      editor.click(200, 100);
-      await editor.settle();
+      await editor.click(100, 200);
+      await editor.click(300, 200);
+      await editor.click(200, 100);
 
-      editor.click(100, 200); // back on the first point
-      await editor.settle();
+      await editor.click(100, 200); // back on the first point
 
       const contour = editor.glyphContours[0];
       expect(contour?.closed).toBe(true);
@@ -71,8 +61,7 @@ describe("Pen tool", () => {
     });
 
     it("two consecutive curve drags create two cubic segments joined by a smooth point", async () => {
-      editor.click(100, 100);
-      await editor.settle();
+      await editor.click(100, 100);
 
       editor.pointerDown(300, 100);
       editor.pointerMove(380, 140);
@@ -96,8 +85,7 @@ describe("Pen tool", () => {
     });
 
     it("adding a point and then dragging should create a cubic curve", async () => {
-      editor.click(200, -800);
-      await editor.settle();
+      await editor.click(200, -800);
       editor.pointerDown(200, -800);
       editor.pointerMove(400, 120);
       editor.pointerMove(400, 140);
@@ -111,8 +99,7 @@ describe("Pen tool", () => {
     });
 
     it("keeps the curve visible when its drag preview ends", async () => {
-      editor.click(100, 100);
-      await editor.settle();
+      await editor.click(100, 100);
 
       const renderModel = editor.sceneGlyphRenderModel;
       if (!renderModel) throw new Error("Expected glyph render model");
@@ -151,24 +138,22 @@ describe("Pen tool", () => {
 
   describe("durability and undo through the workspace", () => {
     it("a click-placed point survives as one undoable ledger entry", async () => {
-      editor.click(100, 200);
-      await editor.settle();
+      await editor.click(100, 200);
       expect(editor.pointCount).toBe(1);
 
-      await editor.undoAndSettle();
+      await editor.undo();
       expect(editor.pointCount).toBe(0);
 
-      await editor.redoAndSettle();
+      await editor.redo();
       expect(editor.pointCount).toBe(1);
     });
 
     it("first click groups contour + point into a single undo step", async () => {
       // The first pen click creates the contour and the point as one user operation.
-      editor.click(100, 200);
-      await editor.settle();
+      await editor.click(100, 200);
       expect(editor.pointCount).toBe(1);
 
-      await editor.undoAndSettle();
+      await editor.undo();
 
       expect(editor.pointCount).toBe(0);
       expect(editor.glyphContours.length).toBe(0);

--- a/apps/desktop/src/renderer/src/lib/tools/select/Select.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/Select.test.ts
@@ -16,44 +16,40 @@ describe("Select tool", () => {
   describe("selection", () => {
     it("selects a point when clicking on it", async () => {
       editor.selectTool("pen");
-      editor.click(100, 200);
-      await editor.settle();
+      await editor.click(100, 200);
       editor.selectTool("select");
 
-      editor.click(100, 200);
+      await editor.click(100, 200);
       expect(editor.selection.ids.some(isPointId)).toBe(true);
     });
 
     it("clears selection when clicking empty space", async () => {
       editor.selectTool("pen");
-      editor.click(100, 200);
-      await editor.settle();
+      await editor.click(100, 200);
       editor.selectTool("select");
 
-      editor.click(100, 200);
-      editor.click(9999, 9999);
+      await editor.click(100, 200);
+      await editor.click(9999, 9999);
       expect(editor.selection.hasSelection()).toBe(false);
     });
 
     it("drags a selected point", async () => {
       editor.selectTool("pen");
-      editor.clickGlyphLocal(100, 200);
-      await editor.settle();
+      await editor.clickGlyphLocal(100, 200);
       editor.selectTool("select");
 
-      editor.clickGlyphLocal(100, 200);
+      await editor.clickGlyphLocal(100, 200);
 
       const [pointId] = editor.selection.ids.filter(isPointId);
       if (!pointId) throw new Error("Expected selected point");
 
       const before = editor.pointPosition(pointId);
 
-      const drag = editor.dragScene({
+      const drag = await editor.dragScene({
         down: before,
         start: { x: before.x + 4, y: before.y },
         end: { x: before.x + 40, y: before.y + 30 },
       });
-      await editor.settle();
 
       const after = editor.pointPosition(pointId);
 
@@ -63,8 +59,7 @@ describe("Select tool", () => {
 
     it("drags an unselected point from the pointer-down handle", async () => {
       editor.selectTool("pen");
-      editor.clickGlyphLocal(100, 200);
-      await editor.settle();
+      await editor.clickGlyphLocal(100, 200);
       editor.selectTool("select");
 
       const layer = editor.requireGlyphLayer();
@@ -72,12 +67,11 @@ describe("Select tool", () => {
       if (!point) throw new Error("Expected point");
 
       const before = editor.pointPosition(point.id);
-      const drag = editor.dragScene({
+      const drag = await editor.dragScene({
         down: before,
         start: { x: before.x + 80, y: before.y },
         end: { x: before.x + 110, y: before.y + 30 },
       });
-      await editor.settle();
 
       const after = editor.pointPosition(point.id);
 
@@ -88,10 +82,8 @@ describe("Select tool", () => {
 
     it("drags the current selection from inside its bounding box", async () => {
       editor.selectTool("pen");
-      editor.clickGlyphLocal(100, 100);
-      await editor.settle();
-      editor.clickGlyphLocal(200, 200);
-      await editor.settle();
+      await editor.clickGlyphLocal(100, 100);
+      await editor.clickGlyphLocal(200, 200);
 
       const layer = editor.requireGlyphLayer();
       const [first, second] = layer.contours[0]?.points ?? [];
@@ -102,12 +94,11 @@ describe("Select tool", () => {
 
       const beforeFirst = editor.pointPosition(first.id);
       const beforeSecond = editor.pointPosition(second.id);
-      const drag = editor.dragScene({
+      const drag = await editor.dragScene({
         down: { x: 120, y: 180 },
         start: { x: 124, y: 180 },
         end: { x: 150, y: 220 },
       });
-      await editor.settle();
 
       const afterFirst = editor.pointPosition(first.id);
       const afterSecond = editor.pointPosition(second.id);
@@ -120,10 +111,8 @@ describe("Select tool", () => {
 
     it("resizes the current selection from the pointer-down bounding-box handle", async () => {
       editor.selectTool("pen");
-      editor.clickGlyphLocal(100, 100);
-      await editor.settle();
-      editor.clickGlyphLocal(200, 200);
-      await editor.settle();
+      await editor.clickGlyphLocal(100, 100);
+      await editor.clickGlyphLocal(200, 200);
 
       const layer = editor.requireGlyphLayer();
       const [first, second] = layer.contours[0]?.points ?? [];
@@ -135,12 +124,11 @@ describe("Select tool", () => {
       const bounds = editor.selectionBounds();
       if (!bounds) throw new Error("Expected selection bounds");
 
-      editor.dragScene({
+      await editor.dragScene({
         down: { x: bounds.right, y: bounds.bottom },
         start: { x: bounds.right + 60, y: bounds.bottom },
         end: { x: bounds.right + 50, y: bounds.bottom + 50 },
       });
-      await editor.settle();
 
       const firstAfter = editor.pointPosition(first.id);
       const secondAfter = editor.pointPosition(second.id);
@@ -153,10 +141,8 @@ describe("Select tool", () => {
 
     it("rotates the current selection from the pointer-down bounding-box zone", async () => {
       editor.selectTool("pen");
-      editor.clickGlyphLocal(100, 100);
-      await editor.settle();
-      editor.clickGlyphLocal(200, 200);
-      await editor.settle();
+      await editor.clickGlyphLocal(100, 100);
+      await editor.clickGlyphLocal(200, 200);
 
       const layer = editor.requireGlyphLayer();
       const [first, second] = layer.contours[0]?.points ?? [];
@@ -169,12 +155,11 @@ describe("Select tool", () => {
       if (!bounds) throw new Error("Expected selection bounds");
 
       const offset = SELECT_BOUNDING_BOX_STYLE.rotationZoneOffsetPx;
-      editor.dragScene({
+      await editor.dragScene({
         down: { x: bounds.right + offset, y: bounds.bottom + offset },
         start: { x: bounds.right + offset + 40, y: bounds.bottom + offset + 40 },
         end: { x: bounds.left - offset, y: bounds.bottom + offset },
       });
-      await editor.settle();
 
       const firstAfter = editor.pointPosition(first.id);
       const secondAfter = editor.pointPosition(second.id);
@@ -187,10 +172,8 @@ describe("Select tool", () => {
 
     it("drags a segment by its endpoints", async () => {
       editor.selectTool("pen");
-      editor.clickGlyphLocal(100, 200);
-      await editor.settle();
-      editor.clickGlyphLocal(180, 200);
-      await editor.settle();
+      await editor.clickGlyphLocal(100, 200);
+      await editor.clickGlyphLocal(180, 200);
 
       const layer = editor.requireGlyphLayer();
       const [first, second] = layer.contours[0]?.points ?? [];
@@ -204,12 +187,11 @@ describe("Select tool", () => {
       };
 
       editor.selectTool("select");
-      const drag = editor.dragScene({
+      const drag = await editor.dragScene({
         down: midpoint,
         start: { x: midpoint.x + 4, y: midpoint.y },
         end: { x: midpoint.x + 30, y: midpoint.y + 20 },
       });
-      await editor.settle();
 
       const afterFirst = editor.pointPosition(first.id);
       const afterSecond = editor.pointPosition(second.id);
@@ -222,10 +204,8 @@ describe("Select tool", () => {
 
     it("duplicates the current selection at the same position", async () => {
       editor.selectTool("pen");
-      editor.clickGlyphLocal(100, 100);
-      await editor.settle();
-      editor.clickGlyphLocal(200, 100);
-      await editor.settle();
+      await editor.clickGlyphLocal(100, 100);
+      await editor.clickGlyphLocal(200, 100);
 
       const layer = editor.requireGlyphLayer();
       const [first, second] = layer.contours[0]?.points ?? [];
@@ -249,17 +229,14 @@ describe("Select tool", () => {
 
     it("cuts the selected points to the clipboard", async () => {
       editor.selectTool("pen");
-      editor.clickGlyphLocal(100, 100);
-      await editor.settle();
-      editor.clickGlyphLocal(200, 100);
-      await editor.settle();
+      await editor.clickGlyphLocal(100, 100);
+      await editor.clickGlyphLocal(200, 100);
 
       const layer = editor.requireGlyphLayer();
       const pointIds = layer.allPoints.map((point) => point.id);
       editor.selection.select(pointIds);
 
       const cut = await editor.cut();
-      await editor.settle();
 
       expect(cut).toBe(true);
       expect(layer.allPoints).toHaveLength(0);
@@ -269,17 +246,14 @@ describe("Select tool", () => {
 
     it("upgrades a line segment to a cubic with alt-click", async () => {
       editor.selectTool("pen");
-      editor.clickGlyphLocal(100, 200);
-      await editor.settle();
-      editor.clickGlyphLocal(190, 230);
-      await editor.settle();
+      await editor.clickGlyphLocal(100, 200);
+      await editor.clickGlyphLocal(190, 230);
 
       const layer = editor.requireGlyphLayer();
       expect(layer.contours[0]?.segments()[0]?.type).toBe("line");
 
       editor.selectTool("select");
-      editor.clickGlyphLocal(130, 210, { altKey: true });
-      await editor.settle();
+      await editor.clickGlyphLocal(130, 210, { altKey: true });
 
       expect(layer.contours[0]?.segments()[0]?.type).toBe("cubic");
       expect(layer.allPoints).toHaveLength(4);
@@ -287,10 +261,8 @@ describe("Select tool", () => {
 
     it("bends a cubic segment with meta-drag", async () => {
       editor.selectTool("pen");
-      editor.clickGlyphLocal(100, 200);
-      await editor.settle();
-      editor.clickGlyphLocal(190, 230);
-      await editor.settle();
+      await editor.clickGlyphLocal(100, 200);
+      await editor.clickGlyphLocal(190, 230);
 
       const layer = editor.requireGlyphLayer();
       const segment = layer.contours[0]?.segments()[0];
@@ -307,13 +279,12 @@ describe("Select tool", () => {
       if (!bendPoint) throw new Error("Expected cubic bend point");
 
       editor.selectTool("select");
-      editor.dragScene({
+      await editor.dragScene({
         down: bendPoint,
         start: { x: bendPoint.x + 4, y: bendPoint.y },
         end: { x: bendPoint.x + 4, y: bendPoint.y + 40 },
         options: { metaKey: true },
       });
-      await editor.settle();
 
       const afterControlStart = editor.pointPosition(cubic.controlStart.id);
       const afterControlEnd = editor.pointPosition(cubic.controlEnd.id);
@@ -324,34 +295,30 @@ describe("Select tool", () => {
 
     it("toggles a point smooth with double-click", async () => {
       editor.selectTool("pen");
-      editor.clickGlyphLocal(100, 200);
-      await editor.settle();
+      await editor.clickGlyphLocal(100, 200);
 
       const layer = editor.requireGlyphLayer();
       const point = layer.allPoints[0];
       if (!point) throw new Error("Expected point");
 
       editor.selectTool("select");
-      editor.clickGlyphLocal(point.x, point.y);
-      editor.clickGlyphLocal(point.x, point.y);
-      await editor.settle();
+      await editor.clickGlyphLocal(point.x, point.y);
+      await editor.clickGlyphLocal(point.x, point.y);
 
       expect(layer.point(point.id)?.smooth).toBe(true);
     });
 
     it("marquee-selects points inside the brushed rectangle", async () => {
       editor.selectTool("pen");
-      editor.clickGlyphLocal(100, 200);
-      await editor.settle();
-      editor.clickGlyphLocal(180, 200);
-      await editor.settle();
+      await editor.clickGlyphLocal(100, 200);
+      await editor.clickGlyphLocal(180, 200);
 
       const layer = editor.requireGlyphLayer();
       const [inside, outside] = layer.contours[0]?.points ?? [];
       if (!inside || !outside) throw new Error("Expected line segment points");
 
       editor.selectTool("select");
-      editor.dragScene({
+      await editor.dragScene({
         down: { x: 80, y: 180 },
         start: { x: 84, y: 180 },
         end: { x: 130, y: 230 },

--- a/apps/desktop/src/renderer/src/lib/tools/shape/Shape.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/shape/Shape.test.ts
@@ -73,7 +73,7 @@ describe("Shape tool", () => {
     await editor.settle();
     expect(contours().length).toBe(1);
 
-    await editor.undoAndSettle();
+    await editor.undo();
     expect(contours().length).toBe(0);
   });
 });

--- a/apps/desktop/src/renderer/src/lib/workspace/ledger.test.ts
+++ b/apps/desktop/src/renderer/src/lib/workspace/ledger.test.ts
@@ -18,62 +18,55 @@ describe("workspace ledger semantics (via TestEditor)", () => {
   const source = () => editor.glyphLayer!;
 
   it("undoes settled operations in reverse order", async () => {
-    editor.clickGlyphLocal(10, 10);
-    await editor.settle();
-    editor.clickGlyphLocal(20, 20);
-    await editor.settle();
+    await editor.clickGlyphLocal(10, 10);
+    await editor.clickGlyphLocal(20, 20);
     expect(editor.pointCount).toBe(2);
 
-    await editor.undoAndSettle();
+    await editor.undo();
     expect(editor.pointCount).toBe(1);
     expect(source().allPoints[0]).toMatchObject({ x: 10, y: 10 });
 
-    await editor.undoAndSettle();
+    await editor.undo();
     expect(editor.pointCount).toBe(0);
   });
 
   it("redoes undone entries in order", async () => {
-    editor.clickGlyphLocal(10, 10);
-    await editor.settle();
-    editor.clickGlyphLocal(20, 20);
-    await editor.settle();
+    await editor.clickGlyphLocal(10, 10);
+    await editor.clickGlyphLocal(20, 20);
 
-    await editor.undoAndSettle();
-    await editor.undoAndSettle();
+    await editor.undo();
+    await editor.undo();
     expect(editor.pointCount).toBe(0);
 
-    await editor.redoAndSettle();
+    await editor.redo();
     expect(editor.pointCount).toBe(1);
     expect(source().allPoints[0]).toMatchObject({ x: 10, y: 10 });
 
-    await editor.redoAndSettle();
+    await editor.redo();
     expect(editor.pointCount).toBe(2);
   });
 
   it("a new edit after undo truncates the redo branch", async () => {
-    editor.clickGlyphLocal(10, 10);
-    await editor.settle();
-    editor.clickGlyphLocal(20, 20);
-    await editor.settle();
+    await editor.clickGlyphLocal(10, 10);
+    await editor.clickGlyphLocal(20, 20);
 
-    await editor.undoAndSettle();
-    editor.clickGlyphLocal(30, 30);
-    await editor.settle();
+    await editor.undo();
+    await editor.clickGlyphLocal(30, 30);
     expect(editor.pointCount).toBe(2);
 
-    await editor.redoAndSettle();
+    await editor.redo();
     expect(editor.pointCount).toBe(2);
     expect(source().allPoints.map(({ x }) => x)).toEqual([10, 30]);
   });
 
   it("undoes the session's glyph creation, then stops at the empty ledger", async () => {
-    await editor.undoAndSettle();
+    await editor.undo();
     expect(editor.font.recordForName("A" as GlyphName)).toBe(null);
 
-    await editor.undoAndSettle();
+    await editor.undo();
     expect(editor.font.recordForName("A" as GlyphName)).toBe(null);
 
-    await editor.redoAndSettle();
+    await editor.redo();
     expect(editor.font.recordForName("A" as GlyphName)).not.toBe(null);
   });
 
@@ -89,7 +82,7 @@ describe("workspace ledger semantics (via TestEditor)", () => {
     expect(source().contours.length).toBe(1);
     expect(source().xAdvance).toBe(640);
 
-    await editor.undoAndSettle();
+    await editor.undo();
     expect(source().contours.length).toBe(0);
     expect(source().xAdvance).toBe(initialAdvance);
   });

--- a/apps/desktop/src/renderer/src/testing/TestEditor.test.ts
+++ b/apps/desktop/src/renderer/src/testing/TestEditor.test.ts
@@ -36,6 +36,42 @@ describe("TestEditor", () => {
     });
   });
 
+  describe("settled user actions", () => {
+    it("waits for glyph-local clicks before returning", async () => {
+      editor.selectTool("pen");
+      await editor.clickGlyphLocal(100, 200);
+      const point = editor.openContour?.points[0];
+      if (!point) throw new Error("Expected point");
+
+      expect(editor.pointPosition(point.id)).toEqual({ x: 100, y: 200 });
+    });
+
+    it("rejects confirmed geometry reads while a raw action is pending", async () => {
+      editor.selectTool("pen");
+      const screen = editor.projectSceneToScreen({ x: 100, y: 200 });
+      editor.pointerDown(screen.x, screen.y).pointerUp(screen.x, screen.y);
+      const point = editor.openContour?.points[0];
+      if (!point) throw new Error("Expected point");
+
+      expect(() => editor.pointPosition(point.id)).toThrow("Workspace edits are pending");
+      await editor.settle();
+      expect(editor.pointPosition(point.id)).toEqual({ x: 100, y: 200 });
+    });
+
+    it("waits for editing key presses before returning", async () => {
+      editor.selectTool("pen");
+      await editor.clickGlyphLocal(100, 200);
+      const point = editor.openContour?.points[0];
+      if (!point) throw new Error("Expected point");
+      editor.selection.select([point.id]);
+      editor.selectTool("select");
+
+      await editor.pressKey("ArrowRight");
+
+      expect(editor.pointPosition(point.id)).toEqual({ x: 101, y: 200 });
+    });
+  });
+
   describe("glyph resolution", () => {
     it("distinguishes catalog records from acquired Glyphs", async () => {
       const record = editor.font.createGlyph("B" as GlyphName);
@@ -72,8 +108,7 @@ describe("TestEditor", () => {
 
     it("resolves placed glyph points", async () => {
       editor.selectTool("pen");
-      editor.clickGlyphLocal(100, 200);
-      await editor.settle();
+      await editor.clickGlyphLocal(100, 200);
 
       const layer = editor.glyphLayer;
       const node = editor.glyphNode;
@@ -103,10 +138,8 @@ describe("TestEditor", () => {
 
     it("resolves placed glyph segments and contours", async () => {
       editor.selectTool("pen");
-      editor.clickGlyphLocal(100, 200);
-      await editor.settle();
-      editor.clickGlyphLocal(180, 200);
-      await editor.settle();
+      await editor.clickGlyphLocal(100, 200);
+      await editor.clickGlyphLocal(180, 200);
 
       const layer = editor.glyphLayer;
       const node = editor.glyphNode;

--- a/apps/desktop/src/renderer/src/testing/TestEditor.ts
+++ b/apps/desktop/src/renderer/src/testing/TestEditor.ts
@@ -4,7 +4,7 @@
  * Usage:
  *   const editor = new TestEditor();
  *   editor.selectTool("pen");
- *   editor.click(100, 200);
+ *   await editor.click(100, 200);
  *   expect(editor.pointCount).toBe(1);
  *
  * Editing sessions return when glyph mutations flow through workspace
@@ -162,18 +162,6 @@ export class TestEditor extends Editor {
     return this;
   }
 
-  /** Undo through the one authority (workspace ledger), settled. */
-  async undoAndSettle(): Promise<this> {
-    await this.font.editCoordinator.undo();
-    return this;
-  }
-
-  /** Redo through the workspace ledger, settled. */
-  async redoAndSettle(): Promise<this> {
-    await this.font.editCoordinator.redo();
-    return this;
-  }
-
   get clipboardBuffer(): string {
     return this.#clipboard.buffer;
   }
@@ -200,6 +188,7 @@ export class TestEditor extends Editor {
   }
 
   pointPosition(pointId: PointId): Point2D {
+    this.#assertWorkspaceSettled();
     const point = this.requireGlyphLayer().point(pointId);
     if (!point) throw new Error("Expected source point");
 
@@ -237,11 +226,12 @@ export class TestEditor extends Editor {
     return this.glyphContours.find((contour) => !contour.closed) ?? null;
   }
 
-  click(x: number, y: number, options?: Partial<typeof DEFAULT_MODIFIERS>): this {
+  async click(x: number, y: number, options?: Partial<typeof DEFAULT_MODIFIERS>): Promise<this> {
     const mods = { ...DEFAULT_MODIFIERS, ...options };
     this.toolManager.handlePointerDown({ x, y }, mods);
     this.toolManager.handlePointerUp({ x, y }, mods);
-    return this;
+
+    return this.settle();
   }
 
   /**
@@ -249,7 +239,11 @@ export class TestEditor extends Editor {
    * Use when a test asserts exact point positions; plain {@link click} takes
    * screen coordinates, which the viewport y-flips.
    */
-  clickGlyphLocal(x: number, y: number, options?: Partial<typeof DEFAULT_MODIFIERS>): this {
+  async clickGlyphLocal(
+    x: number,
+    y: number,
+    options?: Partial<typeof DEFAULT_MODIFIERS>,
+  ): Promise<this> {
     const screen = this.projectSceneToScreen({ x, y });
     return this.click(screen.x, screen.y, options);
   }
@@ -262,12 +256,12 @@ export class TestEditor extends Editor {
    * @returns The scene-space drag points observed through the camera and the
    * delta from `start` to `end`.
    */
-  dragScene(input: {
+  async dragScene(input: {
     down: Point2D;
     start: Point2D;
     end: Point2D;
     options?: Partial<typeof DEFAULT_MODIFIERS>;
-  }): { down: Point2D; start: Point2D; end: Point2D; delta: Point2D } {
+  }): Promise<{ down: Point2D; start: Point2D; end: Point2D; delta: Point2D }> {
     const downScreen = this.projectSceneToScreen(input.down);
     const startScreen = this.projectSceneToScreen(input.start);
     const endScreen = this.projectSceneToScreen(input.end);
@@ -276,6 +270,8 @@ export class TestEditor extends Editor {
     this.pointerMove(startScreen.x, startScreen.y, input.options);
     this.pointerMove(endScreen.x, endScreen.y, input.options);
     this.pointerUp(endScreen.x, endScreen.y, input.options);
+
+    await this.settle();
 
     const down = this.projectScreenToScene(downScreen);
     const start = this.projectScreenToScene(startScreen);
@@ -326,6 +322,12 @@ export class TestEditor extends Editor {
     return this;
   }
 
+  async pressKey(key: string, options?: Partial<typeof DEFAULT_MODIFIERS>): Promise<this> {
+    this.keyDown(key, options);
+
+    return this.settle();
+  }
+
   escape(): this {
     return this.keyDown("Escape");
   }
@@ -333,5 +335,11 @@ export class TestEditor extends Editor {
   selectTool(name: ToolName): this {
     this.setActiveTool(name);
     return this;
+  }
+
+  #assertWorkspaceSettled(): void {
+    if (!this.font.editCoordinator.settledCell.value) {
+      throw new Error("Workspace edits are pending; await the user action before reading geometry");
+    }
   }
 }


### PR DESCRIPTION
## Summary

- make high-level `TestEditor` clicks and drags await workspace confirmation, and add settled `pressKey` input
- keep low-level pointer and key methods synchronous for preview and in-flight tests
- reject confirmed `pointPosition` reads while workspace edits remain pending
- make `Editor` undo, redo, cut, paste, and delete promises resolve after their workspace effects are confirmed
- remove `undoAndSettle` / `redoAndSettle` and migrate tests from action-plus-`settle()` sequences to awaiting the action itself

The shared contract is: an awaited high-level user action returns confirmed state; raw input and low-level model operations retain explicit settlement where that boundary is under test.

## Validation

- `pnpm test` — all workspace tests passed; 61 desktop files / 580 desktop tests
- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm format:check`
- mutation checks confirmed the new harness tests fail when action settlement or the pending-read guard is removed

## Follow-up

PR #212 should rebase onto this contract so its Select outcome tests can await actions instead of manually calling `settle()`.
