### PR TITLE
ci: prune retired Nightly assets

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -299,3 +299,40 @@ jobs:
           git -C site add .
           git -C site commit -m "Publish Shift Nightly ${{ needs.prepare.outputs.version }} update feed"
           git -C site push origin HEAD:update-feeds
+
+  prune:
+    name: Prune retired Nightly assets
+    needs:
+      - prepare
+      - feed
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Find retired assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NIGHTLY_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          gh release view nightly --json assets > nightly-assets.json
+          node scripts/find-obsolete-nightly-assets.mjs nightly-assets.json "$NIGHTLY_VERSION" 14 > retired-assets.txt
+
+      - name: Delete retired assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! -s retired-assets.txt ]]; then
+            echo "No retired Nightly assets"
+            exit 0
+          fi
+
+          while IFS= read -r asset; do
+            echo "Deleting $asset"
+            gh release delete-asset nightly "$asset" --yes
+          done < retired-assets.txt

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -47,12 +47,12 @@ The app waits 30 seconds before its first automatic check to avoid competing wit
 
 - `release-please.yml` maintains a draft release pull request. Merging it creates a numeric version tag and draft GitHub release, then invokes `release-desktop.yml`.
 - `release-desktop.yml` validates `vMAJOR.MINOR.PATCH`, builds macOS arm64/x64 ZIPs and DMGs, a Windows x64 per-user NSIS installer, and Linux x64 packages, smoke-tests packaged applications, uploads checksums/assets, publishes the GitHub prerelease, then advances the Release feed.
-- `nightly.yml` resolves one `0.RUN.ATTEMPT` version, builds the same matrix, and updates the rolling Nightly prerelease only after every build succeeds. It retains exact versioned macOS ZIP and Windows NSIS/blockmap update assets plus stable human-download ZIP, DMG, installer, DEB, and RPM names.
+- `nightly.yml` resolves one `0.RUN.ATTEMPT` version, builds the same matrix, and updates the rolling Nightly prerelease only after every build succeeds. It publishes one exact versioned ZIP, DMG, installer, DEB, and RPM asset set rather than duplicate stable-name aliases.
 - `prepare-update-feed.mjs` performs the one monotonic candidate-version check, stages electron-builder's generated metadata into fixed Pages paths, and rewrites artifact paths to absolute GitHub Release asset URLs. It does not create immutable feed-history directories.
 
 Release and Nightly feed publication share one concurrency group. Binary assets become public before a feed advances. The feed job checks out or creates the `update-feeds` branch, preserves `.nojekyll` and the other distribution directory, updates only its channel, and pushes the branch. GitHub Pages serves it at `https://shift-editor.github.io/shift/updates`.
 
-A separate feed job allows feed deployment to be retried from retained workflow artifacts without rebuilding binaries. The first successful deployment creates `update-feeds`; later deployments update one channel directory.
+A separate feed job allows feed deployment to be retried from retained workflow artifacts without rebuilding binaries. The first successful deployment creates `update-feeds`; later deployments update one channel directory. After the Nightly feed advances, a prune job removes legacy aliases and inactive versioned binaries while retaining inactive blockmaps for 14 days. Those small blockmaps allow recent installations to use differential updates; older installations fall back to a full package download. A failed prune leaves the active feed and binaries intact.
 
 The Release Please workflow mints a short-lived token from the repository-scoped Shift Release Please GitHub App so generated pull requests trigger normal CI.
 
@@ -90,4 +90,5 @@ Electron update orchestration has no worthwhile unit test without mocking Electr
 - A failed versioned build remains a private draft release; fix and rerun it before publication.
 - Never delete or reuse a published numeric version tag. Correct it with the next version.
 - A failed Nightly build or feed deployment leaves the previous feed active. Republish a complete later Nightly rather than editing a feed in place.
