### PR TITLE
fix: preserve quadratic curve endpoints during editing

### DIFF
--- a/apps/desktop/src/renderer/src/lib/model/Glyph.ts
+++ b/apps/desktop/src/renderer/src/lib/model/Glyph.ts
@@ -788,7 +788,10 @@ export class GlyphLayer {
     const points = segment.asQuad()!;
     const [curveA, curveB] = segment.splitAt(t) as [QuadraticCurve, QuadraticCurve];
 
-    const splitPointId = this.insertPointBefore(points.end.id, Point.smooth(curveA.p1));
+    const splitPointId = this.insertPointBefore(
+      points.end.id,
+      Point.create(curveA.p1, points.end.pointType, true),
+    );
     this.insertPointBefore(points.end.id, Point.offCurve(curveB.c));
     this.movePointTo(points.control.id, curveA.c);
 

--- a/apps/desktop/src/renderer/src/lib/model/GlyphLayerGeometry.test.ts
+++ b/apps/desktop/src/renderer/src/lib/model/GlyphLayerGeometry.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, beforeEach } from "vitest";
+import { Point } from "@shift/glyph-state";
 import type { PointId } from "@shift/types";
 import { TestEditor } from "@/testing/TestEditor";
 
@@ -164,6 +165,46 @@ describe("GlyphLayer.splitSegment", () => {
 
     expect(splitId).not.toBe(null);
     expect(layer().point(splitId!)).toMatchObject({ x: 25, y: 25 });
+  });
+
+  describe("quadratic segment", () => {
+    beforeEach(async () => {
+      const edit = layer().beginEdit();
+      const contourId = edit.addContour(false);
+      edit.addPoints(contourId, [
+        Point.onCurve({ x: 0, y: 0 }),
+        Point.offCurve({ x: 50, y: 100 }),
+        Point.create({ x: 100, y: 0 }, "qCurve", true),
+      ]);
+      edit.finish("Add quadratic segment");
+      await editor.settle();
+    });
+
+    it("preserves qCurve endpoints through the workspace", () => {
+      const segment = layer().contours[0]!.segments()[0]!;
+
+      expect(segment.type).toBe("quad");
+      expect(segment.end.pointType).toBe("qCurve");
+    });
+
+    it("keeps both endpoints quadratic after splitting", async () => {
+      const segment = layer().contours[0]!.segments()[0]!;
+
+      const splitId = layer().splitSegment(segment.id, 0.5);
+      await editor.settle();
+
+      expect(layer().point(splitId!)?.pointType).toBe("qCurve");
+      expect(
+        layer()
+          .contours[0]!.segments()
+          .map(({ type }) => type),
+      ).toEqual(["quad", "quad"]);
+      expect(
+        layer()
+          .contours[0]!.segments()
+          .map(({ end }) => end.pointType),
+      ).toEqual(["qCurve", "qCurve"]);
+    });
   });
 
   describe("cubic segment", () => {

--- a/crates/shift-backends/src/formats/opentype/reader.rs
+++ b/crates/shift-backends/src/formats/opentype/reader.rs
@@ -90,9 +90,8 @@ impl OutlinePen for ShiftPen {
     }
 
     /// Preserves the source quadratic as one control and one qcurve endpoint.
-    /// The canonical layer codec retains this distinction; the wire projects
-    /// the endpoint as on-curve, which still lets clients infer one-control
-    /// quadratic segments without cubic expansion.
+    /// The canonical layer codec and wire retain this distinction so clients
+    /// can edit quadratic segments without cubic expansion.
     fn quad_to(&mut self, cx0: f32, cy0: f32, x: f32, y: f32) {
         let control_id = self.next_point_id();
         let endpoint_id = self.next_point_id();

--- a/crates/shift-bridge/index.d.ts
+++ b/crates/shift-bridge/index.d.ts
@@ -726,7 +726,8 @@ export interface NapiPointSeed {
 
 export declare const enum NapiPointType {
   OnCurve = 'onCurve',
-  OffCurve = 'offCurve'
+  OffCurve = 'offCurve',
+  QCurve = 'qCurve'
 }
 
 export interface NapiRemoveAnchorsIntent {

--- a/crates/shift-font/src/ir/contour.rs
+++ b/crates/shift-font/src/ir/contour.rs
@@ -200,7 +200,7 @@ impl From<&BezPath> for Contours {
                 PathEl::QuadTo(ctrl, end) => {
                     if let Some(c) = current.as_mut() {
                         c.add_point(ctrl.x, ctrl.y, PointType::OffCurve, false);
-                        c.add_point(end.x, end.y, PointType::OnCurve, false);
+                        c.add_point(end.x, end.y, PointType::QCurve, false);
                     }
                 }
                 PathEl::CurveTo(c1, c2, end) => {
@@ -415,6 +415,25 @@ mod tests {
         assert_eq!(contours.len(), 1);
         assert!(contours[0].is_closed());
         assert_eq!(contours[0].len(), 3);
+    }
+
+    #[test]
+    fn bezpath_quadratic_to_contour_preserves_qcurve_endpoint() {
+        let mut path = BezPath::new();
+        path.move_to((0.0, 0.0));
+        path.quad_to((50.0, 100.0), (100.0, 0.0));
+
+        let contours = Contours::from(&path);
+        assert_eq!(contours.len(), 1);
+        assert_eq!(contours[0].len(), 3);
+        assert_eq!(
+            contours[0].get_point_at(1).unwrap().point_type(),
+            PointType::OffCurve
+        );
+        assert_eq!(
+            contours[0].get_point_at(2).unwrap().point_type(),
+            PointType::QCurve
+        );
     }
 
     #[test]

--- a/crates/shift-wire/src/bridges/napi/mod.rs
+++ b/crates/shift-wire/src/bridges/napi/mod.rs
@@ -137,6 +137,7 @@ pub struct NapiCatalogAtlasWeights {
 pub enum NapiPointType {
     OnCurve,
     OffCurve,
+    QCurve,
 }
 
 impl From<PointType> for NapiPointType {
@@ -144,6 +145,7 @@ impl From<PointType> for NapiPointType {
         match point_type {
             PointType::OnCurve => Self::OnCurve,
             PointType::OffCurve => Self::OffCurve,
+            PointType::QCurve => Self::QCurve,
         }
     }
 }
@@ -153,6 +155,7 @@ impl From<NapiPointType> for PointType {
         match point_type {
             NapiPointType::OnCurve => Self::OnCurve,
             NapiPointType::OffCurve => Self::OffCurve,
+            NapiPointType::QCurve => Self::QCurve,
         }
     }
 }

--- a/crates/shift-wire/src/lib.rs
+++ b/crates/shift-wire/src/lib.rs
@@ -790,13 +790,15 @@ impl From<&IrPoint> for PointData {
 pub enum PointType {
     OnCurve,
     OffCurve,
+    QCurve,
 }
 
 impl From<IrPointType> for PointType {
     fn from(point_type: IrPointType) -> Self {
         match point_type {
-            IrPointType::OnCurve | IrPointType::QCurve => Self::OnCurve,
+            IrPointType::OnCurve => Self::OnCurve,
             IrPointType::OffCurve => Self::OffCurve,
+            IrPointType::QCurve => Self::QCurve,
         }
     }
 }
@@ -804,8 +806,9 @@ impl From<IrPointType> for PointType {
 impl From<PointType> for IrPointType {
     fn from(point_type: PointType) -> Self {
         match point_type {
-            PointType::OffCurve => IrPointType::OffCurve,
             PointType::OnCurve => IrPointType::OnCurve,
+            PointType::OffCurve => IrPointType::OffCurve,
+            PointType::QCurve => IrPointType::QCurve,
         }
     }
 }

--- a/crates/shift-wire/src/state.rs
+++ b/crates/shift-wire/src/state.rs
@@ -99,7 +99,7 @@ fn restore_components(layer: &mut GlyphLayer, components: &[ComponentData]) -> C
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::values_from_layer;
+    use crate::{values_from_layer, PointType};
     use shift_font::{Anchor, Component, DecomposedTransform, GlyphId, LayerId, SourceId};
 
     fn sample_layer() -> GlyphLayer {
@@ -189,6 +189,56 @@ mod tests {
         assert_eq!(component.base_glyph_name().as_str(), "base");
         assert_eq!(component.transform().translate_x, 7.0);
         assert_eq!(component.transform().t_center_y, 15.0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn layer_state_round_trip_preserves_point_types() -> CoreResult<()> {
+        let mut layer = GlyphLayer::new(LayerId::new(), SourceId::new());
+        let mut contour = IrContour::with_id(ContourId::from_raw(10));
+        contour.add_point_with_id(PointId::from_raw(20), 0.0, 0.0, IrPointType::OnCurve, false);
+        contour.add_point_with_id(
+            PointId::from_raw(21),
+            50.0,
+            100.0,
+            IrPointType::OffCurve,
+            false,
+        );
+        contour.add_point_with_id(PointId::from_raw(22), 100.0, 0.0, IrPointType::QCurve, true);
+        layer.add_contour(contour);
+
+        let structure = GlyphStructure::from(&layer);
+        assert_eq!(
+            structure.contours[0]
+                .points
+                .iter()
+                .map(|point| point.point_type)
+                .collect::<Vec<_>>(),
+            vec![PointType::OnCurve, PointType::OffCurve, PointType::QCurve]
+        );
+
+        let restored = layer_from_state(
+            layer.id(),
+            layer.source_id(),
+            &structure,
+            &values_from_layer(&layer),
+        )?;
+        assert_eq!(
+            restored
+                .contours_iter()
+                .next()
+                .unwrap()
+                .points()
+                .iter()
+                .map(|point| point.point_type())
+                .collect::<Vec<_>>(),
+            vec![
+                IrPointType::OnCurve,
+                IrPointType::OffCurve,
+                IrPointType::QCurve
+            ]
+        );
 
         Ok(())
     }

--- a/packages/glyph-state/src/Contour.ts
+++ b/packages/glyph-state/src/Contour.ts
@@ -90,14 +90,14 @@ export class Contour {
   }
 
   get firstOnCurvePoint(): Point | null {
-    return this.points.find((point) => point.pointType === "onCurve") ?? null;
+    return this.points.find(Point.isOnCurve) ?? null;
   }
 
   get lastOnCurvePoint(): Point | null {
     const points = this.points;
     for (let index = points.length - 1; index >= 0; index--) {
       const point = points[index];
-      if (point?.pointType === "onCurve") return point;
+      if (point && Point.isOnCurve(point)) return point;
     }
     return null;
   }

--- a/packages/glyph-state/src/Point.ts
+++ b/packages/glyph-state/src/Point.ts
@@ -48,7 +48,12 @@ export class Point implements PointInput {
   }
 
   static create(position: Point2D, pointType: PointType, smooth = false): NewPoint {
-    return pointType === "onCurve" ? Point.onCurve(position, smooth) : Point.offCurve(position);
+    return {
+      x: position.x,
+      y: position.y,
+      pointType,
+      smooth: pointType === "offCurve" ? false : smooth,
+    };
   }
 
   static smooth(position: Point2D): NewPoint {
@@ -65,7 +70,7 @@ export class Point implements PointInput {
   }
 
   static isOnCurve(point: { readonly pointType: PointType }): boolean {
-    return point.pointType === "onCurve";
+    return point.pointType === "onCurve" || point.pointType === "qCurve";
   }
 
   static isOffCurve(point: { readonly pointType: PointType }): boolean {

--- a/packages/glyph-state/src/Segment.test.ts
+++ b/packages/glyph-state/src/Segment.test.ts
@@ -42,4 +42,25 @@ describe("segment ids", () => {
       "segment:point_2:point_3",
     ]);
   });
+
+  it("parses qCurve endpoints as quadratic segments", () => {
+    const contour = new Contour(
+      {
+        id: asContourId("contour_qcurve"),
+        closed: false,
+        points: [
+          { id: asPointId("point_start"), pointType: "onCurve", smooth: false },
+          { id: asPointId("point_control"), pointType: "offCurve", smooth: false },
+          { id: asPointId("point_end"), pointType: "qCurve", smooth: true },
+        ],
+      },
+      new Float64Array([500, 0, 0, 50, 100, 100, 0]),
+      1,
+    );
+
+    const segment = contour.segments()[0];
+    expect(segment?.type).toBe("quad");
+    expect(segment?.end.pointType).toBe("qCurve");
+    expect(contour.lastOnCurvePoint?.pointType).toBe("qCurve");
+  });
 });

--- a/packages/types/src/bridge/generated.ts
+++ b/packages/types/src/bridge/generated.ts
@@ -723,7 +723,7 @@ export interface PointSeed {
   smooth: boolean
 }
 
-export type PointType = "onCurve" | "offCurve";
+export type PointType = "onCurve" | "offCurve" | "qCurve";
 
 export interface RemoveAnchorsIntent {
   layerId: LayerId

--- a/packages/validation/src/Validate.test.ts
+++ b/packages/validation/src/Validate.test.ts
@@ -4,6 +4,7 @@ import type { PointLike } from "./types";
 
 const onCurve = (): PointLike => ({ pointType: "onCurve" });
 const offCurve = (): PointLike => ({ pointType: "offCurve" });
+const qCurve = (): PointLike => ({ pointType: "qCurve" });
 
 describe("Validate", () => {
   describe("result constructors", () => {
@@ -32,14 +33,16 @@ describe("Validate", () => {
   });
 
   describe("point predicates", () => {
-    it("isOnCurve returns true for onCurve points", () => {
+    it("treats onCurve and qCurve endpoints as on-curve", () => {
       expect(Validate.isOnCurve(onCurve())).toBe(true);
+      expect(Validate.isOnCurve(qCurve())).toBe(true);
       expect(Validate.isOnCurve(offCurve())).toBe(false);
     });
 
-    it("isOffCurve returns true for offCurve points", () => {
+    it("isOffCurve returns true only for offCurve points", () => {
       expect(Validate.isOffCurve(offCurve())).toBe(true);
       expect(Validate.isOffCurve(onCurve())).toBe(false);
+      expect(Validate.isOffCurve(qCurve())).toBe(false);
     });
   });
 
@@ -57,6 +60,7 @@ describe("Validate", () => {
       expect(Validate.findNextOnCurve(points, 0)).toBe(0);
       expect(Validate.findNextOnCurve(points, 1)).toBe(3);
       expect(Validate.findNextOnCurve(points, 3)).toBe(3);
+      expect(Validate.findNextOnCurve([offCurve(), qCurve()], 0)).toBe(1);
     });
 
     it("findNextOnCurve returns null when no onCurve found", () => {
@@ -75,6 +79,7 @@ describe("Validate", () => {
 
     it("matchesQuadPattern validates quadratic segments", () => {
       expect(Validate.matchesQuadPattern([onCurve(), offCurve(), onCurve()])).toBe(true);
+      expect(Validate.matchesQuadPattern([onCurve(), offCurve(), qCurve()])).toBe(true);
       expect(Validate.matchesQuadPattern([onCurve(), onCurve(), onCurve()])).toBe(false);
       expect(Validate.matchesQuadPattern([onCurve(), offCurve()])).toBe(false);
     });
@@ -214,6 +219,7 @@ describe("Validate", () => {
       expect(Validate.isValidSequence([onCurve()])).toBe(true);
       expect(Validate.isValidSequence([offCurve()])).toBe(false);
       expect(Validate.isValidSequence([onCurve(), onCurve()])).toBe(true);
+      expect(Validate.isValidSequence([onCurve(), offCurve(), qCurve()])).toBe(true);
       expect(Validate.isValidSequence([onCurve(), offCurve()])).toBe(false);
       expect(
         Validate.isValidSequence([onCurve(), offCurve(), offCurve(), offCurve(), onCurve()]),
@@ -225,6 +231,7 @@ describe("Validate", () => {
       expect(Validate.canFormValidSegments([onCurve()])).toBe(false);
       expect(Validate.canFormValidSegments([onCurve(), onCurve()])).toBe(true);
       expect(Validate.canFormValidSegments([onCurve(), offCurve(), onCurve()])).toBe(true);
+      expect(Validate.canFormValidSegments([onCurve(), offCurve(), qCurve()])).toBe(true);
       expect(Validate.canFormValidSegments([onCurve(), offCurve(), offCurve(), onCurve()])).toBe(
         true,
       );
@@ -241,9 +248,9 @@ describe("Validate", () => {
       }
     });
 
-    it("single onCurve has anchor", () => {
-      const result = Validate.hasAnchor([onCurve()]);
-      expect(result.valid).toBe(true);
+    it("onCurve and qCurve points are anchors", () => {
+      expect(Validate.hasAnchor([onCurve()]).valid).toBe(true);
+      expect(Validate.hasAnchor([qCurve()]).valid).toBe(true);
     });
 
     it("single offCurve returns ORPHAN_OFF_CURVE error", () => {
@@ -278,8 +285,9 @@ describe("Validate", () => {
       expect(Validate.hasValidAnchor([])).toBe(false);
     });
 
-    it("returns true for single onCurve", () => {
+    it("returns true for onCurve and qCurve anchors", () => {
       expect(Validate.hasValidAnchor([onCurve()])).toBe(true);
+      expect(Validate.hasValidAnchor([qCurve()])).toBe(true);
     });
 
     it("returns false for single offCurve", () => {

--- a/packages/validation/src/Validate.ts
+++ b/packages/validation/src/Validate.ts
@@ -18,7 +18,7 @@ export const Validate = {
   },
 
   isOnCurve(point: PointLike): boolean {
-    return point.pointType === "onCurve";
+    return point.pointType === "onCurve" || point.pointType === "qCurve";
   },
 
   isOffCurve(point: PointLike): boolean {
@@ -29,7 +29,7 @@ export const Validate = {
     let count = 0;
     for (let i = startIndex; i < points.length; i++) {
       const point = points[i];
-      if (point?.pointType === "offCurve") {
+      if (point && Validate.isOffCurve(point)) {
         count++;
       } else {
         break;
@@ -41,7 +41,7 @@ export const Validate = {
   findNextOnCurve(points: readonly PointLike[], startIndex: number): number | null {
     for (let i = startIndex; i < points.length; i++) {
       const point = points[i];
-      if (point?.pointType === "onCurve") {
+      if (point && Validate.isOnCurve(point)) {
         return i;
       }
     }
@@ -50,16 +50,19 @@ export const Validate = {
 
   matchesLinePattern(points: readonly PointLike[]): boolean {
     const [p0, p1] = points;
-    return points.length === 2 && p0?.pointType === "onCurve" && p1?.pointType === "onCurve";
+    return points.length === 2 && !!p0 && !!p1 && Validate.isOnCurve(p0) && Validate.isOnCurve(p1);
   },
 
   matchesQuadPattern(points: readonly PointLike[]): boolean {
     const [p0, p1, p2] = points;
     return (
       points.length === 3 &&
-      p0?.pointType === "onCurve" &&
-      p1?.pointType === "offCurve" &&
-      p2?.pointType === "onCurve"
+      !!p0 &&
+      !!p1 &&
+      !!p2 &&
+      Validate.isOnCurve(p0) &&
+      Validate.isOffCurve(p1) &&
+      Validate.isOnCurve(p2)
     );
   },
 
@@ -67,10 +70,14 @@ export const Validate = {
     const [p0, p1, p2, p3] = points;
     return (
       points.length === 4 &&
-      p0?.pointType === "onCurve" &&
-      p1?.pointType === "offCurve" &&
-      p2?.pointType === "offCurve" &&
-      p3?.pointType === "onCurve"
+      !!p0 &&
+      !!p1 &&
+      !!p2 &&
+      !!p3 &&
+      Validate.isOnCurve(p0) &&
+      Validate.isOffCurve(p1) &&
+      Validate.isOffCurve(p2) &&
+      Validate.isOnCurve(p3)
     );
   },
 
@@ -80,7 +87,7 @@ export const Validate = {
     }
 
     const firstPoint = points[0];
-    if (!firstPoint || firstPoint.pointType !== "onCurve") {
+    if (!firstPoint || !Validate.isOnCurve(firstPoint)) {
       return Validate.fail(
         Validate.error(
           "MUST_START_WITH_ON_CURVE",
@@ -92,7 +99,7 @@ export const Validate = {
 
     const lastIndex = points.length - 1;
     const lastPoint = points[lastIndex];
-    if (!lastPoint || lastPoint.pointType !== "onCurve") {
+    if (!lastPoint || !Validate.isOnCurve(lastPoint)) {
       return Validate.fail(
         Validate.error("MUST_END_WITH_ON_CURVE", "Point sequence must end with an onCurve point", {
           index: lastIndex,
@@ -103,7 +110,7 @@ export const Validate = {
 
     for (let i = 0; i < points.length; i++) {
       const point = points[i];
-      if (point?.pointType === "offCurve") {
+      if (point && Validate.isOffCurve(point)) {
         const consecutiveCount = Validate.countConsecutiveOffCurve(points, i);
         if (consecutiveCount > 2) {
           return Validate.fail(
@@ -137,7 +144,7 @@ export const Validate = {
     while (i < points.length - 1) {
       const current = points[i];
 
-      if (!current || current.pointType !== "onCurve") {
+      if (!current || !Validate.isOnCurve(current)) {
         return Validate.fail(
           Validate.error("ORPHAN_OFF_CURVE", "offCurve point without preceding onCurve anchor", {
             index: i,
@@ -155,7 +162,7 @@ export const Validate = {
         );
       }
 
-      if (next.pointType === "onCurve") {
+      if (Validate.isOnCurve(next)) {
         i += 1;
         continue;
       }
@@ -181,12 +188,12 @@ export const Validate = {
     if (points.length === 0) return false;
     const firstPoint = points[0];
     const lastPoint = points[points.length - 1];
-    if (!firstPoint || firstPoint.pointType !== "onCurve") return false;
-    if (!lastPoint || lastPoint.pointType !== "onCurve") return false;
+    if (!firstPoint || !Validate.isOnCurve(firstPoint)) return false;
+    if (!lastPoint || !Validate.isOnCurve(lastPoint)) return false;
 
     for (let i = 0; i < points.length; i++) {
       const point = points[i];
-      if (point?.pointType === "offCurve") {
+      if (point && Validate.isOffCurve(point)) {
         const count = Validate.countConsecutiveOffCurve(points, i);
         if (count > 2) return false;
         i += count - 1;
@@ -203,11 +210,11 @@ export const Validate = {
     let i = 0;
     while (i < points.length - 1) {
       const current = points[i];
-      if (!current || current.pointType !== "onCurve") return false;
+      if (!current || !Validate.isOnCurve(current)) return false;
 
       const next = points[i + 1];
       if (!next) return false;
-      if (next.pointType === "onCurve") {
+      if (Validate.isOnCurve(next)) {
         i += 1;
         continue;
       }
@@ -228,7 +235,7 @@ export const Validate = {
       return Validate.fail(Validate.error("EMPTY_SEQUENCE", "Point sequence cannot be empty"));
     }
 
-    const hasOnCurve = points.some((p) => p.pointType === "onCurve");
+    const hasOnCurve = points.some(Validate.isOnCurve);
     if (!hasOnCurve) {
       return Validate.fail(
         Validate.error(
@@ -243,6 +250,6 @@ export const Validate = {
 
   hasValidAnchor(points: readonly PointLike[]): boolean {
     if (points.length === 0) return false;
-    return points.some((p) => p.pointType === "onCurve");
+    return points.some(Validate.isOnCurve);
   },
 } as const;


### PR DESCRIPTION
## Summary

- preserve `qCurve` endpoint identity through Kurbo path reconstruction, `shift-wire`, NAPI snapshots, and generated TypeScript types
- treat quadratic endpoints as on-curve anchors for renderer segmentation and validation without collapsing their authored type
- preserve quadratic endpoint identity when splitting a segment, with real workspace/NAPI and Kurbo round-trip coverage

## Issue

Closes #125

## Testing

- `cargo test -p shift-font -p shift-wire`
- `pnpm test:desktop src/renderer/src/lib/model/GlyphLayerGeometry.test.ts`
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint:check`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- pre-commit workspace Rust, Vitest, formatting, typecheck, lint, and dead-code hooks
