### PR TITLE
fix(desktop): maximize documents opened from Finder

### DIFF
--- a/apps/desktop/e2e/document-lifecycle.spec.ts
+++ b/apps/desktop/e2e/document-lifecycle.spec.ts
@@ -2,7 +2,7 @@ import { execFile } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { promisify } from "node:util";
-import type { ElectronApplication, Page } from "@playwright/test";
+import { _electron as electron, type ElectronApplication, type Page } from "@playwright/test";
 import { createBridge } from "@shift/bridge";
 import {
   DESIGNSPACE_FONT_PATH,
@@ -134,6 +134,22 @@ function sourceTreeSnapshot(rootPath: string): [string, string][] {
   return snapshot;
 }
 
+test("opens a startup document in a maximized window", async ({ testRoot }) => {
+  const documentPath = createSecondDocument(testRoot);
+  const electronApp = await launchStartupDocument(testRoot, documentPath);
+
+  try {
+    const page = await electronApp.firstWindow();
+    await waitForWorkspaceReady(page);
+    const browserWindow = await electronApp.browserWindow(page);
+
+    await expect.poll(() => browserWindow.evaluate((window) => window.isMaximized())).toBe(true);
+    await browserWindow.dispose();
+  } finally {
+    await killApp(electronApp);
+  }
+});
+
 workspaceTest(
   "opens a document sent to the running application",
   async ({ electronApp, testRoot }) => {
@@ -151,6 +167,25 @@ function createSecondDocument(testRoot: string): string {
   const secondPath = path.join(testRoot, "second.shift");
   fs.renameSync(generatedPath, secondPath);
   return secondPath;
+}
+
+async function launchStartupDocument(
+  testRoot: string,
+  documentPath: string,
+): Promise<ElectronApplication> {
+  return electron.launch({
+    args: [
+      MAIN_JS,
+      `--user-data-dir=${path.join(testRoot, "startup-user-data")}`,
+      "--force-device-scale-factor=1",
+      documentPath,
+    ],
+    env: {
+      ...process.env,
+      NODE_ENV: "test",
+      LIBGL_ALWAYS_SOFTWARE: "1",
+    },
+  });
 }
 
 async function launchSecondInstance(

--- a/apps/desktop/e2e/fixtures/electronApp.ts
+++ b/apps/desktop/e2e/fixtures/electronApp.ts
@@ -1,6 +1,7 @@
 import {
   test as base,
   _electron as electron,
+  expect,
   type Page,
   type ElectronApplication,
 } from "@playwright/test";
@@ -216,6 +217,14 @@ export const test = base.extend<ShiftFixtures & ShiftOptions>({
         throw new Error(`Electron ignored isolated user data directory: ${activeUserDataDir}`);
       }
       const browserWindow = await app.browserWindow(page);
+      if (workspacePath) {
+        await expect
+          .poll(() => browserWindow.evaluate((window) => window.isMaximized()), {
+            timeout: 20_000,
+          })
+          .toBe(true);
+      }
+
       await browserWindow.evaluate(
         (win, { w, h }) => {
           win.unmaximize();

--- a/apps/desktop/src/main/app/App.ts
+++ b/apps/desktop/src/main/app/App.ts
@@ -202,10 +202,11 @@ export class App {
     });
   }
 
-  #createWindow(autoShow = true, bounds?: Rectangle): Window {
+  #createWindow(autoShow = true, bounds?: Rectangle, maximised = false): Window {
     const window = new Window({
       preloadPath: path.join(__dirname, "preload.js"),
       autoShow,
+      maximised,
       ...(bounds
         ? {
             width: bounds.width,
@@ -498,7 +499,7 @@ export class App {
           continue;
         }
 
-        const window = this.#createWindow(false);
+        const window = this.#createWindow(false, undefined, true);
         this.#workspaces.attachWindow(session.workspaceId, window);
         this.#loadWorkspace(window);
       } catch (error) {

--- a/apps/desktop/src/main/app/App.ts
+++ b/apps/desktop/src/main/app/App.ts
@@ -347,7 +347,7 @@ export class App {
       this.#applicationMenu.updateCommandStates();
       if (browserWindow.isVisible() || browserWindow.isMinimized()) return;
 
-      window.focus();
+      window.present();
     });
   }
 

--- a/apps/desktop/src/main/windows/Window.ts
+++ b/apps/desktop/src/main/windows/Window.ts
@@ -47,11 +47,11 @@ const BROWSER_WINDOW_DEFAULT_OPTIONS: BrowserWindowConstructorOptions = {
 
 export class Window {
   #window: BrowserWindow;
-  #maximiseOnFirstFocus: boolean;
+  #maximiseOnPresent: boolean;
 
   constructor(options: WindowOptions) {
     const windowOptions = { ...WINDOW_DEFAULT_OPTIONS, ...options };
-    this.#maximiseOnFirstFocus = windowOptions.maximised ?? false;
+    this.#maximiseOnPresent = windowOptions.maximised ?? false;
     const browserWindowOptions = {
       ...BROWSER_WINDOW_DEFAULT_OPTIONS,
       ...windowOptions.browserWindowOptions,
@@ -73,7 +73,7 @@ export class Window {
 
     if (windowOptions.autoShow) {
       this.#window.once("ready-to-show", () => {
-        this.#window.show();
+        this.present();
       });
     }
   }
@@ -86,18 +86,23 @@ export class Window {
     this.#window.close();
   }
 
+  present(): void {
+    this.#window.show();
+
+    if (this.#maximiseOnPresent) {
+      this.#maximiseOnPresent = false;
+      this.#window.maximize();
+    }
+
+    this.#window.focus();
+  }
+
   focus(): void {
     if (this.#window.isMinimized()) {
       this.#window.restore();
     }
 
     this.#window.show();
-
-    if (this.#maximiseOnFirstFocus) {
-      this.#maximiseOnFirstFocus = false;
-      this.#window.maximize();
-    }
-
     this.#window.focus();
   }
 

--- a/apps/desktop/src/main/windows/Window.ts
+++ b/apps/desktop/src/main/windows/Window.ts
@@ -47,9 +47,11 @@ const BROWSER_WINDOW_DEFAULT_OPTIONS: BrowserWindowConstructorOptions = {
 
 export class Window {
   #window: BrowserWindow;
+  #maximiseOnFirstFocus: boolean;
 
   constructor(options: WindowOptions) {
     const windowOptions = { ...WINDOW_DEFAULT_OPTIONS, ...options };
+    this.#maximiseOnFirstFocus = windowOptions.maximised ?? false;
     const browserWindowOptions = {
       ...BROWSER_WINDOW_DEFAULT_OPTIONS,
       ...windowOptions.browserWindowOptions,
@@ -74,10 +76,6 @@ export class Window {
         this.#window.show();
       });
     }
-
-    if (windowOptions.maximised) {
-      this.#window.maximize();
-    }
   }
 
   get window(): BrowserWindow {
@@ -94,6 +92,12 @@ export class Window {
     }
 
     this.#window.show();
+
+    if (this.#maximiseOnFirstFocus) {
+      this.#maximiseOnFirstFocus = false;
+      this.#window.maximize();
+    }
+
     this.#window.focus();
   }
 


### PR DESCRIPTION
## Summary

- maximize a workspace created by cold external `.shift` document activation
- preserve the existing running-application paths for focusing or creating document windows
- cover native startup window state through Electron E2E

## Issue

Closes #280

## Testing

- Passed: `pnpm typecheck`
- Passed: `pnpm lint:check`
- Passed: `pnpm format:check`
- Passed: `pnpm --filter @shift/desktop exec playwright test --project=visual e2e/document-lifecycle.spec.ts --grep "opens a startup document in a maximized window"`
- Full lifecycle run: 23 passed, then 3 Export tests timed out acquiring native window focus; all 3 passed together on immediate focused rerun with `--grep "Export"`
