### PR TITLE
ci: recheck edited pull request titles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,22 +73,6 @@ jobs:
               - '.codex/skills/**'
               - 'scripts/sync-agent-skills.mjs'
 
-  pull-request-title:
-    name: Conventional Pull Request Title
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions: {}
-    steps:
-      - name: Check title
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          if [[ ! "$PR_TITLE" =~ ^(feat|fix|perf|refactor|docs|test|build|ci|style|chore)(\([^\)]+\))?(!)?:\ .+ ]]; then
-            echo "Pull request title must use Conventional Commits syntax." >&2
-            echo "Received: $PR_TITLE" >&2
-            exit 1
-          fi
-
   agent-skills:
     name: Agent Skills
     needs: detect-changes
@@ -473,7 +457,6 @@ jobs:
     if: always()
     needs:
       - detect-changes
-      - pull-request-title
       - agent-skills
       - lint
       - typecheck

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,34 @@
+name: Pull Request Title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions: {}
+
+concurrency:
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  title:
+    name: PR Title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Check current title
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          PR_TITLE="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .title)"
+          if [[ ! "$PR_TITLE" =~ ^(feat|fix|perf|refactor|docs|test|build|ci|style|chore)(\([^\)]+\))?(!)?:\ .+ ]]; then
+            echo "Pull request title must use Conventional Commits syntax." >&2
+            echo "Received: $PR_TITLE" >&2
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- validate pull request titles in a dedicated lightweight workflow
- fetch the current GitHub title so edits and manual reruns do not reuse stale event metadata
- keep code CI independent so title edits never rerun expensive E2E jobs or overwrite code-check results

## Issue

No issue — small CI correctness and efficiency fix.

## Testing

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.11 -color .github/workflows/*.yml`
- `pnpm test:release` — 7 tests passed
- `pnpm version:check`
- `pnpm format:files --check .github/workflows/ci.yml .github/workflows/pr-title.yml`
- fetched and validated the current title of PR #216 through the same GitHub API and regex
- commit hooks: YAML validation

## Follow-up

After merge, branch protection should require both `CI Passed` and `PR Title`.