-- If assets publish but feed deployment fails, rerun the feed job from retained artifacts. Clients continue using the previous feed until deployment succeeds.
+- If assets publish but feed deployment fails, rerun the feed job from retained artifacts. Clients continue using the previous feed until deployment succeeds, and pruning does not run.
+- If Nightly pruning fails after the feed advances, rerun the prune job. Do not move the feed backward or delete the active version's assets.

--- a/scripts/find-obsolete-nightly-assets.mjs
+++ b/scripts/find-obsolete-nightly-assets.mjs
@@ -1,0 +1,77 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const versionPattern = /^\d+\.\d+\.\d+$/;
+const versionedAssetPattern =
+  /^Shift-Nightly-(?<version>\d+\.\d+\.\d+)-(?:macOS-(?:arm64|x64)\.(?:zip(?:\.blockmap)?|dmg)|Windows-x64-Setup\.exe(?:\.blockmap)?|Linux-x64\.(?:deb|rpm))$/;
+const legacyAssetNames = new Set([
+  "Shift-Nightly-macOS-arm64.zip",
+  "Shift-Nightly-macOS-x64.zip",
+  "Shift-Nightly-macOS-arm64.dmg",
+  "Shift-Nightly-macOS-x64.dmg",
+  "Shift-Nightly-Windows-x64.exe",
+  "Shift-Nightly-Linux-x64.deb",
+  "Shift-Nightly-Linux-x64.rpm",
+]);
+
+export function findObsoleteNightlyAssets(
+  assets,
+  activeVersion,
+  blockmapRetentionDays,
+  now = new Date(),
+) {
+  if (!versionPattern.test(activeVersion)) {
+    throw new Error(
+      `Expected a numeric three-component active version, received: ${activeVersion}`,
+    );
+  }
+  if (!Number.isInteger(blockmapRetentionDays) || blockmapRetentionDays < 0) {
+    throw new Error(
+      `Expected non-negative blockmap retention days, received: ${blockmapRetentionDays}`,
+    );
+  }
+  if (!Array.isArray(assets)) throw new Error("Expected a release asset array");
+
+  const blockmapCutoff = now.getTime() - blockmapRetentionDays * 24 * 60 * 60 * 1000;
+  const obsolete = [];
+
+  for (const asset of assets) {
+    if (!asset || typeof asset.name !== "string" || typeof asset.createdAt !== "string") {
+      throw new Error("Release assets must provide name and createdAt strings");
+    }
+    if (legacyAssetNames.has(asset.name)) {
+      obsolete.push(asset.name);
+      continue;
+    }
+
+    const match = versionedAssetPattern.exec(asset.name);
+    if (!match?.groups || match.groups.version === activeVersion) continue;
+    if (!asset.name.endsWith(".blockmap")) {
+      obsolete.push(asset.name);
+      continue;
+    }
+
+    const createdAt = Date.parse(asset.createdAt);
+    if (Number.isNaN(createdAt)) {
+      throw new Error(`Invalid release asset creation time for ${asset.name}: ${asset.createdAt}`);
+    }
+    if (createdAt < blockmapCutoff) obsolete.push(asset.name);
+  }
+
+  return obsolete.sort();
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  const [assetsPath, activeVersion, retentionArgument] = process.argv.slice(2);
+  const blockmapRetentionDays = Number(retentionArgument);
+  if (!assetsPath || !activeVersion || retentionArgument === undefined) {
+    throw new Error(
+      "Usage: find-obsolete-nightly-assets.mjs <release-assets-json> <active-version> <blockmap-retention-days>",
+    );
+  }
+
+  const release = JSON.parse(await readFile(path.resolve(assetsPath), "utf8"));
+  const obsolete = findObsoleteNightlyAssets(release.assets, activeVersion, blockmapRetentionDays);
+  if (obsolete.length > 0) process.stdout.write(`${obsolete.join("\n")}\n`);
+}

