### PR TITLE
fix(desktop): show document failures and preview guidance

### DIFF
--- a/apps/desktop/e2e/document-lifecycle.spec.ts
+++ b/apps/desktop/e2e/document-lifecycle.spec.ts
@@ -56,6 +56,11 @@ const cancelExportTest = workspaceTest.extend({
     await use("");
   },
 });
+const failedOpenTest = test.extend({
+  openFontPath: async ({ testRoot }, use) => {
+    await use(path.join(testRoot, "missing.ufo"));
+  },
+});
 const failedSaveTest = test.extend({
   saveShiftPath: async ({ testRoot }, use) => {
     const nonDirectory = path.join(testRoot, "not-a-directory");
@@ -178,7 +183,11 @@ test.describe("opening a font through the application shell", () => {
     const workspacePage = await openSelectedPreview(page, electronApp);
 
     await workspacePage.getByRole("button", { name: "Create glyph", exact: true }).click();
-    await expect(workspacePage.getByRole("dialog", { name: "Read-only preview" })).toBeVisible();
+    const dialog = workspacePage.getByRole("dialog", { name: "Read-only preview" });
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText(
+      "Compiled TTF and OTF fonts can be inspected here, but this preview cannot be edited or converted.",
+    );
   });
 
   test("does not convert a TTF preview through Save", async ({
@@ -195,6 +204,13 @@ test.describe("opening a font through the application shell", () => {
   });
 });
 
+failedOpenTest("failed Open keeps the launcher available", async ({ electronApp, page }) => {
+  await runCommand(page, electronApp, "file.open");
+
+  await expect(page).toHaveURL(/#\/launcher$/);
+  expect(electronApp.windows()).toHaveLength(1);
+});
+
 otfPreviewTest(
   "does not convert an OTF preview through Save",
   async ({ electronApp, page, saveShiftPath }) => {
@@ -204,6 +220,19 @@ otfPreviewTest(
 
     expect(await workspacePage.evaluate(() => window.shiftSession?.mode)).toBe("preview");
     expect(fs.existsSync(saveShiftPath)).toBe(false);
+  },
+);
+
+convertiblePreviewTest(
+  "convertible previews direct users to save before authoring",
+  async ({ electronApp, page }) => {
+    const workspacePage = await openSelectedPreview(page, electronApp);
+
+    await workspacePage.getByRole("button", { name: "Create glyph", exact: true }).click();
+    const dialog = workspacePage.getByRole("dialog", { name: "Read-only preview" });
+    await expect(dialog).toContainText(
+      "Save this source as a Shift document before making authoring changes.",
+    );
   },
 );
 
@@ -306,7 +335,7 @@ failedPreviewSaveTest(
   async ({ electronApp, page, saveShiftPath, testRoot }) => {
     const workspacePage = await openSelectedPreview(page, electronApp);
 
-    await expect(runCommand(workspacePage, electronApp, "file.save")).rejects.toThrow();
+    await runCommand(workspacePage, electronApp, "file.save");
 
     expect(await workspacePage.evaluate(() => window.shiftSession?.mode)).toBe("preview");
     expect(fs.existsSync(saveShiftPath)).toBe(false);
@@ -451,7 +480,7 @@ failedSaveTest(
       window.shift?.font.editCoordinator.state(),
     );
 
-    await expect(runCommand(workspacePage, electronApp, "file.save")).rejects.toThrow();
+    await runCommand(workspacePage, electronApp, "file.save");
 
     expect(
       await workspacePage.evaluate(async () => window.shift?.font.editCoordinator.state()),

--- a/apps/desktop/src/main/app/App.ts
+++ b/apps/desktop/src/main/app/App.ts
@@ -414,39 +414,37 @@ export class App {
     if (existing) return existing;
 
     const converting = (async () => {
-      const sourcePath = preview.sourcePath;
-      if (!sourcePath || !isConvertiblePreviewPath(sourcePath)) return;
-
-      const parsedSourcePath = path.parse(sourcePath);
-      const suggestedPath = path.join(parsedSourcePath.dir, `${parsedSourcePath.name}.shift`);
-      const documentPath = await this.#nativeDialogs.saveShiftDocument(window, suggestedPath);
-      if (!documentPath) return;
-
-      let authored: FontSessionHost;
       try {
-        authored = await this.#workspaces.createDocumentFromPreview(sourcePath, documentPath);
+        const sourcePath = preview.sourcePath;
+        if (!sourcePath || !isConvertiblePreviewPath(sourcePath)) return;
+
+        const parsedSourcePath = path.parse(sourcePath);
+        const suggestedPath = path.join(parsedSourcePath.dir, `${parsedSourcePath.name}.shift`);
+        const documentPath = await this.#nativeDialogs.saveShiftDocument(window, suggestedPath);
+        if (!documentPath) return;
+
+        const authored = await this.#workspaces.createDocumentFromPreview(sourcePath, documentPath);
+        if (this.#workspaces.getForBrowserWindow(window.window) !== preview) {
+          this.#workspaces.unregister(authored.workspaceId);
+          return;
+        }
+
+        this.#workspaces.detachWindow(window);
+        try {
+          this.#workspaces.attachWindow(authored.workspaceId, window);
+        } catch (error) {
+          this.#workspaces.attachWindow(preview.workspaceId, window);
+          this.#workspaces.unregister(authored.workspaceId);
+          throw error;
+        }
+
+        if (preview.windows.size === 0) this.#workspaces.unregister(preview.workspaceId);
+        this.#applicationMenu.updateCommandStates();
+        window.window.webContents.reload();
       } catch (error) {
+        this.#log.warn("preview save failed", error);
         await this.#nativeDialogs.showSaveFailure(window, this.applicationName, error);
-        throw error;
       }
-
-      if (this.#workspaces.getForBrowserWindow(window.window) !== preview) {
-        this.#workspaces.unregister(authored.workspaceId);
-        return;
-      }
-
-      this.#workspaces.detachWindow(window);
-      try {
-        this.#workspaces.attachWindow(authored.workspaceId, window);
-      } catch (error) {
-        this.#workspaces.attachWindow(preview.workspaceId, window);
-        this.#workspaces.unregister(authored.workspaceId);
-        throw error;
-      }
-
-      if (preview.windows.size === 0) this.#workspaces.unregister(preview.workspaceId);
-      this.#applicationMenu.updateCommandStates();
-      window.window.webContents.reload();
     })();
 
     this.#previewConversions.set(preview.sessionId, converting);
@@ -500,18 +498,28 @@ export class App {
   }
 
   async #createWorkspaceFromWindow(opener: Window): Promise<void> {
-    const session = await this.#workspaces.createUntitled();
-    this.#openWorkspaceWindow(opener, session);
+    try {
+      const session = await this.#workspaces.createUntitled();
+      this.#openWorkspaceWindow(opener, session);
+    } catch (error) {
+      this.#log.warn("new document failed", error);
+      await this.#nativeDialogs.showCreateFailure(opener, this.applicationName, error);
+    }
   }
 
   async #openWorkspaceFromWindow(opener: Window): Promise<void> {
-    const openPath = await this.#nativeDialogs.openFont(opener);
-    if (!openPath) return;
+    try {
+      const openPath = await this.#nativeDialogs.openFont(opener);
+      if (!openPath) return;
 
-    const session = await this.#workspaces.openPath(openPath);
-    if (this.#focusExistingWorkspaceWindow(opener, session)) return;
+      const session = await this.#workspaces.openPath(openPath);
+      if (this.#focusExistingWorkspaceWindow(opener, session)) return;
 
-    this.#openWorkspaceWindow(opener, session);
+      this.#openWorkspaceWindow(opener, session);
+    } catch (error) {
+      this.#log.warn("open document failed", error);
+      await this.#nativeDialogs.showOpenFailure(opener, this.applicationName, error);
+    }
   }
 
   #focusExistingWorkspaceWindow(opener: Window, session: FontSessionHost): boolean {

--- a/apps/desktop/src/main/dialogs/NativeDialogs.ts
+++ b/apps/desktop/src/main/dialogs/NativeDialogs.ts
@@ -13,6 +13,24 @@ export interface NativeDialogs {
   openFont(window: Window | null): Promise<string | null>;
 
   /**
+   * Shows a blocking failure after a new document could not be created.
+   *
+   * @param window - native window that should own the message.
+   * @param applicationName - product name shown by the native shell.
+   * @param error - failure whose safe diagnostic detail is presented.
+   */
+  showCreateFailure(window: Window | null, applicationName: string, error: unknown): Promise<void>;
+
+  /**
+   * Shows a blocking failure after a selected font could not be opened.
+   *
+   * @param window - native window that should own the message.
+   * @param applicationName - product name shown by the native shell.
+   * @param error - failure whose safe diagnostic detail is presented.
+   */
+  showOpenFailure(window: Window | null, applicationName: string, error: unknown): Promise<void>;
+
+  /**
    * Selects an independent `.shift` destination.
    *
    * @param window - native window that should own the choice.

--- a/apps/desktop/src/main/dialogs/electronNativeDialogs.ts
+++ b/apps/desktop/src/main/dialogs/electronNativeDialogs.ts
@@ -6,6 +6,7 @@ import {
 } from "electron";
 import path from "node:path";
 import { errorToMessage } from "../../shared/errors";
+import type { Window } from "../windows/Window";
 import type { NativeDialogs } from "./NativeDialogs";
 
 const OPEN_FONT_EXTENSIONS = [
@@ -17,6 +18,29 @@ const OPEN_FONT_EXTENSIONS = [
   "ufo",
   "designspace",
 ];
+
+async function showFailure(
+  window: Window | null,
+  applicationName: string,
+  message: string,
+  error: unknown,
+): Promise<void> {
+  const options: MessageBoxOptions = {
+    type: "error",
+    buttons: ["OK"],
+    defaultId: 0,
+    title: applicationName,
+    message,
+    detail: errorToMessage(error),
+  };
+
+  if (window) {
+    await dialog.showMessageBox(window.window, options);
+    return;
+  }
+
+  await dialog.showMessageBox(options);
+}
 
 /** Uses Electron's native dialogs for production file and document choices. */
 export const electronNativeDialogs: NativeDialogs = {
@@ -39,6 +63,14 @@ export const electronNativeDialogs: NativeDialogs = {
     if (result.canceled || result.filePaths.length !== 1) return null;
 
     return result.filePaths[0];
+  },
+
+  async showCreateFailure(window, applicationName, error) {
+    await showFailure(window, applicationName, "A new document could not be created.", error);
+  },
+
+  async showOpenFailure(window, applicationName, error) {
+    await showFailure(window, applicationName, "The selected font could not be opened.", error);
   },
 
   async saveShiftDocument(window, suggestedPath) {
@@ -99,38 +131,10 @@ export const electronNativeDialogs: NativeDialogs = {
   },
 
   async showSaveFailure(window, applicationName, error) {
-    const options: MessageBoxOptions = {
-      type: "error",
-      buttons: ["OK"],
-      defaultId: 0,
-      title: applicationName,
-      message: "The document could not be saved.",
-      detail: errorToMessage(error),
-    };
-
-    if (window) {
-      await dialog.showMessageBox(window.window, options);
-      return;
-    }
-
-    await dialog.showMessageBox(options);
+    await showFailure(window, applicationName, "The document could not be saved.", error);
   },
 
   async showExportFailure(window, applicationName, error) {
-    const options: MessageBoxOptions = {
-      type: "error",
-      buttons: ["OK"],
-      defaultId: 0,
-      title: applicationName,
-      message: "The TrueType font could not be exported.",
-      detail: errorToMessage(error),
-    };
-
-    if (window) {
-      await dialog.showMessageBox(window.window, options);
-      return;
-    }
-
-    await dialog.showMessageBox(options);
+    await showFailure(window, applicationName, "The TrueType font could not be exported.", error);
   },
 };

--- a/apps/desktop/src/main/dialogs/scriptedNativeDialogs.ts
+++ b/apps/desktop/src/main/dialogs/scriptedNativeDialogs.ts
@@ -14,6 +14,10 @@ export const scriptedNativeDialogs: NativeDialogs = {
     return process.env.SHIFT_E2E_OPEN_FONT_PATH || process.env.SHIFT_E2E_SAVE_SHIFT_PATH || null;
   },
 
+  async showCreateFailure() {},
+
+  async showOpenFailure() {},
+
   async saveShiftDocument() {
     const savePath = saveShiftPaths[saveShiftPathIndex];
     if (savePath !== undefined) {

--- a/apps/desktop/src/main/document/DocumentSession.ts
+++ b/apps/desktop/src/main/document/DocumentSession.ts
@@ -133,44 +133,54 @@ export class DocumentSession {
     this.#pendingCloseDiscard = null;
   }
 
-  /**
-   * Runs Save, escalating to Save As when the document has no target yet.
-   *
-   * @throws {Error} when the renderer cannot read state or save.
-   */
+  /** Runs Save, escalating to Save As when the document has no target yet. */
   async save(): Promise<void> {
     this.#log.info("save document requested");
-    const state = await this.#requestState();
-    this.acceptState(state);
-    if (!state) {
-      this.#log.info("save document skipped: no document state");
-      return;
-    }
 
-    if (state.needsSaveAs) {
-      await this.#saveToNewPath(state);
-      return;
-    }
+    try {
+      const state = await this.#requestState();
+      if (!state) {
+        this.#log.info("save document skipped: no document state");
+        return;
+      }
 
-    await this.#requestSave(null);
-    this.#log.info("save document completed", { saveTarget: state.saveTarget });
+      if (state.needsSaveAs) {
+        await this.#saveToNewPath(state);
+        return;
+      }
+
+      await this.#requestSave(null);
+      this.#log.info("save document completed", { saveTarget: state.saveTarget });
+    } catch (error) {
+      this.#log.warn("save document failed", error);
+      await this.#nativeDialogs.showSaveFailure(
+        this.#dialogWindow(),
+        this.#applicationName(),
+        error,
+      );
+    }
   }
 
-  /**
-   * Runs Save As from main with a native save dialog.
-   *
-   * @throws {Error} when the renderer cannot read state or save.
-   */
+  /** Runs Save As from main with a native save dialog. */
   async saveAs(): Promise<void> {
     this.#log.info("save as requested");
-    const state = await this.#requestState();
-    this.acceptState(state);
-    if (!state) {
-      this.#log.info("save as skipped: no document state");
-      return;
-    }
 
-    await this.#saveToNewPath(state);
+    try {
+      const state = await this.#requestState();
+      if (!state) {
+        this.#log.info("save as skipped: no document state");
+        return;
+      }
+
+      await this.#saveToNewPath(state);
+    } catch (error) {
+      this.#log.warn("save as failed", error);
+      await this.#nativeDialogs.showSaveFailure(
+        this.#dialogWindow(),
+        this.#applicationName(),
+        error,
+      );
+    }
   }
 
   /**

--- a/apps/desktop/src/renderer/src/app/Screens.tsx
+++ b/apps/desktop/src/renderer/src/app/Screens.tsx
@@ -63,7 +63,9 @@ const FontSessionScreens = () => {
         <div className={catalogActive ? undefined : "relative z-10"}>
           <Outlet />
         </div>
-        {session.mode === "authored" ? null : <ReadOnlyNoticeDialog />}
+        {session.mode === "authored" ? null : (
+          <ReadOnlyNoticeDialog canConvert={session.canConvert} />
+        )}
       </SettingsNavigationProvider>
     </GlyphCatalogProvider>
   );

--- a/apps/desktop/src/renderer/src/components/chrome/ReadOnlyNoticeDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/chrome/ReadOnlyNoticeDialog.tsx
@@ -13,8 +13,12 @@ import {
 
 const MUTATION_CONTROL_SELECTOR = "[data-read-only-mutation]";
 
+export type ReadOnlyNoticeDialogProps = {
+  canConvert: boolean;
+};
+
 /** Intercepts preview mutation controls without changing their authored appearance. */
-export const ReadOnlyNoticeDialog = () => {
+export const ReadOnlyNoticeDialog = ({ canConvert }: ReadOnlyNoticeDialogProps) => {
   const [readOnlyNoticeOpen, setReadOnlyNoticeOpen] = useState(false);
 
   useEffect(() => {
@@ -47,7 +51,9 @@ export const ReadOnlyNoticeDialog = () => {
             Read-only preview
           </DialogTitle>
           <p className="mt-2 text-sm text-secondary">
-            Convert this font to a Shift document before making authoring changes.
+            {canConvert
+              ? "Save this source as a Shift document before making authoring changes."
+              : "Compiled TTF and OTF fonts can be inspected here, but this preview cannot be edited or converted."}
           </p>
           <DialogClose
             className={cn(

--- a/apps/desktop/src/renderer/src/types/fontSession.ts
+++ b/apps/desktop/src/renderer/src/types/fontSession.ts
@@ -17,6 +17,7 @@ export interface AuthoredFontSession extends FontSessionBase {
 
 export interface PreviewFontSession extends FontSessionBase {
   readonly mode: "preview";
+  readonly canConvert: boolean;
   readonly workspace: null;
 }
 

--- a/apps/desktop/src/renderer/src/workspace/FontSession.ts
+++ b/apps/desktop/src/renderer/src/workspace/FontSession.ts
@@ -1,3 +1,4 @@
+import { isConvertiblePreviewPath } from "@shared/workspace/previewConversion";
 import type { Editor } from "@/lib/editor/Editor";
 import type { Font } from "@/lib/model/Font";
 import type { GlyphCatalog } from "@/lib/catalog/GlyphCatalog";
@@ -49,6 +50,7 @@ export function createPreviewFontSession(
 ): PreviewFontSession {
   return {
     mode: "preview",
+    canConvert: isConvertiblePreviewPath(client.sourceCell.peek()?.canonicalPath ?? ""),
     catalog,
     workspace: null,
     font,

--- a/apps/desktop/src/shared/workspace/previewConversion.test.ts
+++ b/apps/desktop/src/shared/workspace/previewConversion.test.ts
@@ -2,14 +2,14 @@ import { describe, expect, it } from "vitest";
 import { isConvertiblePreviewPath } from "./previewConversion";
 
 describe("preview conversion capability", () => {
-  it.each(["font.ufo", "font.designspace", "font.glyphs", "font.glyphspackage"])(
+  it.each(["font.ufo", "/tmp/font.designspace", "C:\\Fonts\\Family.GLYPHS", "font.glyphspackage"])(
     "allows %s to become a Shift document",
     (sourcePath) => {
       expect(isConvertiblePreviewPath(sourcePath)).toBe(true);
     },
   );
 
-  it.each(["font.ttf", "font.otf", "font.shift", "font.txt"])(
+  it.each(["font.ttf", "/tmp/fonts.with.dots/font.otf", ".ufo", "font.shift", "font.txt"])(
     "keeps %s outside preview conversion",
     (sourcePath) => {
       expect(isConvertiblePreviewPath(sourcePath)).toBe(false);

--- a/apps/desktop/src/shared/workspace/previewConversion.ts
+++ b/apps/desktop/src/shared/workspace/previewConversion.ts
@@ -1,5 +1,3 @@
-import path from "node:path";
-
 const CONVERTIBLE_PREVIEW_EXTENSIONS = new Set([
   ".designspace",
   ".glyphs",
@@ -9,5 +7,9 @@ const CONVERTIBLE_PREVIEW_EXTENSIONS = new Set([
 
 /** Returns whether a read-only preview can become a canonical Shift document. */
 export function isConvertiblePreviewPath(sourcePath: string): boolean {
-  return CONVERTIBLE_PREVIEW_EXTENSIONS.has(path.extname(sourcePath).toLowerCase());
+  const separatorIndex = Math.max(sourcePath.lastIndexOf("/"), sourcePath.lastIndexOf("\\"));
+  const extensionIndex = sourcePath.lastIndexOf(".");
+  if (extensionIndex <= separatorIndex + 1) return false;
+
+  return CONVERTIBLE_PREVIEW_EXTENSIONS.has(sourcePath.slice(extensionIndex).toLowerCase());
 }


### PR DESCRIPTION
## Summary

- show owning native error dialogs when New, Open, Save, Save As, or preview conversion fails
- keep handled document commands settled while preserving the current launcher, preview, document, and dirty state
- distinguish convertible source previews from permanently read-only TTF/OTF previews in authoring guidance

## Issue

Closes #257

Refs #91, #143

## Testing

- `pnpm test:desktop src/shared/workspace/previewConversion.test.ts` — 9 passed
- `pnpm test:e2e:visual -- e2e/document-lifecycle.spec.ts` — 25 passed
- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm format:check`
- `pnpm deadcode:strict`
- `git diff --check`

The first concurrent typecheck attempt hit Git submodule lock contention with the other local checks; the serial rerun passed.
