### PR TITLE
fix(desktop): compact the update window

### DIFF
--- a/apps/desktop/src/main/update/UpdateWindow.ts
+++ b/apps/desktop/src/main/update/UpdateWindow.ts
@@ -103,8 +103,8 @@ export class UpdateWindow {
     }
 
     const window = new BrowserWindow({
-      width: 640,
-      height: 390,
+      width: 480,
+      height: 360,
       title: `Updating ${app.name}`,
       show: false,
       resizable: false,


### PR DESCRIPTION
## Summary

- reduce the update window from 640 × 390 to a compact 480 × 360 layout
- preserve readable progress text and all available, downloading, and ready controls

## Issue

Refs #276

## Testing

- pre-commit hooks: Oxfmt, Oxlint, tsgo, dead-code checks, and full Vitest
- `pnpm --filter @shift/desktop build`
- manually previewed available, downloading, and ready states at 480 × 360