--- a/scripts/find-obsolete-nightly-assets.test.mjs
+++ b/scripts/find-obsolete-nightly-assets.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { findObsoleteNightlyAssets } from "./find-obsolete-nightly-assets.mjs";
+
+const activeVersion = "0.18.1";
+const now = new Date("2026-08-23T12:00:00Z");
+
+function asset(name, createdAt = "2026-08-23T06:00:00Z") {
+  return { name, createdAt };
+}
+
+test("retires legacy aliases and inactive versioned binaries", () => {
+  const assets = [
+    asset("SHA256SUMS"),
+    asset("Shift-Nightly-macOS-arm64.dmg"),
+    asset(`Shift-Nightly-${activeVersion}-macOS-arm64.dmg`),
+    asset("Shift-Nightly-0.17.1-macOS-arm64.dmg"),
+    asset("Shift-Nightly-0.17.1-Windows-x64-Setup.exe"),
+    asset("unrelated-debug-symbols.zip"),
+  ];
+
+  assert.deepEqual(findObsoleteNightlyAssets(assets, activeVersion, 14, now), [
+    "Shift-Nightly-0.17.1-Windows-x64-Setup.exe",
+    "Shift-Nightly-0.17.1-macOS-arm64.dmg",
+    "Shift-Nightly-macOS-arm64.dmg",
+  ]);
+});
+
+test("retains recent inactive blockmaps for differential updates", () => {
+  const assets = [
+    asset(`Shift-Nightly-${activeVersion}-macOS-arm64.zip.blockmap`, "2026-07-01T00:00:00Z"),
+    asset("Shift-Nightly-0.17.1-macOS-arm64.zip.blockmap", "2026-08-10T12:00:00Z"),
+    asset("Shift-Nightly-0.16.1-macOS-arm64.zip.blockmap", "2026-08-09T11:59:59Z"),
+    asset("Shift-Nightly-0.16.1-Windows-x64-Setup.exe.blockmap", "2026-08-09T11:59:59Z"),
+  ];
+
+  assert.deepEqual(findObsoleteNightlyAssets(assets, activeVersion, 14, now), [
+    "Shift-Nightly-0.16.1-Windows-x64-Setup.exe.blockmap",
+    "Shift-Nightly-0.16.1-macOS-arm64.zip.blockmap",
+  ]);
+});

