### PR TITLE
feat(desktop): show update download progress

### DIFF
--- a/apps/desktop/src/main/app/App.ts
+++ b/apps/desktop/src/main/app/App.ts
@@ -285,6 +285,18 @@ export class App {
     ipc.handle(ipcMain, "clipboard.writeText", (_event, text) => {
       clipboard.writeText(text);
     });
+    ipc.handle(ipcMain, "update.startDownload", async () => {
+      await this.#updater.startDownload();
+    });
+    ipc.handle(ipcMain, "update.cancelDownload", () => {
+      this.#updater.cancelDownload();
+    });
+    ipc.handle(ipcMain, "update.restartToUpdate", async () => {
+      await this.#updater.restartToUpdate();
+    });
+    ipc.handle(ipcMain, "update.later", () => {
+      this.#updater.later();
+    });
     ipc.handle(ipcMain, "document.connect", (event) => {
       this.#log.info("document connect requested");
       const session = this.#fontSessionForSender(event.sender, "document.connect");

--- a/apps/desktop/src/main/docs/DOCS.md
+++ b/apps/desktop/src/main/docs/DOCS.md
@@ -17,7 +17,7 @@ Electron main process: app startup, windows, menus, document dialogs, and worksp
 - **Architecture Invariant:** Closing every window keeps the application alive on macOS. Activating the windowless app opens a fresh launcher; Windows and Linux quit after the last window closes.
 - **Architecture Invariant:** Release and Nightly builds have distinct product identities and app-data roots. `Shift` uses `app.shift` and the `Shift` data root; `Shift Nightly` uses `app.shift.nightly` and the `Shift Nightly` data root. An explicit `--user-data-dir` switch takes precedence for tests and diagnostics.
 - **Architecture Invariant:** Shift is single-instance within one distribution data root. Operating-system `.shift` activations received before readiness queue in order; later activations focus an already-open document or create another workspace window. Release owns the document association, while Nightly remains an alternate handler.
-- **Architecture Invariant:** `AppUpdater` owns application update state in main. It selects only the fixed electron-updater metadata channel for the compiled distribution and exact platform/architecture, deduplicates checks/downloads/restarts, and cannot call `quitAndInstall()` until `AppLifecycle` commits every document. macOS Release/Nightly and Windows Nightly x64 update automatically; Windows Release and Linux use distribution-matched manual downloads.
+- **Architecture Invariant:** `AppUpdater` owns application update state in main. It selects only the fixed electron-updater metadata channel for the compiled distribution and exact platform/architecture, requires consent before downloading, deduplicates checks/downloads/restarts, and cannot call `quitAndInstall()` until `AppLifecycle` commits every document. `UpdateWindow` reflects main-owned progress and ready state but never owns updater transitions. macOS Release/Nightly and Windows Nightly x64 update automatically; Windows Release and Linux use distribution-matched manual downloads.
 - **Architecture Invariant:** Disposable Slug pages live under the app-wide `derived-cache/slug-atlases` root beside `working-documents`, never inside authored `.shift` content. Utility processes share the one-GiB byte-budgeted LRU; each process validates an artifact index once and then verifies and decompresses its fixed pages independently. Staging paths use readable `run-{pid}-{id}/page-{index}-{id}.zst` names, and every retry owns a distinct file until publication. The LRU scans after an artifact is opened or published, never after every page stream. Stale, corrupt, and evicted entries rebuild.
 - **Architecture Invariant:** IPC channels are type-safe. `ipcMain.handle` calls use the typed wrapper from `shared/ipc/main`, and channel names and payload types live in `shared/ipc/contract.ts` and `shared/workspace/protocol.ts`.
 
@@ -45,7 +45,8 @@ src/main/
   menu/
     ApplicationMenu.ts            -- Electron application menu
   update/
-    AppUpdater.ts                  -- update orchestration, scheduling, and native dialogs
+    AppUpdater.ts                  -- update orchestration, scheduling, consent, and restart safety
+    UpdateWindow.ts                -- native-framed download progress and install prompt window
     types.ts                       -- update status and feed contracts
     updateFeed.ts                  -- pure native feed selection
   windows/
@@ -68,8 +69,9 @@ src/main/
 - `NativeDialogs` -- injected outer boundary for Open, Save As, Export, dirty-close choices, and failure messages.
 - `DocumentSession` -- native document workflow for Save, Save As, Export TrueType, and close confirmation.
 - `AppLifecycle` -- coordinates Electron window close, app quit, and update restart around document vetoes.
-- `AppUpdater` -- main-process owner of native feed selection, Electron auto-update events, and native update UI.
-- `UpdateStatus` -- updater lifecycle: idle, checking, downloading, ready, or restarting.
+- `AppUpdater` -- main-process owner of native feed selection, Electron auto-update events, consent, cancellation, and restart safety.
+- `UpdateWindow` -- native-framed renderer of download progress and ready-to-install choices.
+- `UpdateStatus` -- updater lifecycle: idle, checking, available, downloading, ready, or restarting.
 - `WorkspaceDocumentState` -- utility-owned lifecycle state mirrored into main and renderer.
 
 ## How it works
@@ -98,7 +100,7 @@ Eligible packaged macOS builds and Windows Nightly x64 builds start `AppUpdater`
 
 `AppUpdater.checkForUpdates(trigger)` derives a fixed HTTPS generic-provider URL from the compiled Release or Nightly distribution and exact platform/architecture. electron-updater reads architecture-specific `latest-mac.yml` on macOS and `latest.yml` for Windows Nightly. It owns numeric version comparison, SHA-512 verification, download, macOS code-signature verification, Authenticode verification when configured, installation, and relaunch. Release and Nightly never share feed paths.
 
-Automatic current/error results stay quiet. Manual current checks report the installed version; a manual check during download explains that work can continue. Download completion offers **Restart and Update** / Later, and a manual check while ready reopens that prompt. Restart prepares every document, cancels all prepared closes if one vetoes, commits every agreed close, and only then calls `quitAndInstall()`. Electron closes windows before normal `before-quit`, so `AppLifecycle`'s `confirmed` state allows those closes. An install failure after commit relaunches the currently installed application; closed in-memory sessions are never reconstructed.
+Automatic current/error results stay quiet. When a check finds an update, the native-framed update window offers **Download Update** / Later; declining leaves the version available without prompting again during periodic checks. An accepted download replaces those choices with cumulative progress. Closing the window or choosing Cancel cancels the transfer and returns to available. Download completion replaces progress with **Restart and Install** / Later, and a manual check while available or ready reopens the relevant choice. Later retains a verified download without silently installing it on ordinary quit. Restart prepares every document, cancels all prepared closes if one vetoes, commits every agreed close, and only then calls `quitAndInstall()`. Electron closes windows before normal `before-quit`, so `AppLifecycle`'s `confirmed` state allows those closes. An install failure after commit relaunches the currently installed application; closed in-memory sessions are never reconstructed.
 
 The application menu exposes `app.checkForUpdates` under the macOS app menu and the Windows/Linux Help menu. Update behavior remains main-owned and does not add renderer IPC.
 
@@ -128,7 +130,7 @@ Message lanes reject in-flight calls when their remote port closes. An unexpecte
 
 ### IPC
 
-Renderer IPC in `App` is limited to shell capabilities: command execution, clipboard, optional document-lane port transfer, immutable session mode, readiness, and shared session sync-lane port transfer. Font data stays on that sync lane between renderer and utility.
+Renderer IPC in `App` is limited to shell capabilities: command execution, clipboard, update-window progress/actions, optional document-lane port transfer, immutable session mode, readiness, and shared session sync-lane port transfer. Font data stays on that sync lane between renderer and utility.
 
 ## Workflow recipes
 
@@ -173,7 +175,7 @@ Renderer IPC in `App` is limited to shell capabilities: command execution, clipb
 - Manual installed builds: double-click a `.shift` file on macOS, Windows, GNOME, and KDE; verify the document icon, first launch, existing-instance activation, and Release/Nightly handler priority.
 - Manual: open the same `.shift` document twice and verify the existing workspace session is reused.
 - Manual: edit a document, close the last window, and verify the save/discard prompt appears.
-- Manual installed N → N+1: verify macOS arm64/x64 and unsigned Windows Nightly x64 checks, download, Later, **Restart and Update**, canceled document close, save, discard, install, and relaunch paths. Electron orchestration has no worthwhile unit test without mocking Electron, native dialogs, and electron-updater.
+- Manual installed N → N+1: verify macOS arm64/x64 and unsigned Windows Nightly x64 consent, download progress, progress-window close/Cancel, retry, Later before and after download, **Restart and Install**, canceled document close, save, discard, install, and relaunch paths. Electron orchestration has no worthwhile unit test without mocking Electron, native dialogs, and electron-updater.
 
 ## Related
 

--- a/apps/desktop/src/main/update/AppUpdater.ts
+++ b/apps/desktop/src/main/update/AppUpdater.ts
@@ -1,7 +1,10 @@
 import { app, dialog, shell, type MessageBoxOptions } from "electron";
 import electronUpdater from "electron-updater";
+import path from "node:path";
 import { errorToMessage } from "../../shared/errors";
+import type { UpdateProgress } from "../../shared/update/types";
 import { shiftDistribution, shiftProductVersion, shiftUpdateBaseUrl } from "../release";
+import { UpdateWindow } from "./UpdateWindow";
 import { updateFeed } from "./updateFeed";
 import type { AppUpdaterOptions, UpdateStatus, UpdateTrigger } from "./types";
 
@@ -9,19 +12,28 @@ const INITIAL_CHECK_DELAY_MS = 30_000;
 const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
 const RELEASES_URL = "https://github.com/shift-editor/shift/releases";
 const NIGHTLY_URL = "https://github.com/shift-editor/shift/releases/tag/nightly";
-const { autoUpdater } = electronUpdater;
+const { autoUpdater, CancellationToken } = electronUpdater;
 
-/** Owns native application update checks, dialogs, and restart safety. */
+/** Owns application update checks, user consent, download progress, and restart safety. */
 export class AppUpdater {
   readonly #options: AppUpdaterOptions;
+  readonly #updateWindow: UpdateWindow;
 
   #status: UpdateStatus = { type: "idle" };
   #started = false;
-  #readyPrompt: Promise<void> | null = null;
+  #downloadCancellationToken: InstanceType<typeof CancellationToken> | null = null;
   #relaunching = false;
 
+  /**
+   * Creates the application updater and its lazy progress window.
+   *
+   * @param options - app-shell dependencies used for document safety, window ownership, and logging.
+   */
   constructor(options: AppUpdaterOptions) {
     this.#options = options;
+    this.#updateWindow = new UpdateWindow(path.join(__dirname, "preload.js"), options.log, () =>
+      this.#updateWindowClosed(),
+    );
   }
 
   /** Installs Electron listeners and schedules quiet checks for eligible builds. */
@@ -29,22 +41,26 @@ export class AppUpdater {
     if (this.#started || !app.isPackaged || !this.#feed()) return;
     this.#started = true;
 
-    autoUpdater.autoDownload = true;
+    autoUpdater.autoDownload = false;
     autoUpdater.autoInstallOnAppQuit = false;
     autoUpdater.autoRunAppAfterInstall = true;
     autoUpdater.disableWebInstaller = true;
     autoUpdater.logger = this.#options.log;
-    autoUpdater.on("update-available", () => this.#updateAvailable());
+    autoUpdater.on("update-available", (info) => this.#updateAvailable(info.version));
     autoUpdater.on("update-not-available", () => {
       void this.#updateNotAvailable().catch((error) => {
         this.#options.log.error("update-not-available handler failed", error);
       });
     });
-    autoUpdater.on("update-downloaded", () => {
-      void this.#updateDownloaded().catch((error) => {
-        this.#options.log.error("update-downloaded handler failed", error);
+    autoUpdater.on("download-progress", (progress) => {
+      this.#downloadProgress({
+        percent: Math.min(100, Math.max(0, progress.percent)),
+        transferred: progress.transferred,
+        total: progress.total,
+        bytesPerSecond: progress.bytesPerSecond,
       });
     });
+    autoUpdater.on("update-downloaded", () => this.#updateDownloaded());
     autoUpdater.on("error", (error) => {
       void this.#updateFailed(error).catch((handlerError) => {
         this.#options.log.error("updater error handler failed", handlerError);
@@ -78,11 +94,14 @@ export class AppUpdater {
       case "checking":
       case "restarting":
         return;
+      case "available":
+        if (trigger === "manual") this.#notifyAvailable();
+        return;
       case "downloading":
-        if (trigger === "manual") await this.#showDownloading();
+        if (trigger === "manual") this.#updateWindow.showDownloading();
         return;
       case "ready":
-        if (trigger === "manual") await this.#notifyReady();
+        if (trigger === "manual") this.#notifyReady();
         return;
       case "idle":
         break;
@@ -110,6 +129,44 @@ export class AppUpdater {
     }
   }
 
+  /** Downloads the available update and presents cumulative progress until completion. */
+  async startDownload(): Promise<void> {
+    if (this.#status.type !== "available") return;
+
+    const version = this.#status.version;
+    const cancellationToken = new CancellationToken();
+    this.#status = { type: "downloading", version };
+    this.#downloadCancellationToken = cancellationToken;
+    this.#updateWindow.showDownloading();
+
+    try {
+      await autoUpdater.downloadUpdate(cancellationToken);
+    } catch (error) {
+      if (this.#status.type === "downloading") await this.#updateFailed(error);
+    } finally {
+      if (this.#downloadCancellationToken === cancellationToken) {
+        this.#downloadCancellationToken = null;
+      }
+    }
+  }
+
+  /** Cancels the active download and returns the available update to a deferred state. */
+  cancelDownload(): void {
+    if (this.#status.type !== "downloading") return;
+
+    const version = this.#status.version;
+    this.#status = { type: "available", version };
+    this.#downloadCancellationToken?.cancel();
+    this.#updateWindow.close();
+  }
+
+  /** Defers the available or ready update without discarding its current state. */
+  later(): void {
+    if (this.#status.type !== "available" && this.#status.type !== "ready") return;
+
+    this.#updateWindow.close();
+  }
+
   /** Closes every document, then asks Electron to apply the downloaded update. */
   async restartToUpdate(): Promise<void> {
     if (this.#status.type !== "ready") return;
@@ -129,6 +186,7 @@ export class AppUpdater {
     }
 
     this.#status = { type: "restarting" };
+    this.#updateWindow.close();
     try {
       autoUpdater.quitAndInstall(false, true);
     } catch (error) {
@@ -144,16 +202,11 @@ export class AppUpdater {
     });
   }
 
-  #updateAvailable(): void {
+  #updateAvailable(version: string): void {
     if (this.#status.type !== "checking") return;
 
-    const trigger = this.#status.trigger;
-    this.#status = { type: "downloading", trigger };
-    if (trigger === "manual") {
-      void this.#showDownloading().catch((error) => {
-        this.#options.log.error("update download dialog failed", error);
-      });
-    }
+    this.#status = { type: "available", version };
+    this.#notifyAvailable();
   }
 
   async #updateNotAvailable(): Promise<void> {
@@ -172,64 +225,63 @@ export class AppUpdater {
     });
   }
 
-  async #updateDownloaded(): Promise<void> {
+  #downloadProgress(progress: UpdateProgress): void {
     if (this.#status.type !== "downloading") return;
 
-    this.#status = { type: "ready" };
-    await this.#notifyReady();
+    this.#updateWindow.updateProgress(progress);
+  }
+
+  #updateDownloaded(): void {
+    if (this.#status.type !== "downloading") return;
+
+    const version = this.#status.version;
+    this.#status = { type: "ready", version };
+    this.#downloadCancellationToken = null;
+    this.#notifyReady();
   }
 
   async #updateFailed(error: unknown): Promise<void> {
-    if (this.#status.type === "restarting") {
-      this.#relaunchInstalledVersion(error);
-      return;
-    }
-    if (this.#status.type !== "checking" && this.#status.type !== "downloading") return;
-
-    const trigger = this.#status.trigger;
-    this.#status = { type: "idle" };
-    this.#options.log.warn("application update failed", error);
-    if (trigger === "manual") await this.#showFailure(error);
-  }
-
-  async #showDownloading(): Promise<void> {
-    await this.#showMessage({
-      type: "info",
-      buttons: ["OK"],
-      title: app.name,
-      message: `Downloading an ${app.name} update…`,
-      detail: "You can keep working. Shift will let you know when the update is ready.",
-    });
-  }
-
-  async #notifyReady(): Promise<void> {
-    if (this.#readyPrompt) {
-      await this.#readyPrompt;
-      return;
-    }
-
-    this.#readyPrompt = this.#showReady();
-    try {
-      await this.#readyPrompt;
-    } finally {
-      this.#readyPrompt = null;
+    switch (this.#status.type) {
+      case "restarting":
+        this.#relaunchInstalledVersion(error);
+        return;
+      case "checking": {
+        const trigger = this.#status.trigger;
+        this.#status = { type: "idle" };
+        this.#options.log.warn("application update check failed", error);
+        if (trigger === "manual") await this.#showFailure(error);
+        return;
+      }
+      case "downloading": {
+        const version = this.#status.version;
+        this.#status = { type: "available", version };
+        this.#downloadCancellationToken = null;
+        this.#updateWindow.close();
+        this.#options.log.warn("application update download failed", error);
+        await this.#showDownloadFailure(error);
+        return;
+      }
+      case "idle":
+      case "available":
+      case "ready":
+        return;
     }
   }
 
-  async #showReady(): Promise<void> {
+  #notifyAvailable(): void {
+    if (this.#status.type !== "available") return;
+
+    this.#updateWindow.showAvailable(this.#status.version);
+  }
+
+  #notifyReady(): void {
     if (this.#status.type !== "ready") return;
 
-    const result = await this.#showMessage({
-      type: "info",
-      buttons: ["Restart and Update", "Later"],
-      defaultId: 0,
-      cancelId: 1,
-      noLink: true,
-      title: app.name,
-      message: `${app.name} is ready to update.`,
-      detail: "Shift will ask about unsaved documents before restarting.",
-    });
-    if (result.response === 0) await this.restartToUpdate();
+    this.#updateWindow.showReady(this.#status.version);
+  }
+
+  #updateWindowClosed(): void {
+    if (this.#status.type === "downloading") this.cancelDownload();
   }
 
   async #showFailure(error: unknown): Promise<void> {
@@ -241,6 +293,20 @@ export class AppUpdater {
       noLink: true,
       title: app.name,
       message: `${app.name} couldn't check for updates.`,
+      detail: errorToMessage(error),
+    });
+    if (result.response === 0) await shell.openExternal(this.#downloadsUrl());
+  }
+
+  async #showDownloadFailure(error: unknown): Promise<void> {
+    const result = await this.#showMessage({
+      type: "error",
+      buttons: ["View Downloads", "OK"],
+      defaultId: 0,
+      cancelId: 1,
+      noLink: true,
+      title: app.name,
+      message: `${app.name} couldn't download the update.`,
       detail: errorToMessage(error),
     });
     if (result.response === 0) await shell.openExternal(this.#downloadsUrl());

--- a/apps/desktop/src/main/update/UpdateWindow.ts
+++ b/apps/desktop/src/main/update/UpdateWindow.ts
@@ -1,0 +1,180 @@
+import { app, BrowserWindow, nativeTheme } from "electron";
+import type { ShiftLogger } from "../logging";
+import { getRendererSource } from "../utils";
+import * as ipc from "../../shared/ipc/main";
+import type { UpdateProgress } from "../../shared/update/types";
+
+const INITIAL_PROGRESS: UpdateProgress = {
+  percent: 0,
+  transferred: 0,
+  total: 0,
+  bytesPerSecond: 0,
+};
+
+/** Owns the native-framed window that presents update download and install progress. */
+export class UpdateWindow {
+  readonly #preloadPath: string;
+  readonly #log: ShiftLogger;
+  readonly #onClosed: () => void;
+
+  #window: BrowserWindow | null = null;
+  #progress: UpdateProgress = INITIAL_PROGRESS;
+  #availableVersion: string | null = null;
+  #readyVersion: string | null = null;
+  #closeRequested = false;
+
+  /**
+   * Creates a lazily opened update window.
+   *
+   * @param preloadPath - compiled preload script shared with other app windows.
+   * @param log - logger that receives renderer loading failures.
+   * @param onClosed - called only when the user closes the window frame.
+   */
+  constructor(preloadPath: string, log: ShiftLogger, onClosed: () => void) {
+    this.#preloadPath = preloadPath;
+    this.#log = log;
+    this.#onClosed = onClosed;
+  }
+
+  /**
+   * Opens or focuses the window with choices for an available update.
+   *
+   * @param version - product version available to download.
+   */
+  showAvailable(version: string): void {
+    this.#availableVersion = version;
+    this.#readyVersion = null;
+    this.#open();
+    this.#sendCurrent();
+  }
+
+  /** Opens or focuses the window in download-progress mode. */
+  showDownloading(): void {
+    if (
+      this.#availableVersion !== null ||
+      this.#readyVersion !== null ||
+      !this.#window ||
+      this.#window.isDestroyed()
+    ) {
+      this.#progress = INITIAL_PROGRESS;
+    }
+    this.#availableVersion = null;
+    this.#readyVersion = null;
+    this.#open();
+    this.#sendCurrent();
+  }
+
+  /**
+   * Updates the visible download progress and retains it across renderer loading.
+   *
+   * @param progress - latest cumulative byte and percentage measurements.
+   */
+  updateProgress(progress: UpdateProgress): void {
+    this.#progress = progress;
+    this.#sendCurrent();
+  }
+
+  /**
+   * Replaces download progress with restart choices, opening the window when needed.
+   *
+   * @param version - downloaded product version presented to the user.
+   */
+  showReady(version: string): void {
+    this.#availableVersion = null;
+    this.#readyVersion = version;
+    this.#open();
+    this.#sendCurrent();
+  }
+
+  /** Closes the window without treating the close as a user cancellation. */
+  close(): void {
+    if (!this.#window || this.#window.isDestroyed()) return;
+
+    this.#closeRequested = true;
+    this.#window.close();
+  }
+
+  #open(): void {
+    if (this.#window && !this.#window.isDestroyed()) {
+      if (this.#window.isMinimized()) this.#window.restore();
+      this.#window.show();
+      this.#window.focus();
+      return;
+    }
+
+    const window = new BrowserWindow({
+      width: 640,
+      height: 390,
+      title: `Updating ${app.name}`,
+      show: false,
+      resizable: false,
+      maximizable: false,
+      fullscreenable: false,
+      backgroundColor: nativeTheme.shouldUseDarkColors ? "#242424" : "#ececec",
+      ...(process.platform === "darwin" ? { titleBarStyle: "hiddenInset" as const } : {}),
+      webPreferences: {
+        preload: this.#preloadPath,
+        contextIsolation: true,
+        nodeIntegration: false,
+        sandbox: false,
+      },
+    });
+    this.#window = window;
+    window.setMenu(null);
+
+    window.once("ready-to-show", () => {
+      if (window.isDestroyed()) return;
+
+      window.show();
+      window.focus();
+    });
+    window.webContents.on("did-finish-load", () => this.#sendCurrent());
+    window.on("closed", () => {
+      const closeRequested = this.#closeRequested;
+      if (this.#window === window) this.#window = null;
+      this.#closeRequested = false;
+      if (!closeRequested) this.#onClosed();
+    });
+
+    this.#load(window);
+  }
+
+  #load(window: BrowserWindow): void {
+    const source = getRendererSource();
+    const stateQuery = this.#availableVersion
+      ? `?state=available&version=${encodeURIComponent(this.#availableVersion)}`
+      : this.#readyVersion
+        ? `?state=ready&version=${encodeURIComponent(this.#readyVersion)}`
+        : "";
+    const hash = `/update${stateQuery}`;
+
+    if (source.type === "url") {
+      const url = new URL(source.source);
+      url.hash = hash;
+      void window.loadURL(url.toString()).catch((error) => {
+        this.#log.error("update window failed to load", error);
+      });
+      return;
+    }
+
+    void window.loadFile(source.source, { hash }).catch((error) => {
+      this.#log.error("update window failed to load", error);
+    });
+  }
+
+  #sendCurrent(): void {
+    const window = this.#window;
+    if (!window || window.isDestroyed() || window.webContents.isDestroyed()) return;
+
+    if (this.#availableVersion) {
+      ipc.send(window.webContents, "update.available", this.#availableVersion);
+      return;
+    }
+    if (this.#readyVersion) {
+      ipc.send(window.webContents, "update.ready", this.#readyVersion);
+      return;
+    }
+
+    ipc.send(window.webContents, "update.progress", this.#progress);
+  }
+}

--- a/apps/desktop/src/main/update/types.ts
+++ b/apps/desktop/src/main/update/types.ts
@@ -7,8 +7,9 @@ export type UpdateTrigger = "automatic" | "manual";
 export type UpdateStatus =
   | { type: "idle" }
   | { type: "checking"; trigger: UpdateTrigger }
-  | { type: "downloading"; trigger: UpdateTrigger }
-  | { type: "ready" }
+  | { type: "available"; version: string }
+  | { type: "downloading"; version: string }
+  | { type: "ready"; version: string }
   | { type: "restarting" };
 
 export type UpdateFeed = {

--- a/apps/desktop/src/preload/docs/DOCS.md
+++ b/apps/desktop/src/preload/docs/DOCS.md
@@ -19,7 +19,7 @@ preload/
 
 ## Key Types
 
-- `ShiftHost` -- renderer-facing app-shell API for commands, documents, sessions, UI events, and clipboard access.
+- `ShiftHost` -- renderer-facing app-shell API for commands, documents, sessions, application updates, UI events, and clipboard access.
 - `RendererToMain` -- renderer-to-main request/response channel map.
 - `MainToRenderer` -- main-to-renderer broadcast channel map.
 
@@ -27,7 +27,7 @@ preload/
 
 The preload runs once before the renderer loads:
 
-1. Builds `ShiftHost` methods from typed `invoke` and `listen` IPC helpers.
+1. Builds `ShiftHost` methods from typed `invoke` and `listen` IPC helpers, including update-window progress and actions.
 2. Exposes that object as `window.shiftHost` through `contextBridge`.
 3. Relays session and document `MessagePort`s into the page. Because packaged `file://` pages have opaque origins, receivers authenticate these relays with `event.source === window` plus the expected message type rather than comparing origin strings.
 

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -19,6 +19,15 @@ const shiftHost: ShiftHost = {
     connect: invoke(ipcRenderer, "session.connect"),
     ready: invoke(ipcRenderer, "session.ready"),
   },
+  update: {
+    startDownload: invoke(ipcRenderer, "update.startDownload"),
+    cancelDownload: invoke(ipcRenderer, "update.cancelDownload"),
+    restartToUpdate: invoke(ipcRenderer, "update.restartToUpdate"),
+    later: invoke(ipcRenderer, "update.later"),
+    onProgress: listen(ipcRenderer, "update.progress"),
+    onAvailable: listen(ipcRenderer, "update.available"),
+    onReady: listen(ipcRenderer, "update.ready"),
+  },
   ui: {
     onZoomChanged: listen(ipcRenderer, "ui.zoomChanged"),
   },

--- a/apps/desktop/src/renderer/src/app/Screens.tsx
+++ b/apps/desktop/src/renderer/src/app/Screens.tsx
@@ -11,19 +11,21 @@ import { DebugProvider } from "@/context/DebugProvider";
 import { SettingsNavigationProvider } from "@/context/SettingsNavigationProvider";
 import { GlyphCatalogProvider } from "@/context/GlyphCatalogProvider";
 import { ReadOnlyNoticeDialog } from "@/components/chrome/ReadOnlyNoticeDialog";
+import { UpdateScreen } from "@/views/UpdateScreen";
 
 /**
- * Routes launcher and workspace windows to their screen trees.
+ * Routes launcher, updater, and workspace windows to their screen trees.
  *
  * @remarks
- * Main chooses the initial route when it creates a window. Launcher routes do
- * not connect to a workspace; workspace routes connect through the sender
- * window and fail if main has not attached that window to a session.
+ * Main chooses the initial route when it creates a window. Launcher and updater
+ * routes do not connect to a workspace; workspace routes connect through the
+ * sender window and fail if main has not attached that window to a session.
  */
 export const Screens = () => {
   return (
     <Routes>
       <Route path="/launcher" element={<Landing />} />
+      <Route path="/update" element={<UpdateScreen />} />
       <Route
         element={
           <FontSessionProvider>

--- a/apps/desktop/src/renderer/src/views/UpdateScreen.css
+++ b/apps/desktop/src/renderer/src/views/UpdateScreen.css
@@ -1,0 +1,101 @@
+.update-window {
+  --update-background: #ececec;
+  --update-text: #202020;
+  --update-secondary-text: #626262;
+  --update-track: #d2d2d2;
+  --update-button: #dadada;
+  --update-button-hover: #cecece;
+
+  position: fixed;
+  inset: 0;
+  color: var(--update-text);
+  background: var(--update-background);
+  font-family: -apple-system, BlinkMacSystemFont, "Inter", sans-serif;
+  user-select: none;
+}
+
+.update-window-content {
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 22px;
+  padding: 26px 52px 34px;
+  text-align: center;
+}
+
+.update-window-icon {
+  width: 72px;
+  height: 72px;
+  border-radius: 16px;
+  filter: drop-shadow(0 5px 7px rgb(0 0 0 / 18%));
+}
+
+.update-window-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.update-window-copy h1 {
+  font-size: 17px;
+  font-weight: 650;
+  line-height: 1.25;
+}
+
+.update-window-copy p {
+  color: var(--update-secondary-text);
+  font-size: 13px;
+  line-height: 1.35;
+}
+
+.update-window-progress {
+  width: 100%;
+}
+
+.update-window-progress-track {
+  height: 8px;
+  background: var(--update-track);
+}
+
+.update-window-progress-indicator {
+  background: var(--color-accent);
+  transition-duration: 180ms;
+}
+
+.update-window-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.update-window-button,
+.update-window-primary-button {
+  min-width: 150px;
+  height: 42px;
+  border: 0;
+  border-radius: 999px;
+  font-size: 15px;
+  font-weight: 500;
+  -webkit-app-region: no-drag;
+}
+
+.update-window-button {
+  color: var(--update-text);
+  background: var(--update-button);
+}
+
+.update-window-button:hover {
+  background: var(--update-button-hover);
+}
+
+@media (prefers-color-scheme: dark) {
+  .update-window {
+    --update-background: #242424;
+    --update-text: #e6e6e6;
+    --update-secondary-text: #aaa;
+    --update-track: #3d3d3d;
+    --update-button: #3a3a3a;
+    --update-button-hover: #464646;
+  }
+}

--- a/apps/desktop/src/renderer/src/views/UpdateScreen.tsx
+++ b/apps/desktop/src/renderer/src/views/UpdateScreen.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useState } from "react";
+import { useLocation } from "react-router";
+import { Button, Progress } from "@shift/ui";
+import logo from "@/assets/logo@1024.png";
+import { getShiftHost } from "@/host/shiftHost";
+import type { UpdateProgress } from "@shared/update/types";
+import "./UpdateScreen.css";
+
+const INITIAL_PROGRESS: UpdateProgress = {
+  percent: 0,
+  transferred: 0,
+  total: 0,
+  bytesPerSecond: 0,
+};
+
+export const UpdateScreen = () => {
+  const location = useLocation();
+  const query = new URLSearchParams(location.search);
+  const initialState = query.get("state");
+  const [view, setView] = useState<"available" | "downloading" | "ready">(
+    initialState === "available" || initialState === "ready" ? initialState : "downloading",
+  );
+  const [version, setVersion] = useState(query.get("version") ?? "");
+  const [progress, setProgress] = useState(INITIAL_PROGRESS);
+  const host = getShiftHost();
+
+  useEffect(() => {
+    const unsubscribeAvailable = host.update.onAvailable((availableVersion) => {
+      setVersion(availableVersion);
+      setView("available");
+    });
+    const unsubscribeProgress = host.update.onProgress((nextProgress) => {
+      setProgress(nextProgress);
+      setView("downloading");
+    });
+    const unsubscribeReady = host.update.onReady((readyVersion) => {
+      setVersion(readyVersion);
+      setView("ready");
+    });
+
+    return () => {
+      unsubscribeAvailable();
+      unsubscribeProgress();
+      unsubscribeReady();
+    };
+  }, [host]);
+
+  const startDownload = async () => {
+    try {
+      await host.update.startDownload();
+    } catch (error) {
+      console.error("update download failed to start", error);
+    }
+  };
+
+  const cancelDownload = async () => {
+    try {
+      await host.update.cancelDownload();
+    } catch (error) {
+      console.error("update cancellation failed", error);
+    }
+  };
+
+  const restartToUpdate = async () => {
+    try {
+      await host.update.restartToUpdate();
+    } catch (error) {
+      console.error("update restart failed", error);
+    }
+  };
+
+  const later = async () => {
+    try {
+      await host.update.later();
+    } catch (error) {
+      console.error("closing the update prompt failed", error);
+    }
+  };
+
+  const progressText =
+    progress.total > 0
+      ? `Downloading update… ${formatBytes(progress.transferred)} of ${formatBytes(progress.total)}`
+      : "Preparing download…";
+
+  let content;
+  switch (view) {
+    case "available":
+      content = (
+        <>
+          <div className="update-window-copy">
+            <h1>Shift {version} is available.</h1>
+            <p>Would you like to download it now?</p>
+          </div>
+          <div className="update-window-actions">
+            <Button
+              variant="primary"
+              size="lg"
+              className="update-window-primary-button"
+              onClick={startDownload}
+            >
+              Download Update
+            </Button>
+            <Button size="lg" className="update-window-button" onClick={later}>
+              Later
+            </Button>
+          </div>
+        </>
+      );
+      break;
+    case "downloading":
+      content = (
+        <>
+          <div className="update-window-copy">
+            <h1>{progressText}</h1>
+          </div>
+          <Progress
+            aria-label="Update download progress"
+            aria-valuetext={progressText}
+            value={progress.percent}
+            className="update-window-progress"
+            trackClassName="update-window-progress-track"
+            indicatorClassName="update-window-progress-indicator"
+          />
+          <Button size="lg" className="update-window-button" onClick={cancelDownload}>
+            Cancel
+          </Button>
+        </>
+      );
+      break;
+    case "ready":
+      content = (
+        <>
+          <div className="update-window-copy">
+            <h1>Shift {version} is ready to install.</h1>
+          </div>
+          <div className="update-window-actions">
+            <Button
+              variant="primary"
+              size="lg"
+              className="update-window-primary-button"
+              onClick={restartToUpdate}
+            >
+              Restart and Install
+            </Button>
+            <Button size="lg" className="update-window-button" onClick={later}>
+              Later
+            </Button>
+          </div>
+        </>
+      );
+      break;
+  }
+
+  return (
+    <main className="update-window">
+      <section className="update-window-content" aria-live="polite">
+        <img src={logo} alt="" className="update-window-icon" />
+        {content}
+      </section>
+    </main>
+  );
+};
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1_000_000) return `${Math.max(0, bytes / 1_000).toFixed(0)} KB`;
+
+  return `${(bytes / 1_000_000).toFixed(1)} MB`;
+}

--- a/apps/desktop/src/shared/host/ShiftHost.ts
+++ b/apps/desktop/src/shared/host/ShiftHost.ts
@@ -1,4 +1,5 @@
 import type { CommandId, RendererCommandId } from "../commands";
+import type { UpdateProgress } from "../update/types";
 import type { FontSessionMode } from "../workspace/protocol";
 
 /**
@@ -50,6 +51,38 @@ export interface ShiftHost {
      */
     connect: () => Promise<void>;
     ready: () => Promise<void>;
+  };
+  /** Controls and observes the main-owned application update flow. */
+  update: {
+    /** Starts downloading the available update and opens its progress view. */
+    startDownload: () => Promise<void>;
+    /** Cancels the active update download and closes its progress window. */
+    cancelDownload: () => Promise<void>;
+    /** Restarts the application after document confirmation and installs the ready update. */
+    restartToUpdate: () => Promise<void>;
+    /** Closes the ready prompt while retaining the downloaded update. */
+    later: () => Promise<void>;
+    /**
+     * Subscribes to cumulative update download progress.
+     *
+     * @param callback - receives the latest byte counts, speed, and percentage.
+     * @returns an unsubscribe function.
+     */
+    onProgress: (callback: (progress: UpdateProgress) => void) => () => void;
+    /**
+     * Subscribes to available update versions.
+     *
+     * @param callback - receives the product version available to download.
+     * @returns an unsubscribe function.
+     */
+    onAvailable: (callback: (version: string) => void) => () => void;
+    /**
+     * Subscribes to update download completion.
+     *
+     * @param callback - receives the downloaded product version.
+     * @returns an unsubscribe function.
+     */
+    onReady: (callback: (version: string) => void) => () => void;
   };
   /** App-shell UI events owned by the main process. */
   ui: {

--- a/apps/desktop/src/shared/ipc/contract.ts
+++ b/apps/desktop/src/shared/ipc/contract.ts
@@ -4,6 +4,7 @@ import type {
   WorkspaceDocumentState,
   WorkspaceExportResult,
 } from "../workspace/protocol";
+import type { UpdateProgress } from "../update/types";
 
 export type DocumentCallMap = {
   "document.state": { request: void; response: WorkspaceDocumentState | null };
@@ -45,6 +46,10 @@ export type RendererToMain = {
    */
   "session.connect": () => void;
   "session.ready": () => void;
+  "update.startDownload": () => void;
+  "update.cancelDownload": () => void;
+  "update.restartToUpdate": () => void;
+  "update.later": () => void;
 };
 
 /**
@@ -59,4 +64,10 @@ export type MainToRenderer = {
   "commands.runRenderer": (id: RendererCommandId) => void;
   /** UI (chrome) zoom changed via the View menu or its accelerators. */
   "ui.zoomChanged": (percent: number) => void;
+  /** Reports that an application update is available to download. */
+  "update.available": (version: string) => void;
+  /** Reports cumulative progress for the active application update download. */
+  "update.progress": (progress: UpdateProgress) => void;
+  /** Reports that the downloaded application version can be installed. */
+  "update.ready": (version: string) => void;
 };

--- a/apps/desktop/src/shared/update/types.ts
+++ b/apps/desktop/src/shared/update/types.ts
@@ -1,0 +1,6 @@
+export type UpdateProgress = {
+  percent: number;
+  transferred: number;
+  total: number;
+  bytesPerSecond: number;
+};

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -4,9 +4,9 @@ Shift ships one versioned desktop product. Internal Rust crates and JavaScript p
 
 ## Distribution states
 
-| State     | Product identity | Bundle ID           | Data root       | Publication                   |
-| --------- | ---------------- | ------------------- | --------------- | ----------------------------- |
-| `release` | Shift            | `app.shift`         | `Shift`         | Draft, then GitHub prerelease |
+| State     | Product identity | Bundle ID           | Data root       | Publication                                                |
+| --------- | ---------------- | ------------------- | --------------- | ---------------------------------------------------------- |
+| `release` | Shift            | `app.shift`         | `Shift`         | Draft, then GitHub prerelease                              |
 | `nightly` | Shift Nightly    | `app.shift.nightly` | `Shift Nightly` | Rolling GitHub prerelease and immutable R2 updater archive |
 
 `SHIFT_DISTRIBUTION` accepts only `release` or `nightly` during a build. Release and Nightly have separate application identities, data roots, and update-feed paths. A failed build does not advance its update feed.
@@ -43,7 +43,7 @@ electron-updater compares the aligned numeric versions, verifies generated SHA-5
 
 electron-builder generates architecture-specific `latest-mac.yml` files for exact versioned ZIP assets and `latest.yml` for the Windows Nightly NSIS installer. GitHub Pages hosts the fixed Release/Nightly metadata files. Versioned Release binaries and their differential-update blockmaps remain on GitHub Releases. Nightly metadata instead references immutable updater packages under `nightly/<full-commit>/` in Cloudflare R2. Because electron-updater cannot derive a previous blockmap URL across commit-addressed directories, Nightly updates fall back to full package downloads; Release differential updates are unchanged.
 
-The app waits 30 seconds before its first automatic check to avoid competing with startup, then checks every four hours. Automatic current/error results are quiet. Manual checks report current/download states. A downloaded update offers **Restart and Update** / Later, is not silently installed on ordinary quit, and cannot restart until every document accepts and commits close.
+The app waits 30 seconds before its first automatic check to avoid competing with startup, then checks every four hours. Automatic current/error results are quiet. A native-framed update window asks for consent before downloading, then replaces those choices with byte and percentage progress that can be canceled. Download completion replaces progress with **Restart and Install** / Later, is not silently installed on ordinary quit, and cannot restart until every document accepts and commits close.
 
 ## Workflows
 
@@ -60,11 +60,11 @@ The Release Please workflow mints a short-lived token from the repository-scoped
 
 ## GitHub configuration
 
-| Variable                       | Purpose                                                   |
-| ------------------------------ | --------------------------------------------------------- |
-| `RELEASE_PLEASE_APP_CLIENT_ID` | Public client ID for the Release Please App               |
-| `CLOUDFLARE_ACCOUNT_ID`        | Cloudflare account containing the release bucket          |
-| `R2_RELEASE_BUCKET`            | R2 bucket name; production uses `shift-releases`          |
+| Variable                       | Purpose                                                    |
+| ------------------------------ | ---------------------------------------------------------- |
+| `RELEASE_PLEASE_APP_CLIENT_ID` | Public client ID for the Release Please App                |
+| `CLOUDFLARE_ACCOUNT_ID`        | Cloudflare account containing the release bucket           |
+| `R2_RELEASE_BUCKET`            | R2 bucket name; production uses `shift-releases`           |
 | `R2_RELEASE_BASE_URL`          | HTTPS custom-domain base URL exposing the public R2 bucket |
 
 | Secret                           | Purpose                                                  |
@@ -76,7 +76,7 @@ The Release Please workflow mints a short-lived token from the repository-scoped
 | `APPLE_APP_SPECIFIC_PASSWORD`    | Apple ID app-specific password                           |
 | `APPLE_TEAM_ID`                  | Paid Apple Developer Program team ID                     |
 | `R2_ACCESS_KEY_ID`               | R2 S3 API access key with object read/write permission   |
-| `R2_SECRET_ACCESS_KEY`           | R2 S3 API secret access key                               |
+| `R2_SECRET_ACCESS_KEY`           | R2 S3 API secret access key                              |
 
 Never put private keys or signing credentials in repository files, workflow inputs, artifacts, or logs. macOS release and Nightly jobs fail when signing credentials are absent.
 
@@ -88,7 +88,7 @@ Never put private keys or signing credentials in repository files, workflow inpu
 4. Run a desktop workflow once to create `update-feeds`.
 5. Configure GitHub Pages to publish the root of `update-feeds`.
 6. Confirm packaged Release and Nightly builds contact only their matching feed paths, and that Nightly metadata references the expected full commit in R2.
-7. Perform real installed N → N+1 tests on macOS arm64/x64 and unsigned Windows Nightly x64, including full-download fallback, Save, Don't Save, Cancel, Later, and **Restart and Update**.
+7. Perform real installed N → N+1 tests on macOS arm64/x64 and unsigned Windows Nightly x64, including download consent, full-download fallback, progress, download cancellation and retry, Save, Don't Save, Later, and **Restart and Install**.
 8. Keep Windows Release on manual downloads until Authenticode signing and installed update verification are complete.
 
 Electron update orchestration has no worthwhile unit test without mocking Electron, native dialogs, and electron-updater. Pure tests cover feed selection, canonical versions, generated metadata validation, feed preparation, and Nightly asset partitioning; installed update behavior and retention pruning remain required manual QA.

--- a/packages/ui/docs/DOCS.md
+++ b/packages/ui/docs/DOCS.md
@@ -30,6 +30,7 @@ packages/ui/
       menu/                -- Menu trigger, portal, positioner, popup, item, and separator
       number-field/        -- Numeric root, input, step controls, and scrub area
       popover/             -- Popover trigger, portal, positioner, popup, title, and close
+      progress/            -- Progress root with styled track and indicator
       resizable/           -- ResizablePanelGroup, ResizablePanel, ResizableHandle over react-resizable-panels
       select/              -- Select trigger, popup, list, item, and indicator primitives
       separator/           -- Separator (horizontal/vertical)
@@ -48,6 +49,7 @@ packages/ui/
 - **Form control props** -- `CheckboxProps`, `FieldProps`, `NumberFieldProps`, `SelectProps`, and `TextareaProps` preserve their Base UI or native control contracts while adding Shift styling.
 - **`TabsProps`** and tab-part props -- expose the Base UI Tabs composition so consumers can choose their own panel layout while retaining shared interaction and focus behavior.
 - **`SeparatorProps`** -- adds `orientation` (`"horizontal" | "vertical"`) to the Base UI separator.
+- **`ProgressProps`** -- extends Base UI Progress root props with track and indicator class overrides.
 - **`DialogProps`** / **`DialogBackdropProps`** / **`DialogPopupProps`** / **`DialogTitleProps`** -- thin wrappers over Base UI Dialog sub-component props.
 - **`CollapsibleProps`** / **`CollapsibleTriggerProps`** / **`CollapsiblePanelProps`** -- thin wrappers over Base UI Collapsible sub-component props.
 - **`ToastProviderProps`** -- `children` and `timeout` (default 2000ms).
@@ -61,7 +63,7 @@ Each component follows the same pattern: import the Base UI primitive, wrap it i
 
 **Input** adds label and icon positioning logic (left/right for each) on top of the Base UI input, adjusting padding classes dynamically.
 
-**Field**, **Checkbox**, **NumberField**, **Select**, **Tabs**, and **Textarea** are composable primitive families for settings and inspector forms. Validation and application state remain in the consumer; these wrappers only provide accessible structure, behavior, and Shift styling. `Textarea` renders a native textarea through Base UI Field's `Control` slot so it participates in the same label, validation, and disabled-state contract. `Slider` forwards its `aria-label` to Base UI's interactive thumb rather than leaving the accessible name on the non-interactive root.
+**Field**, **Checkbox**, **NumberField**, **Select**, **Tabs**, and **Textarea** are composable primitive families for settings and inspector forms. Validation and application state remain in the consumer; these wrappers only provide accessible structure, behavior, and Shift styling. `Textarea` renders a native textarea through Base UI Field's `Control` slot so it participates in the same label, validation, and disabled-state contract. `Slider` forwards its `aria-label` to Base UI's interactive thumb rather than leaving the accessible name on the non-interactive root. `Progress` composes Base UI's root, track, and indicator while allowing a consumer to override each visual layer.
 
 **Toast** is the most complex component family. `ToastProvider` wraps Base UI's provider with a default 2-second timeout. `ToastViewport` renders through a portal, centered at the top of the viewport. Individual toasts use enter/exit opacity transitions. Consumers call `useToastManager` (re-exported directly from Base UI) to imperatively add toasts.
 

--- a/packages/ui/src/components/progress/Progress.tsx
+++ b/packages/ui/src/components/progress/Progress.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+import { Progress as BaseProgress } from "@base-ui-components/react/progress";
+import { cn } from "../../lib/utils";
+
+export type ProgressProps = React.ComponentPropsWithoutRef<typeof BaseProgress.Root> & {
+  trackClassName?: string;
+  indicatorClassName?: string;
+};
+
+export const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
+  ({ className, trackClassName, indicatorClassName, ...props }, ref) => (
+    <BaseProgress.Root ref={ref} className={cn("w-full", className)} {...props}>
+      <BaseProgress.Track
+        className={cn("relative h-2 w-full overflow-hidden rounded-full bg-canvas", trackClassName)}
+      >
+        <BaseProgress.Indicator
+          className={cn("h-full rounded-full bg-accent transition-[width]", indicatorClassName)}
+        />
+      </BaseProgress.Track>
+    </BaseProgress.Root>
+  ),
+);
+
+Progress.displayName = "Progress";

--- a/packages/ui/src/components/progress/index.ts
+++ b/packages/ui/src/components/progress/index.ts
@@ -1,0 +1,1 @@
+export { Progress, type ProgressProps } from "./Progress";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -68,6 +68,7 @@ export {
   type SelectItemIndicatorProps,
 } from "./components/select";
 export { Slider, type SliderProps } from "./components/slider";
+export { Progress, type ProgressProps } from "./components/progress";
 export {
   Menu,
   MenuTrigger,


### PR DESCRIPTION
## Summary

- ask for consent before downloading an available application update
- present available, downloading, and ready states in one native-framed update window
- show cumulative byte and percentage progress with safe cancellation and retry behavior
- keep updater transitions in main while exposing typed actions and events to the renderer
- add a shared Base UI Progress wrapper for accessible progress presentation

## Issue

Closes #276

## Testing

- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm format:check`
- `pnpm test:desktop src/main/update/updateFeed.test.ts`
- `pnpm --filter @shift/desktop build`
- pre-commit hooks, including full Vitest, tsgo, Oxlint, and dead-code checks
- manually rendered available, downloading, and ready views in Electron and injected progress/completion events
- `python3 scripts/context-drift-check.py` reports 9 pre-existing review-date warnings in unrelated documentation
- not run: installed N → N+1 updater verification; requires real published candidate artifacts
