### PR TITLE
ci: mint Release Please tokens with GitHub App

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,10 +6,7 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+permissions: {}
 
 concurrency:
   group: release-please-main
@@ -23,10 +20,19 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      - id: release-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_PLEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+
       - id: release
         uses: googleapis/release-please-action@v5
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ steps.release-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -66,20 +66,26 @@ Do not move backward in maturity for the same target version. If scope reopens s
 - `release-desktop.yml` is a reusable and manually dispatchable workflow that builds the draft alpha or beta release for macOS arm64/x64, Windows x64, and Linux x64. It builds the native bridge on each runner, smoke-tests the packaged app, uploads checksums and desktop artifacts, and only then publishes the GitHub prerelease. A failed build leaves the release private and draft.
 - `nightly.yml` builds the same platform matrix as Shift Nightly on a schedule or by manual dispatch. Nightly artifacts expire after 14 days and do not create tags.
 
-The Release Please workflow uses `RELEASE_PLEASE_TOKEN` rather than the default workflow token so its generated pull requests trigger normal CI. The desktop build is called directly from the successful release-creation job rather than relying on a second GitHub event.
+The Release Please workflow mints a short-lived installation token from the repository-scoped Shift Release Please GitHub App. Unlike the default workflow token, the App token lets generated pull requests trigger normal CI without depending on an expiring personal token. The desktop build is called directly from the successful release-creation job rather than relying on a second GitHub event.
+
+## GitHub Actions variable
+
+| Variable                       | Purpose                                     |
+| ------------------------------ | ------------------------------------------- |
+| `RELEASE_PLEASE_APP_CLIENT_ID` | Public client ID for the Release Please App |
 
 ## GitHub secrets
 
-| Secret                        | Purpose                                                                                                      |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `RELEASE_PLEASE_TOKEN`        | Fine-grained personal access token allowed to create pull requests, tags, and releases and trigger workflows |
-| `APPLE_CERTIFICATE`           | Base64-encoded Developer ID Application `.p12`                                                               |
-| `APPLE_CERTIFICATE_PASSWORD`  | Password protecting the `.p12`                                                                               |
-| `APPLE_ID`                    | Apple Developer account login used by `notarytool`                                                           |
-| `APPLE_APP_SPECIFIC_PASSWORD` | Apple ID app-specific password, not the account password                                                     |
-| `APPLE_TEAM_ID`               | Paid Apple Developer Program team ID                                                                         |
+| Secret                           | Purpose                                                  |
+| -------------------------------- | -------------------------------------------------------- |
+| `RELEASE_PLEASE_APP_PRIVATE_KEY` | Private key used to mint installation tokens for one run |
+| `APPLE_CERTIFICATE`              | Base64-encoded Developer ID Application `.p12`           |
+| `APPLE_CERTIFICATE_PASSWORD`     | Password protecting the `.p12`                           |
+| `APPLE_ID`                       | Apple Developer account login used by `notarytool`       |
+| `APPLE_APP_SPECIFIC_PASSWORD`    | Apple ID app-specific password, not the account password |
+| `APPLE_TEAM_ID`                  | Paid Apple Developer Program team ID                     |
 
-Do not put signing credentials in repository files, workflow inputs, artifacts, or logs. macOS release and Nightly jobs fail if signing credentials are absent; they never silently publish unsigned macOS builds. Windows builds remain unsigned until a certificate is acquired.
+Do not put App private keys or signing credentials in repository files, workflow inputs, artifacts, or logs. macOS release and Nightly jobs fail if signing credentials are absent; they never silently publish unsigned macOS builds. Windows builds remain unsigned until a certificate is acquired.
 
 ## Signing setup
 


### PR DESCRIPTION
## Summary

- mint a short-lived, repository-scoped GitHub App token for Release Please
- remove write permissions from the workflow's default token and request only the App permissions Release Please needs
- document the persistent App credentials that replace the expiring personal token

## Issue

No issue — operational hardening of the existing release automation.

## Testing

- `pnpm test:release` — 4 tests passed
- `pnpm version:check`
- `pnpm format:files --check .github/workflows/release-please.yml docs/releases.md`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.11 -color .github/workflows/*.yml`
- `python3 scripts/context-drift-check.py` — exits with the same 23 existing documentation warnings
- commit hooks: YAML validation and formatting

## Risks

- App-token minting requires the installed `Shift Release Please` App and the configured client-ID variable/private-key secret; both configuration names are present, but GitHub can exercise the credentials only after this workflow reaches `main`.
