### PR TITLE
fix: tolerate Windows packaged-smoke cleanup locks

### DIFF
--- a/scripts/smoke-packaged.mjs
+++ b/scripts/smoke-packaged.mjs
@@ -58,6 +58,18 @@ async function reservePort() {
   return address.port;
 }
 
+async function waitForExit(child) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+
+  await new Promise((resolve) => {
+    const timeout = setTimeout(resolve, 5_000);
+    child.once("exit", () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+  });
+}
+
 async function waitForDebugEndpoint(url, child, output) {
   const deadline = Date.now() + 30_000;
   while (Date.now() < deadline) {
@@ -128,22 +140,29 @@ try {
 
   console.log(`Packaged app rendered its landing page: ${executablePath}`);
 } finally {
-  await browser?.close();
-
-  switch (process.platform) {
-    case "win32":
-      spawnSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], { stdio: "ignore" });
-      break;
-    default:
-      if (child.pid) {
-        try {
-          process.kill(-child.pid, "SIGKILL");
-        } catch (error) {
-          if (error.code !== "ESRCH") throw error;
-        }
-      }
-      break;
+  try {
+    await browser?.close();
+  } catch (error) {
+    console.warn("Packaged smoke browser cleanup failed", error);
   }
 
-  await rm(testRoot, { recursive: true, force: true });
+  try {
+    switch (process.platform) {
+      case "win32":
+        spawnSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], { stdio: "ignore" });
+        break;
+      default:
+        if (child.pid) process.kill(-child.pid, "SIGKILL");
+        break;
+    }
+  } catch (error) {
+    if (error.code !== "ESRCH") console.warn("Packaged smoke process cleanup failed", error);
+  }
+
+  await waitForExit(child);
+  try {
+    await rm(testRoot, { recursive: true, force: true, maxRetries: 20, retryDelay: 250 });
+  } catch (error) {
+    console.warn(`Packaged smoke profile cleanup failed: ${testRoot}`, error);
+  }
 }


### PR DESCRIPTION
## Summary

- wait for the packaged Electron process to exit before removing its temporary profile
- retry temporary-profile deletion when Windows retains Chromium file handles
- report browser, process, and profile teardown failures as warnings instead of replacing the smoke-test verdict

The Windows Nightly packaged-app smoke test successfully rendered Shift, then failed while deleting Chromium's locked `user-data\\DIPS` file. Product startup and renderer assertion failures still fail the job; disposable teardown can no longer turn a successful smoke test into a failed build.

## Validation

- `node --check scripts/smoke-packaged.mjs`
- commit hooks, including formatting, lint, dead-code checks, and tests
