### PR TITLE
test: stabilize E2E selector contracts

### DIFF
--- a/apps/desktop/e2e/README.md
+++ b/apps/desktop/e2e/README.md
@@ -58,7 +58,7 @@ A snapshot match alone does not prove GPU content exists. Rendering tests that c
 - Prefer `getByRole()` and `getByLabel()` for semantic controls and named application regions.
 - Use stable domain test IDs when repeated labels cannot identify one record: `source-{id}`, `instance-{id}`, and their `settings-*` variants.
 - Reuse surface and control locators from `fixtures/appLocators.ts`; do not traverse parents, select the first `canvas`/`aside`, or depend on styling classes.
-- Canvas cells have no DOM identity. Keep their locator-relative coordinate contract inside `clickFirstCatalogGlyph()` rather than scattering layout coordinates across specs.
+- Canvas cells have no DOM identity. Use `openCatalogGlyph()` to filter to one stable glyph ID before clicking; keep the remaining locator-relative coordinate contract inside `clickFirstCatalogGlyph()` rather than scattering layout coordinates across specs.
 - Use locator-relative positions for other canvas clicks.
 - For raw mouse drags, derive page coordinates from the target canvas's `boundingBox()`.
 - Keep interactions inside measured bounds; do not assume the host desktop is wider than the fixture window.

--- a/apps/desktop/e2e/README.md
+++ b/apps/desktop/e2e/README.md
@@ -53,9 +53,13 @@ After an intentional visual change:
 
 A snapshot match alone does not prove GPU content exists. Rendering tests that can pass with a blank canvas must also compare frames with and without the relevant canvas or assert equivalent semantic output. Route-return tests must make that comparison after navigation because residency attributes do not prove Chromium retained or repainted the WebGPU presentation.
 
-## Interaction rules
+## Selector and interaction rules
 
-- Use locator-relative positions for canvas clicks.
+- Prefer `getByRole()` and `getByLabel()` for semantic controls and named application regions.
+- Use stable domain test IDs when repeated labels cannot identify one record: `source-{id}`, `instance-{id}`, and their `settings-*` variants.
+- Reuse surface and control locators from `fixtures/appLocators.ts`; do not traverse parents, select the first `canvas`/`aside`, or depend on styling classes.
+- Canvas cells have no DOM identity. Keep their locator-relative coordinate contract inside `clickFirstCatalogGlyph()` rather than scattering layout coordinates across specs.
+- Use locator-relative positions for other canvas clicks.
 - For raw mouse drags, derive page coordinates from the target canvas's `boundingBox()`.
 - Keep interactions inside measured bounds; do not assume the host desktop is wider than the fixture window.
 - GPU fixtures must await workspace-window visibility, then apply the final owning `BrowserWindow` size and await the tested page's matching renderer content size; do not let a hidden-to-visible OS adjustment invalidate a baseline.

--- a/apps/desktop/e2e/fixtures/appLocators.ts
+++ b/apps/desktop/e2e/fixtures/appLocators.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 
 const FIRST_GLYPH_PREVIEW_POINT = { x: 50, y: 50 };
 
@@ -44,4 +44,23 @@ export async function firstAxisSlider(page: Page) {
 /** Keeps the canvas layout coordinate contract in one place. */
 export async function clickFirstCatalogGlyph(page: Page): Promise<void> {
   await glyphCatalogViewport(page).click({ position: FIRST_GLYPH_PREVIEW_POINT });
+}
+
+export async function openCatalogGlyph(
+  page: Page,
+  glyphName: string,
+  glyphId: string,
+): Promise<void> {
+  await page.getByPlaceholder("Search glyphs...").fill(glyphName);
+  const surface = glyphCatalogSurface(page);
+  await expect(surface).toHaveAttribute("data-filtered-glyph-count", "1");
+  await expect(surface).toHaveAttribute("data-first-glyph-id", glyphId);
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      }),
+  );
+  await clickFirstCatalogGlyph(page);
+  await page.waitForURL(new RegExp(`#/editor/${encodeURIComponent(glyphId)}$`));
 }

--- a/apps/desktop/e2e/fixtures/appLocators.ts
+++ b/apps/desktop/e2e/fixtures/appLocators.ts
@@ -1,0 +1,47 @@
+import type { Page } from "@playwright/test";
+
+const FIRST_GLYPH_PREVIEW_POINT = { x: 50, y: 50 };
+
+export function glyphCatalogViewport(page: Page) {
+  return page.getByLabel("Glyph catalog", { exact: true });
+}
+
+export function glyphCatalogSurface(page: Page) {
+  return page.getByRole("region", { name: "Glyph catalog surface", exact: true });
+}
+
+export function glyphCatalogCanvas(page: Page) {
+  return page.getByTestId("glyph-catalog-canvas");
+}
+
+export function editorShell(page: Page) {
+  return page.getByTestId("editor-shell");
+}
+
+export function fontNavigation(page: Page) {
+  return page.getByRole("complementary", { name: "Font navigation" });
+}
+
+export function variationControls(page: Page) {
+  return page.getByRole("complementary", { name: "Variation controls" });
+}
+
+export function glyphProperties(page: Page) {
+  return page.getByRole("complementary", { name: "Glyph properties" });
+}
+
+export function settingsDetails(page: Page) {
+  return page.getByRole("main", { name: "Settings details" });
+}
+
+export async function firstAxisSlider(page: Page) {
+  const axisName = await page.evaluate(() => window.shiftSession?.catalog.axesCell.value[0]?.name);
+  if (!axisName) throw new Error("Expected a variable axis");
+
+  return page.getByRole("slider", { name: axisName, exact: true });
+}
+
+/** Keeps the canvas layout coordinate contract in one place. */
+export async function clickFirstCatalogGlyph(page: Page): Promise<void> {
+  await glyphCatalogViewport(page).click({ position: FIRST_GLYPH_PREVIEW_POINT });
+}

