### PR TITLE
fix(ci): bootstrap empty update-feed branch

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -273,7 +273,7 @@ jobs:
           else
             git worktree add --detach site
             git -C site switch --orphan update-feeds
-            git -C site rm -rf .
+            git -C site rm -rf --ignore-unmatch .
           fi
           touch site/.nojekyll
 

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -334,7 +334,7 @@ jobs:
           else
             git worktree add --detach site
             git -C site switch --orphan update-feeds
-            git -C site rm -rf .
+            git -C site rm -rf --ignore-unmatch .
           fi
           touch site/.nojekyll
 


### PR DESCRIPTION
## Summary

- make first-time Nightly and Release feed publication tolerate an already-empty orphan worktree
- preserve the existing branch path and public-assets-before-feed ordering
- unblock creation of `update-feeds`, after which GitHub Pages can be configured against the branch root

## Issue

Closes #255

## Testing

- parsed both changed workflow files with PyYAML
- reproduced first publication against a temporary bare origin and confirmed it created `update-feeds`
- reproduced a later publication and confirmed it retained and updated the existing feed tree
- repository YAML and whitespace hooks

## Follow-up

After merge, rerun Nightly feed publication to create `update-feeds`, then configure GitHub Pages to serve that branch root before performing the installed N → N+1 test.
