### PR TITLE
fix(ci): restore update-feed publication

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,4 @@
-name: Nightly Desktop
+name: Release Shift Nightly
 
 on:
   schedule:
@@ -248,6 +248,14 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
+
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
 
       - uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1,4 +1,4 @@
-name: Release Desktop
+name: Release Shift
 
 on:
   workflow_call:
@@ -308,6 +308,14 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.tag }}
           fetch-depth: 1
+
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
 
       - uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
## Summary

- install the repository's Node dependencies in isolated Nightly and Release feed jobs before running the metadata preparation script
- rename the workflows to **Release Shift Nightly** and **Release Shift**
- allow a complete feed publication to reach the commit and push steps after the orphan-branch bootstrap

## Issue

Refs #255

## Testing

- `pnpm test:release` — 15 tests passed
- `pnpm format:files --check .github/workflows/nightly.yml .github/workflows/release-desktop.yml`
- parsed both workflow files with Ruby YAML
- commit hooks: YAML, whitespace, large-file, and merge-conflict checks passed
- packaging not rerun locally; hosted run 32569142843 completed all platform builds and asset publication before the feed job failed on its missing `js-yaml` dependency

## Follow-up

After merge, start a new Nightly workflow run. Once it creates `update-feeds`, configure GitHub Pages to serve that branch root.
