### PR TITLE
test(e2e): expand alpha product coverage

### DIFF
--- a/apps/desktop/e2e/README.md
+++ b/apps/desktop/e2e/README.md
@@ -39,7 +39,7 @@ SHIFT_E2E_PREVIEW_FONT_PATH=/path/to/font.ttf pnpm test:e2e:gpu e2e/font-preview
 SHIFT_E2E_VARIABLE_PREVIEW_FONT_PATH=/path/to/variable.ttf pnpm test:e2e:gpu e2e/variable-font-preview.spec.ts
 ```
 
-Fixtures copy source files into a temporary workspace. Tests must not depend on a developer's existing Shift workspace or user-data directory.
+Fixtures copy source files into a temporary workspace. Tests must not depend on a developer's existing Shift workspace or user-data directory. Document-lifecycle tests inject deterministic Open, ordered Save As destinations, Export, and dirty-document choices through `NativeDialogs`; ordered choices exercise Save As adoption, multi-document quit, and re-entrant quit without automating OS pickers.
 
 ## Visual snapshots
 
@@ -64,11 +64,13 @@ A snapshot match alone does not prove GPU content exists. Rendering tests that c
 - Keep interactions inside measured bounds; do not assume the host desktop is wider than the fixture window.
 - GPU fixtures must await workspace-window visibility, then apply the final owning `BrowserWindow` size and await the tested page's matching renderer content size; do not let a hidden-to-visible OS adjustment invalidate a baseline.
 - Wait for a route, visible surface, animation frame, or domain state instead of assuming startup completed after a fixed delay.
+- Use `waitForWorkspaceReady()` for authored workspace startup and `waitForEditorReady()`/`openCatalogGlyph()` for glyph routes. A matching URL alone does not mean React has published the requested scene node.
+- Keep negative asynchronous waits limited to behavior where elapsed time is the contract, such as proving a re-entrant quit does not open another confirmation while the first remains pending.
 - Do not force software rendering or a fixed DPR in GPU and performance tests.
 
 ## Failures and artifacts
 
-Local failures are written to `apps/desktop/e2e/test-results/`. CI uploads the same directory as a Playwright artifact, including screenshots, diffs, traces, and error context. Open a trace with:
+Local failures are written to `apps/desktop/e2e/test-results/`. CI uploads the same directory as a Playwright artifact, including screenshots, diffs, traces, error context, and `electron-diagnostics` with window, renderer error/crash, main-process output, and process-exit evidence. Open a trace with:
 
 ```sh
 pnpm --filter @shift/desktop exec playwright show-trace apps/desktop/e2e/test-results/<test>/trace.zip

