### PR TITLE
ci: filter desktop E2E by affected paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
       typescript: ${{ steps.filter.outputs.typescript }}
+      desktop-e2e: ${{ steps.filter.outputs.desktop-e2e }}
       release: ${{ steps.filter.outputs.release }}
       skills: ${{ steps.filter.outputs.skills }}
     steps:
@@ -53,6 +54,20 @@ jobs:
               - 'pnpm-lock.yaml'
               - 'tsconfig*.json'
               - 'turbo.json'
+            desktop-e2e:
+              - 'apps/desktop/**'
+              - 'packages/**'
+              - 'crates/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'tsconfig*.json'
+              - 'turbo.json'
+              - '.github/workflows/ci.yml'
+              - 'scripts/generate-bridge-types.mjs'
             release:
               - '.github/workflows/**'
               - '.release-please-manifest.json'
@@ -382,6 +397,8 @@ jobs:
   # ---------------------------------------------------------------------------
   e2e:
     name: E2E ${{ matrix.name }}
+    needs: detect-changes
+    if: github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.desktop-e2e == 'true'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

- run desktop Visual and GPU E2E only when desktop runtime, shared package, native, dependency, or CI configuration paths change
- skip expensive macOS E2E jobs for documentation, release-only, agent-skill, and PR-title workflow changes
- continue forcing E2E for manual CI dispatches

## Issue

No issue — CI runner-efficiency follow-up to #231.

## Testing

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.11 -color .github/workflows/*.yml`
- `pnpm format:files --check .github/workflows/ci.yml`
- `pnpm test:release` — 7 tests passed
- `pnpm version:check`
- commit hooks: YAML validation
- this PR changes `ci.yml`, so its hosted Visual and GPU E2E jobs exercise the positive path

## Risk

Path filters can miss indirect runtime inputs. The filter therefore includes the complete desktop app, all shared packages and native crates, root dependency/toolchain configuration, bridge type generation, and `ci.yml` itself.
