### PR TITLE
ci: pass desktop versions across matrix shells

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -93,9 +93,7 @@ jobs:
         run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Set shared Nightly version
-        env:
-          NIGHTLY_VERSION: ${{ needs.prepare.outputs.version }}
-        run: node scripts/product-version.mjs set "$NIGHTLY_VERSION"
+        run: node scripts/product-version.mjs set "${{ needs.prepare.outputs.version }}"
 
       - name: Build native bridge
         run: pnpm build:native

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -125,9 +125,7 @@ jobs:
         run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Verify release version
-        env:
-          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
-        run: node scripts/product-version.mjs check "$RELEASE_VERSION"
+        run: node scripts/product-version.mjs check "${{ needs.prepare.outputs.version }}"
 
       - name: Build native bridge
         run: pnpm build:native


### PR DESCRIPTION
## Summary

- pass prepared Nightly and Release versions directly to the version script
- avoid shell-specific environment expansion in Windows matrix jobs

## Issue

No issue — small CI regression in the desktop packaging workflows.

## Testing

- `pnpm test:release` — 15 tests passed
- `pnpm version:check`
- parsed both workflows with `js-yaml` and verified the matrix version steps use shell-independent arguments

## Risks

- hosted Windows packaging still needs a workflow run to verify the runner-specific path