--- a/apps/desktop/e2e/application-quit.spec.ts
+++ b/apps/desktop/e2e/application-quit.spec.ts
@@ -1,0 +1,172 @@
+import { expect, type ElectronApplication, type Page } from "@playwright/test";
+import fs from "node:fs";
+import path from "node:path";
+import { documentTest as test, waitForWorkspaceReady } from "./fixtures/electronApp";
+import { openCatalogGlyph } from "./fixtures/appLocators";
+import {
+  addSquare,
+  hoverVisibleUnselectedPoint,
+  selectVisiblePoint,
+} from "./fixtures/editorInteractions";
+import {
+  createNewFont,
+  quitApp,
+  requestAppQuit,
+  runCommand,
+  windowTitle,
+} from "./fixtures/documentLifecycle";
+
+const discardOnQuitTest = test.extend({
+  dirtyDocumentChoice: ["discard", { option: true }],
+});
+const saveOnQuitTest = test.extend({
+  dirtyDocumentChoice: ["save", { option: true }],
+});
+const reentrantQuitTest = test.extend({
+  dirtyDocumentChoices: [["cancel", "discard"], { option: true }],
+  dirtyDocumentDelayMs: [150, { option: true }],
+});
+
+async function dirtyNewFont(page: Page, electronApp: ElectronApplication): Promise<Page> {
+  const workspacePage = await createNewFont(page, electronApp);
+  await workspacePage.getByRole("button", { name: "Create glyph", exact: true }).click();
+  await expect.poll(() => windowTitle(workspacePage, electronApp)).toContain("Untitled *");
+  return workspacePage;
+}
+
+async function createAnotherDirtyFont(page: Page, electronApp: ElectronApplication): Promise<Page> {
+  const nextWindow = electronApp.waitForEvent("window");
+  await runCommand(page, electronApp, "file.new");
+  const nextPage = await nextWindow;
+  await waitForWorkspaceReady(nextPage);
+  await nextPage.getByRole("button", { name: "Create glyph", exact: true }).click();
+  await expect.poll(() => windowTitle(nextPage, electronApp)).toContain("Untitled *");
+  return nextPage;
+}
+
+async function glyphIdForName(page: Page, name: string): Promise<string> {
+  await expect
+    .poll(() =>
+      page.evaluate(
+        (glyphName) => window.shift?.font.glyphRecords().some(({ name }) => name === glyphName),
+        name,
+      ),
+    )
+    .toBe(true);
+  const glyphId = await page.evaluate(
+    (glyphName) => window.shift?.font.glyphRecords().find(({ name }) => name === glyphName)?.id,
+    name,
+  );
+  if (!glyphId) throw new Error(`Expected ${name} glyph`);
+  return glyphId;
+}
+
+async function saveThenDirty(page: Page, savePath: string): Promise<Buffer> {
+  await page.evaluate(async (target) => {
+    const coordinator = window.shift?.font.editCoordinator;
+    if (!coordinator) throw new Error("Expected edit coordinator");
+
+    await coordinator.save(target);
+  }, savePath);
+  const saved = fs.readFileSync(savePath);
+  await page.getByRole("button", { name: "Create glyph", exact: true }).click();
+  return saved;
+}
+
+test("canceling dirty app quit keeps the document open and dirty", async ({
+  electronApp,
+  page,
+  saveShiftPath,
+}) => {
+  const workspacePage = await dirtyNewFont(page, electronApp);
+
+  await requestAppQuit(electronApp);
+  await workspacePage.waitForTimeout(100);
+
+  await expect(workspacePage.getByLabel("Glyph catalog", { exact: true })).toBeVisible();
+  await expect.poll(() => windowTitle(workspacePage, electronApp)).toContain("Untitled *");
+  expect(fs.existsSync(saveShiftPath)).toBe(false);
+});
+
+saveOnQuitTest(
+  "saving dirty app quit writes before the process exits",
+  async ({ electronApp, page, saveShiftPath }) => {
+    await dirtyNewFont(page, electronApp);
+
+    await quitApp(electronApp);
+
+    expect(fs.existsSync(saveShiftPath)).toBe(true);
+  },
+);
+
+discardOnQuitTest(
+  "discarding dirty app quit exits without writing",
+  async ({ electronApp, page, saveShiftPath }) => {
+    await dirtyNewFont(page, electronApp);
+
+    await quitApp(electronApp);
+
+    expect(fs.existsSync(saveShiftPath)).toBe(false);
+  },
+);
+
+saveOnQuitTest(
+  "saves every dirty document before quitting",
+  async ({ electronApp, page, testRoot }) => {
+    const firstPage = await dirtyNewFont(page, electronApp);
+    const firstPath = path.join(testRoot, "first.shift");
+    const firstSaved = await saveThenDirty(firstPage, firstPath);
+    const secondPage = await createAnotherDirtyFont(firstPage, electronApp);
+    const secondPath = path.join(testRoot, "second.shift");
+    const secondSaved = await saveThenDirty(secondPage, secondPath);
+
+    await quitApp(electronApp);
+
+    expect(fs.readFileSync(firstPath).equals(firstSaved)).toBe(false);
+    expect(fs.readFileSync(secondPath).equals(secondSaved)).toBe(false);
+  },
+);
+
+test("keeps authored document state isolated between windows", async ({ electronApp, page }) => {
+  const firstPage = await dirtyNewFont(page, electronApp);
+  const secondPage = await createAnotherDirtyFont(firstPage, electronApp);
+  const firstGlyphId = await glyphIdForName(firstPage, "newGlyph");
+  const secondGlyphId = await glyphIdForName(secondPage, "newGlyph");
+
+  await openCatalogGlyph(firstPage, "newGlyph", firstGlyphId);
+  await addSquare(firstPage);
+  await selectVisiblePoint(firstPage);
+  await hoverVisibleUnselectedPoint(firstPage);
+  await openCatalogGlyph(secondPage, "newGlyph", secondGlyphId);
+
+  expect(await secondPage.evaluate(() => window.shift?.editor.selection.ids)).toEqual([]);
+  expect(await secondPage.evaluate(() => window.shift?.editor.hover.id)).toBeNull();
+  expect((await firstPage.evaluate(() => window.shift?.editor.selection.ids.length)) ?? 0).toBe(1);
+  expect(await firstPage.evaluate(() => window.shift?.editor.hover.id)).not.toBeNull();
+
+  await firstPage.getByRole("button", { name: "Display all glyphs" }).click();
+  await firstPage.waitForURL(/#\/home$/);
+  await firstPage.getByRole("button", { name: "Create glyph", exact: true }).click();
+  await glyphIdForName(firstPage, "newGlyph.1");
+  expect(
+    await secondPage.evaluate(() =>
+      window.shift?.font.glyphRecords().some((glyph) => glyph.name === "newGlyph.1"),
+    ),
+  ).toBe(false);
+});
+
+reentrantQuitTest(
+  "does not start another confirmation while quit is pending",
+  async ({ electronApp, page, saveShiftPath }) => {
+    const workspacePage = await dirtyNewFont(page, electronApp);
+
+    await Promise.all([requestAppQuit(electronApp), requestAppQuit(electronApp)]);
+    await workspacePage.waitForTimeout(250);
+
+    await expect(workspacePage.getByLabel("Glyph catalog", { exact: true })).toBeVisible();
+    expect(fs.existsSync(saveShiftPath)).toBe(false);
+
+    await quitApp(electronApp);
+    expect(fs.existsSync(saveShiftPath)).toBe(false);
+  },
+);

--- a/apps/desktop/e2e/document-lifecycle.spec.ts
+++ b/apps/desktop/e2e/document-lifecycle.spec.ts
@@ -1,5 +1,3 @@
-import { _electron as electron, type ElectronApplication, type Page } from "@playwright/test";
-import { once } from "node:events";
 import fs from "node:fs";
 import path from "node:path";
 import {
@@ -7,14 +5,33 @@ import {
   documentWorkspaceTest as workspaceTest,
   expect,
   FONT_PATH,
-  MAIN_JS,
+  waitForWorkspaceReady,
 } from "./fixtures/electronApp";
+import {
+  closeWindow,
+  createNewFont,
+  killApp,
+  quitApp,
+  relaunchApp,
+  runCommand,
+  windowTitle,
+} from "./fixtures/documentLifecycle";
 
 const discardTest = test.extend({
   dirtyDocumentChoice: ["discard", { option: true }],
 });
 const saveOnCloseTest = test.extend({
   dirtyDocumentChoice: ["save", { option: true }],
+});
+const saveAsTest = test.extend({
+  saveShiftPaths: async ({ saveShiftPath, saveAsShiftPath }, use) => {
+    await use([saveShiftPath, saveAsShiftPath]);
+  },
+});
+const copiedDocumentTest = test.extend({
+  openFontPath: async ({ copyShiftPath }, use) => {
+    await use(copyShiftPath);
+  },
 });
 const cancelSaveTest = test.extend({
   saveShiftPath: async ({}, use) => {
@@ -40,89 +57,6 @@ const failedExportTest = workspaceTest.extend({
     await use(path.join(nonDirectory, "exported.ttf"));
   },
 });
-
-async function createNewFont(page: Page, electronApp: ElectronApplication): Promise<Page> {
-  const workspaceWindow = electronApp.waitForEvent("window");
-  await page.getByRole("button", { name: "New font", exact: true }).click();
-
-  const workspacePage = await workspaceWindow;
-  await workspacePage.waitForURL(/#\/home$/);
-  await expect(workspacePage.getByLabel("Glyph catalog", { exact: true })).toBeVisible();
-  return workspacePage;
-}
-
-async function runCommand(
-  page: Page,
-  electronApp: ElectronApplication,
-  command: "file.save" | "file.exportTtf",
-): Promise<void> {
-  const browserWindow = await electronApp.browserWindow(page);
-  await expect
-    .poll(() =>
-      browserWindow.evaluate((window) => {
-        window.focus();
-        return window.isFocused();
-      }),
-    )
-    .toBe(true);
-  await browserWindow.dispose();
-
-  await page.evaluate(async (id) => {
-    const host = window.shiftHost;
-    if (!host) throw new Error("Expected Shift host");
-
-    await host.commands.run(id);
-  }, command);
-}
-
-async function windowTitle(page: Page, electronApp: ElectronApplication): Promise<string> {
-  const browserWindow = await electronApp.browserWindow(page);
-  const title = await browserWindow.evaluate((window) => window.getTitle());
-  await browserWindow.dispose();
-  return title;
-}
-
-async function closeWindow(page: Page, electronApp: ElectronApplication): Promise<void> {
-  const browserWindow = await electronApp.browserWindow(page);
-  await browserWindow.evaluate((window) => window.close());
-  await browserWindow.dispose();
-}
-
-async function quitApp(electronApp: ElectronApplication): Promise<void> {
-  const childProcess = electronApp.process();
-  const exited = once(childProcess, "exit");
-  await electronApp.evaluate(({ app }) => {
-    setTimeout(() => app.quit(), 0);
-  });
-  await exited;
-}
-
-async function relaunchApp(testRoot: string, saveShiftPath: string): Promise<ElectronApplication> {
-  return electron.launch({
-    args: [
-      MAIN_JS,
-      `--user-data-dir=${path.join(testRoot, "user-data")}`,
-      "--force-device-scale-factor=1",
-    ],
-    env: {
-      ...process.env,
-      NODE_ENV: "test",
-      LIBGL_ALWAYS_SOFTWARE: "1",
-      SHIFT_E2E_NATIVE_DIALOGS: "1",
-      SHIFT_E2E_OPEN_FONT_PATH: saveShiftPath,
-      SHIFT_E2E_SAVE_SHIFT_PATH: saveShiftPath,
-    },
-  });
-}
-
-async function killApp(electronApp: ElectronApplication): Promise<void> {
-  const childProcess = electronApp.process();
-  if (childProcess.exitCode !== null || childProcess.signalCode !== null) return;
-
-  const exited = once(childProcess, "exit");
-  childProcess.kill("SIGKILL");
-  await exited;
-}
 
 test.describe("opening a font through the application shell", () => {
   test.use({ openFontPath: FONT_PATH });
@@ -253,6 +187,105 @@ discardTest(
 
     await expect.poll(() => workspacePage.isClosed()).toBe(true);
     expect(fs.existsSync(saveShiftPath)).toBe(false);
+  },
+);
+
+discardTest(
+  "discarding edits to a saved document reopens its last clean snapshot",
+  async ({ electronApp, page, saveShiftPath, testRoot }) => {
+    const workspacePage = await createNewFont(page, electronApp);
+    await workspacePage.getByRole("button", { name: "Create glyph", exact: true }).click();
+    await runCommand(workspacePage, electronApp, "file.save");
+    await expect.poll(() => fs.existsSync(saveShiftPath)).toBe(true);
+
+    await workspacePage.getByRole("button", { name: "Create glyph", exact: true }).click();
+    await expect.poll(() => windowTitle(workspacePage, electronApp)).toContain("saved.shift *");
+    await closeWindow(workspacePage, electronApp);
+    await expect.poll(() => workspacePage.isClosed()).toBe(true);
+    await quitApp(electronApp);
+
+    const relaunchedApp = await relaunchApp(testRoot, saveShiftPath);
+    try {
+      const launcherPage = await relaunchedApp.firstWindow();
+      await launcherPage.waitForURL(/#\/launcher$/);
+      const reopenedWindow = relaunchedApp.waitForEvent("window");
+      await launcherPage.getByRole("button", { name: /Load font/ }).click();
+      const reopenedPage = await reopenedWindow;
+      await waitForWorkspaceReady(reopenedPage);
+
+      expect(
+        await reopenedPage.evaluate(() =>
+          window.shift?.font.glyphRecords().map((glyph) => glyph.name),
+        ),
+      ).toContain("newGlyph");
+      expect(
+        await reopenedPage.evaluate(() =>
+          window.shift?.font.glyphRecords().map((glyph) => glyph.name),
+        ),
+      ).not.toContain("newGlyph.1");
+      expect(await windowTitle(reopenedPage, relaunchedApp)).not.toContain(" *");
+    } finally {
+      await killApp(relaunchedApp);
+    }
+  },
+);
+
+saveAsTest(
+  "Save As adopts an independent copy without changing the source document",
+  async ({ electronApp, page, saveShiftPath, saveAsShiftPath }) => {
+    const workspacePage = await createNewFont(page, electronApp);
+    await workspacePage.getByRole("button", { name: "Create glyph", exact: true }).click();
+    await runCommand(workspacePage, electronApp, "file.save");
+    await expect.poll(() => fs.existsSync(saveShiftPath)).toBe(true);
+    const sourceSnapshot = fs.readFileSync(saveShiftPath);
+
+    await runCommand(workspacePage, electronApp, "file.saveAs");
+    await expect.poll(() => fs.existsSync(saveAsShiftPath)).toBe(true);
+    await expect.poll(() => windowTitle(workspacePage, electronApp)).toContain("saved-as.shift -");
+    const copySnapshot = fs.readFileSync(saveAsShiftPath);
+    expect(fs.readFileSync(saveShiftPath)).toEqual(sourceSnapshot);
+
+    await workspacePage.getByRole("button", { name: "Create glyph", exact: true }).click();
+    await runCommand(workspacePage, electronApp, "file.save");
+
+    expect(fs.readFileSync(saveShiftPath)).toEqual(sourceSnapshot);
+    expect(fs.readFileSync(saveAsShiftPath)).not.toEqual(copySnapshot);
+    expect(await windowTitle(workspacePage, electronApp)).toContain("saved-as.shift -");
+  },
+);
+
+copiedDocumentTest(
+  "opening a copied package creates a separate clean document session",
+  async ({ electronApp, page, saveShiftPath, copyShiftPath }) => {
+    const originalPage = await createNewFont(page, electronApp);
+    await originalPage.getByRole("button", { name: "Create glyph", exact: true }).click();
+    await runCommand(originalPage, electronApp, "file.save");
+    await expect.poll(() => fs.existsSync(saveShiftPath)).toBe(true);
+    fs.copyFileSync(saveShiftPath, copyShiftPath);
+
+    const copiedWindow = electronApp.waitForEvent("window");
+    await runCommand(originalPage, electronApp, "file.open");
+    const copiedPage = await copiedWindow;
+    await waitForWorkspaceReady(copiedPage);
+
+    const originalState = await originalPage.evaluate(async () =>
+      window.shift?.font.editCoordinator.state(),
+    );
+    const copiedState = await copiedPage.evaluate(async () =>
+      window.shift?.font.editCoordinator.state(),
+    );
+    expect(copiedState?.documentId).not.toBe(originalState?.documentId);
+    expect(copiedState).toMatchObject({ dirty: false });
+    expect(originalState).toMatchObject({ dirty: false });
+
+    await copiedPage.getByRole("button", { name: "Create glyph", exact: true }).click();
+    await expect.poll(() => windowTitle(copiedPage, electronApp)).toContain("copied.shift *");
+    expect(await windowTitle(originalPage, electronApp)).toContain("saved.shift -");
+    expect(
+      await originalPage.evaluate(() =>
+        window.shift?.font.glyphRecords().some((glyph) => glyph.name === "newGlyph.1"),
+      ),
+    ).toBe(false);
   },
 );
 

--- a/apps/desktop/e2e/fixtures/appLocators.ts
+++ b/apps/desktop/e2e/fixtures/appLocators.ts
@@ -46,6 +46,39 @@ export async function clickFirstCatalogGlyph(page: Page): Promise<void> {
   await glyphCatalogViewport(page).click({ position: FIRST_GLYPH_PREVIEW_POINT });
 }
 
+/**
+ * Waits until the requested glyph owns the visible editor scene.
+ *
+ * @param page - workspace window navigating to the editor.
+ * @param glyphId - glyph identity that must own the published scene node.
+ */
+export async function waitForEditorReady(page: Page, glyphId: string): Promise<void> {
+  await page.waitForURL(new RegExp(`#/editor/${encodeURIComponent(glyphId)}$`));
+  await expect(editorShell(page)).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        (expectedGlyphId) =>
+          window.shift?.editor.scene.nodesOfKind("glyph")[0]?.glyphId === expectedGlyphId,
+        glyphId,
+      ),
+    )
+    .toBe(true);
+}
+
+/**
+ * Navigates directly to a glyph route and waits for its scene publication.
+ *
+ * @param page - workspace window navigating to the editor.
+ * @param glyphId - glyph identity that must own the published scene node.
+ */
+export async function openGlyphRoute(page: Page, glyphId: string): Promise<void> {
+  await page.evaluate((id) => {
+    window.location.hash = `#/editor/${encodeURIComponent(id)}`;
+  }, glyphId);
+  await waitForEditorReady(page, glyphId);
+}
+
 export async function openCatalogGlyph(
   page: Page,
   glyphName: string,
@@ -63,5 +96,5 @@ export async function openCatalogGlyph(
       }),
   );
   await clickFirstCatalogGlyph(page);
-  await page.waitForURL(new RegExp(`#/editor/${encodeURIComponent(glyphId)}$`));
+  await waitForEditorReady(page, glyphId);
 }

--- a/apps/desktop/e2e/fixtures/documentLifecycle.ts
+++ b/apps/desktop/e2e/fixtures/documentLifecycle.ts
@@ -1,0 +1,98 @@
+import {
+  _electron as electron,
+  expect,
+  type ElectronApplication,
+  type Page,
+} from "@playwright/test";
+import type { CommandId } from "../../src/shared/commands";
+import { once } from "node:events";
+import path from "node:path";
+import { MAIN_JS, waitForWorkspaceReady } from "./electronApp";
+
+export async function createNewFont(page: Page, electronApp: ElectronApplication): Promise<Page> {
+  const workspaceWindow = electronApp.waitForEvent("window");
+  await page.getByRole("button", { name: "New font", exact: true }).click();
+
+  const workspacePage = await workspaceWindow;
+  await waitForWorkspaceReady(workspacePage);
+  return workspacePage;
+}
+
+export async function runCommand(
+  page: Page,
+  electronApp: ElectronApplication,
+  command: CommandId,
+): Promise<void> {
+  const browserWindow = await electronApp.browserWindow(page);
+  await expect
+    .poll(() =>
+      browserWindow.evaluate((window) => {
+        window.focus();
+        return window.isFocused();
+      }),
+    )
+    .toBe(true);
+  await browserWindow.dispose();
+
+  await page.evaluate(async (id) => {
+    const host = window.shiftHost;
+    if (!host) throw new Error("Expected Shift host");
+
+    await host.commands.run(id);
+  }, command);
+}
+
+export async function windowTitle(page: Page, electronApp: ElectronApplication): Promise<string> {
+  const browserWindow = await electronApp.browserWindow(page);
+  const title = await browserWindow.evaluate((window) => window.getTitle());
+  await browserWindow.dispose();
+  return title;
+}
+
+export async function closeWindow(page: Page, electronApp: ElectronApplication): Promise<void> {
+  const browserWindow = await electronApp.browserWindow(page);
+  await browserWindow.evaluate((window) => window.close());
+  await browserWindow.dispose();
+}
+
+export async function requestAppQuit(electronApp: ElectronApplication): Promise<void> {
+  await electronApp.evaluate(({ app }) => {
+    setTimeout(() => app.quit(), 0);
+  });
+}
+
+export async function quitApp(electronApp: ElectronApplication): Promise<void> {
+  const exited = once(electronApp.process(), "exit");
+  await requestAppQuit(electronApp);
+  await exited;
+}
+
+export async function relaunchApp(
+  testRoot: string,
+  saveShiftPath: string,
+): Promise<ElectronApplication> {
+  return electron.launch({
+    args: [
+      MAIN_JS,
+      `--user-data-dir=${path.join(testRoot, "user-data")}`,
+      "--force-device-scale-factor=1",
+    ],
+    env: {
+      ...process.env,
+      NODE_ENV: "test",
+      LIBGL_ALWAYS_SOFTWARE: "1",
+      SHIFT_E2E_NATIVE_DIALOGS: "1",
+      SHIFT_E2E_OPEN_FONT_PATH: saveShiftPath,
+      SHIFT_E2E_SAVE_SHIFT_PATH: saveShiftPath,
+    },
+  });
+}
+
+export async function killApp(electronApp: ElectronApplication): Promise<void> {
+  const childProcess = electronApp.process();
+  if (childProcess.exitCode !== null || childProcess.signalCode !== null) return;
+
+  const exited = once(childProcess, "exit");
+  childProcess.kill("SIGKILL");
+  await exited;
+}

--- a/apps/desktop/e2e/fixtures/editorInteractions.ts
+++ b/apps/desktop/e2e/fixtures/editorInteractions.ts
@@ -1,0 +1,135 @@
+import { expect, type Page } from "@playwright/test";
+
+export interface EditablePointDrag {
+  readonly id: string;
+  readonly start: { readonly x: number; readonly y: number };
+  readonly end: { readonly x: number; readonly y: number };
+  readonly expected: { readonly x: number; readonly y: number };
+}
+
+export async function addSquare(page: Page): Promise<number> {
+  return page.evaluate(async () => {
+    const editor = window.shift?.editor;
+    if (!editor) throw new Error("Expected editor");
+
+    const inserted = editor.insertContent({
+      contours: [
+        {
+          closed: true,
+          points: [
+            { x: 0, y: 0, pointType: "onCurve", smooth: false },
+            { x: 100, y: 0, pointType: "onCurve", smooth: false },
+            { x: 100, y: 100, pointType: "onCurve", smooth: false },
+            { x: 0, y: 100, pointType: "onCurve", smooth: false },
+          ],
+        },
+      ],
+    });
+    if (!inserted) throw new Error("Expected inserted contour");
+
+    await editor.font.editCoordinator.settled();
+    return inserted.length;
+  });
+}
+
+export async function selectVisiblePoint(page: Page): Promise<EditablePointDrag> {
+  const point = await page.evaluate(() => {
+    const workspace = window.shift;
+    const canvas = document.querySelector<HTMLCanvasElement>("#interactive-canvas");
+    const node = workspace?.editor.scene.nodesOfKind("glyph")[0];
+    const glyph = node ? workspace?.editor.glyphForId(node.glyphId) : null;
+    const layer = node ? glyph?.layerForSource(node.sourceId) : null;
+    if (!workspace || !canvas || !node || !layer) throw new Error("Expected editable glyph");
+
+    const bounds = canvas.getBoundingClientRect();
+    const candidates = layer.allPoints
+      .filter((candidate) => candidate.pointType === "onCurve")
+      .map((candidate) => ({
+        point: candidate,
+        screen: workspace.editor.projectSceneToScreen({
+          x: candidate.x + node.position.x,
+          y: candidate.y + node.position.y,
+        }),
+      }))
+      .filter(
+        ({ screen }) =>
+          screen.x >= 50 &&
+          screen.y >= 50 &&
+          screen.x <= bounds.width - 100 &&
+          screen.y <= bounds.height - 100,
+      )
+      .sort(
+        (a, b) =>
+          Math.hypot(a.screen.x - bounds.width / 2, a.screen.y - bounds.height / 2) -
+          Math.hypot(b.screen.x - bounds.width / 2, b.screen.y - bounds.height / 2),
+      );
+    const candidate = candidates[0];
+    if (!candidate) throw new Error("Expected visible on-curve point");
+
+    const endScreen = { x: candidate.screen.x + 40, y: candidate.screen.y + 30 };
+    const endScene = workspace.editor.projectScreenToScene(endScreen);
+    return {
+      id: candidate.point.id,
+      start: { x: bounds.left + candidate.screen.x, y: bounds.top + candidate.screen.y },
+      end: { x: bounds.left + endScreen.x, y: bounds.top + endScreen.y },
+      expected: { x: endScene.x - node.position.x, y: endScene.y - node.position.y },
+    };
+  });
+
+  await page.mouse.click(point.start.x, point.start.y);
+  await expect
+    .poll(() =>
+      page.evaluate(
+        (pointId) => window.shift?.editor.selection.ids.some((id) => id === pointId) ?? false,
+        point.id,
+      ),
+    )
+    .toBe(true);
+
+  return point;
+}
+
+export async function hoverVisibleUnselectedPoint(page: Page): Promise<string> {
+  const target = await page.evaluate(() => {
+    const workspace = window.shift;
+    const canvas = document.querySelector<HTMLCanvasElement>("#interactive-canvas");
+    const node = workspace?.editor.scene.nodesOfKind("glyph")[0];
+    const glyph = node ? workspace?.editor.glyphForId(node.glyphId) : null;
+    const layer = node ? glyph?.layerForSource(node.sourceId) : null;
+    if (!workspace || !canvas || !node || !layer) throw new Error("Expected editable glyph");
+
+    const point = layer.allPoints.find(
+      (candidate) =>
+        candidate.pointType === "onCurve" && !workspace.editor.selection.has(candidate.id),
+    );
+    if (!point) throw new Error("Expected unselected point");
+
+    const screen = workspace.editor.projectSceneToScreen({
+      x: point.x + node.position.x,
+      y: point.y + node.position.y,
+    });
+    const bounds = canvas.getBoundingClientRect();
+    return { id: point.id, x: bounds.left + screen.x, y: bounds.top + screen.y };
+  });
+
+  await page.mouse.move(target.x, target.y);
+  await expect.poll(() => page.evaluate(() => window.shift?.editor.hover.id)).toBe(target.id);
+  return target.id;
+}
+
+export async function pointPosition(
+  page: Page,
+  pointId: string,
+): Promise<{ x: number; y: number }> {
+  return page.evaluate((id) => {
+    const workspace = window.shift;
+    const node = workspace?.editor.scene.nodesOfKind("glyph")[0];
+    const glyph = node ? workspace?.editor.glyphForId(node.glyphId) : null;
+    const point = node
+      ? glyph?.layerForSource(node.sourceId)?.allPoints.find((candidate) => candidate.id === id)
+      : null;
+    if (!point) throw new Error("Expected editable point");
+
+    return { x: point.x, y: point.y };
+  }, pointId);
+}

--- a/apps/desktop/e2e/fixtures/electronApp.ts
+++ b/apps/desktop/e2e/fixtures/electronApp.ts
@@ -30,6 +30,8 @@ type ShiftFixtures = {
   page: Page;
   testRoot: string;
   saveShiftPath: string;
+  saveAsShiftPath: string;
+  copyShiftPath: string;
   exportTtfPath: string;
 };
 
@@ -37,7 +39,10 @@ type ShiftOptions = {
   startupFontPath: string | undefined;
   scriptedDialogs: boolean;
   openFontPath: string | undefined;
+  saveShiftPaths: readonly string[] | undefined;
   dirtyDocumentChoice: DirtyDocumentChoice;
+  dirtyDocumentChoices: readonly DirtyDocumentChoice[] | undefined;
+  dirtyDocumentDelayMs: number;
 };
 
 /** Base fixture for launcher tests; workspace tests override `startupFontPath`. */
@@ -45,7 +50,10 @@ export const test = base.extend<ShiftFixtures & ShiftOptions>({
   startupFontPath: [undefined, { option: true }],
   scriptedDialogs: [false, { option: true }],
   openFontPath: [undefined, { option: true }],
+  saveShiftPaths: [undefined, { option: true }],
   dirtyDocumentChoice: ["cancel", { option: true }],
+  dirtyDocumentChoices: [undefined, { option: true }],
+  dirtyDocumentDelayMs: [0, { option: true }],
 
   testRoot: async ({}, use) => {
     const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), "shift-e2e-"));
@@ -61,6 +69,14 @@ export const test = base.extend<ShiftFixtures & ShiftOptions>({
     await use(path.join(testRoot, "saved.shift"));
   },
 
+  saveAsShiftPath: async ({ testRoot }, use) => {
+    await use(path.join(testRoot, "saved-as.shift"));
+  },
+
+  copyShiftPath: async ({ testRoot }, use) => {
+    await use(path.join(testRoot, "copied.shift"));
+  },
+
   exportTtfPath: async ({ testRoot }, use) => {
     await use(path.join(testRoot, "exported.ttf"));
   },
@@ -70,17 +86,26 @@ export const test = base.extend<ShiftFixtures & ShiftOptions>({
       startupFontPath,
       scriptedDialogs,
       openFontPath,
+      saveShiftPaths,
       dirtyDocumentChoice,
+      dirtyDocumentChoices,
+      dirtyDocumentDelayMs,
       testRoot,
       saveShiftPath,
       exportTtfPath,
     },
     use,
+    testInfo,
   ) => {
     const userDataDir = path.join(testRoot, "user-data");
     let workspacePath: string | undefined;
     let app: ElectronApplication | null = null;
     let childProcess: ChildProcess | null = null;
+    const diagnostics: string[] = [];
+    const recordDiagnostic = (message: string) => {
+      diagnostics.push(`${new Date().toISOString()} ${message}`);
+      if (diagnostics.length > 500) diagnostics.shift();
+    };
 
     if (startupFontPath) {
       workspacePath = createAuthoredPackage(startupFontPath, path.join(testRoot, "workspace"));
@@ -98,8 +123,17 @@ export const test = base.extend<ShiftFixtures & ShiftOptions>({
     if (scriptedDialogs) {
       environment.SHIFT_E2E_NATIVE_DIALOGS = "1";
       environment.SHIFT_E2E_SAVE_SHIFT_PATH = saveShiftPath;
+      if (saveShiftPaths) {
+        environment.SHIFT_E2E_SAVE_SHIFT_PATHS = JSON.stringify(saveShiftPaths);
+      }
       environment.SHIFT_E2E_EXPORT_TTF_PATH = exportTtfPath;
       environment.SHIFT_E2E_DIRTY_DOCUMENT_CHOICE = dirtyDocumentChoice;
+      if (dirtyDocumentChoices) {
+        environment.SHIFT_E2E_DIRTY_DOCUMENT_CHOICES = dirtyDocumentChoices.join(",");
+      }
+      if (dirtyDocumentDelayMs > 0) {
+        environment.SHIFT_E2E_DIRTY_DOCUMENT_DELAY_MS = String(dirtyDocumentDelayMs);
+      }
       if (openFontPath) environment.SHIFT_E2E_OPEN_FONT_PATH = openFontPath;
     }
 
@@ -109,6 +143,29 @@ export const test = base.extend<ShiftFixtures & ShiftOptions>({
         env: environment,
       });
       childProcess = app.process();
+      childProcess.once("exit", (code, signal) => {
+        recordDiagnostic(`Electron exited: code=${code ?? "null"}, signal=${signal ?? "null"}`);
+      });
+      childProcess.stdout?.on("data", (data) =>
+        recordDiagnostic(`main stdout: ${String(data).trim()}`),
+      );
+      childProcess.stderr?.on("data", (data) =>
+        recordDiagnostic(`main stderr: ${String(data).trim()}`),
+      );
+
+      const observePage = (observedPage: Page) => {
+        recordDiagnostic(`window opened: ${observedPage.url()}`);
+        observedPage.on("console", (message) => {
+          if (message.type() === "error" || message.type() === "warning") {
+            recordDiagnostic(`renderer ${message.type()}: ${message.text()}`);
+          }
+        });
+        observedPage.on("pageerror", (error) => recordDiagnostic(`renderer error: ${error.stack}`));
+        observedPage.on("crash", () => recordDiagnostic(`renderer crashed: ${observedPage.url()}`));
+        observedPage.on("close", () => recordDiagnostic(`window closed: ${observedPage.url()}`));
+      };
+      for (const observedPage of app.windows()) observePage(observedPage);
+      app.on("window", observePage);
 
       // Size the window that owns the test page instead of whichever app window was created first.
       const page = await app.firstWindow();
@@ -135,6 +192,24 @@ export const test = base.extend<ShiftFixtures & ShiftOptions>({
 
       await use(app);
     } finally {
+      if (testInfo.status !== testInfo.expectedStatus) {
+        if (app) {
+          for (const [index, observedPage] of app.windows().entries()) {
+            try {
+              recordDiagnostic(
+                `final window ${index}: title=${await observedPage.title()}, url=${observedPage.url()}`,
+              );
+            } catch (error) {
+              recordDiagnostic(`final window ${index} unavailable: ${String(error)}`);
+            }
+          }
+        }
+        await testInfo.attach("electron-diagnostics", {
+          body: diagnostics.join("\n"),
+          contentType: "text/plain",
+        });
+      }
+
       if (childProcess && childProcess.exitCode === null && childProcess.signalCode === null) {
         const exited = once(childProcess, "exit");
         childProcess.kill("SIGKILL");
@@ -164,8 +239,7 @@ export const workspaceTest = test.extend<ShiftOptions>({
   startupFontPath: FONT_PATH,
 
   page: async ({ page }, use) => {
-    await page.waitForURL(/#\/home/, { timeout: 20_000 });
-    await page.getByLabel("Glyph catalog", { exact: true }).waitFor({ state: "visible" });
+    await waitForWorkspaceReady(page);
     await use(page);
   },
 });
@@ -175,11 +249,23 @@ export const documentWorkspaceTest = documentTest.extend<ShiftOptions>({
   startupFontPath: FONT_PATH,
 
   page: async ({ page }, use) => {
-    await page.waitForURL(/#\/home/, { timeout: 20_000 });
-    await page.getByLabel("Glyph catalog", { exact: true }).waitFor({ state: "visible" });
+    await waitForWorkspaceReady(page);
     await use(page);
   },
 });
+
+/**
+ * Waits until an authored workspace has published its loaded font and catalog.
+ *
+ * @param page - workspace window whose renderer state must settle.
+ */
+export async function waitForWorkspaceReady(page: Page): Promise<void> {
+  await page.waitForURL(/#\/home/, { timeout: 20_000 });
+  await page.waitForFunction(() => window.shift?.font.loaded === true, undefined, {
+    timeout: 20_000,
+  });
+  await page.getByLabel("Glyph catalog", { exact: true }).waitFor({ state: "visible" });
+}
 
 /**
  * Navigate to the editor for Unicode codepoint (hex, e.g. "41" = A).

--- a/apps/desktop/e2e/glyph-navigation.spec.ts
+++ b/apps/desktop/e2e/glyph-navigation.spec.ts
@@ -1,6 +1,12 @@
 import type { Page } from "@playwright/test";
 import type { GlyphId, GlyphName } from "@shift/types";
 import { expect, workspaceTest as test } from "./fixtures/electronApp";
+import { openCatalogGlyph } from "./fixtures/appLocators";
+import {
+  addSquare,
+  hoverVisibleUnselectedPoint,
+  selectVisiblePoint,
+} from "./fixtures/editorInteractions";
 
 interface NavigationGlyphs {
   firstId: GlyphId;
@@ -52,28 +58,7 @@ test("preserves confirmed edits and document history across glyph navigation", a
   const glyphs = await createNavigationGlyphs(page);
   await openGlyph(page, glyphs.firstId);
 
-  const authored = await page.evaluate(async () => {
-    const editor = window.shift?.editor;
-    if (!editor) throw new Error("Expected editor");
-
-    const inserted = editor.insertContent({
-      contours: [
-        {
-          closed: true,
-          points: [
-            { x: 0, y: 0, pointType: "onCurve", smooth: false },
-            { x: 100, y: 0, pointType: "onCurve", smooth: false },
-            { x: 100, y: 100, pointType: "onCurve", smooth: false },
-            { x: 0, y: 100, pointType: "onCurve", smooth: false },
-          ],
-        },
-      ],
-    });
-    if (!inserted) throw new Error("Expected inserted contour");
-
-    await editor.font.editCoordinator.settled();
-    return inserted.length;
-  });
+  const authored = await addSquare(page);
   expect(authored).toBe(4);
   await expect
     .poll(() => currentGlyph(page))
@@ -103,4 +88,80 @@ test("preserves confirmed edits and document history across glyph navigation", a
     await window.shift?.font.editCoordinator.redo();
   });
   await expect.poll(async () => (await currentGlyph(page)).contourCount).toBe(1);
+});
+
+test("starts a fresh Pen context after navigating to another glyph", async ({ page }) => {
+  const glyphs = await createNavigationGlyphs(page);
+  await openCatalogGlyph(page, "navigationA", glyphs.firstId);
+  await page.getByRole("button", { name: "Pen Tool (P)" }).click();
+  const canvas = page.locator("#interactive-canvas");
+  const bounds = await canvas.boundingBox();
+  if (!bounds) throw new Error("Expected editor canvas");
+  await page.mouse.click(bounds.x + bounds.width / 2, bounds.y + bounds.height / 2);
+
+  await returnHome(page);
+  await openCatalogGlyph(page, "navigationB", glyphs.secondId);
+  const secondBounds = await canvas.boundingBox();
+  if (!secondBounds) throw new Error("Expected editor canvas");
+  await page.mouse.click(
+    secondBounds.x + secondBounds.width / 2,
+    secondBounds.y + secondBounds.height / 2,
+  );
+  await page.evaluate(async () => window.shift?.font.editCoordinator.settled());
+
+  const pointCounts = await page.evaluate(({ firstId, secondId }) => {
+    const editor = window.shift?.editor;
+    const sourceId = editor?.font.defaultSource.id;
+    return {
+      first: sourceId ? editor?.glyphForId(firstId)?.layerForSource(sourceId)?.allPoints.length : 0,
+      second: sourceId
+        ? editor?.glyphForId(secondId)?.layerForSource(sourceId)?.allPoints.length
+        : 0,
+    };
+  }, glyphs);
+  expect(pointCounts).toEqual({ first: 1, second: 1 });
+});
+
+test("clears transient editor state when navigating between glyphs", async ({ page }) => {
+  const glyphs = await createNavigationGlyphs(page);
+  await openCatalogGlyph(page, "navigationA", glyphs.firstId);
+  await addSquare(page);
+  await selectVisiblePoint(page);
+  await hoverVisibleUnselectedPoint(page);
+
+  await returnHome(page);
+  await openCatalogGlyph(page, "navigationB", glyphs.secondId);
+
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const editor = window.shift?.editor;
+        const node = editor?.scene.nodesOfKind("glyph")[0];
+        return {
+          glyphId: node?.glyphId,
+          selection: editor?.selection.ids,
+          hover: editor?.hover.id,
+          editing: editor?.editing.nodeIds,
+          nodeId: node?.id,
+          toolState: editor?.toolManager.activeTool?.getState().type,
+        };
+      }),
+    )
+    .toEqual({
+      glyphId: glyphs.secondId,
+      selection: [],
+      hover: null,
+      editing: expect.any(Array),
+      nodeId: expect.any(String),
+      toolState: "ready",
+    });
+  const state = await page.evaluate(() => {
+    const editor = window.shift?.editor;
+    return { editing: editor?.editing.nodeIds, nodeId: editor?.scene.nodesOfKind("glyph")[0]?.id };
+  });
+  expect(state.editing).toEqual([state.nodeId]);
+
+  await returnHome(page);
+  await openCatalogGlyph(page, "navigationA", glyphs.firstId);
+  expect(await currentGlyph(page)).toEqual({ glyphId: glyphs.firstId, contourCount: 1 });
 });

--- a/apps/desktop/e2e/glyph-rendering.spec.ts
+++ b/apps/desktop/e2e/glyph-rendering.spec.ts
@@ -178,8 +178,7 @@ test.describe("Pen tool drawing — segment snapshots", () => {
   });
 
   test("multiple segments — mixed straight and cubic", async ({ page }) => {
-    await page.keyboard.press("p");
-    await page.waitForTimeout(200);
+    await page.getByRole("button", { name: "Pen Tool (P)" }).click();
 
     const canvas = page.locator("#interactive-canvas");
 
@@ -200,7 +199,25 @@ test.describe("Pen tool drawing — segment snapshots", () => {
     await canvas.click({
       position: { x: Math.round(canvasBounds.width * 0.9), y: 500 },
     });
-    await page.waitForTimeout(300);
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const editor = window.shift?.editor;
+          const node = editor?.scene.nodesOfKind("glyph")[0];
+          if (!editor || !node) return 0;
+
+          return (
+            editor.glyphForId(node.glyphId)?.layerForSource(node.sourceId)?.allPoints.length ?? 0
+          );
+        }),
+      )
+      .toBeGreaterThanOrEqual(6);
+    await page.evaluate(
+      () =>
+        new Promise<void>((resolve) => {
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+        }),
+    );
 
     const canvasUtil = new CanvasUtil(page);
     const screenshot = await canvasUtil.screenshotCanvasContainer();

--- a/apps/desktop/e2e/glyph-view.spec.ts
+++ b/apps/desktop/e2e/glyph-view.spec.ts
@@ -1,0 +1,87 @@
+import type { Page } from "@playwright/test";
+import type { GlyphId, GlyphName } from "@shift/types";
+import { expect, workspaceTest as test } from "./fixtures/electronApp";
+import { openGlyphRoute } from "./fixtures/appLocators";
+
+async function createViewGlyphs(page: Page): Promise<readonly { id: GlyphId; name: string }[]> {
+  return page.evaluate(async () => {
+    const workspace = window.shift;
+    if (!workspace) throw new Error("Expected workspace");
+
+    const definitions = [
+      { name: "viewEmpty", width: null },
+      { name: "viewNarrow", width: 20 },
+      { name: "viewWide", width: 1200 },
+      { name: "viewExtreme", width: 5000 },
+    ];
+    const records = definitions.map(({ name }) => workspace.editor.createGlyph(name as GlyphName));
+    await workspace.font.editCoordinator.settled();
+
+    for (const [index, record] of records.entries()) {
+      const width = definitions[index]?.width;
+      const glyph = await workspace.font.loadGlyph(record.id);
+      const layer = glyph.layerForSource(workspace.font.defaultSource.id);
+      if (!layer) throw new Error("Expected authored layer");
+
+      layer.setXAdvance(width ?? 500);
+      if (width === null) continue;
+
+      const contourId = layer.addContour();
+      for (const point of [
+        { x: 0, y: -100 },
+        { x: width, y: -100 },
+        { x: width, y: 900 },
+        { x: 0, y: 900 },
+      ]) {
+        layer.addPoint(contourId, { ...point, pointType: "onCurve", smooth: false });
+      }
+      layer.closeContour(contourId);
+    }
+    await workspace.font.editCoordinator.settled();
+    return records.map(({ id, name }) => ({ id, name }));
+  });
+}
+
+async function cameraFrame(page: Page) {
+  return page.evaluate(() => {
+    const workspace = window.shift;
+    const canvas = document.querySelector<HTMLCanvasElement>("#interactive-canvas");
+    if (!workspace || !canvas) throw new Error("Expected editor canvas");
+
+    const metrics = workspace.font.metricsAtLocation(workspace.editor.externalLocation);
+    return {
+      transform: workspace.editor.getCameraTransform(),
+      origin: workspace.editor.projectSceneToScreen({ x: 0, y: 0 }),
+      ascender: workspace.editor.projectSceneToScreen({ x: 0, y: metrics.ascender }),
+      descender: workspace.editor.projectSceneToScreen({ x: 0, y: metrics.descender }),
+      viewport: { width: canvas.clientWidth, height: canvas.clientHeight },
+    };
+  });
+}
+
+test("keeps a useful stable UPM frame across empty and extreme glyphs", async ({ page }) => {
+  const glyphs = await createViewGlyphs(page);
+  const firstGlyph = glyphs[0];
+  if (!firstGlyph) throw new Error("Expected view glyphs");
+
+  await openGlyphRoute(page, firstGlyph.id);
+  const expectedTransform = (await cameraFrame(page)).transform;
+  await page.getByRole("button", { name: "Display all glyphs" }).click();
+  await page.waitForURL(/#\/home$/);
+
+  for (const glyph of glyphs) {
+    await openGlyphRoute(page, glyph.id);
+    const frame = await cameraFrame(page);
+
+    expect(frame.transform).toEqual(expectedTransform);
+    expect(frame.origin.x).toBeGreaterThanOrEqual(0);
+    expect(frame.origin.x).toBeLessThanOrEqual(frame.viewport.width);
+    for (const point of [frame.ascender, frame.origin, frame.descender]) {
+      expect(point.y).toBeGreaterThanOrEqual(0);
+      expect(point.y).toBeLessThanOrEqual(frame.viewport.height);
+    }
+
+    await page.getByRole("button", { name: "Display all glyphs" }).click();
+    await page.waitForURL(/#\/home$/);
+  }
+});

--- a/apps/desktop/e2e/home.spec.ts
+++ b/apps/desktop/e2e/home.spec.ts
@@ -30,6 +30,40 @@ test.describe("Home view", () => {
     expect(renderedFrame.equals(frameWithoutGlyphs)).toBe(false);
   });
 
+  test("finds encoded characters and unencoded glyph names", async ({ page }) => {
+    const search = page.getByPlaceholder("Search glyphs...");
+    const surface = glyphCatalogSurface(page);
+    const encodedId = await page.evaluate(() => {
+      const font = window.shift?.font;
+      if (!font) throw new Error("Expected font");
+
+      const handle = font.glyphHandleForUnicode(0x41);
+      return font.recordForName(handle.name)?.id;
+    });
+
+    await search.fill("A");
+    await expect(surface).toHaveAttribute("data-first-glyph-id", encodedId ?? "");
+
+    await page.getByRole("button", { name: "Create glyph", exact: true }).click();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            window.shift?.font.glyphRecords().some((glyph) => glyph.name.startsWith("newGlyph")) ??
+            false,
+        ),
+      )
+      .toBe(true);
+    const unencoded = await page.evaluate(() =>
+      window.shift?.font.glyphRecords().find((glyph) => glyph.name.startsWith("newGlyph")),
+    );
+    if (!unencoded) throw new Error("Expected unencoded glyph");
+
+    await search.fill(unencoded.name);
+    await expect(surface).toHaveAttribute("data-filtered-glyph-count", "1");
+    await expect(surface).toHaveAttribute("data-first-glyph-id", unencoded.id);
+  });
+
   test("keeps the resident grid when returning from the editor", async ({ page }) => {
     const glyphCanvas = glyphCatalogCanvas(page);
     await expect(glyphCanvas).toBeVisible({ timeout: 30_000 });

--- a/apps/desktop/e2e/tools.spec.ts
+++ b/apps/desktop/e2e/tools.spec.ts
@@ -1,83 +1,10 @@
 import type { Page } from "@playwright/test";
 import { workspaceTest as test, expect, navigateToEditor } from "./fixtures/electronApp";
-
-interface EditablePointDrag {
-  readonly id: string;
-  readonly start: { readonly x: number; readonly y: number };
-  readonly end: { readonly x: number; readonly y: number };
-  readonly expected: { readonly x: number; readonly y: number };
-}
-
-async function selectVisiblePoint(page: Page): Promise<EditablePointDrag> {
-  const point = await page.evaluate(() => {
-    const workspace = window.shift;
-    const canvas = document.querySelector<HTMLCanvasElement>("#interactive-canvas");
-    const node = workspace?.editor.scene.nodesOfKind("glyph")[0];
-    const glyph = node ? workspace?.editor.glyphForId(node.glyphId) : null;
-    const layer = node ? glyph?.layerForSource(node.sourceId) : null;
-    if (!workspace || !canvas || !node || !layer) throw new Error("Expected editable glyph");
-
-    const bounds = canvas.getBoundingClientRect();
-    const candidates = layer.allPoints
-      .filter((candidate) => candidate.pointType === "onCurve")
-      .map((candidate) => ({
-        point: candidate,
-        screen: workspace.editor.projectSceneToScreen({
-          x: candidate.x + node.position.x,
-          y: candidate.y + node.position.y,
-        }),
-      }))
-      .filter(
-        ({ screen }) =>
-          screen.x >= 50 &&
-          screen.y >= 50 &&
-          screen.x <= bounds.width - 100 &&
-          screen.y <= bounds.height - 100,
-      )
-      .sort(
-        (a, b) =>
-          Math.hypot(a.screen.x - bounds.width / 2, a.screen.y - bounds.height / 2) -
-          Math.hypot(b.screen.x - bounds.width / 2, b.screen.y - bounds.height / 2),
-      );
-    const candidate = candidates[0];
-    if (!candidate) throw new Error("Expected visible on-curve point");
-
-    const endScreen = { x: candidate.screen.x + 40, y: candidate.screen.y + 30 };
-    const endScene = workspace.editor.projectScreenToScene(endScreen);
-    return {
-      id: candidate.point.id,
-      start: { x: bounds.left + candidate.screen.x, y: bounds.top + candidate.screen.y },
-      end: { x: bounds.left + endScreen.x, y: bounds.top + endScreen.y },
-      expected: { x: endScene.x - node.position.x, y: endScene.y - node.position.y },
-    };
-  });
-
-  await page.mouse.click(point.start.x, point.start.y);
-  await expect
-    .poll(() =>
-      page.evaluate(
-        (pointId) => window.shift?.editor.selection.ids.some((id) => id === pointId) ?? false,
-        point.id,
-      ),
-    )
-    .toBe(true);
-
-  return point;
-}
-
-async function pointPosition(page: Page, pointId: string): Promise<{ x: number; y: number }> {
-  return page.evaluate((id) => {
-    const workspace = window.shift;
-    const node = workspace?.editor.scene.nodesOfKind("glyph")[0];
-    const glyph = node ? workspace?.editor.glyphForId(node.glyphId) : null;
-    const point = node
-      ? glyph?.layerForSource(node.sourceId)?.allPoints.find((candidate) => candidate.id === id)
-      : null;
-    if (!point) throw new Error("Expected editable point");
-
-    return { x: point.x, y: point.y };
-  }, pointId);
-}
+import {
+  pointPosition,
+  selectVisiblePoint,
+  type EditablePointDrag,
+} from "./fixtures/editorInteractions";
 
 async function dragWithEarlyCaptureLoss(page: Page, point: EditablePointDrag): Promise<void> {
   const canvas = page.locator("#interactive-canvas");
@@ -99,6 +26,42 @@ async function dragWithEarlyCaptureLoss(page: Page, point: EditablePointDrag): P
     (element, event) => {
       element.dispatchEvent(
         new PointerEvent("lostpointercapture", {
+          bubbles: true,
+          pointerId: event.pointerId,
+          pointerType: "mouse",
+          isPrimary: true,
+          button: -1,
+          buttons: 0,
+          clientX: event.x,
+          clientY: event.y,
+        }),
+      );
+    },
+    { pointerId, x: point.end.x, y: point.end.y },
+  );
+  await page.mouse.up();
+}
+
+async function dragWithPointerCancel(page: Page, point: EditablePointDrag): Promise<void> {
+  const canvas = page.locator("#interactive-canvas");
+  await canvas.evaluate((element) => {
+    element.addEventListener(
+      "pointerdown",
+      (event) => {
+        element.dataset.e2ePointerId = String((event as PointerEvent).pointerId);
+      },
+      { once: true },
+    );
+  });
+
+  await page.mouse.move(point.start.x, point.start.y);
+  await page.mouse.down();
+  await page.mouse.move(point.end.x, point.end.y, { steps: 5 });
+  const pointerId = Number(await canvas.getAttribute("data-e2e-pointer-id"));
+  await canvas.evaluate(
+    (element, event) => {
+      element.dispatchEvent(
+        new PointerEvent("pointercancel", {
           bubbles: true,
           pointerId: event.pointerId,
           pointerType: "mouse",
@@ -167,6 +130,17 @@ test.describe("Canvas pointer lifecycle", () => {
     const after = await pointPosition(page, point.id);
     expect(after.x).toBeCloseTo(point.expected.x);
     expect(after.y).toBeCloseTo(point.expected.y);
+  });
+
+  test("rolls back a point drag canceled by the DOM", async ({ page }) => {
+    const point = await selectVisiblePoint(page);
+    const before = await pointPosition(page, point.id);
+
+    await dragWithPointerCancel(page, point);
+    await page.evaluate(async () => window.shift?.font.editCoordinator.settled());
+
+    expect(await pointPosition(page, point.id)).toEqual(before);
+    await expect(page.getByTestId("editor-shell")).toHaveAttribute("data-gesture", "idle");
   });
 });
 

--- a/apps/desktop/src/main/dialogs/scriptedNativeDialogs.ts
+++ b/apps/desktop/src/main/dialogs/scriptedNativeDialogs.ts
@@ -1,6 +1,13 @@
 import type { DirtyDocumentChoice } from "../document/types";
 import type { NativeDialogs } from "./NativeDialogs";
 
+const dirtyDocumentChoices = parseDirtyDocumentChoices(
+  process.env.SHIFT_E2E_DIRTY_DOCUMENT_CHOICES,
+);
+const saveShiftPaths = parseSaveShiftPaths(process.env.SHIFT_E2E_SAVE_SHIFT_PATHS);
+let dirtyDocumentChoiceIndex = 0;
+let saveShiftPathIndex = 0;
+
 /** Supplies deterministic outer-dialog choices to Electron E2E tests. */
 export const scriptedNativeDialogs: NativeDialogs = {
   async openFont() {
@@ -8,6 +15,12 @@ export const scriptedNativeDialogs: NativeDialogs = {
   },
 
   async saveShiftDocument() {
+    const savePath = saveShiftPaths[saveShiftPathIndex];
+    if (savePath !== undefined) {
+      saveShiftPathIndex++;
+      return savePath || null;
+    }
+
     return process.env.SHIFT_E2E_SAVE_SHIFT_PATH || null;
   },
 
@@ -16,6 +29,14 @@ export const scriptedNativeDialogs: NativeDialogs = {
   },
 
   async confirmDirtyDocument() {
+    await dirtyDocumentDelay();
+
+    const choice = dirtyDocumentChoices[dirtyDocumentChoiceIndex];
+    if (choice) {
+      dirtyDocumentChoiceIndex++;
+      return choice;
+    }
+
     return dirtyDocumentChoice(process.env.SHIFT_E2E_DIRTY_DOCUMENT_CHOICE);
   },
 
@@ -32,4 +53,28 @@ function dirtyDocumentChoice(value: string | undefined): DirtyDocumentChoice {
     default:
       return "cancel";
   }
+}
+
+function parseDirtyDocumentChoices(value: string | undefined): DirtyDocumentChoice[] {
+  if (!value) return [];
+
+  return value.split(",").map(dirtyDocumentChoice);
+}
+
+function parseSaveShiftPaths(value: string | undefined): string[] {
+  if (!value) return [];
+
+  const parsed: unknown = JSON.parse(value);
+  if (!Array.isArray(parsed) || !parsed.every((entry) => typeof entry === "string")) {
+    throw new Error("SHIFT_E2E_SAVE_SHIFT_PATHS must be a JSON string array");
+  }
+
+  return parsed;
+}
+
+async function dirtyDocumentDelay(): Promise<void> {
+  const delayMs = Number(process.env.SHIFT_E2E_DIRTY_DOCUMENT_DELAY_MS ?? 0);
+  if (!Number.isFinite(delayMs) || delayMs <= 0) return;
+
+  await new Promise((resolve) => setTimeout(resolve, delayMs));
 }

--- a/apps/desktop/src/main/docs/DOCS.md
+++ b/apps/desktop/src/main/docs/DOCS.md
@@ -146,7 +146,8 @@ Renderer IPC in `App` is limited to shell capabilities: command execution, clipb
 - `pnpm test:desktop src/main/update/updateFeed.test.ts`
 - `pnpm test:release`
 - Electron E2E fixtures copy their startup workspace under a fresh `testRoot`, launch with a fresh `userDataDir`, assert Electron honored that path, and remove the root after force-closing the disposable process.
-- `document-lifecycle.spec.ts` injects scripted native choices and verifies New/Open, first and ordinary Save, Save cancellation/failure safety, dirty-close choices, clean quit/relaunch/reopen, and Export safety through application commands.
+- `document-lifecycle.spec.ts` injects ordered scripted paths/choices and verifies New/Open, first and ordinary Save, independent Save As, saved-document discard/reopen, copied-package session isolation, Save cancellation/failure safety, dirty-close choices, clean quit/relaunch/reopen, and Export safety through application commands.
+- `application-quit.spec.ts` verifies dirty Save/Discard/Cancel, every dirty document in a multi-document quit, re-entrant quit suppression, and document isolation across windows. Ordered scripted choices are consumed once per actual confirmation.
 - Manual: open the same `.shift` package twice and verify the existing workspace session is reused.
 - Manual: edit a package, close the last window, and verify the save/discard prompt appears.
 - Manual installed N → N+1: verify macOS arm64/x64 and unsigned Windows Nightly x64 checks, download, Later, **Restart and Update**, canceled document close, save, discard, install, and relaunch paths. Electron orchestration has no worthwhile unit test without mocking Electron, native dialogs, and electron-updater.

--- a/apps/desktop/src/renderer/src/context/GlyphCatalogProvider.tsx
+++ b/apps/desktop/src/renderer/src/context/GlyphCatalogProvider.tsx
@@ -5,6 +5,7 @@ import { asGlyphId, type GlyphId, type GlyphName } from "@shift/types";
 import { effect, useSignalState } from "@/lib/signals";
 import { useFontSession } from "@/workspace/WorkspaceContext";
 import { getGlyphInfo } from "@/workspace/glyphInfo";
+import { GlyphOpenGate } from "@/lib/catalog/GlyphOpenGate";
 import { GlyphCatalogContext } from "./GlyphCatalogContext";
 import type { GlyphCatalogItem, GlyphCatalogSource } from "@/types/glyphCatalog";
 
@@ -31,7 +32,7 @@ const useGlyphCatalogSource = (): GlyphCatalogSource => {
   const sourceId = useSignalState(catalog.sourceIdCell);
   const [openedGlyph, setOpenedGlyph] = useState<GlyphCatalogSource["openedGlyph"]>(null);
   const openedGlyphKeyRef = useRef<GlyphCatalogItem["id"] | null>(null);
-  const openGenerationRef = useRef(0);
+  const openGateRef = useRef(new GlyphOpenGate());
   const observeAtlasInvalidation = useCallback<GlyphCatalogSource["observeAtlasInvalidation"]>(
     (listener) => {
       const subscription = effect(
@@ -92,13 +93,11 @@ const useGlyphCatalogSource = (): GlyphCatalogSource => {
 
   const openGlyph = useCallback<GlyphCatalogSource["openGlyph"]>(
     async (glyph) => {
-      const generation = openGenerationRef.current + 1;
-      openGenerationRef.current = generation;
       openedGlyphKeyRef.current = glyph.id;
-      const renderGlyph = await catalog.openGlyph(glyph.id);
-      if (openGenerationRef.current !== generation) return;
+      const result = await openGateRef.current.open(() => catalog.openGlyph(glyph.id));
+      if (result.status === "stale") return;
 
-      setOpenedGlyph(renderGlyph);
+      setOpenedGlyph(result.glyph);
       navigateRef.current(`/editor/${encodeURIComponent(glyph.id)}`);
     },
     [catalog],
@@ -108,12 +107,14 @@ const useGlyphCatalogSource = (): GlyphCatalogSource => {
     const sourceGlyphId = glyphIdFromPath(routeLocation.pathname);
     if (sourceGlyphId === null) {
       if (routeLocation.pathname.startsWith("/editor/")) {
+        openGateRef.current.invalidate();
         openedGlyphKeyRef.current = null;
         setOpenedGlyph(null);
       }
       return;
     }
     if (!availableGlyphs.some((glyph) => glyph.id === sourceGlyphId)) {
+      openGateRef.current.invalidate();
       openedGlyphKeyRef.current = null;
       setOpenedGlyph(null);
       return;
@@ -122,16 +123,14 @@ const useGlyphCatalogSource = (): GlyphCatalogSource => {
     if (openedGlyphKeyRef.current === glyphId) return;
 
     openedGlyphKeyRef.current = glyphId;
-    const generation = openGenerationRef.current + 1;
-    openGenerationRef.current = generation;
     let active = true;
 
     async function openRouteGlyph(): Promise<void> {
       try {
-        const renderGlyph = await catalog.openGlyph(glyphId);
-        if (!active || openGenerationRef.current !== generation) return;
+        const result = await openGateRef.current.open(() => catalog.openGlyph(glyphId));
+        if (!active || result.status === "stale") return;
 
-        setOpenedGlyph(renderGlyph);
+        setOpenedGlyph(result.glyph);
       } catch (error) {
         console.error("failed to open route glyph", error);
       }
@@ -147,17 +146,14 @@ const useGlyphCatalogSource = (): GlyphCatalogSource => {
     const openedGlyphId = openedGlyphKeyRef.current;
     if (openedGlyphId === null) return;
     const glyphId = openedGlyphId;
-
-    const generation = openGenerationRef.current + 1;
-    openGenerationRef.current = generation;
     let active = true;
 
     async function refreshOpenedGlyph(): Promise<void> {
       try {
-        const renderGlyph = await catalog.openGlyph(glyphId);
-        if (!active || openGenerationRef.current !== generation) return;
+        const result = await openGateRef.current.open(() => catalog.openGlyph(glyphId));
+        if (!active || result.status === "stale") return;
 
-        setOpenedGlyph(renderGlyph);
+        setOpenedGlyph(result.glyph);
       } catch (error) {
         console.error("failed to refresh opened glyph", error);
       }

--- a/apps/desktop/src/renderer/src/lib/catalog/GlyphOpenGate.test.ts
+++ b/apps/desktop/src/renderer/src/lib/catalog/GlyphOpenGate.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { GlyphOpenGate } from "./GlyphOpenGate";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+describe("latest glyph-open publication", () => {
+  it("rejects an older glyph that resolves after the current request", async () => {
+    const gate = new GlyphOpenGate();
+    const first = deferred<string>();
+    const second = deferred<string>();
+    const firstResult = gate.open(() => first.promise);
+    const secondResult = gate.open(() => second.promise);
+
+    second.resolve("B");
+    expect(await secondResult).toEqual({ status: "current", glyph: "B" });
+    first.resolve("A");
+    expect(await firstResult).toEqual({ status: "stale" });
+  });
+
+  it("rejects a request invalidated while leaving the glyph route", async () => {
+    const gate = new GlyphOpenGate();
+    const pending = deferred<string>();
+    const result = gate.open(() => pending.promise);
+
+    gate.invalidate();
+    pending.resolve("A");
+    expect(await result).toEqual({ status: "stale" });
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/catalog/GlyphOpenGate.ts
+++ b/apps/desktop/src/renderer/src/lib/catalog/GlyphOpenGate.ts
@@ -1,0 +1,25 @@
+import type { GlyphOpenResult } from "@/types/glyphCatalog";
+
+/** Allows only the latest asynchronous glyph-open request to publish. */
+export class GlyphOpenGate {
+  #generation = 0;
+
+  /**
+   * Loads a glyph and permits publication only while it remains the latest request.
+   *
+   * @param load - asynchronous glyph acquisition started for this request.
+   * @returns the loaded current glyph, or `stale` after a newer request or invalidation.
+   */
+  async open<T>(load: () => Promise<T>): Promise<GlyphOpenResult<T>> {
+    const generation = ++this.#generation;
+    const glyph = await load();
+    if (generation !== this.#generation) return { status: "stale" };
+
+    return { status: "current", glyph };
+  }
+
+  /** Invalidates every request that began before this call. */
+  invalidate(): void {
+    this.#generation++;
+  }
+}

--- a/apps/desktop/src/renderer/src/lib/commands/rendererCommands.test.ts
+++ b/apps/desktop/src/renderer/src/lib/commands/rendererCommands.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { mintContourId } from "@shift/types";
+import { TestEditor } from "@/testing/TestEditor";
+import { runRendererCommand } from "./rendererCommands";
+
+describe("empty and invalid editor operations", () => {
+  let editor: TestEditor;
+
+  beforeEach(async () => {
+    editor = new TestEditor();
+    await editor.startSession("empty", null);
+  });
+
+  it("refuses clipboard mutations without selected content", async () => {
+    expect(await editor.copy()).toBe(false);
+    expect(await editor.cut()).toBe(false);
+    expect(await editor.paste()).toBe(false);
+    expect(editor.clipboardBuffer).toBe("");
+    expect(editor.pointCount).toBe(0);
+  });
+
+  it("refuses deletion and duplication without selected geometry", async () => {
+    expect(await editor.deleteSelection()).toBe(false);
+    expect(editor.duplicateSelection()).toEqual([]);
+    expect(editor.pointCount).toBe(0);
+  });
+
+  it("refuses contour commands without a valid contour selection", () => {
+    expect(runRendererCommand(editor, "glyph.reverseSelectedContour")).toBe(false);
+    expect(editor.glyphContours).toEqual([]);
+  });
+
+  it("ignores boolean operations with missing contour identities", () => {
+    editor.boolean(mintContourId(), mintContourId(), "union");
+    expect(editor.glyphContours).toEqual([]);
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/editor/docs/DOCS.md
+++ b/apps/desktop/src/renderer/src/lib/editor/docs/DOCS.md
@@ -12,7 +12,7 @@ Central orchestrator for the canvas-based glyph editing surface, wiring viewport
 
 **Architecture Invariant:** `Editor.#store` is the generic `ShiftStore<ShiftEditorRecord>` for scene and session records. The injected `Editor.#fontStore` owns canonical complete Glyph objects for those ID-based records. Neither store contains the other store's domain objects.
 
-**Architecture Invariant:** `Font.loadGlyph()` is the only asynchronous Glyph acquisition API. `Editor.glyphForId()` is the synchronous runtime and NodeDefinition lookup: it returns the canonical complete Glyph when available, returns `null` otherwise, and never starts I/O. Use `Font.recordForId()` when code must distinguish a nonexistent current-font ID from a Glyph that has not been acquired.
+**Architecture Invariant:** `Font.loadGlyph()` is the only asynchronous Glyph acquisition API. `Editor.glyphForId()` is the synchronous runtime and NodeDefinition lookup: it returns the canonical complete Glyph when available, returns `null` otherwise, and never starts I/O. Use `Font.recordForId()` when code must distinguish a nonexistent current-font ID from a Glyph that has not been acquired. `GlyphOpenGate` permits only the latest asynchronous catalog request to publish; superseded or invalidated results never replace the requested route glyph.
 
 **Architecture Invariant:** Pointer events carry only `screen` and `scene` coordinates (`Coordinates`). Node-local conversion is not global: rendering enters a node's space via `ctx.canvas.withTranslation(node.position, ...)`, and hit-test paths derive node-local coordinates after identifying the target node.
 
@@ -28,11 +28,11 @@ Central orchestrator for the canvas-based glyph editing surface, wiring viewport
 
 **Architecture Invariant:** Lifecycle events (`EventEmitter`) are for one-shot imperative actions; `LifecycleEventMap` currently contains only `destroying`. Continuous state changes use signals. Do not mix the two patterns.
 
-**Architecture Invariant:** `Editor.toolCell` is the public active-tool state surface. It derives `{ id, state }` from the active tool instance and its `stateCell`; consumers use `toolIf(id)` for built-in state narrowing and do not reach through `ToolManager` for active state.
+**Architecture Invariant:** `Editor.toolCell` is the public active-tool state surface. It derives `{ id, state }` from the active tool instance and its `stateCell`; consumers use `toolIf(id)` for built-in state narrowing and do not reach through `ToolManager` for active state. Entering or leaving a glyph route resets the active tool instance, selection, hover, and editing scope so transient interaction state cannot cross glyphs.
 
 **Architecture Invariant:** `ToolManager` is authoritative for installed manifests. `Editor.toolRegistryCell` derives reactive toolbar metadata from that collection, and `registerTool()` returns the `ToolRegistration` that exclusively owns replacement and removal of the contributed ID.
 
-**Architecture Invariant:** Camera and text-layout metrics resolve from the active design location through `Font.metricsAtLocation()`. Exact master locations use authored source values; intermediate locations evaluate the Rust-built source-metric interpolation model.
+**Architecture Invariant:** Camera and text-layout metrics resolve from the active design location through `Font.metricsAtLocation()`. Exact master locations use authored source values; intermediate locations evaluate the Rust-built source-metric interpolation model. Glyph navigation preserves one stable UPM scale and origin rather than fitting each outline independently; empty, narrow, wide, and extreme glyphs therefore retain comparable editing scale.
 
 **Architecture Invariant:** A newly created source becomes the editor's active source only after its workspace echo makes that identity readable from `Font`. While creation is pending, the editor exposes the requested external location with no active source ID, so catalog and rendering consumers cannot observe a dangling source.
 
@@ -172,6 +172,7 @@ Glyph geometry exposes domain hit queries for points, anchors, and segments. Too
 - Outcome tests treat editor actions as asynchronous: metric setters need `await editor.settle()` before asserting, clipboard and history actions (`copy`, `paste`, `undo`, `redo`) return promises that must be awaited, and drag helpers give every drag sample its cumulative delta from the pointer-down origin.
 - `pnpm test:desktop src/renderer/src/lib/model/positions/PositionEdits.test.ts` -- position-edit (move/rotate/scale) tests.
 - `pnpm test:desktop src/renderer/src/lib/editor/managers/Camera.test.ts` -- camera manager tests.
+- `pnpm test:e2e:visual e2e/glyph-navigation.spec.ts e2e/glyph-view.spec.ts e2e/tools.spec.ts` -- stale/transient navigation, stable UPM framing, and DOM cancellation evidence.
 - Manual: open a font, zoom/pan, select points, drag, toggle preview mode, verify GPU/CPU handle rendering toggle.
 
 ## Related

--- a/apps/desktop/src/renderer/src/lib/tools/core/ToolManager.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/core/ToolManager.ts
@@ -301,7 +301,7 @@ export class ToolManager implements ToolSwitchHandler {
     this.#publishManifests();
   }
 
-  /** @knipclassignore */
+  /** Resets gesture and active-tool state at an editor context boundary. */
   reset(): void {
     if (this.editor.isDragging) {
       this.cancelPointerGesture();
@@ -311,6 +311,9 @@ export class ToolManager implements ToolSwitchHandler {
     }
 
     if (this.overrideTool) this.#clearOverride();
+
+    const primaryToolId = this.primaryToolId;
+    if (primaryToolId) this.activate(primaryToolId);
   }
 
   notifySelectionChanged(): void {

--- a/apps/desktop/src/renderer/src/types/glyphCatalog.ts
+++ b/apps/desktop/src/renderer/src/types/glyphCatalog.ts
@@ -15,6 +15,11 @@ export interface GlyphCatalogItem {
   readonly unicode: number | null;
 }
 
+/** Publication decision for an asynchronously opened glyph. */
+export type GlyphOpenResult<T> =
+  | { readonly status: "current"; readonly glyph: T }
+  | { readonly status: "stale" };
+
 /** Dense external-axis coordinates ordered like `GlyphCatalogSource.axesCell`. */
 export type CatalogLocation = readonly number[];
 

--- a/apps/desktop/src/renderer/src/views/Editor.tsx
+++ b/apps/desktop/src/renderer/src/views/Editor.tsx
@@ -49,10 +49,14 @@ export const Editor = () => {
       },
     ]);
     editor.editing.enter(nodeId);
+    editor.toolManager.reset();
 
     return () => {
-      editor.scene.deleteNode(nodeId);
+      editor.toolManager.reset();
+      editor.selection.clear();
+      editor.hover.clear();
       if (editor.editing.has(nodeId)) editor.editing.clear();
+      editor.scene.deleteNode(nodeId);
     };
   }, [editor, glyph]);
 


### PR DESCRIPTION
## Summary

- expand Electron coverage for dirty app quit, multi-document and re-entrant confirmation, Save As independence, discard/reopen, and copied-document isolation
- protect stale glyph publication, transient editor-state boundaries, pointer cancellation, search, stable UPM framing, and invalid command refusal
- make workspace/editor readiness explicit and attach renderer, process, window, and main-output diagnostics only when E2E fails

## Issue

Refs #91

## Testing

- `pnpm test:desktop` — 73 files, 702 tests passed
- `pnpm test:e2e` — 80 passed, 1 existing dark-theme test skipped
- `pnpm lint:check`
- `pnpm format:check`
- `pnpm typecheck`
- `git diff --check origin/main...HEAD`
- `node scripts/check-docs-fences.mjs` — 3 fences checked, 0 failing
- `python3 scripts/context-drift-check.py` — reported 19 repository-wide documentation warnings and no missing documentation or routing errors

## Follow-up

- rebase #244 after this lands and extend its native SQLite recovery test to automatically restore dirty saved and untitled documents
- repair the intermittent variable Settings form race rather than hiding it with retries
- add actionable startup and Save/Export failure surfaces
