### PR TITLE
feat(document): add atomic preview conversion core

### DIFF
--- a/apps/desktop/src/main/workspace/FontSessionHost.ts
+++ b/apps/desktop/src/main/workspace/FontSessionHost.ts
@@ -21,6 +21,7 @@ export type FontSessionHostOptions =
   | {
       readonly mode: "preview";
       readonly sessionId: FontSessionId;
+      readonly sourcePath: string;
       readonly workspaceProcess: WorkspaceProcess;
     };
 
@@ -34,6 +35,7 @@ export type FontSessionHostOptions =
 export class FontSessionHost {
   readonly mode: FontSessionMode;
   readonly sessionId: FontSessionId;
+  readonly sourcePath: string | null;
   readonly workspaceProcess: WorkspaceProcess;
   readonly documentClient: DocumentClient | null;
   readonly document: DocumentSession | null;
@@ -45,6 +47,7 @@ export class FontSessionHost {
   constructor(options: FontSessionHostOptions) {
     this.mode = options.mode;
     this.sessionId = options.sessionId;
+    this.sourcePath = options.mode === "preview" ? options.sourcePath : null;
     this.workspaceProcess = options.workspaceProcess;
 
     switch (options.mode) {

--- a/apps/desktop/src/main/workspace/WorkspaceManager.test.ts
+++ b/apps/desktop/src/main/workspace/WorkspaceManager.test.ts
@@ -7,6 +7,7 @@ function previewSession(workspaceId: string): FontSessionHost {
   return new FontSessionHost({
     mode: "preview",
     sessionId: workspaceId,
+    sourcePath: `/tmp/${workspaceId}.ufo`,
     workspaceProcess: new WorkspaceProcess(),
   });
 }

--- a/apps/desktop/src/main/workspace/WorkspaceManager.ts
+++ b/apps/desktop/src/main/workspace/WorkspaceManager.ts
@@ -10,6 +10,7 @@ import type {
 import { WorkspaceProcess } from "./WorkspaceProcess";
 import { FontSessionHost, type FontSessionId } from "./FontSessionHost";
 import { DocumentSessionIndex } from "./DocumentSessionIndex";
+import { isConvertiblePreviewPath } from "../../shared/workspace/previewConversion";
 
 /** Provides app-owned values required when a workspace session is created. */
 export interface WorkspaceManagerOptions {
@@ -54,6 +55,20 @@ export class WorkspaceManager {
    */
   async createUntitled(): Promise<FontSessionHost> {
     return this.#createSession((workspaceProcess) => workspaceProcess.createWorkspace());
+  }
+
+  /** Fully imports a convertible preview and publishes a new canonical document. */
+  async createDocumentFromPreview(
+    sourcePath: string,
+    documentPath: string,
+  ): Promise<FontSessionHost> {
+    if (!isConvertiblePreviewPath(sourcePath)) {
+      throw new Error(`Preview source cannot become a Shift document: ${sourcePath}`);
+    }
+
+    return this.#createSession((workspaceProcess) =>
+      workspaceProcess.createDocumentFromSource(sourcePath, documentPath),
+    );
   }
 
   /**
@@ -303,6 +318,7 @@ export class WorkspaceManager {
       const session = new FontSessionHost({
         mode: "preview",
         sessionId: state.sessionId,
+        sourcePath: state.canonicalPath,
         workspaceProcess,
       });
       this.register(session);

--- a/apps/desktop/src/main/workspace/WorkspaceProcess.ts
+++ b/apps/desktop/src/main/workspace/WorkspaceProcess.ts
@@ -99,6 +99,17 @@ export class WorkspaceProcess {
     return this.#requireChannel().call("workspace.create", undefined);
   }
 
+  /** Fully imports a foreign source and atomically publishes its first Shift document. */
+  createDocumentFromSource(
+    sourcePath: string,
+    documentPath: string,
+  ): Promise<WorkspaceDocumentState> {
+    return this.#requireChannel().call("workspace.createFromSource", {
+      sourcePath,
+      documentPath,
+    });
+  }
+
   /** Reads canonical document identity before Open for live-session reuse. */
   inspectDocument(path: string): Promise<WorkspaceDocumentIdentity> {
     return this.#requireChannel().call("workspace.inspectDocument", { path });

--- a/apps/desktop/src/shared/workspace/previewConversion.test.ts
+++ b/apps/desktop/src/shared/workspace/previewConversion.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { isConvertiblePreviewPath } from "./previewConversion";
+
+describe("preview conversion capability", () => {
+  it.each(["font.ufo", "font.designspace", "font.glyphs", "font.glyphspackage"])(
+    "allows %s to become a Shift document",
+    (sourcePath) => {
+      expect(isConvertiblePreviewPath(sourcePath)).toBe(true);
+    },
+  );
+
+  it.each(["font.ttf", "font.otf", "font.shift", "font.txt"])(
+    "keeps %s outside preview conversion",
+    (sourcePath) => {
+      expect(isConvertiblePreviewPath(sourcePath)).toBe(false);
+    },
+  );
+});

--- a/apps/desktop/src/shared/workspace/previewConversion.ts
+++ b/apps/desktop/src/shared/workspace/previewConversion.ts
@@ -1,0 +1,13 @@
+import path from "node:path";
+
+const CONVERTIBLE_PREVIEW_EXTENSIONS = new Set([
+  ".designspace",
+  ".glyphs",
+  ".glyphspackage",
+  ".ufo",
+]);
+
+/** Returns whether a read-only preview can become a canonical Shift document. */
+export function isConvertiblePreviewPath(sourcePath: string): boolean {
+  return CONVERTIBLE_PREVIEW_EXTENSIONS.has(path.extname(sourcePath).toLowerCase());
+}

--- a/apps/desktop/src/shared/workspace/protocol.ts
+++ b/apps/desktop/src/shared/workspace/protocol.ts
@@ -151,13 +151,19 @@ export type WorkspaceExportResult = {
  * @remarks
  * `workspace.connect` carries the renderer's sync-lane port as a transferred
  * port, not as payload. Create/open return document lifecycle state only; font
- * records stay on the sync lane. Save is NOT here: it rides the sync lane as a
- * committed operation so FIFO orders it behind edits (see `workspace.save`).
- * Main reads `document.state` to decide Save vs Save As and learns save
- * outcomes from the `document.changed` event.
+ * records stay on the sync lane. Authored Save is NOT here: it rides the sync
+ * lane so FIFO orders it behind edits (see `workspace.save`). Preview conversion
+ * is the exception because a preview has no authored renderer lane or edits;
+ * `workspace.createFromSource` atomically creates its first canonical document.
+ * Main reads `document.state` to decide Save vs Save As and learns save outcomes
+ * from the `document.changed` event.
  */
 export type ShellCallMap = {
   "workspace.create": { request: void; response: WorkspaceDocumentState };
+  "workspace.createFromSource": {
+    request: { sourcePath: string; documentPath: string };
+    response: WorkspaceDocumentState;
+  };
   "workspace.inspectDocument": {
     request: { path: string };
     response: WorkspaceDocumentIdentity;

--- a/apps/desktop/src/utility/workspace/WorkspaceHost.test.ts
+++ b/apps/desktop/src/utility/workspace/WorkspaceHost.test.ts
@@ -39,6 +39,10 @@ const retainedFontPath = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "../../renderer/src/assets/fonts/HostGrotesk-VariableFont_wght.ttf",
 );
+const convertibleFontPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../../../fixtures/fonts/mutatorsans/MutatorSansLightCondensed.ufo",
+);
 
 const createGlyph = (
   name: GlyphName,
@@ -361,6 +365,56 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     expect(await sync.call("source.snapshot", undefined)).not.toBeNull();
     expect(await shell.call("source.close", undefined)).toBeNull();
     expect(await sync.call("source.snapshot", undefined)).toBeNull();
+  });
+
+  it("creates a canonical document atomically from a foreign source", async () => {
+    const documentPath = path.join(tmpRoot, "Converted.shift");
+
+    const state = await shell.call("workspace.createFromSource", {
+      sourcePath: convertibleFontPath,
+      documentPath,
+    });
+    const sync = await connectSyncLane();
+    const snapshot = await sync.call("workspace.snapshot", undefined);
+
+    expect(state).toMatchObject({
+      sourceKind: "document",
+      documentId: expect.stringMatching(/^document_/),
+      saveTarget: documentPath,
+      canonicalPath: fs.realpathSync(documentPath),
+      dirty: false,
+      needsSaveAs: false,
+    });
+    expect(snapshot?.workspaceId).toBe(state.workspaceId);
+    expect(snapshot?.glyphs.length).toBeGreaterThan(0);
+    expect(canonicalGlyphNames(documentPath)).toEqual(
+      expect.arrayContaining(snapshot?.glyphs.map((glyph) => glyph.name) ?? []),
+    );
+  });
+
+  it("preserves an occupied destination and returns to closed after conversion fails", async () => {
+    const occupiedPath = path.join(tmpRoot, "Occupied.shift");
+    fs.writeFileSync(occupiedPath, "occupied");
+
+    await expect(
+      shell.call("workspace.createFromSource", {
+        sourcePath: convertibleFontPath,
+        documentPath: occupiedPath,
+      }),
+    ).rejects.toThrow("document already exists");
+
+    expect(fs.readFileSync(occupiedPath, "utf8")).toBe("occupied");
+    await expect(shell.call("document.state", undefined)).resolves.toBeNull();
+    const workspacesRoot = path.join(tmpRoot, "workspaces");
+    expect(fs.existsSync(workspacesRoot) ? fs.readdirSync(workspacesRoot) : []).toEqual([]);
+
+    const retryPath = path.join(tmpRoot, "Retried.shift");
+    await expect(
+      shell.call("workspace.createFromSource", {
+        sourcePath: convertibleFontPath,
+        documentPath: retryPath,
+      }),
+    ).resolves.toMatchObject({ saveTarget: retryPath, needsSaveAs: false });
   });
 
   it("streams one authored Slug generation through bounded native chunks", async () => {

--- a/apps/desktop/src/utility/workspace/WorkspaceHost.ts
+++ b/apps/desktop/src/utility/workspace/WorkspaceHost.ts
@@ -104,6 +104,8 @@ export class WorkspaceHost {
   start(): void {
     this.#shell = serveChannel<ShellCallMap, ShellEventMap>(this.#shellTransport, {
       "workspace.create": () => this.#serialize(() => this.#create()),
+      "workspace.createFromSource": ({ sourcePath, documentPath }) =>
+        this.#serialize(() => this.#createFromSource(sourcePath, documentPath)),
       "workspace.inspectDocument": ({ path }) => this.#serialize(() => this.#inspectDocument(path)),
       "workspace.open": ({ path }) => this.#serialize(() => this.#open(path)),
       "workspace.close": ({ discard }) => this.#serialize(() => this.#close(discard)),
@@ -567,6 +569,53 @@ export class WorkspaceHost {
     this.#atlasCacheRevision = null;
 
     return this.#emitDocumentChanged();
+  }
+
+  #createFromSource(sourcePath: string, documentPath: string): WorkspaceDocumentState {
+    if (this.#state.kind !== "closed") {
+      throw new Error("a preview or document is already open");
+    }
+
+    const allocation = this.#documents.createWorkspace();
+
+    try {
+      this.#bridge.openWorkspace(sourcePath, allocation.storePath);
+      this.#bridge.setWorkspaceId(allocation.workspaceId);
+      this.#state = {
+        kind: "document",
+        allocation,
+        binding: { kind: "unbound" },
+      };
+      this.#atlasCacheRevision = null;
+
+      return this.#saveAs(documentPath);
+    } catch (error) {
+      const workspace = this.#state.kind === "document" ? this.#state : null;
+      let publishedDocument = false;
+      try {
+        const saveTarget = workspace ? this.#bridge.documentState().saveTarget : null;
+        publishedDocument =
+          typeof saveTarget === "string" && path.resolve(saveTarget) === path.resolve(documentPath);
+      } catch {
+        // The original error remains authoritative; cleanup is best-effort.
+      }
+
+      if (workspace?.binding.kind === "bound") {
+        this.#documents.removeDocumentBinding(workspace.binding.address);
+      }
+      this.#bridge.closeWorkspace();
+      this.#state = { kind: "closed" };
+      this.#atlasCacheRevision = null;
+      this.#documents.deleteWorkspace(allocation.workspaceId);
+
+      if (publishedDocument) {
+        for (const suffix of ["", "-wal", "-shm", "-journal"]) {
+          fs.rmSync(`${documentPath}${suffix}`, { force: true });
+        }
+      }
+
+      throw error;
+    }
   }
 
   #inspectDocument(documentPath: string): WorkspaceDocumentIdentity {


### PR DESCRIPTION
## Summary

- add an explicit allowlist for UFO, Designspace, Glyphs, and Glyphspackage preview conversion while excluding TTF and OTF
- add `workspace.createFromSource` to fully import a foreign source and atomically publish its first canonical SQLite document
- expose preview source identity and `WorkspaceManager.createDocumentFromPreview` for the desktop lifecycle layer
- clean temporary workspace, recovery, binding, and newly published state when conversion fails without replacing an occupied destination

## Issue

Refs #154

## Testing

- `pnpm typecheck`
- `pnpm --filter @shift/desktop exec vitest run src/shared/workspace/previewConversion.test.ts src/utility/workspace/WorkspaceHost.test.ts src/main/workspace/WorkspaceManager.test.ts` — 51 passed
- pre-commit: formatting, lint, typecheck, dead code, and Vitest passed

## Risks

- conversion deliberately remains an explicit eager transition from an immutable preview to a canonical authored document; foreign sources are never edited in place
- this PR exposes the atomic conversion boundary but does not yet wire Save/Save As in the application shell; that is the stacked follow-up PR
