### PR TITLE
ci: publish complete rolling Nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -106,16 +106,27 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: pnpm --filter @shift/desktop exec electron-forge make --arch ${{ matrix.arch }} --targets "${{ matrix.targets }}"
 
-      - name: Configure Linux sandbox for smoke test
-        if: matrix.platform == 'linux'
+      - name: Prepare packaged application for smoke test
+        id: smoke-package
         shell: bash
+        env:
+          PACKAGE_PATH: apps/desktop/out/${{ matrix.package-dir }}
+          PLATFORM: ${{ matrix.platform }}
         run: |
-          SANDBOX="apps/desktop/out/${{ matrix.package-dir }}/chrome-sandbox"
-          sudo chown root:root "$SANDBOX"
-          sudo chmod 4755 "$SANDBOX"
+          set -euo pipefail
+
+          if [[ "$PLATFORM" == "linux" ]]; then
+            SMOKE_PACKAGE_PATH="apps/desktop/out/shift-nightly-linux-x64"
+            mv "$PACKAGE_PATH" "$SMOKE_PACKAGE_PATH"
+            PACKAGE_PATH="$SMOKE_PACKAGE_PATH"
+            sudo chown root:root "$PACKAGE_PATH/chrome-sandbox"
+            sudo chmod 4755 "$PACKAGE_PATH/chrome-sandbox"
+          fi
+
+          echo "path=$PACKAGE_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Smoke-test packaged application
-        run: node scripts/smoke-packaged.mjs "apps/desktop/out/${{ matrix.package-dir }}"
+        run: node scripts/smoke-packaged.mjs "${{ steps.smoke-package.outputs.path }}" nightly
 
       - name: Verify macOS signature
         if: matrix.platform == 'darwin'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -106,6 +106,14 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: pnpm --filter @shift/desktop exec electron-forge make --arch ${{ matrix.arch }} --targets "${{ matrix.targets }}"
 
+      - name: Configure Linux sandbox for smoke test
+        if: matrix.platform == 'linux'
+        shell: bash
+        run: |
+          SANDBOX="apps/desktop/out/${{ matrix.package-dir }}/chrome-sandbox"
+          sudo chown root:root "$SANDBOX"
+          sudo chmod 4755 "$SANDBOX"
+
       - name: Smoke-test packaged application
         run: node scripts/smoke-packaged.mjs "apps/desktop/out/${{ matrix.package-dir }}"
 
