### PR TITLE
docs: add Windows code signing policy

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -334,7 +334,7 @@ jobs:
           > [!WARNING]
           > **Experimental Nightly:** Work on copies and keep independent backups. This build may contain bugs, crashes, data loss, or security vulnerabilities.
 
-          Built from [\`$SHORT_SHA\`]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commit/$GITHUB_SHA) after every platform completed packaging and its packaged-app smoke test. macOS builds are signed and notarized; Windows and Linux builds are currently unsigned.
+          Built from [\`$SHORT_SHA\`]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commit/$GITHUB_SHA) after every platform completed packaging and its packaged-app smoke test. macOS builds are signed and notarized; Windows and Linux builds are currently unsigned. See the [code signing policy](https://github.com/shift-editor/shift/blob/main/CODE_SIGNING_POLICY.md).
 
           This rolling prerelease is replaced only by a later complete Nightly build.
           EOF

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -249,7 +249,7 @@ jobs:
           generated = marker.sub("", Path("generated-notes.md").read_text()).lstrip()
           notice = """<!-- shift-preview-notice:start -->
           > [!WARNING]
-          > **Developer Preview:** Work on copies and keep independent backups. The macOS builds are signed and notarized. Windows builds are currently unsigned and may trigger Microsoft SmartScreen. Linux packages are unsigned.
+          > **Developer Preview:** Work on copies and keep independent backups. The macOS builds are signed and notarized. Windows builds are currently unsigned and may trigger Microsoft SmartScreen. Linux packages are unsigned. See the [code signing policy](https://github.com/shift-editor/shift/blob/main/CODE_SIGNING_POLICY.md).
           <!-- shift-preview-notice:end -->
 
           """

--- a/CODE_SIGNING_POLICY.md
+++ b/CODE_SIGNING_POLICY.md
@@ -1,0 +1,50 @@
+# Code signing policy
+
+## Current status
+
+Shift's Windows artifacts are currently unsigned. This policy defines the controls that will apply to versioned Windows releases after the project is accepted for SignPath Foundation's open-source code-signing service. Nightly builds remain outside the initial signing scope.
+
+For releases signed under this policy: Free code signing provided by [SignPath.io](https://about.signpath.io), certificate by [SignPath Foundation](https://signpath.org).
+
+## Signing scope
+
+The signing scope is limited to Shift's versioned Windows release artifacts:
+
+- the Shift application executable built from this repository; and
+- the per-user NSIS installer containing that executable.
+
+Signed files must identify the product as `Shift` and use the numeric version from the corresponding `vMAJOR.MINOR.PATCH` Git tag. Shift does not submit unrelated software, locally produced binaries, or Nightly artifacts for signing under this policy.
+
+## Source and build integrity
+
+Signed artifacts must:
+
+1. originate from the public [`shift-editor/shift`](https://github.com/shift-editor/shift) repository;
+2. be built by the repository's versioned release workflow on GitHub-hosted runners;
+3. correspond to the exact immutable release tag being published;
+4. pass the repository's required tests and packaged-application smoke test; and
+5. be manually approved for signing before publication.
+
+The SignPath GitHub integration verifies the workflow origin of submitted artifacts. Signing credentials are restricted to the release workflow and are never stored in source files, workflow artifacts, release assets, or logs.
+
+## Team roles
+
+The project currently has one maintainer, so the required roles are held by the same person:
+
+- **Committer:** [Kostya Farber](https://github.com/kostyafarber)
+- **Reviewer:** [Kostya Farber](https://github.com/kostyafarber)
+- **Signing approver:** [Kostya Farber](https://github.com/kostyafarber)
+
+Changes proposed by people without commit access require review by a committer. Changes to build workflows, release configuration, dependencies, or this policy receive the same review as application source changes. Every signing request requires an explicit decision by the signing approver.
+
+## Privacy and network access
+
+Shift does not include analytics, advertising, account services, cloud document storage, or usage telemetry. Font and Shift document contents remain on the user's computer unless the user exports or copies them through an explicit operating-system action.
+
+Eligible packaged builds automatically request release metadata from Shift's HTTPS update feed shortly after startup and periodically while the application remains open. If an update is available, Shift downloads the package from the project's GitHub Releases or Cloudflare R2 distribution only after the user consents. These services receive the network information ordinarily exposed by an HTTPS request, such as the source IP address and user agent; Shift does not add font, document, or usage data to the request.
+
+User-initiated actions may open the Shift release page in the default browser. No other project-operated network transfer is part of normal editor use.
+
+## Reporting concerns
+
+Report suspected signing-policy violations or compromised release artifacts privately to [Kostya Farber](mailto:kostya.farber@gmail.com). Report ordinary release problems through the [public issue tracker](https://github.com/shift-editor/shift/issues).

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ See [crates/shift-cli/README.md](crates/shift-cli/README.md) for the supported v
 
 See [ROADMAP.md](ROADMAP.md) for current implementation status and planned features. We are planning to ship a production grade font editor.
 
+## Security and signing
+
+Windows releases are currently unsigned while Shift applies for open-source code signing. See the [code signing policy](CODE_SIGNING_POLICY.md) for the signing scope, release controls, team roles, and network/privacy disclosures.
+
+Security vulnerabilities can be reported privately to [Kostya Farber](mailto:kostya.farber@gmail.com).
+
 ## Community
 
 Join our [Discord server](https://discord.gg/582FxBdNH7) to ask questions, report bugs, or contribute!


### PR DESCRIPTION
## Summary

- define the Windows release signing scope, provenance controls, team roles, and network/privacy disclosures required for a SignPath Foundation application
- link the policy from the repository homepage and generated Release/Nightly notices while clearly retaining the current unsigned status

## Issue

No issue — small policy prerequisite for an external open-source signing application.

## Testing

- `node --test scripts/*.test.mjs`
- `python3 scripts/context-drift-check.py --ci` (passed with 12 pre-existing documentation freshness warnings)
- `git diff --check`
- Packaging not rerun; this change does not enable signing or alter packaged artifacts.