--- a/scripts/prepare-nightly-release.mjs
+++ b/scripts/prepare-nightly-release.mjs
@@ -12,11 +12,11 @@ if (!distArgument || !outputArgument || !/^\d+\.\d+\.\d+$/.test(version)) {
 
 const assets = [
   {
-    destinations: (source) => ["Shift-Nightly-macOS-arm64.zip", path.basename(source)],
+    destinations: (source) => [path.basename(source)],
     pattern: new RegExp(`Shift-Nightly-${escapeRegex(version)}-macOS-arm64\\.zip$`),
   },
   {
-    destinations: (source) => ["Shift-Nightly-macOS-x64.zip", path.basename(source)],
+    destinations: (source) => [path.basename(source)],
     pattern: new RegExp(`Shift-Nightly-${escapeRegex(version)}-macOS-x64\\.zip$`),
   },
   {
@@ -28,15 +28,15 @@ const assets = [
     pattern: new RegExp(`Shift-Nightly-${escapeRegex(version)}-macOS-x64\\.zip\\.blockmap$`),
   },
   {
-    destinations: (source) => ["Shift-Nightly-macOS-arm64.dmg", path.basename(source)],
+    destinations: (source) => [path.basename(source)],
     pattern: new RegExp(`Shift-Nightly-${escapeRegex(version)}-macOS-arm64\\.dmg$`),
   },
   {
-    destinations: (source) => ["Shift-Nightly-macOS-x64.dmg", path.basename(source)],
+    destinations: (source) => [path.basename(source)],
     pattern: new RegExp(`Shift-Nightly-${escapeRegex(version)}-macOS-x64\\.dmg$`),
   },
   {
-    destinations: (source) => ["Shift-Nightly-Windows-x64.exe", path.basename(source)],
+    destinations: (source) => [path.basename(source)],
     pattern: new RegExp(`Shift-Nightly-${escapeRegex(version)}-Windows-x64-Setup\\.exe$`),
   },
   {
@@ -46,11 +46,11 @@ const assets = [
     ),
   },
   {
-    destinations: () => ["Shift-Nightly-Linux-x64.deb"],
+    destinations: (source) => [path.basename(source)],
     pattern: new RegExp(`Shift-Nightly-${escapeRegex(version)}-Linux-x64\\.deb$`),
   },
   {
-    destinations: () => ["Shift-Nightly-Linux-x64.rpm"],
+    destinations: (source) => [path.basename(source)],
     pattern: new RegExp(`Shift-Nightly-${escapeRegex(version)}-Linux-x64\\.rpm$`),
   },
 ];

--- a/scripts/prepare-nightly-release.test.mjs
+++ b/scripts/prepare-nightly-release.test.mjs
@@ -27,21 +27,16 @@ const fixtures = [
   [`desktop-nightly-linux-x64/Shift-Nightly-${version}-Linux-x64.rpm`, "linux-rpm"],
 ];
 const outputs = new Map([
-  ["Shift-Nightly-macOS-arm64.zip", "mac-arm64"],
   [`Shift-Nightly-${version}-macOS-arm64.zip`, "mac-arm64"],
-  ["Shift-Nightly-macOS-x64.zip", "mac-x64"],
   [`Shift-Nightly-${version}-macOS-x64.zip`, "mac-x64"],
   [`Shift-Nightly-${version}-macOS-arm64.zip.blockmap`, "mac-arm64-blockmap"],
   [`Shift-Nightly-${version}-macOS-x64.zip.blockmap`, "mac-x64-blockmap"],
-  ["Shift-Nightly-macOS-arm64.dmg", "dmg-arm64"],
   [`Shift-Nightly-${version}-macOS-arm64.dmg`, "dmg-arm64"],
-  ["Shift-Nightly-macOS-x64.dmg", "dmg-x64"],
   [`Shift-Nightly-${version}-macOS-x64.dmg`, "dmg-x64"],
-  ["Shift-Nightly-Windows-x64.exe", "windows"],
   [`Shift-Nightly-${version}-Windows-x64-Setup.exe`, "windows"],
   [`Shift-Nightly-${version}-Windows-x64-Setup.exe.blockmap`, "blockmap"],
-  ["Shift-Nightly-Linux-x64.deb", "linux-deb"],
-  ["Shift-Nightly-Linux-x64.rpm", "linux-rpm"],
+  [`Shift-Nightly-${version}-Linux-x64.deb`, "linux-deb"],
+  [`Shift-Nightly-${version}-Linux-x64.rpm`, "linux-rpm"],
 ]);
 
 async function runScript(dist, output, candidateVersion = version) {
@@ -61,7 +56,7 @@ async function writeFixtures(root, entries = fixtures) {
   }
 }
 
-test("prepares human downloads and exact electron-updater assets", async (context) => {
+test("prepares one exact versioned Nightly asset set", async (context) => {
   const root = await mkdtemp(path.join(os.tmpdir(), "shift-nightly-release-"));
   context.after(() => rm(root, { recursive: true, force: true }));
   const dist = path.join(root, "dist");


### PR DESCRIPTION
## Summary

- publish one exact versioned asset set on the rolling Nightly release
- prune legacy aliases and inactive binaries only after the update feed advances
- retain inactive blockmaps for 14 days so recent installations can use differential updates

## Issue

No issue — small release-workflow maintenance.

## Testing

- `node --test scripts/*.test.mjs`
- commit hooks: Oxfmt, Oxlint, deadcode, and full Turbo tests
- workflow YAML parsed with `js-yaml`
- `python3 scripts/context-drift-check.py` reported nine pre-existing documentation freshness warnings
- packaging smoke tests not run locally; the hosted Nightly matrix remains the platform packaging/signing validation