@@ -122,3 +130,60 @@ jobs:
           path: apps/desktop/out/make/**
           if-no-files-found: error
           retention-days: 14
+
+  publish:
+    name: Publish rolling Nightly
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: Shift-Nightly-*
+          path: dist
+          merge-multiple: true
+
+      - name: Prepare public assets
+        run: node scripts/prepare-nightly-release.mjs dist public
+
+      - name: Write Nightly release notes
+        shell: bash
+        run: |
+          SHORT_SHA="${GITHUB_SHA:0:8}"
+          cat > nightly-notes.md <<EOF
+          > [!WARNING]
+          > **Experimental Nightly:** Work on copies and keep independent backups. This build may contain bugs, crashes, data loss, or security vulnerabilities.
+
+          Built from [\`$SHORT_SHA\`]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commit/$GITHUB_SHA) after every platform completed packaging and its packaged-app smoke test. macOS builds are signed and notarized; Windows and Linux builds are currently unsigned.
+
+          This rolling prerelease is replaced only by a later complete Nightly build.
+          EOF
+
+      - name: Publish rolling Nightly release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if gh release view nightly >/dev/null 2>&1; then
+            gh release upload nightly public/* --clobber
+            gh api --method PATCH "repos/$GITHUB_REPOSITORY/git/refs/tags/nightly" \
+              -f sha="$GITHUB_SHA" \
+              -F force=true >/dev/null
+            gh release edit nightly \
+              --title "Shift Nightly" \
+              --notes-file nightly-notes.md \
+              --prerelease \
+              --target "$GITHUB_SHA"
+          else
+            gh release create nightly public/* \
+              --title "Shift Nightly" \
+              --notes-file nightly-notes.md \
+              --prerelease \
+              --target "$GITHUB_SHA"
+          fi

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -135,6 +135,14 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: pnpm --filter @shift/desktop exec electron-forge make --arch ${{ matrix.arch }} --targets "${{ matrix.targets }}"
 
+      - name: Configure Linux sandbox for smoke test
+        if: matrix.platform == 'linux'
+        shell: bash
+        run: |
+          SANDBOX="apps/desktop/out/${{ matrix.package-dir }}/chrome-sandbox"
+          sudo chown root:root "$SANDBOX"
+          sudo chmod 4755 "$SANDBOX"
+
       - name: Smoke-test packaged application
         run: node scripts/smoke-packaged.mjs "apps/desktop/out/${{ matrix.package-dir }}"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1386,6 +1386,7 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 Shift aims to redefine font editing by combining the power of Rust for performance-critical tasks with the flexibility of web-based UI technologies. Whether you're a type designer or a developer, Shift offers a fresh approach to creating and editing fonts with a focus on speed, precision, and extensibility.
 
 > [!WARNING]
-> Shift is an unstable Developer Preview. Versioned Alpha builds are for early testing, not production font work. Work on copies and retain independent backups. Installable builds, when available, are published through [GitHub Releases](https://github.com/shift-editor/shift/releases).
+> Shift is an unstable Developer Preview. Versioned Alpha builds are for early testing, not production font work. Work on copies and retain independent backups. Installable builds are published through [GitHub Releases](https://github.com/shift-editor/shift/releases); the latest complete development snapshot is available as [Shift Nightly](https://github.com/shift-editor/shift/releases/tag/nightly).
 
 ## Architecture
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -820,9 +820,9 @@ These are allowed to jump around when energy is high, but they should not silent
 
 **macOS**
 
-- [ ] Signed `.app` bundle
+- [x] Signed `.app` bundle
 - [ ] `.dmg` installer
-- [ ] Notarization
+- [x] Notarization
 - [ ] Universal binary (Intel + Apple Silicon)
 - [ ] Auto-updater (Sparkle)
 
@@ -835,8 +835,8 @@ These are allowed to jump around when energy is high, but they should not silent
 **Linux**
 
 - [ ] AppImage
-- [ ] .deb package
-- [ ] .rpm package
+- [x] .deb package
+- [x] .rpm package
 
 **Release Infrastructure**
 

--- a/crates/shift-store/Cargo.toml
+++ b/crates/shift-store/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 shift-font = { workspace = true }
 blake3 = "1.8"
 getrandom = "0.3"
-rusqlite = { version = "0.37.0", features = ["blob", "backup", "limits"] }
+rusqlite = { version = "0.37.0", features = ["blob", "backup", "bundled-windows", "limits"] }
 rayon = "1.10"
 rmp-serde = "1.3"
 serde = "1.0"

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -7,9 +7,9 @@ Shift ships one versioned desktop product. Internal Rust crates and JavaScript p
 | State     | Product identity | Bundle ID           | Data root       | Publication                   |
 | --------- | ---------------- | ------------------- | --------------- | ----------------------------- |
 | `release` | Shift            | `app.shift`         | `Shift`         | Draft, then GitHub prerelease |
-| `nightly` | Shift Nightly    | `app.shift.nightly` | `Shift Nightly` | Expiring workflow artifact    |
+| `nightly` | Shift Nightly    | `app.shift.nightly` | `Shift Nightly` | Rolling GitHub prerelease     |
 
-`SHIFT_DISTRIBUTION` accepts only `release` or `nightly` during a build. A commit on `main` may produce a Nightly. Merging a Release Please pull request creates an alpha tag and a draft GitHub release. Nightly artifacts never promote themselves, and the release workflow rejects stable tags until the stable transition is deliberately enabled.
+`SHIFT_DISTRIBUTION` accepts only `release` or `nightly` during a build. A commit on `main` may produce a Nightly. Merging a Release Please pull request creates an alpha tag and a draft GitHub release. A complete Nightly matrix advances the mutable `nightly` tag and replaces the assets on one public prerelease; a failed matrix leaves the previous Nightly untouched. Nightly builds never promote themselves into versioned releases, and the release workflow rejects stable tags until the stable transition is deliberately enabled.
 
 Development builds append ` Dev` to their product identity. An explicit Electron `--user-data-dir` switch always wins, allowing E2E and manual tests to own isolated state.
 
@@ -17,7 +17,7 @@ Development builds append ` Dev` to their product identity. An explicit Electron
 
 An Alpha is a permanent, public Developer Preview, not a claim that the invited-tester workflow is ready. Publish Alpha snapshots early enough to exercise tagging, signing, packaging, checksums, installation, and upgrade behavior. Continue to make rapid and breaking UI, API, and document changes, but never silently corrupt or reinterpret user work; refuse unsupported documents explicitly.
 
-Invitations are a separate communication decision. Invite testers to whichever current Alpha passes the stronger product gate. The first invited build does not need to be `alpha.1`, and publishing an Alpha does not require a website announcement or waitlist message.
+Invitations are a separate communication decision. Invite testers to whichever current Alpha or Nightly passes the stronger product gate. The first invited build does not need to be `alpha.1`, and publishing an Alpha or rolling Nightly does not require a website announcement or waitlist message. A public but unadvertised Nightly link is not access control; a genuinely gated update channel requires a separate design for issuing and revoking access.
 
 ## Versions
 
@@ -64,7 +64,7 @@ Do not move backward in maturity for the same target version. If scope reopens s
 
 - `release-please.yml` maintains a draft release pull request. Merging it creates an alpha tag and a draft GitHub release, then calls the desktop release workflow with that exact tag. `force-tag-creation` materializes the tag immediately because GitHub otherwise delays tags for draft releases.
 - `release-desktop.yml` is a reusable and manually dispatchable workflow that builds the draft alpha or beta release for macOS arm64/x64, Windows x64, and Linux x64. It builds the native bridge on each runner, smoke-tests the packaged app, uploads checksums and desktop artifacts, and only then publishes the GitHub prerelease. A failed build leaves the release private and draft.
-- `nightly.yml` builds the same platform matrix as Shift Nightly on a schedule or by manual dispatch. Nightly artifacts expire after 14 days and do not create tags.
+- `nightly.yml` builds the same platform matrix as Shift Nightly on a schedule or by manual dispatch. Each platform keeps a 14-day workflow artifact for diagnostics. After every platform packages and smoke-tests successfully, a final job updates the mutable `nightly` tag and replaces the stable-name assets and checksums on the single public **Shift Nightly** prerelease. A failed matrix cannot alter the public Nightly.
 
 The Release Please workflow uses `RELEASE_PLEASE_TOKEN` rather than the default workflow token so its generated pull requests trigger normal CI. The desktop build is called directly from the successful release-creation job rather than relying on a second GitHub event.
 
@@ -95,4 +95,4 @@ Do not put signing credentials in repository files, workflow inputs, artifacts, 
 - Revert the release-preparation commit to restore the previous package and application identity behavior.
 - A failed versioned build remains a private draft release. Fix the release workflow and rerun it for the existing tag; do not publish incomplete assets.
 - Never delete or reuse a published version tag. Correct it with the next prerelease version.
-- A Nightly rollback requires no migration because Shift Nightly has a separate application identity and data root.
+- A failed Nightly build leaves the previous public Nightly in place. Roll back a bad published Nightly by republishing a known-good commit to the mutable `nightly` tag; never move or reuse a versioned release tag. Shift Nightly requires no release-channel data migration because it has a separate application identity and data root.

--- a/scripts/prepare-nightly-release.mjs
+++ b/scripts/prepare-nightly-release.mjs
@@ -1,0 +1,87 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { copyFile, mkdir, readdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const assets = [
+  {
+    destination: "Shift-Nightly-macOS-arm64.zip",
+    pattern: /(^|\/)zip\/darwin\/arm64\/[^/]+\.zip$/,
+  },
+  {
+    destination: "Shift-Nightly-macOS-x64.zip",
+    pattern: /(^|\/)zip\/darwin\/x64\/[^/]+\.zip$/,
+  },
+  {
+    destination: "Shift-Nightly-Windows-x64.exe",
+    pattern: /(^|\/)squirrel\.windows\/x64\/[^/]+Setup\.exe$/,
+  },
+  {
+    destination: "Shift-Nightly-Linux-x64.deb",
+    pattern: /(^|\/)deb\/x64\/[^/]+\.deb$/,
+  },
+  {
+    destination: "Shift-Nightly-Linux-x64.rpm",
+    pattern: /(^|\/)rpm\/x64\/[^/]+\.rpm$/,
+  },
+];
+
+async function collectFiles(root) {
+  const files = [];
+
+  for (const entry of await readdir(root, { withFileTypes: true })) {
+    const entryPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectFiles(entryPath)));
+    } else if (entry.isFile()) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}
+
+async function sha256(file) {
+  const hash = createHash("sha256");
+
+  await new Promise((resolve, reject) => {
+    createReadStream(file)
+      .on("data", (chunk) => hash.update(chunk))
+      .on("end", resolve)
+      .on("error", reject);
+  });
+
+  return hash.digest("hex");
+}
+
+const [distArgument, outputArgument] = process.argv.slice(2);
+if (!distArgument || !outputArgument) {
+  throw new Error("Usage: prepare-nightly-release.mjs <dist-directory> <output-directory>");
+}
+
+const distRoot = path.resolve(distArgument);
+const outputRoot = path.resolve(outputArgument);
+await mkdir(outputRoot, { recursive: true });
+
+const existingOutput = await readdir(outputRoot);
+if (existingOutput.length > 0) {
+  throw new Error(`Nightly output directory is not empty: ${outputRoot}`);
+}
+
+const files = await collectFiles(distRoot);
+const checksums = [];
+
+for (const asset of assets) {
+  const matches = files.filter((file) =>
+    asset.pattern.test(path.relative(distRoot, file).split(path.sep).join("/")),
+  );
+  if (matches.length !== 1) {
+    throw new Error(`Expected one source for ${asset.destination}, found ${matches.length}`);
+  }
+
+  const destination = path.join(outputRoot, asset.destination);
+  await copyFile(matches[0], destination);
+  checksums.push(`${await sha256(destination)}  ${asset.destination}`);
+}
+
+await writeFile(path.join(outputRoot, "SHA256SUMS"), `${checksums.join("\n")}\n`);

--- a/scripts/prepare-nightly-release.test.mjs
+++ b/scripts/prepare-nightly-release.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import test from "node:test";
+
+const script = path.resolve("scripts/prepare-nightly-release.mjs");
+const fixtures = [
+  ["zip/darwin/arm64/Shift Nightly-darwin-arm64-version.zip", "mac-arm64"],
+  ["zip/darwin/x64/Shift Nightly-darwin-x64-version.zip", "mac-x64"],
+  ["squirrel.windows/x64/Shift Nightly-version-Setup.exe", "windows-x64"],
+  ["deb/x64/shift-nightly_version_amd64.deb", "linux-deb"],
+  ["rpm/x64/shift-nightly-version.x86_64.rpm", "linux-rpm"],
+];
+const destinations = [
+  "Shift-Nightly-macOS-arm64.zip",
+  "Shift-Nightly-macOS-x64.zip",
+  "Shift-Nightly-Windows-x64.exe",
+  "Shift-Nightly-Linux-x64.deb",
+  "Shift-Nightly-Linux-x64.rpm",
+];
+
+async function runScript(dist, output) {
+  return await new Promise((resolve) => {
+    const child = spawn(process.execPath, [script, dist, output]);
+    let stderr = "";
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+    child.on("close", (code) => resolve({ code, stderr }));
+  });
+}
+
+async function writeFixtures(root, entries = fixtures) {
+  for (const [relativePath, content] of entries) {
+    const file = path.join(root, relativePath);
+    await mkdir(path.dirname(file), { recursive: true });
+    await writeFile(file, content);
+  }
+}
+
+test("prepares stable-name Nightly assets and checksums", async (context) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "shift-nightly-release-"));
+  context.after(() => rm(root, { recursive: true, force: true }));
+  const dist = path.join(root, "dist");
+  const output = path.join(root, "public");
+  await writeFixtures(dist);
+
+  const result = await runScript(dist, output);
+  assert.equal(result.code, 0, result.stderr);
+
+  for (const [index, destination] of destinations.entries()) {
+    const content = await readFile(path.join(output, destination), "utf8");
+    assert.equal(content, fixtures[index][1]);
+  }
+
+  const checksumLines = (await readFile(path.join(output, "SHA256SUMS"), "utf8"))
+    .trim()
+    .split("\n");
+  assert.deepEqual(
+    checksumLines,
+    destinations.map((destination, index) => {
+      const digest = createHash("sha256").update(fixtures[index][1]).digest("hex");
+      return `${digest}  ${destination}`;
+    }),
+  );
+});
+
+test("rejects incomplete Nightly artifact sets", async (context) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "shift-nightly-release-"));
+  context.after(() => rm(root, { recursive: true, force: true }));
+  const dist = path.join(root, "dist");
+  await writeFixtures(dist, fixtures.slice(1));
+
+  const result = await runScript(dist, path.join(root, "public"));
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /Expected one source for Shift-Nightly-macOS-arm64\.zip, found 0/);
+});
+
+test("rejects ambiguous Nightly artifacts", async (context) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "shift-nightly-release-"));
+  context.after(() => rm(root, { recursive: true, force: true }));
+  const dist = path.join(root, "dist");
+  await writeFixtures(dist);
+  await writeFixtures(dist, [["duplicate/zip/darwin/arm64/other.zip", "duplicate"]]);
+
+  const result = await runScript(dist, path.join(root, "public"));
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /Expected one source for Shift-Nightly-macOS-arm64\.zip, found 2/);
+});

--- a/scripts/smoke-packaged.mjs
+++ b/scripts/smoke-packaged.mjs
@@ -13,14 +13,23 @@ if (process.platform === "linux" && !process.env.DISPLAY) {
   process.exit(result.status ?? 1);
 }
 
-const [packagePathArgument] = process.argv.slice(2);
-if (!packagePathArgument) throw new Error("Usage: smoke-packaged.mjs <package-path>");
+const [packagePathArgument, distribution = "release"] = process.argv.slice(2);
+if (!packagePathArgument) {
+  throw new Error("Usage: smoke-packaged.mjs <package-path> [release|nightly]");
+}
 
 const packagePath = path.resolve(packagePathArgument);
-const packageName = path
-  .basename(packagePath)
-  .replace(/-(?:darwin|linux|win32)-(?:arm64|x64)$/, "");
-const executableName = packageName === "Shift Nightly" ? "shift-nightly" : "shift";
+const packageName = (() => {
+  switch (distribution) {
+    case "release":
+      return "Shift";
+    case "nightly":
+      return "Shift Nightly";
+    default:
+      throw new Error(`Unsupported distribution: ${distribution}`);
+  }
+})();
+const executableName = distribution === "nightly" ? "shift-nightly" : "shift";
 
 const executablePath = (() => {
   switch (process.platform) {


### PR DESCRIPTION
## Summary

- publish one rolling public **Shift Nightly** prerelease with stable platform filenames and checksums only after the complete build matrix passes
- keep Nightly side-by-side with versioned releases while retaining 14-day workflow artifacts for diagnostics
- bundle SQLite on Windows and stage Linux smoke tests at a sandbox-safe, install-like path without changing the product identity
- document the public Nightly link, invitation boundary, rollback behavior, and completed distribution capabilities

## Issue

Refs #223

## Testing

- `cargo check --workspace --tests`
- `cargo tree --target x86_64-pc-windows-msvc -p shift-bridge -e features -i libsqlite3-sys` — confirms `bundled-windows`
- `pnpm test:release` — 7 tests passed, including complete/missing/ambiguous Nightly artifact sets
- `pnpm format:check`
- `pnpm lint:check`
- `pnpm format:files --check scripts/smoke-packaged.mjs .github/workflows/nightly.yml`
- `node --check scripts/smoke-packaged.mjs`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.11 -color .github/workflows/*.yml`
- `cargo fmt --all --check`
- parsed `.github/workflows/nightly.yml` and `.github/workflows/release-desktop.yml` as YAML
- `python3 scripts/context-drift-check.py` — exits with the same 23 existing documentation warnings as `origin/main`

## Risks

- The first hosted rerun confirmed both macOS builds, exposed the Linux whitespace-path failure after the sandbox fix, and left the bundled Windows build running. The updated Linux staging and final Windows result still require hosted validation. Branch runs never publish the public Nightly.

