### PR TITLE
fix(desktop): keep the update window white

### DIFF
--- a/apps/desktop/src/main/update/UpdateWindow.ts
+++ b/apps/desktop/src/main/update/UpdateWindow.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, nativeTheme } from "electron";
+import { app, BrowserWindow } from "electron";
 import type { ShiftLogger } from "../logging";
 import { getRendererSource } from "../utils";
 import * as ipc from "../../shared/ipc/main";
@@ -110,7 +110,7 @@ export class UpdateWindow {
       resizable: false,
       maximizable: false,
       fullscreenable: false,
-      backgroundColor: nativeTheme.shouldUseDarkColors ? "#242424" : "#ececec",
+      backgroundColor: "#ffffff",
       ...(process.platform === "darwin" ? { titleBarStyle: "hiddenInset" as const } : {}),
       webPreferences: {
         preload: this.#preloadPath,

--- a/apps/desktop/src/renderer/src/views/UpdateScreen.css
+++ b/apps/desktop/src/renderer/src/views/UpdateScreen.css
@@ -1,5 +1,5 @@
 .update-window {
-  --update-background: #ececec;
+  --update-background: #ffffff;
   --update-text: #202020;
   --update-secondary-text: #626262;
   --update-track: #d2d2d2;
@@ -87,15 +87,4 @@
 
 .update-window-button:hover {
   background: var(--update-button-hover);
-}
-
-@media (prefers-color-scheme: dark) {
-  .update-window {
-    --update-background: #242424;
-    --update-text: #e6e6e6;
-    --update-secondary-text: #aaa;
-    --update-track: #3d3d3d;
-    --update-button: #3a3a3a;
-    --update-button-hover: #464646;
-  }
 }


### PR DESCRIPTION
## Summary

- keep the update window white instead of following the system dark appearance
- align the native loading background and rendered window background to avoid a dark flash

## Issue

No issue — small visual correction to updater window styling.

## Testing

- pre-commit hooks: Oxfmt, Oxlint, tsgo, dead-code checks, and full Vitest
- `pnpm lint:check -- apps/desktop/src/main/update/UpdateWindow.ts apps/desktop/src/renderer/src/views/UpdateScreen.css`
- not manually verified in a packaged updater window
