### PR TITLE
fix(desktop): open directory font sources on every platform

### DIFF
--- a/apps/desktop/src/main/dialogs/electronNativeDialogs.ts
+++ b/apps/desktop/src/main/dialogs/electronNativeDialogs.ts
@@ -30,7 +30,7 @@ export const electronNativeDialogs: NativeDialogs = {
         { name: "Glyphs", extensions: ["glyphs", "glyphspackage"] },
         { name: "UFO/Designspace", extensions: ["ufo", "designspace"] },
       ],
-      properties: process.platform === "darwin" ? ["openFile", "openDirectory"] : ["openFile"],
+      properties: ["openFile", "openDirectory"],
     };
     const result = window
       ? await dialog.showOpenDialog(window.window, options)


### PR DESCRIPTION
## Summary

- allow the native Open Font dialog to select supported files or directories on every desktop platform
- make the existing UFO and Glyphs Package preview paths reachable on Windows and Linux without changing single-selection or cancellation behavior

## Issue

Closes #258

## Testing

- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm format:check`
- `git diff --check`
- pre-commit TypeScript, dead-code, and Vitest hooks
- focused review of the Electron `OpenDialogOptions` platform behavior; no separate automated test was added for declarative native-dialog configuration