--- a/apps/desktop/e2e/fixtures/electronApp.ts
+++ b/apps/desktop/e2e/fixtures/electronApp.ts
@@ -113,7 +113,7 @@ export const workspaceTest = test.extend<ShiftOptions>({
 
   page: async ({ page }, use) => {
     await page.waitForURL(/#\/home/, { timeout: 20_000 });
-    await page.getByLabel("Glyph catalog").waitFor({ state: "visible" });
+    await page.getByLabel("Glyph catalog", { exact: true }).waitFor({ state: "visible" });
     await use(page);
   },
 });

--- a/apps/desktop/e2e/font-preview.spec.ts
+++ b/apps/desktop/e2e/font-preview.spec.ts
@@ -1,6 +1,17 @@
 import fs from "node:fs";
 import type { GlyphId } from "@shift/types";
 import { previewTest as test, expect } from "./fixtures/perfApp";
+import {
+  clickFirstCatalogGlyph,
+  editorShell,
+  firstAxisSlider,
+  fontNavigation,
+  glyphCatalogCanvas,
+  glyphCatalogSurface,
+  glyphCatalogViewport,
+  glyphProperties,
+  settingsDetails,
+} from "./fixtures/appLocators";
 
 test.describe("retained font source Grid preview", () => {
   test("opens through home with complete source residency and no authored workspace", async ({
@@ -10,49 +21,47 @@ test.describe("retained font source Grid preview", () => {
     await expect.poll(() => page.evaluate(() => Boolean(navigator.gpu))).toBe(true);
     await expect.poll(() => page.evaluate(() => window.shiftSession?.mode)).toBe("imported");
 
-    const scrollViewport = page.getByLabel("Glyph catalog");
+    const scrollViewport = glyphCatalogViewport(page);
     await scrollViewport.waitFor({ state: "visible" });
-    const glyphCanvas = scrollViewport.locator("..").locator("canvas").first();
+    const glyphCanvas = glyphCatalogCanvas(page);
     await expect(glyphCanvas).toHaveAttribute("data-grid-readiness", "Complete", {
       timeout: 30_000,
     });
     await expect(glyphCanvas).toHaveAttribute("data-fully-resident", "true");
 
     const state = await page.evaluate(() => {
-      const canvas = document.querySelector<HTMLCanvasElement>(
-        '[aria-label="Glyph catalog"] + canvas',
-      );
-      if (!canvas) throw new Error("Expected resident glyph canvas");
-
       const session = window.shiftSession;
       return {
         mode: session?.mode,
         workspace: session?.workspace ?? null,
         authoredGlobal: window.shift ?? null,
-        residentGlyphCount: Number(canvas.dataset.residentGlyphCount),
-        targetGlyphCount: Number(canvas.dataset.targetGlyphCount),
         loadedGlyphCount:
           session?.font
             .glyphEntries()
             .filter((entry) => session.editor.glyphForId(entry.id) !== null).length ?? -1,
       };
     });
+    const residency = await glyphCanvas.evaluate((canvas) => ({
+      residentGlyphCount: Number(canvas.dataset.residentGlyphCount),
+      targetGlyphCount: Number(canvas.dataset.targetGlyphCount),
+    }));
     expect(state.mode).toBe("imported");
     expect(state.workspace).toBeNull();
     expect(state.authoredGlobal).toBeNull();
-    expect(state.residentGlyphCount).toBeGreaterThan(0);
-    expect(state.residentGlyphCount).toBe(state.targetGlyphCount);
+    expect(residency.residentGlyphCount).toBeGreaterThan(0);
+    expect(residency.residentGlyphCount).toBe(residency.targetGlyphCount);
     expect(state.loadedGlyphCount).toBe(0);
 
     await expect(page.locator("header")).toBeVisible();
-    await expect(page.locator("aside")).toHaveCount(2);
+    await expect(fontNavigation(page)).toBeVisible();
+    await expect(glyphProperties(page)).toBeVisible();
 
-    await scrollViewport.click({ position: { x: 50, y: 50 } });
+    await clickFirstCatalogGlyph(page);
     await page.waitForURL(/#\/editor\//);
     const sceneCanvas = page.locator("#scene-canvas");
     await expect(sceneCanvas).toBeVisible();
     await expect(page.locator("#marker-canvas")).toBeVisible();
-    const readOnlyGlyphInputs = page.locator("aside").last().locator("input:disabled");
+    const readOnlyGlyphInputs = glyphProperties(page).locator("input:disabled");
     await expect(readOnlyGlyphInputs).toHaveCount(3);
     const readOnlyGlyphValues = await readOnlyGlyphInputs.evaluateAll((inputs) =>
       inputs.map((input) => (input as HTMLInputElement).value),
@@ -120,7 +129,7 @@ test.describe("retained font source Grid preview", () => {
     expect(inspection.objectBounds).not.toBeNull();
     expect(inspection.selectionBounds).not.toBeNull();
 
-    const editorSurface = page.locator(".shift-editor-shell");
+    const editorSurface = editorShell(page);
     const editorFrame = await editorSurface.screenshot();
     await sceneCanvas.evaluate((canvas) => {
       canvas.style.visibility = "hidden";
@@ -143,8 +152,11 @@ test.describe("retained font source Grid preview", () => {
         throw new Error("resident atlas page was rebuilt");
       };
     });
-    const axisSlider = editorSurface.getByRole("slider").first();
-    if ((await axisSlider.count()) > 0) {
+    const axisCount = await page.evaluate(
+      () => window.shiftSession?.catalog.axesCell.value.length ?? 0,
+    );
+    if (axisCount > 0) {
+      const axisSlider = await firstAxisSlider(page);
       const beforeScrub = await sceneCanvas.screenshot();
       const beforeLocation = await page.evaluate(() =>
         Array.from(window.shiftSession?.editor.externalLocation.values() ?? []),
@@ -188,7 +200,7 @@ test.describe("retained font source Grid preview", () => {
         }),
     );
 
-    const catalogSurface = scrollViewport.locator("..");
+    const catalogSurface = glyphCatalogSurface(page);
     const returnedFrame = await catalogSurface.screenshot();
     const previousVisibility = await glyphCanvas.evaluate((canvas) => {
       const visibility = canvas.style.visibility;
@@ -203,7 +215,7 @@ test.describe("retained font source Grid preview", () => {
 
     // Reopening the resident root after its source was removed must reuse the
     // same projection rather than attempting another source read.
-    await scrollViewport.click({ position: { x: 50, y: 50 } });
+    await clickFirstCatalogGlyph(page);
     await page.waitForURL(/#\/editor\//);
     await expect(page.locator("#scene-canvas")).toBeVisible();
     const reopenedGlyphId = await page.evaluate(() => {
@@ -225,7 +237,7 @@ test.describe("retained font source Grid preview", () => {
     await expect(styleNameInput).toHaveValue("Regular");
     await expect(styleNameInput).toBeDisabled();
 
-    const fontControls = settingsDialog.locator("main input, main textarea");
+    const fontControls = settingsDetails(page).locator("input, textarea");
     await expect.poll(() => fontControls.count()).toBeGreaterThan(0);
     await expect
       .poll(() =>

--- a/apps/desktop/e2e/glyph-grid.spec.ts
+++ b/apps/desktop/e2e/glyph-grid.spec.ts
@@ -1,6 +1,12 @@
 import type { ElectronApplication, Locator, Page } from "@playwright/test";
 import type { AxisId, SourceId } from "@shift/types";
 import { test, expect, navigateToEditor } from "./fixtures/perfApp";
+import {
+  clickFirstCatalogGlyph,
+  glyphCatalogCanvas,
+  glyphCatalogSurface,
+  glyphCatalogViewport,
+} from "./fixtures/appLocators";
 
 const RESIDENT_GPU_ERROR = /resident glyph (device lost|frame failed|initialization failed)/i;
 
@@ -17,9 +23,9 @@ test.describe("Resident Glyph Grid", () => {
 
     await expect.poll(() => page.evaluate(() => Boolean(navigator.gpu))).toBe(true);
 
-    const scrollViewport = page.getByLabel("Glyph catalog");
+    const scrollViewport = glyphCatalogViewport(page);
     await scrollViewport.waitFor({ state: "visible" });
-    const glyphCanvas = scrollViewport.locator("..").locator("canvas").first();
+    const glyphCanvas = glyphCatalogCanvas(page);
     await expect(glyphCanvas).toHaveAttribute("data-grid-readiness", "Complete", {
       timeout: 30_000,
     });
@@ -67,7 +73,7 @@ test.describe("Resident Glyph Grid", () => {
       )
       .toEqual(initialSize);
 
-    await scrollViewport.click({ position: { x: 50, y: 50 } });
+    await clickFirstCatalogGlyph(page);
     await page.waitForURL(/#\/editor\//);
     await expect(page.locator("#scene-canvas")).toBeVisible();
     await afterNextPaint(page);
@@ -85,7 +91,7 @@ test.describe("Resident Glyph Grid", () => {
     await expect(glyphCanvas).toBeVisible();
     await expectCompleteResidency(glyphCanvas);
 
-    const catalogSurface = scrollViewport.locator("..");
+    const catalogSurface = glyphCatalogSurface(page);
     const returnedFrame = await catalogSurface.screenshot();
     const previousVisibility = await glyphCanvas.evaluate((canvas) => {
       const visibility = canvas.style.visibility;
@@ -119,9 +125,9 @@ test.describe("Resident Glyph Grid", () => {
 
     await expect.poll(() => page.evaluate(() => Boolean(navigator.gpu))).toBe(true);
 
-    const scrollViewport = page.getByLabel("Glyph catalog");
-    const catalogSurface = scrollViewport.locator("..");
-    const glyphCanvas = catalogSurface.locator("canvas").first();
+    const scrollViewport = glyphCatalogViewport(page);
+    const catalogSurface = glyphCatalogSurface(page);
+    const glyphCanvas = glyphCatalogCanvas(page);
     await expect(glyphCanvas).toBeVisible({ timeout: 30_000 });
     await expect(glyphCanvas).toHaveAttribute("data-fully-resident", "true");
 
@@ -134,7 +140,7 @@ test.describe("Resident Glyph Grid", () => {
       .toBe(true);
     await page.evaluate(() => {
       const canvas = document.querySelector<HTMLCanvasElement>(
-        '[aria-label="Glyph catalog"] + canvas',
+        '[data-testid="glyph-catalog-canvas"]',
       );
       if (!canvas) throw new Error("Expected resident glyph canvas");
 
@@ -187,9 +193,9 @@ test.describe("Resident Glyph Grid", () => {
   test("restores the current viewport after a topology edit", async ({ page }) => {
     await expect.poll(() => page.evaluate(() => Boolean(navigator.gpu))).toBe(true);
 
-    const scrollViewport = page.getByLabel("Glyph catalog");
+    const scrollViewport = glyphCatalogViewport(page);
     await scrollViewport.waitFor({ state: "visible" });
-    const glyphCanvas = scrollViewport.locator("..").locator("canvas").first();
+    const glyphCanvas = glyphCatalogCanvas(page);
     await expect(glyphCanvas).toBeVisible({ timeout: 30_000 });
 
     await navigateToEditor(page, "53");
@@ -230,9 +236,9 @@ test.describe("Resident Glyph Grid", () => {
   test("keeps distant glyphs resident after a topology patch", async ({ electronApp, page }) => {
     await expect.poll(() => page.evaluate(() => Boolean(navigator.gpu))).toBe(true);
 
-    const scrollViewport = page.getByLabel("Glyph catalog");
+    const scrollViewport = glyphCatalogViewport(page);
     await scrollViewport.waitFor({ state: "visible" });
-    const glyphCanvas = scrollViewport.locator("..").locator("canvas").first();
+    const glyphCanvas = glyphCatalogCanvas(page);
     await expect(glyphCanvas).toBeVisible({ timeout: 30_000 });
     await electronApp.evaluate(async ({ BrowserWindow }) => {
       BrowserWindow.getAllWindows()[0]?.setSize(760, 500);
@@ -280,7 +286,7 @@ test.describe("Resident Glyph Grid", () => {
     expect(state.readiness).toEqual([]);
     expect(state.hiddenTransitions).toBe(0);
 
-    const catalogSurface = scrollViewport.locator("..");
+    const catalogSurface = glyphCatalogSurface(page);
     const paintedFrame = await catalogSurface.screenshot();
     const visibility = await glyphCanvas.evaluate((canvas) => {
       const previous = canvas.style.visibility;
@@ -358,9 +364,9 @@ test.describe("Resident Glyph Grid", () => {
   test("fits oversized outlines without resizing cells while scrubbing an axis", async ({
     page,
   }) => {
-    const scrollViewport = page.getByLabel("Glyph catalog");
-    const catalogSurface = scrollViewport.locator("..");
-    const glyphCanvas = catalogSurface.locator("canvas").first();
+    const scrollViewport = glyphCatalogViewport(page);
+    const catalogSurface = glyphCatalogSurface(page);
+    const glyphCanvas = glyphCatalogCanvas(page);
     await expect(glyphCanvas).toHaveAttribute("data-grid-readiness", "Complete", {
       timeout: 30_000,
     });
@@ -395,19 +401,16 @@ test.describe("Resident Glyph Grid", () => {
     await expect(glyphCanvas).toHaveAttribute("data-grid-readiness", "Complete", {
       timeout: 30_000,
     });
-    const initialGeometry = await scrollViewport.evaluate((element) => {
-      const canvas = element.parentElement?.querySelector<HTMLCanvasElement>("canvas");
-      if (!canvas) throw new Error("Expected resident glyph canvas");
-
-      return {
-        previewHeight: Number(canvas.dataset.previewHeight),
-        scrollHeight: element.scrollHeight,
-      };
-    });
+    const initialGeometry = {
+      previewHeight: Number(await glyphCanvas.getAttribute("data-preview-height")),
+      scrollHeight: await scrollViewport.evaluate((element) => element.scrollHeight),
+    };
     const geometrySamples = await page.evaluate(async ({ axisId }) => {
       const workspace = window.shift;
       const viewport = document.querySelector<HTMLElement>('[aria-label="Glyph catalog"]');
-      const canvas = viewport?.parentElement?.querySelector<HTMLCanvasElement>("canvas");
+      const canvas = document.querySelector<HTMLCanvasElement>(
+        '[data-testid="glyph-catalog-canvas"]',
+      );
       if (!workspace || !viewport || !canvas) throw new Error("Expected Grid runtime");
 
       const samples: Array<{ previewHeight: number; scrollHeight: number }> = [];
@@ -483,8 +486,8 @@ async function prepareCompleteGrid(electronApp: ElectronApplication, page: Page)
     BrowserWindow.getAllWindows()[0]?.setSize(760, 500);
   });
 
-  const scrollViewport = page.getByLabel("Glyph catalog");
-  const glyphCanvas = scrollViewport.locator("..").locator("canvas").first();
+  const scrollViewport = glyphCatalogViewport(page);
+  const glyphCanvas = glyphCatalogCanvas(page);
   await expect(glyphCanvas).toHaveAttribute("data-grid-readiness", "Complete", {
     timeout: 30_000,
   });
@@ -494,7 +497,7 @@ async function prepareCompleteGrid(electronApp: ElectronApplication, page: Page)
 async function trackGridTransitions(page: Page): Promise<void> {
   await page.evaluate(() => {
     const canvas = document.querySelector<HTMLCanvasElement>(
-      '[aria-label="Glyph catalog"] + canvas',
+      '[data-testid="glyph-catalog-canvas"]',
     );
     if (!canvas) throw new Error("Expected resident glyph canvas");
 

--- a/apps/desktop/e2e/glyph-grid.spec.ts
+++ b/apps/desktop/e2e/glyph-grid.spec.ts
@@ -6,6 +6,7 @@ import {
   glyphCatalogCanvas,
   glyphCatalogSurface,
   glyphCatalogViewport,
+  openCatalogGlyph,
 } from "./fixtures/appLocators";
 
 const RESIDENT_GPU_ERROR = /resident glyph (device lost|frame failed|initialization failed)/i;
@@ -73,8 +74,9 @@ test.describe("Resident Glyph Grid", () => {
       )
       .toEqual(initialSize);
 
-    await clickFirstCatalogGlyph(page);
-    await page.waitForURL(/#\/editor\//);
+    const firstGlyph = await page.evaluate(() => window.shift?.font.glyphEntries()[0]);
+    if (!firstGlyph) throw new Error("Expected first catalog glyph");
+    await openCatalogGlyph(page, firstGlyph.name, firstGlyph.id);
     await expect(page.locator("#scene-canvas")).toBeVisible();
     await afterNextPaint(page);
 

--- a/apps/desktop/e2e/home.spec.ts
+++ b/apps/desktop/e2e/home.spec.ts
@@ -1,5 +1,10 @@
 import type { Page } from "@playwright/test";
 import { workspaceTest as test, expect } from "./fixtures/electronApp";
+import {
+  clickFirstCatalogGlyph,
+  glyphCatalogCanvas,
+  glyphCatalogSurface,
+} from "./fixtures/appLocators";
 
 test.describe("Home view", () => {
   test("glyph grid matches snapshot", async ({ page }) => {
@@ -7,9 +12,8 @@ test.describe("Home view", () => {
   });
 
   test("glyph canvas contributes rendered outlines", async ({ page }) => {
-    const scrollViewport = page.getByLabel("Glyph catalog");
-    const catalogSurface = scrollViewport.locator("..");
-    const glyphCanvas = catalogSurface.locator("canvas").first();
+    const catalogSurface = glyphCatalogSurface(page);
+    const glyphCanvas = glyphCatalogCanvas(page);
     await expect(glyphCanvas).toBeVisible({ timeout: 30_000 });
 
     const renderedFrame = await catalogSurface.screenshot();
@@ -27,8 +31,7 @@ test.describe("Home view", () => {
   });
 
   test("keeps the resident grid when returning from the editor", async ({ page }) => {
-    const scrollViewport = page.getByLabel("Glyph catalog");
-    const glyphCanvas = scrollViewport.locator("..").locator("canvas").first();
+    const glyphCanvas = glyphCatalogCanvas(page);
     await expect(glyphCanvas).toBeVisible({ timeout: 30_000 });
     await expect(glyphCanvas).toHaveAttribute("data-grid-readiness", "Complete", {
       timeout: 30_000,
@@ -39,7 +42,7 @@ test.describe("Home view", () => {
       height: canvas.height,
     }));
 
-    await scrollViewport.click({ position: { x: 50, y: 50 } });
+    await clickFirstCatalogGlyph(page);
     await page.waitForURL(/#\/editor\//);
     await afterNextPaint(page);
 

--- a/apps/desktop/e2e/selector-contracts.spec.ts
+++ b/apps/desktop/e2e/selector-contracts.spec.ts
@@ -48,9 +48,11 @@ test("exposes stable semantic selectors for major application surfaces", async (
   });
   await page.getByRole("button", { name: "Axes", exact: true }).click();
   await expect(await firstAxisSlider(page)).toBeVisible();
+  await expect(page.getByLabel("Weight value", { exact: true })).toBeVisible();
 
   await navigateToEditor(page, "41");
   await expect(editorShell(page)).toBeVisible();
   await expect(variationControls(page)).toBeVisible();
   await expect(glyphProperties(page)).toBeVisible();
+  await expect(glyphProperties(page).getByLabel("Advance width", { exact: true })).toBeVisible();
 });

--- a/apps/desktop/e2e/selector-contracts.spec.ts
+++ b/apps/desktop/e2e/selector-contracts.spec.ts
@@ -1,0 +1,56 @@
+import { expect, navigateToEditor, workspaceTest as test } from "./fixtures/electronApp";
+import {
+  editorShell,
+  firstAxisSlider,
+  fontNavigation,
+  glyphCatalogCanvas,
+  glyphCatalogSurface,
+  glyphProperties,
+  settingsDetails,
+  variationControls,
+} from "./fixtures/appLocators";
+
+test("exposes stable semantic selectors for major application surfaces", async ({ page }) => {
+  await expect(fontNavigation(page)).toBeVisible();
+  await expect(glyphProperties(page)).toBeVisible();
+  await expect(glyphCatalogSurface(page)).toBeVisible();
+  await expect(glyphCatalogCanvas(page)).toBeAttached();
+
+  const defaultSourceId = await page.evaluate(() => window.shift?.font.defaultSource.id);
+  if (!defaultSourceId) throw new Error("Expected default source");
+  await page.getByRole("button", { name: "Sources", exact: true }).click();
+  await expect(page.getByTestId(`source-${defaultSourceId}`)).toBeVisible();
+
+  await page.getByLabel(/Display and edit font information/).click();
+  const settings = page.getByRole("dialog", { name: "Settings" });
+  await expect(settings.getByRole("navigation", { name: "Settings categories" })).toBeVisible();
+  await expect(settingsDetails(page)).toBeVisible();
+  await settings.getByRole("button", { name: "Sources", exact: true }).click();
+  await expect(page.getByTestId(`settings-source-${defaultSourceId}`)).toBeVisible();
+  await settings.getByLabel("Close settings").click();
+
+  await page.evaluate(async () => {
+    const font = window.shift?.font;
+    if (!font) throw new Error("Expected authored font");
+
+    font.createAxis({
+      tag: "wght",
+      name: "Weight",
+      role: "external",
+      axisType: "continuous",
+      minimum: 100,
+      default: 400,
+      maximum: 900,
+      labels: [],
+      hidden: false,
+    });
+    await font.editCoordinator.settled();
+  });
+  await page.getByRole("button", { name: "Axes", exact: true }).click();
+  await expect(await firstAxisSlider(page)).toBeVisible();
+
+  await navigateToEditor(page, "41");
+  await expect(editorShell(page)).toBeVisible();
+  await expect(variationControls(page)).toBeVisible();
+  await expect(glyphProperties(page)).toBeVisible();
+});

--- a/apps/desktop/e2e/source-font-preview.spec.ts
+++ b/apps/desktop/e2e/source-font-preview.spec.ts
@@ -1,12 +1,21 @@
 import type { Page } from "@playwright/test";
 import { expect, glyphsPreviewTest, ufoPreviewTest } from "./fixtures/perfApp";
+import {
+  clickFirstCatalogGlyph,
+  editorShell,
+  firstAxisSlider,
+  glyphCatalogCanvas,
+  glyphCatalogSurface,
+  glyphCatalogViewport,
+  variationControls,
+} from "./fixtures/appLocators";
 
 async function expectRenderedGrid(page: Page): Promise<void> {
   await expect.poll(() => page.evaluate(() => window.shiftSession?.mode)).toBe("imported");
 
-  const viewport = page.getByLabel("Glyph catalog");
+  const viewport = glyphCatalogViewport(page);
   await viewport.waitFor({ state: "visible" });
-  const canvas = viewport.locator("..").locator("canvas").first();
+  const canvas = glyphCatalogCanvas(page);
   await expect(canvas).toHaveAttribute("data-grid-readiness", "Complete", { timeout: 30_000 });
   await expect(canvas).toHaveAttribute("data-fully-resident", "true");
 
@@ -17,7 +26,7 @@ async function expectRenderedGrid(page: Page): Promise<void> {
   expect(counts.resident).toBeGreaterThan(0);
   expect(counts.resident).toBe(counts.target);
 
-  const surface = viewport.locator("..");
+  const surface = glyphCatalogSurface(page);
   const rendered = await surface.screenshot();
   const visibility = await canvas.evaluate((element) => element.style.visibility);
   try {
@@ -40,23 +49,23 @@ ufoPreviewTest("UFO sources render a complete resident Grid", async ({ page }) =
 glyphsPreviewTest("Glyphs sources render a complete resident Grid", async ({ page }) => {
   await expectRenderedGrid(page);
 
-  const viewport = page.getByLabel("Glyph catalog");
-  const surface = viewport.locator("..");
+  const surface = glyphCatalogSurface(page);
   const beforeFrame = await surface.screenshot();
   const beforeLocation = await page.evaluate(() => window.shiftSession?.catalog.locationCell.value);
 
-  await viewport.click({ position: { x: 50, y: 50 } });
+  await clickFirstCatalogGlyph(page);
   await page.waitForURL(/#\/editor\//);
 
   const sceneCanvas = page.locator("#scene-canvas");
   const beforeSourceFrame = await sceneCanvas.screenshot();
-  const sourceButtons = page
-    .locator(".shift-editor-shell aside")
-    .first()
-    .getByRole("button", { name: "Regular", exact: true });
+  const sourceButtons = variationControls(page).getByRole("button", {
+    name: "Regular",
+    exact: true,
+  });
   await expect(sourceButtons).toHaveCount(2);
   const targetSourceId = await page.evaluate(() => window.shiftSession?.font.sources[1]?.id);
-  await sourceButtons.nth(1).click();
+  if (!targetSourceId) throw new Error("Expected a second source");
+  await page.getByTestId(`source-${targetSourceId}`).click();
   await expect
     .poll(() => page.evaluate(() => window.shiftSession?.editor.activeSourceId))
     .toBe(targetSourceId);
@@ -67,19 +76,16 @@ glyphsPreviewTest("Glyphs sources render a complete resident Grid", async ({ pag
     .poll(async () => (await sceneCanvas.screenshot()).equals(beforeSourceFrame))
     .toBe(false);
 
-  await page.getByRole("slider").first().press("End");
+  await (await firstAxisSlider(page)).press("End");
   await expect
     .poll(() => page.evaluate(() => window.shiftSession?.editor.activeSourceId))
     .toBeNull();
   await expect
     .poll(() => page.evaluate(() => window.shiftSession?.catalog.locationCell.value))
     .not.toEqual(beforeLocation);
-  await page.locator(".shift-editor-shell").getByLabel("Display all glyphs").click();
+  await editorShell(page).getByLabel("Display all glyphs").click();
   await page.waitForURL(/#\/home$/);
-  await expect(surface.locator("canvas").first()).toHaveAttribute(
-    "data-grid-readiness",
-    "Complete",
-  );
+  await expect(glyphCatalogCanvas(page)).toHaveAttribute("data-grid-readiness", "Complete");
   await expect
     .poll(async () => (await surface.screenshot()).equals(beforeFrame), { timeout: 5_000 })
     .toBe(false);

--- a/apps/desktop/e2e/variable-font-preview.spec.ts
+++ b/apps/desktop/e2e/variable-font-preview.spec.ts
@@ -33,9 +33,11 @@ test.describe("variable imported font projection", () => {
 
     const variationSidebar = variationControls(page);
     await expect(variationSidebar.getByText("Regular", { exact: true })).toHaveCount(2);
-    await expect(
-      variationSidebar.getByRole("button", { name: "Regular", exact: true }),
-    ).toBeEnabled();
+    const regularSourceId = await page.evaluate(
+      () => window.shiftSession?.font.sources.find(({ name }) => name === "Regular")?.id,
+    );
+    if (!regularSourceId) throw new Error("Expected Regular source");
+    await expect(page.getByTestId(`source-${regularSourceId}`)).toBeEnabled();
     await expect(variationSidebar.getByText("Light", { exact: true })).toBeVisible();
     await expect(variationSidebar.getByLabel("Actions for Medium")).toHaveCount(0);
     const mediumSourceId = await page.evaluate(

--- a/apps/desktop/e2e/variable-font-preview.spec.ts
+++ b/apps/desktop/e2e/variable-font-preview.spec.ts
@@ -40,11 +40,11 @@ test.describe("variable imported font projection", () => {
     await expect(page.getByTestId(`source-${regularSourceId}`)).toBeEnabled();
     await expect(variationSidebar.getByText("Light", { exact: true })).toBeVisible();
     await expect(variationSidebar.getByLabel("Actions for Medium")).toHaveCount(0);
-    const mediumSourceId = await page.evaluate(
-      () => window.shiftSession?.font.sources.find(({ name }) => name === "Medium")?.id,
+    const mediumInstanceId = await page.evaluate(
+      () => window.shiftSession?.font.namedInstances.find(({ name }) => name === "Medium")?.id,
     );
-    if (!mediumSourceId) throw new Error("Expected Medium source");
-    await page.getByTestId(`source-${mediumSourceId}`).click();
+    if (!mediumInstanceId) throw new Error("Expected Medium instance");
+    await page.getByTestId(`instance-${mediumInstanceId}`).click();
     await expect
       .poll(() =>
         page.evaluate(() => window.shiftSession?.editor.externalLocation.values().next().value),

--- a/apps/desktop/e2e/variable-font-preview.spec.ts
+++ b/apps/desktop/e2e/variable-font-preview.spec.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import { variablePreviewTest as test, expect } from "./fixtures/perfApp";
+import { firstAxisSlider, glyphCatalogCanvas, variationControls } from "./fixtures/appLocators";
 
 test.describe("variable imported font projection", () => {
   test("scrubs retained glyph geometry without source reads or projection acquisition", async ({
@@ -8,7 +9,7 @@ test.describe("variable imported font projection", () => {
   }) => {
     await expect.poll(() => page.evaluate(() => window.shiftSession?.mode)).toBe("imported");
 
-    const glyphCanvas = page.getByLabel("Glyph catalog").locator("..").locator("canvas").first();
+    const glyphCanvas = glyphCatalogCanvas(page);
     await expect(glyphCanvas).toHaveAttribute("data-grid-readiness", "Complete", {
       timeout: 30_000,
     });
@@ -27,17 +28,21 @@ test.describe("variable imported font projection", () => {
 
     const sceneCanvas = page.locator("#scene-canvas");
     await expect(sceneCanvas).toBeVisible();
-    const slider = page.getByRole("slider").first();
+    const slider = await firstAxisSlider(page);
     await expect(slider).toBeVisible();
 
-    const variationSidebar = page.locator(".shift-editor-shell aside").first();
-    const regularLabels = variationSidebar.getByText("Regular", { exact: true });
-    await expect(regularLabels).toHaveCount(2);
-    await expect(regularLabels.first()).toHaveRole("button");
-    await expect(regularLabels.first()).toBeEnabled();
+    const variationSidebar = variationControls(page);
+    await expect(variationSidebar.getByText("Regular", { exact: true })).toHaveCount(2);
+    await expect(
+      variationSidebar.getByRole("button", { name: "Regular", exact: true }),
+    ).toBeEnabled();
     await expect(variationSidebar.getByText("Light", { exact: true })).toBeVisible();
     await expect(variationSidebar.getByLabel("Actions for Medium")).toHaveCount(0);
-    await variationSidebar.getByText("Medium", { exact: true }).click();
+    const mediumSourceId = await page.evaluate(
+      () => window.shiftSession?.font.sources.find(({ name }) => name === "Medium")?.id,
+    );
+    if (!mediumSourceId) throw new Error("Expected Medium source");
+    await page.getByTestId(`source-${mediumSourceId}`).click();
     await expect
       .poll(() =>
         page.evaluate(() => window.shiftSession?.editor.externalLocation.values().next().value),

--- a/apps/desktop/e2e/variable-source-font-preview.spec.ts
+++ b/apps/desktop/e2e/variable-source-font-preview.spec.ts
@@ -5,6 +5,7 @@ import {
   glyphsPreviewTest,
   variablePreviewTest,
 } from "./fixtures/perfApp";
+import { firstAxisSlider } from "./fixtures/appLocators";
 
 interface VariationSample {
   readonly activeSourceId: string | null;
@@ -27,7 +28,7 @@ async function openVariableGlyph(page: Page): Promise<string> {
     return entry.id;
   });
   await page.waitForURL(new RegExp(`#/editor/${encodeURIComponent(glyphId)}$`));
-  await expect(page.getByRole("slider").first()).toBeVisible();
+  await expect(await firstAxisSlider(page)).toBeVisible();
 
   return glyphId;
 }
@@ -47,7 +48,7 @@ async function variationSample(page: Page, glyphId: string): Promise<VariationSa
 }
 
 async function moveSliderToMiddle(page: Page): Promise<void> {
-  const slider = page.getByRole("slider").first();
+  const slider = await firstAxisSlider(page);
   const track = await slider.evaluate((input) => {
     const bounds = input.parentElement?.parentElement?.getBoundingClientRect();
     if (!bounds) throw new Error("Expected slider track");
@@ -59,7 +60,7 @@ async function moveSliderToMiddle(page: Page): Promise<void> {
 
 async function expectContinuousVariablePreview(page: Page): Promise<void> {
   const glyphId = await openVariableGlyph(page);
-  const slider = page.getByRole("slider").first();
+  const slider = await firstAxisSlider(page);
 
   await slider.press("Home");
   const minimum = await variationSample(page, glyphId);

--- a/apps/desktop/src/renderer/src/components/chrome/settings/AxesSettingsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/chrome/settings/AxesSettingsPanel.tsx
@@ -57,6 +57,7 @@ export const AxesSettingsPanel = ({ initialAxisId, canAuthor }: AxesSettingsPane
           {axes.map((axis) => (
             <SidebarActionRow
               key={axis.id}
+              data-testid={`settings-axis-${axis.id}`}
               isActive={axis.id === selectedAxisId}
               className={cn(
                 "h-8",

--- a/apps/desktop/src/renderer/src/components/chrome/settings/InstancesSettingsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/chrome/settings/InstancesSettingsPanel.tsx
@@ -63,6 +63,7 @@ export const InstancesSettingsPanel = ({
           {instances.map((instance) => (
             <SidebarActionRow
               key={instance.id}
+              data-testid={`settings-instance-${instance.id}`}
               isActive={instance.id === selectedInstance?.id}
               className={cn(
                 "h-8",

--- a/apps/desktop/src/renderer/src/components/chrome/settings/SettingsDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/chrome/settings/SettingsDialog.tsx
@@ -55,7 +55,10 @@ export const SettingsDialog = ({
             }}
           />
 
-          <main className="relative min-h-0 min-w-0 overflow-hidden bg-canvas">
+          <main
+            aria-label="Settings details"
+            className="relative min-h-0 min-w-0 overflow-hidden bg-canvas"
+          >
             <DialogClose
               className={cn(
                 "absolute right-2 top-2 z-10 inline-flex h-7 w-7 cursor-pointer",

--- a/apps/desktop/src/renderer/src/components/chrome/settings/SettingsSidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/chrome/settings/SettingsSidebar.tsx
@@ -19,7 +19,10 @@ const categories: { id: SettingsCategory; label: string; icon: SVG }[] = [
 ];
 
 export const SettingsSidebar = ({ category, onCategoryChange }: SettingsSidebarProps) => (
-  <nav className="flex min-h-0 flex-col gap-0.5 border-r border-line-subtle bg-white p-2">
+  <nav
+    aria-label="Settings categories"
+    className="flex min-h-0 flex-col gap-0.5 border-r border-line-subtle bg-white p-2"
+  >
     {categories.map((item) => {
       const Icon = item.icon;
       const active = item.id === category;

--- a/apps/desktop/src/renderer/src/components/chrome/settings/SourcesSettingsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/chrome/settings/SourcesSettingsPanel.tsx
@@ -60,6 +60,7 @@ export const SourcesSettingsPanel = ({ initialSourceId, canAuthor }: SourcesSett
           {sources.map((source) => (
             <SidebarActionRow
               key={source.id}
+              data-testid={`settings-source-${source.id}`}
               isActive={source.id === selectedSource?.id}
               className={cn(
                 "h-8",

--- a/apps/desktop/src/renderer/src/components/editor/LeftSidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/editor/LeftSidebar.tsx
@@ -4,7 +4,10 @@ import { InstancesSection } from "@/components/variation/InstancesSection";
 import { SourcesSection } from "@/components/variation/SourcesSection";
 
 export const LeftSidebar = () => (
-  <aside className="h-full w-full min-w-0 bg-panel border-r border-line-subtle flex flex-col overflow-hidden">
+  <aside
+    aria-label="Variation controls"
+    className="h-full w-full min-w-0 bg-panel border-r border-line-subtle flex flex-col overflow-hidden"
+  >
     <div className="px-1 py-3 flex flex-col gap-2">
       <SourcesSection defaultOpen />
       <Separator />

--- a/apps/desktop/src/renderer/src/components/editor/RightSidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/editor/RightSidebar.tsx
@@ -19,7 +19,10 @@ export const RightSidebar = () => {
   const hasAnchorSelection = selection.ids.some(isAnchorId);
 
   return (
-    <aside className="h-full w-full min-w-0 bg-panel border-l border-line-subtle flex flex-col overflow-hidden">
+    <aside
+      aria-label="Glyph properties"
+      className="h-full w-full min-w-0 bg-panel border-l border-line-subtle flex flex-col overflow-hidden"
+    >
       <div className="px-3 py-2 flex items-center justify-between">
         <span className="text-ui font-medium text-primary truncate">{familyName}</span>
         <span className="text-ui font-medium text-muted">{Math.round(zoom * 100)}%</span>

--- a/apps/desktop/src/renderer/src/components/editor/sidebar-right/EditableSidebarInput.tsx
+++ b/apps/desktop/src/renderer/src/components/editor/sidebar-right/EditableSidebarInput.tsx
@@ -8,6 +8,7 @@ export interface EditableSidebarInputHandle {
 }
 
 interface EditableSidebarInputProps {
+  ariaLabel?: string;
   label?: string | React.ReactNode;
   labelPosition?: "left" | "right";
   className?: string;
@@ -32,6 +33,7 @@ export const EditableSidebarInput = forwardRef<
 >(
   (
     {
+      ariaLabel,
       label,
       labelPosition,
       className,
@@ -132,6 +134,7 @@ export const EditableSidebarInput = forwardRef<
     return (
       <Input
         ref={inputRef}
+        aria-label={ariaLabel}
         label={label}
         labelPosition={labelPosition}
         value={isEditing ? editValue : displayValue === null ? "" : `${displayValue}${suffix}`}

--- a/apps/desktop/src/renderer/src/components/editor/sidebar-right/GlyphSection.tsx
+++ b/apps/desktop/src/renderer/src/components/editor/sidebar-right/GlyphSection.tsx
@@ -69,6 +69,7 @@ export const GlyphSection = () => {
         </div>
         <div className="mt-2">
           <EditableSidebarInput
+            ariaLabel="Advance width"
             className="text-center"
             value={Math.round(xAdvance.xAdvance)}
             disabled={!xAdvance.hasLayer}

--- a/apps/desktop/src/renderer/src/components/home/GlyphCatalogCanvas.tsx
+++ b/apps/desktop/src/renderer/src/components/home/GlyphCatalogCanvas.tsx
@@ -99,6 +99,7 @@ export function GlyphCatalogCanvas({
       <canvas
         ref={glyphCanvasRef}
         aria-hidden="true"
+        data-testid="glyph-catalog-canvas"
         className="pointer-events-none absolute left-0 top-0 z-[2] h-full w-full bg-transparent"
         style={{ visibility: ready ? "visible" : "hidden" }}
       />

--- a/apps/desktop/src/renderer/src/components/home/GlyphGrid.tsx
+++ b/apps/desktop/src/renderer/src/components/home/GlyphGrid.tsx
@@ -76,6 +76,8 @@ export const GlyphGrid = memo(function GlyphGrid() {
   return (
     <section
       aria-label="Glyph catalog surface"
+      data-filtered-glyph-count={filteredGlyphs.length}
+      data-first-glyph-id={filteredGlyphs[0]?.id}
       className="relative h-full min-h-0 w-full overflow-hidden font-ui text-primary"
     >
       <div

--- a/apps/desktop/src/renderer/src/components/home/GlyphGrid.tsx
+++ b/apps/desktop/src/renderer/src/components/home/GlyphGrid.tsx
@@ -74,7 +74,10 @@ export const GlyphGrid = memo(function GlyphGrid() {
   }, [showMeasuredWorkspace]);
 
   return (
-    <section className="relative h-full min-h-0 w-full overflow-hidden font-ui text-primary">
+    <section
+      aria-label="Glyph catalog surface"
+      className="relative h-full min-h-0 w-full overflow-hidden font-ui text-primary"
+    >
       <div
         ref={scrollContainerRef}
         className="absolute inset-0 overflow-x-hidden overflow-y-auto"

--- a/apps/desktop/src/renderer/src/components/home/LeftSidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/home/LeftSidebar.tsx
@@ -5,7 +5,10 @@ import { SourcesSection } from "@/components/variation/SourcesSection";
 import { GlyphCatalogView } from "./glyph-catalog";
 
 export const LeftSidebar = () => (
-  <aside className="flex h-full w-full min-w-0 gap-1.5 flex-col bg-panel px-3 overflow-hidden border-r border-line-subtle">
+  <aside
+    aria-label="Font navigation"
+    className="flex h-full w-full min-w-0 gap-1.5 flex-col bg-panel px-3 overflow-hidden border-r border-line-subtle"
+  >
     <Separator />
     <GlyphCatalogView />
     <Separator className="-mx-3 w-auto" />

--- a/apps/desktop/src/renderer/src/components/sidebar/SidebarActionRow.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/SidebarActionRow.tsx
@@ -8,6 +8,7 @@ interface SidebarActionRowProps {
   onClick?: () => void;
   className?: string;
   contentClassName?: string;
+  "data-testid"?: string;
 }
 
 export const SidebarActionRow = ({
@@ -17,6 +18,7 @@ export const SidebarActionRow = ({
   onClick,
   className,
   contentClassName,
+  "data-testid": testId,
 }: SidebarActionRowProps) => (
   <div
     className={cn(
@@ -30,6 +32,7 @@ export const SidebarActionRow = ({
       <Button
         variant="ghost"
         size="sm"
+        data-testid={testId}
         onClick={onClick}
         className={cn(
           "min-w-0 flex-1 justify-start bg-transparent px-2 hover:bg-transparent data-[active]:bg-transparent",
@@ -39,7 +42,9 @@ export const SidebarActionRow = ({
         {children}
       </Button>
     ) : (
-      <div className={cn("min-w-0 flex-1 px-2", contentClassName)}>{children}</div>
+      <div data-testid={testId} className={cn("min-w-0 flex-1 px-2", contentClassName)}>
+        {children}
+      </div>
     )}
     {actions && <SidebarActionSlot>{actions}</SidebarActionSlot>}
   </div>

--- a/apps/desktop/src/renderer/src/components/variation/AxesPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/variation/AxesPanel.tsx
@@ -52,6 +52,7 @@ export const AxesPanel = () => {
 
           <div className="grid grid-cols-[3.5rem_minmax(0,1fr)_1.5rem] items-center gap-4 pl-2">
             <EditableSidebarInput
+              ariaLabel={`${axis.name} value`}
               value={axisValue(location, axis)}
               className="w-14"
               onValueChange={(value) => onAxisChange(axis, value)}

--- a/apps/desktop/src/renderer/src/components/variation/AxesPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/variation/AxesPanel.tsx
@@ -95,6 +95,7 @@ const AxisSlider = ({ axis, value, onChange, onReset }: AxisSliderProps) => (
     }}
   >
     <Slider
+      aria-label={axis.name}
       min={axis.minimum}
       max={axis.maximum}
       step={0.01}

--- a/apps/desktop/src/renderer/src/components/variation/Instances.tsx
+++ b/apps/desktop/src/renderer/src/components/variation/Instances.tsx
@@ -34,6 +34,7 @@ export const Instances = ({ canAuthor }: { canAuthor: boolean }) => {
       {instances.map((instance) => (
         <SidebarActionRow
           key={instance.id}
+          data-testid={`instance-${instance.id}`}
           onClick={() => previewInstance(instance)}
           contentClassName="h-6 text-ui"
           actions={

--- a/apps/desktop/src/renderer/src/components/variation/Sources.tsx
+++ b/apps/desktop/src/renderer/src/components/variation/Sources.tsx
@@ -47,6 +47,7 @@ export const Sources = ({ canAuthor }: { canAuthor: boolean }) => {
       {sources.map((s) => (
         <SidebarActionRow
           key={s.id}
+          data-testid={`source-${s.id}`}
           isActive={s.id === activeSourceId}
           onClick={() => selectSource(s.id)}
           contentClassName="h-6 text-ui"

--- a/apps/desktop/src/renderer/src/views/Editor.tsx
+++ b/apps/desktop/src/renderer/src/views/Editor.tsx
@@ -125,6 +125,7 @@ const EditorLayout = ({
   children: ReactNode;
 }) => (
   <div
+    data-testid="editor-shell"
     className="shift-editor-shell flex h-screen w-screen min-w-[600px] flex-col bg-white"
     data-gesture={gesture}
     style={{ "--shift-cursor": cursorStyle } as React.CSSProperties}

--- a/packages/ui/docs/DOCS.md
+++ b/packages/ui/docs/DOCS.md
@@ -55,7 +55,7 @@ Each component follows the same pattern: import the Base UI primitive, wrap it i
 
 **Input** adds label and icon positioning logic (left/right for each) on top of the Base UI input, adjusting padding classes dynamically.
 
-**Field**, **Checkbox**, **NumberField**, **Select**, **Tabs**, and **Textarea** are composable primitive families for settings and inspector forms. Validation and application state remain in the consumer; these wrappers only provide accessible structure, behavior, and Shift styling. `Textarea` renders a native textarea through Base UI Field's `Control` slot so it participates in the same label, validation, and disabled-state contract.
+**Field**, **Checkbox**, **NumberField**, **Select**, **Tabs**, and **Textarea** are composable primitive families for settings and inspector forms. Validation and application state remain in the consumer; these wrappers only provide accessible structure, behavior, and Shift styling. `Textarea` renders a native textarea through Base UI Field's `Control` slot so it participates in the same label, validation, and disabled-state contract. `Slider` forwards its `aria-label` to Base UI's interactive thumb rather than leaving the accessible name on the non-interactive root.
 
 **Toast** is the most complex component family. `ToastProvider` wraps Base UI's provider with a default 2-second timeout. `ToastViewport` renders through a portal, centered at the top of the viewport. Individual toasts use enter/exit opacity transitions. Consumers call `useToastManager` (re-exported directly from Base UI) to imperatively add toasts.
 

--- a/packages/ui/src/components/slider/Slider.tsx
+++ b/packages/ui/src/components/slider/Slider.tsx
@@ -18,7 +18,15 @@ export interface SliderProps extends Omit<
 
 export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
   (
-    { className, trackClassName, indicatorClassName, thumbClassName, onValueChange, ...props },
+    {
+      "aria-label": ariaLabel,
+      className,
+      trackClassName,
+      indicatorClassName,
+      thumbClassName,
+      onValueChange,
+      ...props
+    },
     ref,
   ) => {
     return (
@@ -37,6 +45,7 @@ export const Slider = React.forwardRef<HTMLDivElement, SliderProps>(
               className={cn("absolute h-full bg-accent rounded-full", indicatorClassName)}
             />
             <BaseSlider.Thumb
+              aria-label={ariaLabel}
               className={cn(
                 "w-3.5 h-3.5 rounded-full bg-white border-2 border-black shadow-sm",
                 "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent",


### PR DESCRIPTION
## Summary
- add named application regions and stable domain test IDs for canvas, source, instance, and Settings interactions
- centralize shared Playwright locators and the unavoidable canvas-cell coordinate contract in `fixtures/appLocators.ts`
- replace parent traversal, styling selectors, ordinal canvas/sidebar selection, and scattered fixed Grid clicks across the E2E suites
- forward slider accessible names to Base UI's interactive thumb

## Tests
- `pnpm test:e2e:visual e2e/selector-contracts.spec.ts`
- Playwright discovery: 57 tests in 15 files
- `pnpm test` (62 desktop files, 589 desktop tests; all workspace tests green)
- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm format:check`
- `pnpm check-deps`
- `git diff --check`

`context-drift-check.py` reports the same 21 existing documentation warnings; this change adds no new warning.
