### PR TITLE
fix(editor): prevent stale direct-edit feedback

### DIFF
--- a/apps/desktop/e2e/editor.spec.ts
+++ b/apps/desktop/e2e/editor.spec.ts
@@ -1,6 +1,25 @@
+import type { Locator, Page } from "@playwright/test";
 import { workspaceTest as test, expect, navigateToEditor } from "./fixtures/electronApp";
 import { glyphProperties } from "./fixtures/appLocators";
 import { CanvasUtil } from "./fixtures/CanvasUtil";
+
+async function selectionBounds(page: Page) {
+  const bounds = await page.evaluate(() => window.shift?.editor.selectionBounds());
+  if (!bounds) throw new Error("Expected selection bounds");
+
+  return bounds;
+}
+
+async function selectionCenter(page: Page) {
+  const bounds = await selectionBounds(page);
+  return { x: bounds.x + bounds.width / 2, y: bounds.y + bounds.height / 2 };
+}
+
+async function setInputValue(input: Locator, value: number): Promise<void> {
+  await input.click();
+  await input.fill(String(value));
+  await input.press("Enter");
+}
 
 test.describe("Editor view", () => {
   test.beforeEach(async ({ page }) => {
@@ -48,5 +67,71 @@ test.describe("Editor view", () => {
     await rightSidebearingInput.press("Enter");
 
     await expect(advanceInput).toHaveValue(String(initialAdvance + 25));
+  });
+
+  test("does not move a selection when its displayed position is reapplied", async ({ page }) => {
+    await page.keyboard.press("Meta+a");
+    const properties = glyphProperties(page);
+    const xInput = properties.getByLabel("X position", { exact: true });
+    const yInput = properties.getByLabel("Y position", { exact: true });
+    const initialBounds = await selectionBounds(page);
+
+    await expect(xInput).toHaveValue(String(Math.round(initialBounds.x)));
+    await expect(yInput).toHaveValue(String(Math.round(initialBounds.y)));
+    await xInput.press("Enter");
+    await yInput.press("Enter");
+
+    await expect.poll(() => selectionBounds(page)).toEqual(initialBounds);
+  });
+
+  test("positions a selection from its top-left independently of the scale anchor", async ({
+    page,
+  }) => {
+    await page.keyboard.press("Meta+a");
+    const properties = glyphProperties(page);
+    const xInput = properties.getByLabel("X position", { exact: true });
+    const yInput = properties.getByLabel("Y position", { exact: true });
+    const initialBounds = await selectionBounds(page);
+    const targetX = Math.round(initialBounds.x) + 25;
+    const targetY = Math.round(initialBounds.y) + 30;
+
+    await properties.getByLabel("Top-left scale anchor", { exact: true }).click();
+    await setInputValue(xInput, targetX);
+    await setInputValue(yInput, targetY);
+
+    await expect.poll(() => selectionBounds(page)).toMatchObject({ x: targetX, y: targetY });
+  });
+
+  test("applies scaling around the selected scale anchor", async ({ page }) => {
+    await page.keyboard.press("Meta+a");
+    const properties = glyphProperties(page);
+    const initialBounds = await selectionBounds(page);
+
+    await properties.getByLabel("Top-left scale anchor", { exact: true }).click();
+    const scaleInput = properties.getByLabel("Scale factor", { exact: true });
+    await setInputValue(scaleInput, 2);
+
+    await expect
+      .poll(() => selectionBounds(page))
+      .toMatchObject({
+        x: initialBounds.x,
+        y: initialBounds.y,
+        width: initialBounds.width * 2,
+        height: initialBounds.height * 2,
+      });
+  });
+
+  test("keeps rotation and flipping centered regardless of the scale anchor", async ({ page }) => {
+    await page.keyboard.press("Meta+a");
+    const properties = glyphProperties(page);
+    await properties.getByLabel("Top-left scale anchor", { exact: true }).click();
+    const initialCenter = await selectionCenter(page);
+
+    await properties.getByRole("button", { name: "Rotate 90 degrees clockwise" }).click();
+    await expect.poll(() => selectionCenter(page)).toEqual(initialCenter);
+    const rotatedBounds = await selectionBounds(page);
+
+    await properties.getByRole("button", { name: "Flip horizontally" }).click();
+    await expect.poll(() => selectionBounds(page)).toEqual(rotatedBounds);
   });
 });

--- a/apps/desktop/e2e/fixtures/appLocators.ts
+++ b/apps/desktop/e2e/fixtures/appLocators.ts
@@ -1,6 +1,7 @@
 import { expect, type Page } from "@playwright/test";
 
 const FIRST_GLYPH_PREVIEW_POINT = { x: 50, y: 50 };
+const FIRST_GLYPH_NAME_POINT = { x: 50, y: 117 };
 
 export function glyphCatalogViewport(page: Page) {
   return page.getByLabel("Glyph catalog", { exact: true });
@@ -41,9 +42,14 @@ export async function firstAxisSlider(page: Page) {
   return page.getByRole("slider", { name: axisName, exact: true });
 }
 
-/** Keeps the canvas layout coordinate contract in one place. */
+/** Keeps the canvas preview coordinate contract in one place. */
 export async function clickFirstCatalogGlyph(page: Page): Promise<void> {
   await glyphCatalogViewport(page).click({ position: FIRST_GLYPH_PREVIEW_POINT });
+}
+
+/** Keeps the canvas name-cell coordinate contract in one place. */
+export async function clickFirstCatalogGlyphName(page: Page): Promise<void> {
+  await glyphCatalogViewport(page).click({ position: FIRST_GLYPH_NAME_POINT });
 }
 
 /**

--- a/apps/desktop/e2e/font-preview.spec.ts
+++ b/apps/desktop/e2e/font-preview.spec.ts
@@ -226,7 +226,7 @@ test.describe("retained font source Grid preview", () => {
   });
 
   test("shows preview font settings with disabled authoring controls", async ({ page }) => {
-    await expect.poll(() => page.evaluate(() => window.shiftSession?.canAuthor)).toBe(false);
+    await expect.poll(() => page.evaluate(() => window.shiftSession?.mode)).toBe("preview");
 
     await page.getByLabel(/Display and edit font information/).click();
     const settingsDialog = page.getByRole("dialog", { name: "Settings" });

--- a/apps/desktop/e2e/home.spec.ts
+++ b/apps/desktop/e2e/home.spec.ts
@@ -2,6 +2,7 @@ import type { Page } from "@playwright/test";
 import { workspaceTest as test, expect } from "./fixtures/electronApp";
 import {
   clickFirstCatalogGlyph,
+  clickFirstCatalogGlyphName,
   glyphCatalogCanvas,
   glyphCatalogSurface,
 } from "./fixtures/appLocators";
@@ -64,6 +65,26 @@ test.describe("Home view", () => {
     await expect(surface).toHaveAttribute("data-first-glyph-id", unencoded.id);
   });
 
+  test("keeps a renamed glyph visible until the catalog confirms its new name", async ({
+    page,
+  }) => {
+    const glyph = await createQuickGlyph(page);
+    const nextName = `${glyph.name}.renamed`;
+    await page.getByPlaceholder("Search glyphs...").fill(glyph.name);
+    await expect(glyphCatalogSurface(page)).toHaveAttribute("data-filtered-glyph-count", "1");
+    await afterNextPaint(page);
+    await clickFirstCatalogGlyphName(page);
+
+    const input = page.getByLabel("Glyph name", { exact: true });
+    await input.fill(nextName);
+    const remainedVisible = observeRenameTransition(page, glyph.id, nextName);
+    await input.press("Enter");
+
+    expect(await remainedVisible).toBe(true);
+    await expect(input).toHaveCount(0);
+    await expect(glyphCatalogCanvas(page)).toHaveAttribute("data-first-glyph-name", nextName);
+  });
+
   test("keeps the resident grid when returning from the editor", async ({ page }) => {
     const glyphCanvas = glyphCatalogCanvas(page);
     await expect(glyphCanvas).toBeVisible({ timeout: 30_000 });
@@ -98,6 +119,66 @@ test.describe("Home view", () => {
       .toEqual(initialSize);
   });
 });
+
+async function createQuickGlyph(page: Page) {
+  await page.getByRole("button", { name: "Create glyph", exact: true }).click();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          window.shift?.font.glyphRecords().find((glyph) => glyph.name.startsWith("newGlyph")) ??
+          null,
+      ),
+    )
+    .not.toBeNull();
+
+  const glyph = await page.evaluate(() =>
+    window.shift?.font.glyphRecords().find((record) => record.name.startsWith("newGlyph")),
+  );
+  if (!glyph) throw new Error("Expected new glyph");
+
+  return glyph;
+}
+
+async function observeRenameTransition(
+  page: Page,
+  glyphId: string,
+  nextName: string,
+): Promise<boolean> {
+  return page.evaluate(
+    ({ glyphId, nextName }) =>
+      new Promise<boolean>((resolve) => {
+        function sample(): void {
+          const currentName = window.shift?.font
+            .glyphRecords()
+            .find(({ id }) => id === glyphId)?.name;
+          const input = document.querySelector<HTMLInputElement>('[aria-label="Glyph name"]');
+          const canvas = document.querySelector<HTMLCanvasElement>(
+            '[data-testid="glyph-catalog-canvas"]',
+          );
+          if (input) {
+            requestAnimationFrame(sample);
+            return;
+          }
+
+          const visibleName = canvas?.dataset.firstGlyphName;
+          if (currentName === nextName) {
+            resolve(visibleName === nextName);
+            return;
+          }
+          if (visibleName !== nextName) {
+            resolve(false);
+            return;
+          }
+
+          requestAnimationFrame(sample);
+        }
+
+        requestAnimationFrame(sample);
+      }),
+    { glyphId, nextName },
+  );
+}
 
 async function afterNextPaint(page: Page): Promise<void> {
   await page.evaluate(

--- a/apps/desktop/src/renderer/src/app/Screens.tsx
+++ b/apps/desktop/src/renderer/src/app/Screens.tsx
@@ -63,7 +63,7 @@ const FontSessionScreens = () => {
         <div className={catalogActive ? undefined : "relative z-10"}>
           <Outlet />
         </div>
-        {session.canAuthor ? null : <ReadOnlyNoticeDialog />}
+        {session.mode === "authored" ? null : <ReadOnlyNoticeDialog />}
       </SettingsNavigationProvider>
     </GlyphCatalogProvider>
   );
@@ -79,8 +79,8 @@ const ShiftSessionSetup = () => {
     if (!documentLoaded) return;
 
     editor.setExternalLocation(font.defaultLocation());
-    if (session.canAuthor) editor.selectSource(font.defaultSource.id);
-  }, [documentLoaded, editor, font, session.canAuthor]);
+    if (session.mode === "authored") editor.selectSource(font.defaultSource.id);
+  }, [documentLoaded, editor, font, session.mode]);
 
   return null;
 };

--- a/apps/desktop/src/renderer/src/components/editor/sidebar-right/IconButton.tsx
+++ b/apps/desktop/src/renderer/src/components/editor/sidebar-right/IconButton.tsx
@@ -1,13 +1,15 @@
 import { Button } from "@shift/ui";
 
 type IconButtonProps = {
+  ariaLabel?: string;
   icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   onClick: () => void;
   disabled?: boolean;
 };
 
-export const IconButton = ({ icon: Icon, onClick, disabled }: IconButtonProps) => (
+export const IconButton = ({ ariaLabel, icon: Icon, onClick, disabled }: IconButtonProps) => (
   <Button
+    aria-label={ariaLabel}
     className="h-6 w-6 p-1 text-sidebar-icon bg-icon-button hover:bg-icon-button-hover"
     variant="ghost"
     onClick={onClick}

--- a/apps/desktop/src/renderer/src/components/editor/sidebar-right/ScaleSection.tsx
+++ b/apps/desktop/src/renderer/src/components/editor/sidebar-right/ScaleSection.tsx
@@ -87,6 +87,7 @@ export const ScaleSection = () => {
         <div className="flex flex-col gap-2">
           <div className="text-xs text-secondary">Scale</div>
           <EditableSidebarInput
+            ariaLabel="Scale factor"
             className="max-w-18 pl-7"
             value={1}
             suffix="x"

--- a/apps/desktop/src/renderer/src/components/editor/sidebar-right/TransformGrid.tsx
+++ b/apps/desktop/src/renderer/src/components/editor/sidebar-right/TransformGrid.tsx
@@ -10,16 +10,21 @@ export interface TransformGridProps {
 const INACTIVE_COLOR = "#C2C2C2";
 const ACTIVE_COLOR = "#0C92F4";
 
-const anchorPositions: { id: AnchorPosition; cx: number; cy: number }[] = [
-  { id: "tl", cx: 4, cy: 4 },
-  { id: "tm", cx: 31, cy: 4 },
-  { id: "tr", cx: 58, cy: 4 },
-  { id: "lm", cx: 4, cy: 27 },
-  { id: "m", cx: 32, cy: 27 },
-  { id: "rm", cx: 58, cy: 27 },
-  { id: "bl", cx: 4, cy: 48 },
-  { id: "bm", cx: 31, cy: 48 },
-  { id: "br", cx: 58, cy: 48 },
+const anchorPositions: {
+  id: AnchorPosition;
+  label: string;
+  cx: number;
+  cy: number;
+}[] = [
+  { id: "tl", label: "Top-left scale anchor", cx: 4, cy: 4 },
+  { id: "tm", label: "Top scale anchor", cx: 31, cy: 4 },
+  { id: "tr", label: "Top-right scale anchor", cx: 58, cy: 4 },
+  { id: "lm", label: "Left scale anchor", cx: 4, cy: 27 },
+  { id: "m", label: "Center scale anchor", cx: 32, cy: 27 },
+  { id: "rm", label: "Right scale anchor", cx: 58, cy: 27 },
+  { id: "bl", label: "Bottom-left scale anchor", cx: 4, cy: 48 },
+  { id: "bm", label: "Bottom scale anchor", cx: 31, cy: 48 },
+  { id: "br", label: "Bottom-right scale anchor", cx: 58, cy: 48 },
 ];
 
 export const TransformGrid = ({
@@ -37,9 +42,11 @@ export const TransformGrid = ({
       xmlns="http://www.w3.org/2000/svg"
     >
       <rect x="4" y="4" width="54" height="44" stroke="#C2C2C2" strokeWidth="2" />
-      {anchorPositions.map(({ id, cx, cy }) => (
+      {anchorPositions.map(({ id, label, cx, cy }) => (
         <circle
           key={id}
+          role="button"
+          aria-label={label}
           cx={cx}
           cy={cy}
           r="4"

--- a/apps/desktop/src/renderer/src/components/editor/sidebar-right/TransformSection.tsx
+++ b/apps/desktop/src/renderer/src/components/editor/sidebar-right/TransformSection.tsx
@@ -2,10 +2,9 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { SidebarSection } from "./SidebarSection";
 import { EditableSidebarInput, type EditableSidebarInputHandle } from "./EditableSidebarInput";
 import { IconButton } from "./IconButton";
-import { useTransformOrigin } from "@/context/TransformOriginContext";
 import { useEditor } from "@/workspace/WorkspaceContext";
-import { anchorToPoint } from "@/lib/transform/anchor";
 import { useSignalState } from "@/lib/signals";
+import { Bounds } from "@shift/geo";
 import { useSelectionBounds } from "@/hooks/useSelectionBounds";
 
 import RotateIcon from "@/assets/sidebar-right/rotate.svg";
@@ -92,7 +91,6 @@ const DistributeButtonsRow = React.memo(function DistributeButtonsRow({
 
 export const TransformSection = () => {
   const editor = useEditor();
-  const { anchor } = useTransformOrigin();
   const selection = useSignalState(editor.selection.stateCell);
   const selectedPointIds = useMemo(() => selection.ids.filter(isPointId), [selection]);
   const selectionBounds = useSelectionBounds();
@@ -140,8 +138,8 @@ export const TransformSection = () => {
   );
 
   const origin = useMemo(
-    () => (selectionBounds ? anchorToPoint(anchor, selectionBounds) : undefined),
-    [anchor, selectionBounds],
+    () => (selectionBounds ? Bounds.center(selectionBounds) : undefined),
+    [selectionBounds],
   );
 
   const handleRotate90 = () => {
@@ -176,11 +174,11 @@ export const TransformSection = () => {
       if (!layer) return;
       if (!selectionBounds) return;
 
-      const anchorPoint = anchorToPoint(anchor, selectionBounds);
-      const target = axis === "x" ? { x: value, y: anchorPoint.y } : { x: anchorPoint.x, y: value };
-      layer.moveSelectionTo([...selectedPointIds], target, anchorPoint);
+      const position = selectionBounds.min;
+      const target = axis === "x" ? { x: value, y: position.y } : { x: position.x, y: value };
+      layer.moveSelectionTo([...selectedPointIds], target, position);
     },
-    [anchor, layer, selectedPointIds, selectionBounds],
+    [layer, selectedPointIds, selectionBounds],
   );
 
   return (
@@ -199,12 +197,14 @@ export const TransformSection = () => {
         <div className="flex gap-2">
           <EditableSidebarInput
             ref={xRef}
+            ariaLabel="X position"
             label="X"
             disabled={!editable}
             onValueChange={(v) => handlePositionChange("x", v)}
           />
           <EditableSidebarInput
             ref={yRef}
+            ariaLabel="Y position"
             label="Y"
             disabled={!editable}
             onValueChange={(v) => handlePositionChange("y", v)}
@@ -216,6 +216,7 @@ export const TransformSection = () => {
         <div className="text-xs text-secondary">Rotation</div>
         <div className="flex gap-2 items-center">
           <EditableSidebarInput
+            ariaLabel="Rotation"
             className="max-w-32"
             value={rotation}
             suffix="°"
@@ -225,9 +226,24 @@ export const TransformSection = () => {
             icon={<RotateIcon className="w-5 h-5" />}
           />
           <div className="flex w-full items-center justify-start gap-1">
-            <IconButton icon={RotateCwIcon} disabled={!editable} onClick={handleRotate90} />
-            <IconButton icon={FlipHIcon} disabled={!editable} onClick={handleFlipH} />
-            <IconButton icon={FlipVIcon} disabled={!editable} onClick={handleFlipV} />
+            <IconButton
+              ariaLabel="Rotate 90 degrees clockwise"
+              icon={RotateCwIcon}
+              disabled={!editable}
+              onClick={handleRotate90}
+            />
+            <IconButton
+              ariaLabel="Flip horizontally"
+              icon={FlipHIcon}
+              disabled={!editable}
+              onClick={handleFlipH}
+            />
+            <IconButton
+              ariaLabel="Flip vertically"
+              icon={FlipVIcon}
+              disabled={!editable}
+              onClick={handleFlipV}
+            />
           </div>
         </div>
       </div>

--- a/apps/desktop/src/renderer/src/components/home/GlyphCatalogCanvas.tsx
+++ b/apps/desktop/src/renderer/src/components/home/GlyphCatalogCanvas.tsx
@@ -1,8 +1,14 @@
-import { useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { GlyphCatalogController } from "./GlyphCatalogController";
 import { GlyphNameInput } from "./GlyphNameInput";
 import { useTheme } from "@/context/ThemeContext";
-import type { GlyphCatalogCanvasProps, GlyphCatalogItem } from "@/types/glyphCatalog";
+import type {
+  GlyphCatalogCanvasProps,
+  GlyphCatalogItem,
+  PendingGlyphNames,
+} from "@/types/glyphCatalog";
+import { useEditor } from "@/workspace/WorkspaceContext";
+import { useSignalState } from "@/lib/signals";
 
 /** Thin React shell around the imperative, canvas-owned glyph catalog. */
 export function GlyphCatalogCanvas({
@@ -20,6 +26,8 @@ export function GlyphCatalogCanvas({
   onUnavailable,
 }: GlyphCatalogCanvasProps) {
   const { themeName } = useTheme();
+  const editor = useEditor();
+  const editsSettled = useSignalState(editor.font.editCoordinator.settledCell);
   const glyphCanvasRef = useRef<HTMLCanvasElement>(null);
   const overlayCanvasRef = useRef<HTMLCanvasElement>(null);
   const inputContainerRef = useRef<HTMLDivElement>(null);
@@ -27,6 +35,7 @@ export function GlyphCatalogCanvas({
   const controllerRef = useRef<GlyphCatalogController | null>(null);
   const [ready, setReady] = useState(false);
   const [editingGlyph, setEditingGlyph] = useState<GlyphCatalogItem | null>(null);
+  const [pendingGlyphNames, setPendingGlyphNames] = useState<PendingGlyphNames>(() => new Map());
 
   useLayoutEffect(() => {
     const container = containerRef.current;
@@ -75,7 +84,15 @@ export function GlyphCatalogCanvas({
   useLayoutEffect(() => {
     controllerRef.current?.update(
       {
-        glyphs,
+        glyphs: glyphs.map((glyph) =>
+          pendingGlyphNames.has(glyph.id)
+            ? {
+                ...glyph,
+                name: pendingGlyphNames.get(glyph.id)!,
+                displayName: pendingGlyphNames.get(glyph.id)!,
+              }
+            : glyph,
+        ),
         location,
         metrics,
         sourceId,
@@ -85,7 +102,7 @@ export function GlyphCatalogCanvas({
       },
       inputContainerRef.current,
     );
-  }, [active, editingGlyph, glyphs, location, metrics, sourceId, themeName]);
+  }, [active, editingGlyph, glyphs, location, metrics, pendingGlyphNames, sourceId, themeName]);
 
   useLayoutEffect(() => {
     if (!editingGlyph) return;
@@ -94,12 +111,34 @@ export function GlyphCatalogCanvas({
     inputRef.current?.select();
   }, [editingGlyph]);
 
+  useEffect(() => {
+    if (pendingGlyphNames.size === 0) return;
+
+    setPendingGlyphNames((current) => {
+      const next = new Map(current);
+
+      for (const [glyphId, pendingName] of current) {
+        const visibleGlyph = glyphs.find(({ id }) => id === glyphId);
+        const committedName = editor.font.recordForId(glyphId)?.name;
+        const visibleNameConfirmed =
+          committedName === pendingName && (!visibleGlyph || visibleGlyph.name === pendingName);
+        const renameRejected = editsSettled && committedName !== pendingName;
+        if (visibleNameConfirmed || renameRejected) next.delete(glyphId);
+      }
+
+      return next.size === current.size ? current : next;
+    });
+  }, [editor, editsSettled, glyphs, pendingGlyphNames]);
+
   return (
     <>
       <canvas
         ref={glyphCanvasRef}
         aria-hidden="true"
         data-testid="glyph-catalog-canvas"
+        data-first-glyph-name={
+          glyphs[0] ? (pendingGlyphNames.get(glyphs[0].id) ?? glyphs[0].displayName) : undefined
+        }
         className="pointer-events-none absolute left-0 top-0 z-[2] h-full w-full bg-transparent"
         style={{ visibility: ready ? "visible" : "hidden" }}
       />
@@ -117,7 +156,12 @@ export function GlyphCatalogCanvas({
           <GlyphNameInput
             ref={inputRef}
             glyph={editingGlyph}
-            onFinished={() => setEditingGlyph(null)}
+            onFinished={(nextName) => {
+              if (nextName) {
+                setPendingGlyphNames((current) => new Map(current).set(editingGlyph.id, nextName));
+              }
+              setEditingGlyph((current) => (current?.id === editingGlyph.id ? null : current));
+            }}
           />
         </div>
       ) : null}

--- a/apps/desktop/src/renderer/src/components/home/GlyphCatalogCanvas.tsx
+++ b/apps/desktop/src/renderer/src/components/home/GlyphCatalogCanvas.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, useSyncExternalStore } from "react";
 import { GlyphCatalogController } from "./GlyphCatalogController";
 import { GlyphNameInput } from "./GlyphNameInput";
 import { useTheme } from "@/context/ThemeContext";
@@ -7,8 +7,8 @@ import type {
   GlyphCatalogItem,
   PendingGlyphNames,
 } from "@/types/glyphCatalog";
-import { useEditor } from "@/workspace/WorkspaceContext";
-import { useSignalState } from "@/lib/signals";
+import { useFontSession } from "@/workspace/WorkspaceContext";
+import { effect, track } from "@/lib/signals";
 
 /** Thin React shell around the imperative, canvas-owned glyph catalog. */
 export function GlyphCatalogCanvas({
@@ -26,8 +26,21 @@ export function GlyphCatalogCanvas({
   onUnavailable,
 }: GlyphCatalogCanvasProps) {
   const { themeName } = useTheme();
-  const editor = useEditor();
-  const editsSettled = useSignalState(editor.font.editCoordinator.settledCell);
+  const session = useFontSession();
+  const workspace = session.workspace;
+  const editsSettled =
+    useSyncExternalStore(
+      (callback) => {
+        if (!workspace) return () => {};
+
+        const subscription = effect(() => {
+          track(workspace.applyStatusCell);
+          callback();
+        });
+        return () => subscription.dispose();
+      },
+      () => workspace?.applyStatusCell.peek() ?? "idle",
+    ) === "idle";
   const glyphCanvasRef = useRef<HTMLCanvasElement>(null);
   const overlayCanvasRef = useRef<HTMLCanvasElement>(null);
   const inputContainerRef = useRef<HTMLDivElement>(null);
@@ -119,7 +132,7 @@ export function GlyphCatalogCanvas({
 
       for (const [glyphId, pendingName] of current) {
         const visibleGlyph = glyphs.find(({ id }) => id === glyphId);
-        const committedName = editor.font.recordForId(glyphId)?.name;
+        const committedName = session.font.recordForId(glyphId)?.name;
         const visibleNameConfirmed =
           committedName === pendingName && (!visibleGlyph || visibleGlyph.name === pendingName);
         const renameRejected = editsSettled && committedName !== pendingName;
@@ -128,7 +141,7 @@ export function GlyphCatalogCanvas({
 
       return next.size === current.size ? current : next;
     });
-  }, [editor, editsSettled, glyphs, pendingGlyphNames]);
+  }, [editsSettled, glyphs, pendingGlyphNames, session.font]);
 
   return (
     <>

--- a/apps/desktop/src/renderer/src/components/home/GlyphNameInput.tsx
+++ b/apps/desktop/src/renderer/src/components/home/GlyphNameInput.tsx
@@ -23,31 +23,30 @@ export const GlyphNameInput = forwardRef<HTMLInputElement, GlyphNameInputProps>(
       setDraft(next);
     };
 
-    const commit = (): void => {
+    const commit = (): GlyphName | null => {
       const next = draftRef.current.trim() as GlyphName;
       if (next === glyphName) {
         updateDraft(glyphName);
-        return;
+        return null;
       }
 
       if (!next || editor.font.recordForName(next)) {
         updateDraft(glyphName);
-        return;
+        return null;
       }
 
       const resolved = glyphInfo.getGlyphByName(next);
       editor.font.updateGlyphIdentity(glyph.id, next, resolved ? [resolved.codepoint] : []);
+      return next;
     };
 
     return (
       <Input
         ref={ref}
+        aria-label="Glyph name"
         value={draft}
         onChange={(event) => updateDraft(event.currentTarget.value as GlyphName)}
-        onBlur={() => {
-          commit();
-          onFinished();
-        }}
+        onBlur={() => onFinished(commit())}
         onKeyDown={(event) => {
           event.nativeEvent.stopImmediatePropagation();
 

--- a/apps/desktop/src/renderer/src/components/variation/AxesPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/variation/AxesPanel.tsx
@@ -22,7 +22,7 @@ import VerticalElipsis from "@/assets/general/vertical-ellipsis.svg";
 
 export const AxesPanel = () => {
   const font = useFont();
-  const canAuthor = useFontSession().canAuthor;
+  const canAuthor = useFontSession().mode === "authored";
   const axes = useAxes().filter(axisVaries);
   const [location, setExternalLocation] = useExternalLocation();
   const settings = useSettingsNavigation();

--- a/apps/desktop/src/renderer/src/components/variation/AxesSection.tsx
+++ b/apps/desktop/src/renderer/src/components/variation/AxesSection.tsx
@@ -12,7 +12,7 @@ interface AxesSectionProps {
 export const AxesSection = ({ defaultOpen = false }: AxesSectionProps) => {
   const [open, setOpen] = useState(defaultOpen);
   const [axisMenuOpen, setAxisMenuOpen] = useState(false);
-  const canAuthor = useFontSession().canAuthor;
+  const canAuthor = useFontSession().mode === "authored";
 
   return (
     <CollapsibleSection

--- a/apps/desktop/src/renderer/src/components/variation/InstancesSection.tsx
+++ b/apps/desktop/src/renderer/src/components/variation/InstancesSection.tsx
@@ -12,7 +12,7 @@ interface InstancesSectionProps {
 export const InstancesSection = ({ defaultOpen = false }: InstancesSectionProps) => {
   const [open, setOpen] = useState(defaultOpen);
   const [instanceMenuOpen, setInstanceMenuOpen] = useState(false);
-  const canAuthor = useFontSession().canAuthor;
+  const canAuthor = useFontSession().mode === "authored";
 
   return (
     <CollapsibleSection

--- a/apps/desktop/src/renderer/src/components/variation/SourcesSection.tsx
+++ b/apps/desktop/src/renderer/src/components/variation/SourcesSection.tsx
@@ -12,7 +12,7 @@ interface SourcesSectionProps {
 export const SourcesSection = ({ defaultOpen = false }: SourcesSectionProps) => {
   const [open, setOpen] = useState(defaultOpen);
   const [sourceMenuOpen, setSourceMenuOpen] = useState(false);
-  const canAuthor = useFontSession().canAuthor;
+  const canAuthor = useFontSession().mode === "authored";
 
   return (
     <CollapsibleSection

--- a/apps/desktop/src/renderer/src/context/GlyphCatalogProvider.tsx
+++ b/apps/desktop/src/renderer/src/context/GlyphCatalogProvider.tsx
@@ -22,7 +22,7 @@ const useGlyphCatalogSource = (): GlyphCatalogSource => {
   const routeLocation = useLocation();
   const glyphInfo = getGlyphInfo();
   const catalog = session.catalog;
-  const canAuthor = session.canAuthor;
+  const canAuthor = session.mode === "authored";
   const workspace = session.workspace;
 
   const availableGlyphs = useSignalState(catalog.glyphsCell);

--- a/apps/desktop/src/renderer/src/context/SettingsNavigationProvider.tsx
+++ b/apps/desktop/src/renderer/src/context/SettingsNavigationProvider.tsx
@@ -34,7 +34,7 @@ export const SettingsNavigationProvider = ({ children }: { children: ReactNode }
       {children}
       <SettingsDialog
         target={target}
-        canAuthor={session.canAuthor}
+        canAuthor={session.mode === "authored"}
         onTargetChange={setTarget}
         onOpenChange={(open) => {
           if (!open) setTarget(null);

--- a/apps/desktop/src/renderer/src/lib/model/docs/DOCS.md
+++ b/apps/desktop/src/renderer/src/lib/model/docs/DOCS.md
@@ -1,12 +1,12 @@
 # Renderer font model
 
-<!-- reviewed: 2026-08-22 review-every: 90d -->
+<!-- reviewed: 2026-08-24 review-every: 90d -->
 
 Reactive TypeScript font, authored glyph-layer, and derived glyph-view surfaces.
 
 ## Architecture Invariants
 
-- **Architecture Invariant:** `FontSession` is the renderer's one immutable connection composition. Both `"authored"` and `"preview"` modes use `FontStore → Font → Editor → Scene → Renderer` and expose one concrete `GlyphCatalog`; only authored mode also owns a `Workspace` and mutation coordinator. Preview sessions eagerly receive stable session `GlyphId` values but no authored `GlyphRecord` or `GlyphLayer`.
+- **Architecture Invariant:** `FontSession` is the renderer's discriminated union of immutable `AuthoredFontSession` and `PreviewFontSession` compositions. Both modes use `FontStore → Font → Editor → Scene → Renderer` and expose one concrete `GlyphCatalog`; only the `"authored"` variant owns a non-null `Workspace` and mutation coordinator. Presentation code may derive authoring affordances from `session.mode`, while mutation and workspace-lifecycle code must narrow to the authored variant. Preview sessions eagerly receive stable session `GlyphId` values but no authored `GlyphRecord` or `GlyphLayer`.
 - **Architecture Invariant:** `Font.loadGlyph()` is the asynchronous acquisition boundary. It returns one canonical `Glyph` only after every authored layer and transitive component dependency is available; retained calls return that same object without workspace I/O. `Editor.glyphForId()` may synchronously expose that object to runtime and plugin code after acquisition, but never initiates loading.
 - **Architecture Invariant:** A loaded `Glyph` owns all authored `GlyphLayer` objects and direct component-Glyph references. Its record and layer collections update reactively without replacing the Glyph; its synchronous properties never initiate I/O.
 - **Architecture Invariant:** `FontStore.#glyphs` contains only completely assembled Glyphs. Failed assembly installs nothing, and workspace replacement clears the complete object graph.
@@ -56,8 +56,8 @@ types/
   glyph.ts                   -- GlyphReader and model construction contracts
   glyphRender.ts             -- renderer contour/anchor contracts plus passive RenderGlyph
 apps/desktop/src/renderer/src/workspace/
-  FontSession.ts             -- immutable mode/catalog/optional-workspace composition
-  FontSessionProvider.tsx    -- one renderer bootstrap and context boundary
+  FontSession.ts             -- authored and preview composition factories
+  FontSessionProvider.tsx    -- one renderer bootstrap and discriminated session context
 lib/catalog/
   GlyphCatalog.ts              -- common Font/Editor projection consumed by the resident Grid
 components/home/glyph-catalog/

--- a/apps/desktop/src/renderer/src/lib/transform/docs/DOCS.md
+++ b/apps/desktop/src/renderer/src/lib/transform/docs/DOCS.md
@@ -1,6 +1,6 @@
 # Transform
 
-<!-- reviewed: 2026-08-18 review-every: 90d -->
+<!-- reviewed: 2026-08-24 review-every: 90d -->
 
 Pure geometry transformation system for rotating, scaling, reflecting, aligning, and distributing selected points.
 
@@ -60,7 +60,7 @@ Segment-aware selection bounds are not part of this module. `Contour.selectionBo
 
 ### Anchor mapping
 
-`anchorToPoint` converts a 9-position `AnchorPosition` into a `Point2D` on a `Bounds` rectangle. The sidebar `TransformSection` and `ScaleSection` components call it to resolve the transform origin from the selection bounds; `TransformGrid` only renders the 9-dot picker that selects the `AnchorPosition`.
+`anchorToPoint` converts a 9-position `AnchorPosition` into a `Point2D` on a `Bounds` rectangle. `ScaleSection` uses it to resolve the scale origin selected through `TransformGrid`. Position edits always target the selection's top-left, while rotation and reflection use the selection center; the scale anchor does not affect those operations.
 
 ### Zoom from wheel
 
@@ -99,18 +99,20 @@ const result = Transform.applyMatrix(points, matrix, origin);
 ## Gotchas
 
 - `reflectPoints("horizontal")` flips Y (mirrors across the X axis), not X. The naming follows "flip across the horizontal center line" convention, which inverts the vertical coordinate.
-- `applyMatrix` defaults origin to `{ x: 0, y: 0 }`, not the selection center. Callers must supply the pivot themselves — the sidebar sections resolve it with `anchorToPoint` over the selection bounds, and the select tool's `BoundingBox` uses the scene rect's center (its local `rectCenter` helper).
+- `applyMatrix` defaults origin to `{ x: 0, y: 0 }`, not the selection center. Callers must supply the pivot themselves — `ScaleSection` resolves its selected scale anchor with `anchorToPoint`, `TransformSection` uses the selection center for rotation and reflection, and the select tool's `BoundingBox` uses the scene rect's center (its local `rectCenter` helper).
 - `distributePoints` with fewer than 3 points is a no-op -- no error is thrown, the input is returned unchanged.
 - There is no `SelectionBounds.ts` here anymore. Segment-aware bounds moved to `Contour.selectionBounds` in `@shift/glyph-state` (only fully selected segments contribute curve bounds there), but nothing in production calls it — the visible selection box is `Editor.selectionBounds()`, which unions full per-object bounds.
 
 ## Verification
 
 ```bash
-# Unit tests for all transform files
-npx vitest run --reporter verbose src/renderer/src/lib/transform/
+# Focused transform tests
+pnpm test:desktop src/renderer/src/lib/transform/Transform.test.ts
+pnpm test:desktop src/renderer/src/lib/transform/Alignment.test.ts
+pnpm test:desktop src/renderer/src/lib/transform/zoomFromWheel.test.ts
 
 # Layer integration tests
-pnpm --filter @shift/desktop test -- src/renderer/src/lib/model/GlyphLayerGeometry.test.ts
+pnpm test:desktop src/renderer/src/lib/model/GlyphLayerGeometry.test.ts
 ```
 
 ## Related
@@ -118,5 +120,5 @@ pnpm --filter @shift/desktop test -- src/renderer/src/lib/model/GlyphLayerGeomet
 - `GlyphLayer` -- mutating transform API over authored glyph geometry
 - `Mat`, `MatModel`, `Bounds` -- matrix and bounds math from `@shift/geo`
 - `Contour.selectionBounds` (`@shift/glyph-state`) -- segment-aware selection bounding boxes, formerly this module's `SelectionBounds.ts`; currently unused in production, `Editor.selectionBounds()` supplies the visible selection rectangle
-- `TransformSection`, `ScaleSection` -- sidebar UI components that resolve origins via `anchorToPoint` and drive transforms through `GlyphLayer`; `TransformGrid` renders the anchor picker they share
+- `TransformSection`, `ScaleSection` -- sidebar UI components that drive transforms through `GlyphLayer`; `ScaleSection` resolves its origin via `anchorToPoint`, and `TransformGrid` renders its anchor picker
 - `Canvas` (`components/editor/Canvas.tsx`) -- consumes `zoomMultiplierFromWheel` for viewport zoom

--- a/apps/desktop/src/renderer/src/types/fontSession.ts
+++ b/apps/desktop/src/renderer/src/types/fontSession.ts
@@ -1,0 +1,23 @@
+import type { Editor } from "@/lib/editor/Editor";
+import type { Font } from "@/lib/model/Font";
+import type { GlyphCatalog } from "@/lib/catalog/GlyphCatalog";
+import type { Workspace } from "@/workspace/Workspace";
+
+interface FontSessionBase {
+  readonly catalog: GlyphCatalog;
+  readonly font: Font;
+  readonly editor: Editor;
+  dispose(): void;
+}
+
+export interface AuthoredFontSession extends FontSessionBase {
+  readonly mode: "authored";
+  readonly workspace: Workspace;
+}
+
+export interface PreviewFontSession extends FontSessionBase {
+  readonly mode: "preview";
+  readonly workspace: null;
+}
+
+export type FontSession = AuthoredFontSession | PreviewFontSession;

--- a/apps/desktop/src/renderer/src/types/glyphCatalog.ts
+++ b/apps/desktop/src/renderer/src/types/glyphCatalog.ts
@@ -15,6 +15,8 @@ export interface GlyphCatalogItem {
   readonly unicode: number | null;
 }
 
+export type PendingGlyphNames = ReadonlyMap<GlyphId, GlyphName>;
+
 /** Publication decision for an asynchronously opened glyph. */
 export type GlyphOpenResult<T> =
   | { readonly status: "current"; readonly glyph: T }
@@ -98,7 +100,7 @@ export interface GlyphCatalogControllerFrame {
 
 export interface GlyphNameInputProps {
   readonly glyph: GlyphCatalogItem;
-  readonly onFinished: () => void;
+  readonly onFinished: (nextName: GlyphName | null) => void;
 }
 
 export interface GlyphCatalogCanvasProps {

--- a/apps/desktop/src/renderer/src/types/window.ts
+++ b/apps/desktop/src/renderer/src/types/window.ts
@@ -1,4 +1,4 @@
-import type { FontSession } from "@/workspace/FontSession";
+import type { FontSession } from "./fontSession";
 import type { Workspace } from "@/workspace/Workspace";
 
 declare global {

--- a/apps/desktop/src/renderer/src/workspace/FontSession.ts
+++ b/apps/desktop/src/renderer/src/workspace/FontSession.ts
@@ -1,45 +1,62 @@
-import type { FontSessionMode } from "@shared/workspace/protocol";
 import type { Editor } from "@/lib/editor/Editor";
 import type { Font } from "@/lib/model/Font";
 import type { GlyphCatalog } from "@/lib/catalog/GlyphCatalog";
 import type { FontSessionClient } from "@/lib/workspace/FontSessionClient";
+import type { AuthoredFontSession, PreviewFontSession } from "@/types/fontSession";
 import type { Workspace } from "./Workspace";
 
-/** Immutable renderer composition for one connected font session. */
-export class FontSession {
-  readonly mode: FontSessionMode;
-  /** Whether this immutable session permits durable authoring operations. */
-  readonly canAuthor: boolean;
-  readonly catalog: GlyphCatalog;
-  readonly workspace: Workspace | null;
-  readonly font: Font;
-  readonly editor: Editor;
-  readonly #client: FontSessionClient;
+/**
+ * Creates an authored renderer composition with durable workspace capabilities.
+ *
+ * @param catalog - Resident catalog owned for the session lifetime.
+ * @param workspace - Connected authored workspace disposed with the session.
+ * @param client - Session transport disposed after the renderer composition.
+ * @returns an authored session whose disposal releases every owned resource.
+ */
+export function createAuthoredFontSession(
+  catalog: GlyphCatalog,
+  workspace: Workspace,
+  client: FontSessionClient,
+): AuthoredFontSession {
+  return {
+    mode: "authored",
+    catalog,
+    workspace,
+    font: workspace.font,
+    editor: workspace.editor,
+    dispose() {
+      catalog.dispose();
+      workspace.dispose();
+      client.dispose();
+    },
+  };
+}
 
-  constructor(
-    mode: FontSessionMode,
-    catalog: GlyphCatalog,
-    workspace: Workspace | null,
-    client: FontSessionClient,
-    font: Font,
-    editor: Editor,
-  ) {
-    this.mode = mode;
-    this.canAuthor = mode === "authored";
-    this.catalog = catalog;
-    this.workspace = workspace;
-    this.font = font;
-    this.editor = editor;
-    this.#client = client;
-  }
-
-  dispose(): void {
-    this.catalog.dispose();
-    if (this.workspace) {
-      this.workspace.dispose();
-    } else {
-      this.font.dispose();
-    }
-    this.#client.dispose();
-  }
+/**
+ * Creates a read-only renderer composition over an imported font source.
+ *
+ * @param catalog - Resident catalog owned for the session lifetime.
+ * @param client - Session transport disposed after the renderer composition.
+ * @param font - Imported font model disposed with the session.
+ * @param editor - Read-only editor sharing the imported font model.
+ * @returns a preview session whose disposal releases every owned resource.
+ */
+export function createPreviewFontSession(
+  catalog: GlyphCatalog,
+  client: FontSessionClient,
+  font: Font,
+  editor: Editor,
+): PreviewFontSession {
+  return {
+    mode: "preview",
+    catalog,
+    workspace: null,
+    font,
+    editor,
+    dispose() {
+      catalog.dispose();
+      font.dispose();
+      client.dispose();
+    },
+  };
 }

--- a/apps/desktop/src/renderer/src/workspace/FontSessionProvider.tsx
+++ b/apps/desktop/src/renderer/src/workspace/FontSessionProvider.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type ReactNode } from "react";
 import "@/types/window";
-import type { FontSession } from "./FontSession";
+import type { FontSession } from "@/types/fontSession";
 import { FontSessionContext, WorkspaceContext } from "./WorkspaceContext";
 import { getFontSession } from "./runtime";
 

--- a/apps/desktop/src/renderer/src/workspace/WorkspaceContext.ts
+++ b/apps/desktop/src/renderer/src/workspace/WorkspaceContext.ts
@@ -1,7 +1,7 @@
 import { createContext, useContext } from "react";
 import type { Editor } from "@/lib/editor/Editor";
 import type { Font } from "@/lib/model/Font";
-import type { FontSession } from "./FontSession";
+import type { FontSession } from "@/types/fontSession";
 import type { Workspace } from "./Workspace";
 
 export const FontSessionContext = createContext<FontSession | null>(null);

--- a/apps/desktop/src/renderer/src/workspace/runtime.ts
+++ b/apps/desktop/src/renderer/src/workspace/runtime.ts
@@ -12,7 +12,8 @@ import type { GlyphReader } from "@/types/glyph";
 import { FontSessionClient } from "@/lib/workspace/FontSessionClient";
 import { getShiftHost } from "@/host/shiftHost";
 import { Workspace } from "./Workspace";
-import { FontSession } from "./FontSession";
+import { createAuthoredFontSession, createPreviewFontSession } from "./FontSession";
+import type { FontSession } from "@/types/fontSession";
 import { getGlyphInfo } from "./glyphInfo";
 
 declare global {
@@ -54,14 +55,7 @@ async function createFontSession(
         () => workspace.font.getAxisMappingBases(),
       );
       const catalog = new GlyphCatalog(workspace.editor, glyphInfo, atlas);
-      return new FontSession(
-        "authored",
-        catalog,
-        workspace,
-        client,
-        workspace.font,
-        workspace.editor,
-      );
+      return createAuthoredFontSession(catalog, workspace, client);
     }
     case "preview": {
       await client.connect();
@@ -75,7 +69,7 @@ async function createFontSession(
       editor.setActiveTool("select");
 
       const catalog = new GlyphCatalog(editor, glyphInfo, new ImportedGlyphAtlasSource(client));
-      return new FontSession("preview", catalog, null, client, font, editor);
+      return createPreviewFontSession(catalog, client, font, editor);
     }
   }
 }


### PR DESCRIPTION
## Summary

- make sidebar X/Y edits target the displayed top-left position while limiting the nine-point anchor to scaling
- keep rotation and reflection centered independently of the scale anchor
- render submitted glyph names until the canonical catalog confirms or rejects them
- model authored and preview font sessions as distinct capabilities so shared catalog UI cannot require authored workspace state

## Issue

Closes #269

## Testing

- `pnpm test:e2e` — 106 passed, 1 skipped, 1 flaky GPU setup timeout passed on retry
- `pnpm test:e2e:gpu e2e/font-preview.spec.ts`
- `pnpm test:e2e:visual e2e/home.spec.ts`
- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm format:check`
- `python3 scripts/context-drift-check.py --ci` — 9 existing documentation freshness warnings, no link or invariant errors
