### PR TITLE
feat: add trusted Linux package channels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
               - 'apps/desktop/vite.preload.config.ts'
               - 'scripts/find-retired-nightly-objects.mjs'
               - 'scripts/find-retired-nightly-objects.test.mjs'
+              - 'scripts/prepare-linux-repositories.mjs'
+              - 'scripts/prepare-linux-repositories.test.mjs'
               - 'scripts/prepare-nightly-release.mjs'
               - 'scripts/prepare-nightly-release.test.mjs'
               - 'scripts/prepare-update-feed.mjs'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -113,7 +113,7 @@ jobs:
             runner: ubuntu-latest
             platform: linux
             arch: x64
-            builder-args: "--linux deb rpm --x64"
+            builder-args: "--linux deb rpm AppImage --x64"
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -230,6 +230,7 @@ jobs:
             apps/desktop/out/${{ matrix.platform }}-${{ matrix.arch }}/*.blockmap
             apps/desktop/out/${{ matrix.platform }}-${{ matrix.arch }}/*.deb
             apps/desktop/out/${{ matrix.platform }}-${{ matrix.arch }}/*.rpm
+            apps/desktop/out/${{ matrix.platform }}-${{ matrix.arch }}/*.AppImage
             apps/desktop/out/${{ matrix.platform }}-${{ matrix.arch }}/latest*.yml
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -269,7 +269,9 @@ jobs:
           trap 'rm -f "$PASSPHRASE_FILE"' EXIT
           install -m 600 /dev/null "$PASSPHRASE_FILE"
           printf '%s' "$LINUX_REPOSITORY_GPG_PASSPHRASE" > "$PASSPHRASE_FILE"
+          GPG_BIN="$(command -v gpg)"
           rpmsign --addsign \
+            --define "__gpg $GPG_BIN" \
             --define "_gpg_name $FINGERPRINT" \
             --define "_openpgp_sign_id $FINGERPRINT" \
             --define "_gpg_path $GNUPGHOME" \
@@ -277,10 +279,12 @@ jobs:
             "${RPMS[0]}"
 
           gpg --batch --export "$FINGERPRINT" > shift-repository.gpg
+          RPM_PUBLIC_KEY="$RUNNER_TEMP/shift-repository-rpm.asc"
+          gpg --batch --armor --export "$FINGERPRINT" > "$RPM_PUBLIC_KEY"
           RPM_DB="$RUNNER_TEMP/linux-signing-rpmdb"
           install -d "$RPM_DB"
           rpm --dbpath "$RPM_DB" --initdb
-          rpmkeys --dbpath "$RPM_DB" --import shift-repository.gpg
+          rpmkeys --dbpath "$RPM_DB" --import "$RPM_PUBLIC_KEY"
           rpmkeys --dbpath "$RPM_DB" --checksig "${RPMS[0]}"
 
       - name: Add Developer Preview notice
@@ -430,10 +434,12 @@ jobs:
           }
           cmp dist/shift-repository.gpg <(gpg --batch --export "$FINGERPRINT")
 
+          RPM_PUBLIC_KEY="$RUNNER_TEMP/shift-repository-rpm.asc"
+          gpg --batch --armor --export "$FINGERPRINT" > "$RPM_PUBLIC_KEY"
           RPM_DB="$RUNNER_TEMP/linux-repository-rpmdb"
           install -d "$RPM_DB"
           rpm --dbpath "$RPM_DB" --initdb
-          rpmkeys --dbpath "$RPM_DB" --import dist/shift-repository.gpg
+          rpmkeys --dbpath "$RPM_DB" --import "$RPM_PUBLIC_KEY"
           rpmkeys --dbpath "$RPM_DB" --checksig "dist/Shift-${{ needs.prepare.outputs.version }}-Linux-x64.rpm"
 
       - name: Build and sign repository metadata

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -78,7 +78,7 @@ jobs:
             runner: ubuntu-latest
             platform: linux
             arch: x64
-            builder-args: "--linux deb rpm --x64"
+            builder-args: "--linux deb rpm AppImage --x64"
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -196,6 +196,7 @@ jobs:
             apps/desktop/out/${{ matrix.platform }}-${{ matrix.arch }}/*.blockmap
             apps/desktop/out/${{ matrix.platform }}-${{ matrix.arch }}/*.deb
             apps/desktop/out/${{ matrix.platform }}-${{ matrix.arch }}/*.rpm
+            apps/desktop/out/${{ matrix.platform }}-${{ matrix.arch }}/*.AppImage
             apps/desktop/out/${{ matrix.platform }}-${{ matrix.arch }}/latest*.yml
           if-no-files-found: error
           retention-days: 14
@@ -232,6 +233,56 @@ jobs:
             exit 1
           fi
 
+      - name: Install Linux signing tools
+        run: sudo apt-get update && sudo apt-get install --yes gnupg rpm
+
+      - name: Sign Linux release artifacts
+        shell: bash
+        env:
+          LINUX_REPOSITORY_GPG_FINGERPRINT: ${{ vars.LINUX_REPOSITORY_GPG_FINGERPRINT }}
+          LINUX_REPOSITORY_GPG_PASSPHRASE: ${{ secrets.LINUX_REPOSITORY_GPG_PASSPHRASE }}
+          LINUX_REPOSITORY_GPG_PRIVATE_KEY: ${{ secrets.LINUX_REPOSITORY_GPG_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          : "${LINUX_REPOSITORY_GPG_FINGERPRINT:?LINUX_REPOSITORY_GPG_FINGERPRINT is required}"
+          : "${LINUX_REPOSITORY_GPG_PASSPHRASE:?LINUX_REPOSITORY_GPG_PASSPHRASE is required}"
+          : "${LINUX_REPOSITORY_GPG_PRIVATE_KEY:?LINUX_REPOSITORY_GPG_PRIVATE_KEY is required}"
+          export GNUPGHOME="$RUNNER_TEMP/linux-signing-gnupg"
+          install -d -m 700 "$GNUPGHOME"
+          printf '%s' "$LINUX_REPOSITORY_GPG_PRIVATE_KEY" | gpg --batch --import
+
+          FINGERPRINT="${LINUX_REPOSITORY_GPG_FINGERPRINT//[[:space:]]/}"
+          ACTUAL_FINGERPRINT="$(gpg --batch --with-colons --fingerprint "$FINGERPRINT" \
+            | awk -F: '$1 == "fpr" { print $10; exit }')"
+          [[ "$ACTUAL_FINGERPRINT" == "$FINGERPRINT" ]] || {
+            echo "Imported Linux signing key does not match the configured fingerprint" >&2
+            exit 1
+          }
+          gpg --batch --list-secret-keys "$FINGERPRINT" >/dev/null
+
+          mapfile -d '' RPMS < <(find dist -type f -name 'Shift-*-Linux-x64.rpm' -print0)
+          [[ "${#RPMS[@]}" == 1 ]] || {
+            echo "Expected one Linux RPM, found ${#RPMS[@]}" >&2
+            exit 1
+          }
+          PASSPHRASE_FILE="$RUNNER_TEMP/linux-signing-passphrase"
+          trap 'rm -f "$PASSPHRASE_FILE"' EXIT
+          install -m 600 /dev/null "$PASSPHRASE_FILE"
+          printf '%s' "$LINUX_REPOSITORY_GPG_PASSPHRASE" > "$PASSPHRASE_FILE"
+          rpmsign --addsign \
+            --define "_gpg_name $FINGERPRINT" \
+            --define "_openpgp_sign_id $FINGERPRINT" \
+            --define "_gpg_path $GNUPGHOME" \
+            --define "_gpg_sign_cmd_extra_args --batch --pinentry-mode loopback --passphrase-file $PASSPHRASE_FILE" \
+            "${RPMS[0]}"
+
+          gpg --batch --export "$FINGERPRINT" > shift-repository.gpg
+          RPM_DB="$RUNNER_TEMP/linux-signing-rpmdb"
+          install -d "$RPM_DB"
+          rpm --dbpath "$RPM_DB" --initdb
+          rpmkeys --dbpath "$RPM_DB" --import shift-repository.gpg
+          rpmkeys --dbpath "$RPM_DB" --checksig "${RPMS[0]}"
+
       - name: Add Developer Preview notice
         env:
           GH_TOKEN: ${{ github.token }}
@@ -249,7 +300,7 @@ jobs:
           generated = marker.sub("", Path("generated-notes.md").read_text()).lstrip()
           notice = """<!-- shift-preview-notice:start -->
           > [!WARNING]
-          > **Developer Preview:** Work on copies and keep independent backups. The macOS builds are signed and notarized. Windows builds are currently unsigned and may trigger Microsoft SmartScreen. Linux packages are unsigned. See the [code signing policy](https://github.com/shift-editor/shift/blob/main/CODE_SIGNING_POLICY.md).
+          > **Developer Preview:** Work on copies and keep independent backups. The macOS builds are signed and notarized. Windows builds are currently unsigned and may trigger Microsoft SmartScreen. Linux RPMs and the checksum manifest are signed with the Shift repository key. See the [code signing policy](https://github.com/shift-editor/shift/blob/main/CODE_SIGNING_POLICY.md).
           <!-- shift-preview-notice:end -->
 
           """
@@ -257,9 +308,14 @@ jobs:
           PY
           gh release edit "$RELEASE_TAG" --notes-file release-notes.md
 
-      - name: Generate checksums
+      - name: Generate and sign checksums
         shell: bash
+        env:
+          LINUX_REPOSITORY_GPG_FINGERPRINT: ${{ vars.LINUX_REPOSITORY_GPG_FINGERPRINT }}
+          LINUX_REPOSITORY_GPG_PASSPHRASE: ${{ secrets.LINUX_REPOSITORY_GPG_PASSPHRASE }}
         run: |
+          set -euo pipefail
+          export GNUPGHOME="$RUNNER_TEMP/linux-signing-gnupg"
           mapfile -d '' FILES < <(find dist -type f ! -name 'latest*.yml' -print0 | sort -z)
           DUPLICATES="$(printf '%s\0' "${FILES[@]}" | xargs -0 -n1 basename | sort | uniq --repeated)"
           if [[ -n "$DUPLICATES" ]]; then
@@ -275,6 +331,19 @@ jobs:
           done
           cat SHA256SUMS
 
+          FINGERPRINT="${LINUX_REPOSITORY_GPG_FINGERPRINT//[[:space:]]/}"
+          printf '%s' "$LINUX_REPOSITORY_GPG_PASSPHRASE" | gpg \
+            --batch \
+            --yes \
+            --pinentry-mode loopback \
+            --passphrase-fd 0 \
+            --local-user "$FINGERPRINT" \
+            --armor \
+            --detach-sign \
+            --output SHA256SUMS.asc \
+            SHA256SUMS
+          gpg --batch --verify SHA256SUMS.asc SHA256SUMS
+
       - name: Upload files to GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -284,13 +353,349 @@ jobs:
           while IFS= read -r -d '' file; do
             gh release upload "$RELEASE_TAG" "$file" --clobber
           done < <(find dist -type f ! -name 'latest*.yml' -print0)
-          gh release upload "$RELEASE_TAG" SHA256SUMS --clobber
+          gh release upload \
+            "$RELEASE_TAG" \
+            SHA256SUMS \
+            SHA256SUMS.asc \
+            shift-repository.gpg \
+            --clobber
 
       - name: Publish GitHub prerelease
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
         run: gh release edit "$RELEASE_TAG" --draft=false --prerelease
+
+  linux-repositories:
+    name: Publish Linux repositories
+    needs:
+      - prepare
+      - publish
+    runs-on: ubuntu-latest
+    concurrency:
+      group: linux-repository-publication
+      cancel-in-progress: false
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
+          fetch-depth: 1
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      - name: Install repository tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes apt-utils createrepo-c gnupg rpm
+
+      - name: Download signed Linux release artifacts
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir dist
+          gh release download "$RELEASE_TAG" \
+            --dir dist \
+            --pattern "Shift-${RELEASE_VERSION}-Linux-x64.deb" \
+            --pattern "Shift-${RELEASE_VERSION}-Linux-x64.rpm" \
+            --pattern "Shift-${RELEASE_VERSION}-Linux-x64.AppImage" \
+            --pattern shift-repository.gpg
+
+      - name: Import and verify repository signing key
+        shell: bash
+        env:
+          LINUX_REPOSITORY_GPG_FINGERPRINT: ${{ vars.LINUX_REPOSITORY_GPG_FINGERPRINT }}
+          LINUX_REPOSITORY_GPG_PRIVATE_KEY: ${{ secrets.LINUX_REPOSITORY_GPG_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          : "${LINUX_REPOSITORY_GPG_FINGERPRINT:?LINUX_REPOSITORY_GPG_FINGERPRINT is required}"
+          : "${LINUX_REPOSITORY_GPG_PRIVATE_KEY:?LINUX_REPOSITORY_GPG_PRIVATE_KEY is required}"
+          export GNUPGHOME="$RUNNER_TEMP/linux-repository-gnupg"
+          install -d -m 700 "$GNUPGHOME"
+          printf '%s' "$LINUX_REPOSITORY_GPG_PRIVATE_KEY" | gpg --batch --import
+
+          FINGERPRINT="${LINUX_REPOSITORY_GPG_FINGERPRINT//[[:space:]]/}"
+          ACTUAL_FINGERPRINT="$(gpg --batch --with-colons --fingerprint "$FINGERPRINT" \
+            | awk -F: '$1 == "fpr" { print $10; exit }')"
+          [[ "$ACTUAL_FINGERPRINT" == "$FINGERPRINT" ]] || {
+            echo "Imported Linux signing key does not match the configured fingerprint" >&2
+            exit 1
+          }
+          cmp dist/shift-repository.gpg <(gpg --batch --export "$FINGERPRINT")
+
+          RPM_DB="$RUNNER_TEMP/linux-repository-rpmdb"
+          install -d "$RPM_DB"
+          rpm --dbpath "$RPM_DB" --initdb
+          rpmkeys --dbpath "$RPM_DB" --import dist/shift-repository.gpg
+          rpmkeys --dbpath "$RPM_DB" --checksig "dist/Shift-${{ needs.prepare.outputs.version }}-Linux-x64.rpm"
+
+      - name: Build and sign repository metadata
+        shell: bash
+        env:
+          LINUX_PACKAGE_BASE_URL: ${{ vars.LINUX_PACKAGE_BASE_URL }}
+          LINUX_REPOSITORY_GPG_FINGERPRINT: ${{ vars.LINUX_REPOSITORY_GPG_FINGERPRINT }}
+          LINUX_REPOSITORY_GPG_PASSPHRASE: ${{ secrets.LINUX_REPOSITORY_GPG_PASSPHRASE }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          : "${LINUX_PACKAGE_BASE_URL:?LINUX_PACKAGE_BASE_URL is required}"
+          : "${LINUX_REPOSITORY_GPG_PASSPHRASE:?LINUX_REPOSITORY_GPG_PASSPHRASE is required}"
+          export GNUPGHOME="$RUNNER_TEMP/linux-repository-gnupg"
+          FINGERPRINT="${LINUX_REPOSITORY_GPG_FINGERPRINT//[[:space:]]/}"
+
+          node scripts/prepare-linux-repositories.mjs stage dist repository "$RELEASE_VERSION"
+          (
+            cd repository/apt
+            apt-ftparchive packages pool/main \
+              > dists/release/main/binary-amd64/Packages
+            gzip -9 -n -c dists/release/main/binary-amd64/Packages \
+              > dists/release/main/binary-amd64/Packages.gz
+          )
+          createrepo_c \
+            --checksum sha256 \
+            "repository/rpm/releases/${RELEASE_VERSION}/x86_64"
+
+          REPOMD="repository/rpm/releases/${RELEASE_VERSION}/x86_64/repodata/repomd.xml"
+          printf '%s' "$LINUX_REPOSITORY_GPG_PASSPHRASE" | gpg \
+            --batch \
+            --yes \
+            --pinentry-mode loopback \
+            --passphrase-fd 0 \
+            --local-user "$FINGERPRINT" \
+            --armor \
+            --detach-sign \
+            --output "${REPOMD}.asc" \
+            "$REPOMD"
+
+          node scripts/prepare-linux-repositories.mjs finalize \
+            repository \
+            "$RELEASE_VERSION" \
+            "$LINUX_PACKAGE_BASE_URL" \
+            "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+          RELEASE_FILE="repository/apt/dists/release/Release"
+          printf '%s' "$LINUX_REPOSITORY_GPG_PASSPHRASE" | gpg \
+            --batch \
+            --yes \
+            --pinentry-mode loopback \
+            --passphrase-fd 0 \
+            --local-user "$FINGERPRINT" \
+            --digest-algo SHA256 \
+            --clearsign \
+            --output repository/apt/dists/release/InRelease \
+            "$RELEASE_FILE"
+          install -d repository/keys
+          cp dist/shift-repository.gpg repository/keys/shift-repository.gpg
+
+          gpg --batch --verify "${REPOMD}.asc" "$REPOMD"
+          gpg --batch --verify repository/apt/dists/release/InRelease
+
+      - name: Upload inactive repository content
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_EC2_METADATA_DISABLED: "true"
+          AWS_REGION: auto
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          R2_BUCKET: ${{ vars.R2_RELEASE_BUCKET }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          : "${R2_ACCOUNT_ID:?CLOUDFLARE_ACCOUNT_ID is required}"
+          : "${R2_BUCKET:?R2_RELEASE_BUCKET is required}"
+          ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+          DESTINATION="s3://${R2_BUCKET}"
+
+          aws s3 cp repository/apt/pool "${DESTINATION}/apt/pool/" \
+            --recursive \
+            --endpoint-url "$ENDPOINT" \
+            --cache-control "public, max-age=31536000, immutable" \
+            --no-progress \
+            --only-show-errors
+          aws s3 cp repository/apt/dists/release/main "${DESTINATION}/apt/dists/release/main/" \
+            --recursive \
+            --endpoint-url "$ENDPOINT" \
+            --cache-control "no-cache" \
+            --no-progress \
+            --only-show-errors
+          aws s3 cp repository/apt/dists/release/Release "${DESTINATION}/apt/dists/release/Release" \
+            --endpoint-url "$ENDPOINT" \
+            --cache-control "no-cache" \
+            --no-progress \
+            --only-show-errors
+          aws s3 cp \
+            "repository/rpm/releases/${RELEASE_VERSION}/x86_64" \
+            "${DESTINATION}/rpm/releases/${RELEASE_VERSION}/x86_64/" \
+            --recursive \
+            --endpoint-url "$ENDPOINT" \
+            --cache-control "public, max-age=31536000, immutable" \
+            --no-progress \
+            --only-show-errors
+          aws s3 cp repository/config "${DESTINATION}/config/" \
+            --recursive \
+            --endpoint-url "$ENDPOINT" \
+            --cache-control "no-cache" \
+            --no-progress \
+            --only-show-errors
+          aws s3 cp repository/keys "${DESTINATION}/keys/" \
+            --recursive \
+            --endpoint-url "$ENDPOINT" \
+            --cache-control "no-cache" \
+            --no-progress \
+            --only-show-errors
+
+      - name: Verify inactive public content
+        shell: bash
+        env:
+          LINUX_PACKAGE_BASE_URL: ${{ vars.LINUX_PACKAGE_BASE_URL }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          BASE_URL="${LINUX_PACKAGE_BASE_URL%/}"
+          [[ "$BASE_URL" == https://* ]] || {
+            echo "LINUX_PACKAGE_BASE_URL must use HTTPS" >&2
+            exit 1
+          }
+          curl --fail --retry 5 --retry-all-errors \
+            "$BASE_URL/keys/shift-repository.gpg" \
+            --output public-repository-key.gpg
+          cmp repository/keys/shift-repository.gpg public-repository-key.gpg
+          curl --fail --head --retry 5 --retry-all-errors \
+            "$BASE_URL/apt/pool/main/s/shift/shift_${RELEASE_VERSION}_amd64.deb" >/dev/null
+
+          REPOMD_URL="$BASE_URL/rpm/releases/${RELEASE_VERSION}/x86_64/repodata/repomd.xml"
+          curl --fail --retry 5 --retry-all-errors "$REPOMD_URL" --output public-repomd.xml
+          curl --fail --retry 5 --retry-all-errors "${REPOMD_URL}.asc" --output public-repomd.xml.asc
+          export GNUPGHOME="$RUNNER_TEMP/linux-repository-gnupg"
+          gpg --batch --verify public-repomd.xml.asc public-repomd.xml
+
+      - name: Activate and test Linux repositories
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_EC2_METADATA_DISABLED: "true"
+          AWS_REGION: auto
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          LINUX_PACKAGE_BASE_URL: ${{ vars.LINUX_PACKAGE_BASE_URL }}
+          R2_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          R2_BUCKET: ${{ vars.R2_RELEASE_BUCKET }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+          DESTINATION="s3://${R2_BUCKET}"
+          PREVIOUS="$RUNNER_TEMP/previous-linux-repository"
+          mkdir "$PREVIOUS"
+          DNF_KEY="rpm/release/x86_64/metalink.xml"
+          APT_KEY="apt/dists/release/InRelease"
+          DNF_PREVIOUS=false
+          APT_PREVIOUS=false
+          DNF_ACTIVATED=false
+          APT_ACTIVATED=false
+
+          if aws s3api head-object --endpoint-url "$ENDPOINT" --bucket "$R2_BUCKET" --key "$DNF_KEY" >/dev/null 2>&1; then
+            DNF_PREVIOUS=true
+            aws s3 cp "${DESTINATION}/${DNF_KEY}" "$PREVIOUS/metalink.xml" \
+              --endpoint-url "$ENDPOINT" --no-progress --only-show-errors
+          fi
+          if aws s3api head-object --endpoint-url "$ENDPOINT" --bucket "$R2_BUCKET" --key "$APT_KEY" >/dev/null 2>&1; then
+            APT_PREVIOUS=true
+            aws s3 cp "${DESTINATION}/${APT_KEY}" "$PREVIOUS/InRelease" \
+              --endpoint-url "$ENDPOINT" --no-progress --only-show-errors
+          fi
+
+          restore_object() {
+            local had_previous="$1"
+            local backup="$2"
+            local key="$3"
+            if [[ "$had_previous" == true ]]; then
+              aws s3 cp "$backup" "${DESTINATION}/${key}" \
+                --endpoint-url "$ENDPOINT" \
+                --cache-control "no-cache" \
+                --no-progress \
+                --only-show-errors
+            else
+              aws s3api delete-object \
+                --endpoint-url "$ENDPOINT" \
+                --bucket "$R2_BUCKET" \
+                --key "$key" >/dev/null
+            fi
+          }
+          rollback() {
+            local status=$?
+            if [[ "$status" != 0 ]]; then
+              echo "Linux repository activation failed; restoring preceding roots" >&2
+              if [[ "$APT_ACTIVATED" == true ]]; then
+                restore_object "$APT_PREVIOUS" "$PREVIOUS/InRelease" "$APT_KEY"
+              fi
+              if [[ "$DNF_ACTIVATED" == true ]]; then
+                restore_object "$DNF_PREVIOUS" "$PREVIOUS/metalink.xml" "$DNF_KEY"
+              fi
+            fi
+            exit "$status"
+          }
+          trap rollback EXIT
+
+          aws s3 cp repository/rpm/release/x86_64/metalink.xml "${DESTINATION}/${DNF_KEY}" \
+            --endpoint-url "$ENDPOINT" \
+            --cache-control "no-cache" \
+            --no-progress \
+            --only-show-errors
+          DNF_ACTIVATED=true
+          aws s3 cp repository/apt/dists/release/InRelease "${DESTINATION}/${APT_KEY}" \
+            --endpoint-url "$ENDPOINT" \
+            --cache-control "no-cache" \
+            --no-progress \
+            --only-show-errors
+          APT_ACTIVATED=true
+
+          BASE_URL="${LINUX_PACKAGE_BASE_URL%/}"
+          curl --fail --retry 5 --retry-all-errors \
+            "$BASE_URL/rpm/release/x86_64/metalink.xml" \
+            --output active-metalink.xml
+          cmp repository/rpm/release/x86_64/metalink.xml active-metalink.xml
+          curl --fail --retry 5 --retry-all-errors \
+            "$BASE_URL/apt/dists/release/InRelease" \
+            --output active-InRelease
+          cmp repository/apt/dists/release/InRelease active-InRelease
+
+          docker run --rm \
+            --env BASE_URL="$BASE_URL" \
+            --env EXPECTED_VERSION="$RELEASE_VERSION" \
+            ubuntu:24.04 \
+            bash -euxo pipefail -c '
+              apt-get update
+              apt-get install --yes ca-certificates curl
+              install -d -m 755 /etc/apt/keyrings
+              curl --fail "$BASE_URL/keys/shift-repository.gpg" \
+                --output /etc/apt/keyrings/shift-repository.gpg
+              curl --fail "$BASE_URL/config/shift.sources" \
+                --output /etc/apt/sources.list.d/shift.sources
+              apt-get update
+              apt-get install --yes shift
+              test "$(dpkg-query --show --showformat="\${Version}" shift)" = "$EXPECTED_VERSION"
+            '
+          docker run --rm \
+            --env BASE_URL="$BASE_URL" \
+            --env EXPECTED_VERSION="$RELEASE_VERSION" \
+            fedora:latest \
+            bash -euxo pipefail -c '
+              dnf install --assumeyes ca-certificates curl
+              curl --fail "$BASE_URL/config/shift.repo" \
+                --output /etc/yum.repos.d/shift.repo
+              dnf install --assumeyes shift
+              test "$(rpm --query --queryformat "%{VERSION}" shift)" = "$EXPECTED_VERSION"
+            '
+
+          trap - EXIT
 
   feed:
     name: Publish release update feed

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Shift aims to redefine font editing by combining the power of Rust for performan
 > [!WARNING]
 > Shift is an unstable Developer Preview. Versioned Alpha builds are for early testing, not production font work. Work on copies and retain independent backups. Installable builds are published through [GitHub Releases](https://github.com/shift-editor/shift/releases); the latest complete development snapshot is available as [Shift Nightly](https://github.com/shift-editor/shift/releases/tag/nightly).
 
+Linux versioned releases are available through signed [APT and DNF repositories](docs/releases.md#linux-installation), with DEB, RPM, and AppImage direct downloads retained as alternatives.
+
 ## Architecture
 
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -834,7 +834,7 @@ These are allowed to jump around when energy is high, but they should not silent
 
 **Linux**
 
-- [ ] AppImage
+- [x] AppImage
 - [x] .deb package
 - [x] .rpm package
 

--- a/apps/desktop/electron-builder.config.ts
+++ b/apps/desktop/electron-builder.config.ts
@@ -208,7 +208,7 @@ const config: Configuration = {
     artifactName: `${artifactName}-${productVersion}-Windows-${buildArchitecture}-Setup.\${ext}`,
   },
   linux: {
-    target: ["deb", "rpm"],
+    target: ["deb", "rpm", "AppImage"],
     icon: `../../icons/${iconName}.png`,
     executableName: packageName,
     category: "Graphics",
@@ -218,6 +218,9 @@ const config: Configuration = {
     vendor: "Shift",
     syncDesktopName: true,
     mimeTypes: [documentMimeType],
+    artifactName: `${artifactName}-${productVersion}-Linux-${buildArchitecture}.\${ext}`,
+  },
+  appImage: {
     artifactName: `${artifactName}-${productVersion}-Linux-${buildArchitecture}.\${ext}`,
   },
   deb: {

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -30,12 +30,13 @@ Use Conventional Commit prefixes. `feat`, `fix`, and `perf` appear in the public
 
 ## Packaging and updates
 
-| Target              | Package/update policy                                                                |
-| ------------------- | ------------------------------------------------------------------------------------ |
-| macOS arm64/x64     | Signed and notarized ZIP for automatic updates; DMG for manual installation          |
-| Windows Nightly x64 | Unsigned per-user NSIS installer and automatic updates for installed N → N+1 testing |
-| Windows Release x64 | Manual GitHub downloads until Authenticode signing is configured                     |
-| Linux x64           | Manual GitHub downloads (`.deb` / `.rpm`)                                            |
+| Target              | Package/update policy                                                                                           |
+| ------------------- | --------------------------------------------------------------------------------------------------------------- |
+| macOS arm64/x64     | Signed and notarized ZIP for automatic updates; DMG for manual installation                                         |
+| Windows Nightly x64 | Unsigned per-user NSIS installer and automatic updates for installed N → N+1 testing                            |
+| Windows Release x64 | Manual GitHub downloads until Authenticode signing is configured                                                |
+| Linux Nightly x64   | Unsigned direct GitHub downloads (`.deb`, `.rpm`, and AppImage)                                                 |
+| Linux Release x64   | Signed RPM and checksum manifest; direct downloads plus signed APT/DNF repositories and an AppImage             |
 
 Packaged builds register `.shift` as a Shift Document with shared document artwork. Release is the preferred handler; Nightly remains an alternate so installing it does not take document ownership from Release. macOS composites the Shift badge onto its standard document shape from bundle metadata and the packaged asset catalog, Windows uses per-user NSIS registry entries, and Linux DEB/RPM packages install `application/x-shift-document` metadata and hicolor MIME icons.
 
@@ -43,14 +44,45 @@ electron-updater compares the aligned numeric versions, verifies generated SHA-5
 
 electron-builder generates architecture-specific `latest-mac.yml` files for exact versioned ZIP assets and `latest.yml` for the Windows Nightly NSIS installer. GitHub Pages hosts the fixed Release/Nightly metadata files. Versioned Release binaries and their differential-update blockmaps remain on GitHub Releases. Nightly metadata instead references immutable updater packages under `nightly/<full-commit>/` in Cloudflare R2. Because electron-updater cannot derive a previous blockmap URL across commit-addressed directories, Nightly updates fall back to full package downloads; Release differential updates are unchanged.
 
+Linux Release packages use the dedicated `Shift Package Signing` RSA-4096 key. The RPM carries an embedded signature, and the signed `SHA256SUMS.asc` authenticates every direct-download Linux format, including DEB and AppImage. APT authenticates package hashes through `InRelease`; DNF checks both the RPM signature and the detached `repomd.xml` signature. The public key is published as `shift-repository.gpg` with the GitHub release and at `https://packages.shift.graphics/keys/shift-repository.gpg`.
+
 The app waits 30 seconds before its first automatic check to avoid competing with startup, then checks every four hours. Automatic current/error results are quiet. A native-framed update window asks for consent before downloading, then replaces those choices with byte and percentage progress that can be canceled. Download completion replaces progress with **Restart and Install** / Later, is not silently installed on ordinary quit, and cannot restart until every document accepts and commits close.
+
+## Linux installation
+
+APT users install the scoped repository key and deb822 source definition before installing Shift:
+
+```sh
+sudo install -d -m 755 /etc/apt/keyrings
+curl -fsSL https://packages.shift.graphics/keys/shift-repository.gpg \
+  | sudo tee /etc/apt/keyrings/shift-repository.gpg >/dev/null
+curl -fsSL https://packages.shift.graphics/config/shift.sources \
+  | sudo tee /etc/apt/sources.list.d/shift.sources >/dev/null
+sudo apt update
+sudo apt install shift
+```
+
+DNF users install the repository definition, which enables both package and repository-metadata signature checks:
+
+```sh
+sudo curl -fsSL \
+  https://packages.shift.graphics/config/shift.repo \
+  -o /etc/yum.repos.d/shift.repo
+sudo dnf install shift
+```
+
+The AppImage remains a direct-download alternative. Verify it through the release's `SHA256SUMS` and `SHA256SUMS.asc`, make it executable, and run it without installing a repository.
 
 ## Workflows
 
 - `release-please.yml` maintains a draft release pull request. Merging it creates a numeric version tag and draft GitHub release, then invokes `release-desktop.yml`.
-- `release-desktop.yml` validates `vMAJOR.MINOR.PATCH`, builds macOS arm64/x64 ZIPs and DMGs, a Windows x64 per-user NSIS installer, and Linux x64 packages, smoke-tests packaged applications, uploads checksums/assets, publishes the GitHub prerelease, then advances the Release feed.
+- `release-desktop.yml` validates `vMAJOR.MINOR.PATCH`, builds macOS arm64/x64 ZIPs and DMGs, a Windows x64 per-user NSIS installer, and Linux x64 DEB/RPM/AppImage packages, smoke-tests packaged applications, signs the Release RPM and checksum manifest, uploads the GitHub prerelease, publishes signed APT/DNF repositories, then advances the Release feed.
 - `nightly.yml` resolves one `0.RUN.ATTEMPT` version and builds the same matrix. After every build succeeds, it archives versioned updater assets in the immutable R2 prefix `nightly/<full-commit>/`, replaces the rolling GitHub prerelease's friendly download aliases, and advances the feed to the exact R2 prefix. A commit whose R2 manifest and feed are already active is skipped.
 - `prepare-update-feed.mjs` performs the one monotonic candidate-version check and stages electron-builder's generated metadata into fixed Pages paths. Release asset URLs continue to target their versioned GitHub release; Nightly URLs target the candidate's immutable R2 prefix. It does not create feed-history directories.
+
+The Linux repository follows `built → signed → active`. `built` means the complete x64 artifact set passed its packaged-app smoke test. `signed` means the RPM, APT `Release`, DNF `repomd.xml`, and direct-download checksum manifest have signatures from the configured repository key. `active` means the public APT `InRelease` and DNF metalink reference that signed release.
+
+APT uploads immutable package and by-hash content before replacing the single signed `InRelease` root. DNF stores each complete repository under `rpm/releases/<version>/x86_64/`; the stable `rpm/release/x86_64/metalink.xml` activates one immutable version. Activation saves the preceding roots, updates the DNF metalink and APT `InRelease`, verifies both through the public domain, and installs Shift in clean Ubuntu and Fedora containers. Any failure during activation or installation restores the preceding roots. Nightlies never enter either native repository.
 
 Release and Nightly feed publication share one concurrency group. Binary assets become public before a feed advances. The feed job checks out or creates the `update-feeds` branch, preserves `.nojekyll` and the other distribution directory, updates only its channel, and pushes the branch. GitHub Pages serves it at `https://shift-editor.github.io/shift/updates`.
 
@@ -66,6 +98,8 @@ The Release Please workflow mints a short-lived token from the repository-scoped
 | `CLOUDFLARE_ACCOUNT_ID`        | Cloudflare account containing the release bucket           |
 | `R2_RELEASE_BUCKET`            | R2 bucket name; production uses `shift-releases`           |
 | `R2_RELEASE_BASE_URL`          | HTTPS custom-domain base URL exposing the public R2 bucket |
+| `LINUX_PACKAGE_BASE_URL`       | Linux repository origin; production uses `https://packages.shift.graphics` |
+| `LINUX_REPOSITORY_GPG_FINGERPRINT` | Full fingerprint of the dedicated Linux repository signing key |
 
 | Secret                           | Purpose                                                  |
 | -------------------------------- | -------------------------------------------------------- |
@@ -77,6 +111,8 @@ The Release Please workflow mints a short-lived token from the repository-scoped
 | `APPLE_TEAM_ID`                  | Paid Apple Developer Program team ID                     |
 | `R2_ACCESS_KEY_ID`               | R2 S3 API access key with object read/write permission   |
 | `R2_SECRET_ACCESS_KEY`           | R2 S3 API secret access key                              |
+| `LINUX_REPOSITORY_GPG_PRIVATE_KEY` | ASCII-armored private Linux repository signing key     |
+| `LINUX_REPOSITORY_GPG_PASSPHRASE` | Passphrase protecting the Linux repository signing key |
 
 Never put private keys or signing credentials in repository files, workflow inputs, artifacts, or logs. macOS release and Nightly jobs fail when signing credentials are absent.
 
@@ -85,11 +121,14 @@ Never put private keys or signing credentials in repository files, workflow inpu
 1. Add the Apple signing/notarization secrets.
 2. Create the Standard-storage R2 bucket `shift-releases`. Do not configure a bucket lifecycle rule; workflow pruning protects the active build.
 3. Attach a production custom domain to the bucket and configure the three R2 variables and two R2 secrets above.
-4. Run a desktop workflow once to create `update-feeds`.
-5. Configure GitHub Pages to publish the root of `update-feeds`.
-6. Confirm packaged Release and Nightly builds contact only their matching feed paths, and that Nightly metadata references the expected full commit in R2.
-7. Perform real installed N → N+1 tests on macOS arm64/x64 and unsigned Windows Nightly x64, including download consent, full-download fallback, progress, download cancellation and retry, Save, Don't Save, Later, and **Restart and Install**.
-8. Keep Windows Release on manual downloads until Authenticode signing and installed update verification are complete.
+4. Attach `packages.shift.graphics` to the same bucket and set `LINUX_PACKAGE_BASE_URL` to that HTTPS origin.
+5. Create a dedicated RSA-4096 key whose identity is exactly `Shift Package Signing`. Keep an offline backup, add its armored private key and passphrase as repository secrets, and configure its full fingerprint as `LINUX_REPOSITORY_GPG_FINGERPRINT`.
+6. Run a desktop workflow once to create `update-feeds` and the Linux repositories.
+7. Configure GitHub Pages to publish the root of `update-feeds`.
+8. Confirm packaged Release and Nightly builds contact only their matching feed paths, and that Nightly metadata references the expected full commit in R2.
+9. Confirm the repository job installs the exact candidate version in its clean Ubuntu and Fedora containers. After a second versioned release exists, perform an installed N → N+1 APT and DNF upgrade test.
+10. Perform real installed N → N+1 tests on macOS arm64/x64 and unsigned Windows Nightly x64, including download consent, full-download fallback, progress, download cancellation and retry, Save, Don't Save, Later, and **Restart and Install**.
+11. Keep Windows Release on manual downloads until Authenticode signing and installed update verification are complete.
 
 Electron update orchestration has no worthwhile unit test without mocking Electron, native dialogs, and electron-updater. Pure tests cover feed selection, canonical versions, generated metadata validation, feed preparation, and Nightly asset partitioning; installed update behavior and retention pruning remain required manual QA.
 
@@ -100,4 +139,5 @@ Electron update orchestration has no worthwhile unit test without mocking Electr
 - Never delete or reuse a published numeric version tag. Correct it with the next version.
 - A failed Nightly build or feed deployment leaves the previous feed active. Republish a complete later Nightly rather than editing a feed in place.
 - If R2 assets and GitHub aliases publish but feed deployment fails, rerun the failed feed job from the original run's retained artifacts. A full workflow rerun refuses to overwrite the complete immutable R2 prefix. Clients continue using the previous feed until deployment succeeds, and pruning does not run.
+- If Linux repository preparation or inactive upload fails, fix and rerun the repository job; neither activation root changed. Activation and clean-container failures restore the preceding APT `InRelease` and DNF metalink. Never rewrite a published version directory.
 - If Nightly pruning fails after the feed advances, rerun the prune job. Do not move the feed backward or delete the active commit's R2 prefix.

--- a/scripts/prepare-linux-repositories.mjs
+++ b/scripts/prepare-linux-repositories.mjs
@@ -1,0 +1,243 @@
+import { createHash } from "node:crypto";
+import { copyFile, mkdir, readFile, readdir, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const versionPattern = /^\d+\.\d+\.\d+$/;
+const architecture = "x86_64";
+const debianArchitecture = "amd64";
+
+export async function stageLinuxPackages({ artifactsRoot, repositoryRoot, version }) {
+  validateVersion(version);
+  const artifacts = path.resolve(artifactsRoot);
+  const repository = path.resolve(repositoryRoot);
+  await prepareEmptyDirectory(repository);
+
+  const files = await collectFiles(artifacts);
+  const deb = findArtifact(files, `Shift-${version}-Linux-x64.deb`);
+  const rpm = findArtifact(files, `Shift-${version}-Linux-x64.rpm`);
+  findArtifact(files, `Shift-${version}-Linux-x64.AppImage`);
+
+  const debDestination = path.join(
+    repository,
+    "apt",
+    "pool",
+    "main",
+    "s",
+    "shift",
+    `shift_${version}_${debianArchitecture}.deb`,
+  );
+  const rpmDestination = path.join(
+    repository,
+    "rpm",
+    "releases",
+    version,
+    architecture,
+    `shift-${version}-1.${architecture}.rpm`,
+  );
+
+  await Promise.all([
+    copy(deb, debDestination),
+    copy(rpm, rpmDestination),
+    mkdir(path.join(repository, "apt", "dists", "release", "main", "binary-amd64"), {
+      recursive: true,
+    }),
+  ]);
+
+  return { deb: debDestination, rpm: rpmDestination };
+}
+
+export async function finalizeLinuxRepositories({ repositoryRoot, version, baseUrl, publishedAt }) {
+  validateVersion(version);
+  const repository = path.resolve(repositoryRoot);
+  const packageBaseUrl = validateBaseUrl(baseUrl);
+  const publicationDate = parsePublicationDate(publishedAt);
+  const aptRoot = path.join(repository, "apt");
+  const aptDistribution = path.join(aptRoot, "dists", "release");
+  const aptBinary = path.join(aptDistribution, "main", "binary-amd64");
+  const rpmRoot = path.join(repository, "rpm", "releases", version, architecture);
+  const repomd = path.join(rpmRoot, "repodata", "repomd.xml");
+  const repomdSignature = `${repomd}.asc`;
+  const packages = [path.join(aptBinary, "Packages"), path.join(aptBinary, "Packages.gz")];
+
+  await Promise.all([
+    requireFile(repomd),
+    requireFile(repomdSignature),
+    ...packages.map((file) => requireFile(file)),
+  ]);
+
+  const releaseSections = [];
+  for (const algorithm of ["sha256", "sha512"]) {
+    const entries = [];
+    for (const file of packages) {
+      const digest = await hashFile(file, algorithm);
+      const relative = relativePath(aptDistribution, file);
+      const byHash = path.join(path.dirname(file), "by-hash", algorithm.toUpperCase(), digest);
+      await copy(file, byHash);
+      entries.push(` ${digest} ${(await stat(file)).size} ${relative}`);
+    }
+    releaseSections.push(`${algorithm.toUpperCase()}:\n${entries.join("\n")}`);
+  }
+
+  const release = [
+    "Origin: Shift",
+    "Label: Shift",
+    "Suite: release",
+    "Codename: release",
+    `Date: ${publicationDate.toUTCString()}`,
+    "Architectures: amd64",
+    "Components: main",
+    "Description: Shift font editor packages",
+    "Acquire-By-Hash: yes",
+    ...releaseSections,
+    "",
+  ].join("\n");
+  await writeFile(path.join(aptDistribution, "Release"), release);
+
+  const repomdSize = (await stat(repomd)).size;
+  const repomdUrl = `${packageBaseUrl}/rpm/releases/${version}/${architecture}/repodata/repomd.xml`;
+  const metalink = [
+    '<?xml version="1.0" encoding="utf-8"?>',
+    `<metalink version="3.0" xmlns="http://www.metalinker.org/" type="static" pubdate="${publicationDate.toUTCString()}" generator="Shift">`,
+    " <files>",
+    '  <file name="repomd.xml">',
+    `   <size>${repomdSize}</size>`,
+    "   <verification>",
+    `    <hash type="sha256">${await hashFile(repomd, "sha256")}</hash>`,
+    `    <hash type="sha512">${await hashFile(repomd, "sha512")}</hash>`,
+    "   </verification>",
+    '   <resources maxconnections="1">',
+    `    <url protocol="https" type="https" preference="100">${repomdUrl}</url>`,
+    "   </resources>",
+    "  </file>",
+    " </files>",
+    "</metalink>",
+    "",
+  ].join("\n");
+  await write(path.join(repository, "rpm", "release", architecture, "metalink.xml"), metalink);
+
+  const keyUrl = `${packageBaseUrl}/keys/shift-repository.gpg`;
+  const aptSource = [
+    "Types: deb",
+    `URIs: ${packageBaseUrl}/apt`,
+    "Suites: release",
+    "Components: main",
+    "Architectures: amd64",
+    "Signed-By: /etc/apt/keyrings/shift-repository.gpg",
+    "",
+  ].join("\n");
+  const dnfRepository = [
+    "[shift-release]",
+    "name=Shift Release",
+    `metalink=${packageBaseUrl}/rpm/release/$basearch/metalink.xml`,
+    "enabled=1",
+    "gpgcheck=1",
+    "repo_gpgcheck=1",
+    `gpgkey=${keyUrl}`,
+    "metadata_expire=6h",
+    "skip_if_unavailable=False",
+    "",
+  ].join("\n");
+  await Promise.all([
+    write(path.join(repository, "config", "shift.sources"), aptSource),
+    write(path.join(repository, "config", "shift.repo"), dnfRepository),
+  ]);
+}
+
+function validateVersion(version) {
+  if (!versionPattern.test(version)) {
+    throw new Error(`Expected a numeric three-component version, received: ${version}`);
+  }
+}
+
+function validateBaseUrl(value) {
+  const url = new URL(value);
+  if (url.protocol !== "https:") throw new Error("Linux package base URL must use HTTPS");
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error("Linux package base URL cannot contain credentials, a query, or a fragment");
+  }
+  return url.toString().replace(/\/$/, "");
+}
+
+function parsePublicationDate(value) {
+  const date = value ? new Date(value) : new Date();
+  if (Number.isNaN(date.getTime())) throw new Error(`Invalid publication date: ${value}`);
+  return date;
+}
+
+async function prepareEmptyDirectory(directory) {
+  await mkdir(directory, { recursive: true });
+  if ((await readdir(directory)).length > 0) {
+    throw new Error(`Linux repository output directory is not empty: ${directory}`);
+  }
+}
+
+async function collectFiles(root) {
+  const files = [];
+  for (const entry of await readdir(root, { withFileTypes: true })) {
+    const entryPath = path.join(root, entry.name);
+    if (entry.isDirectory()) files.push(...(await collectFiles(entryPath)));
+    else if (entry.isFile()) files.push(entryPath);
+  }
+  return files;
+}
+
+function findArtifact(files, name) {
+  const matches = files.filter((file) => path.basename(file) === name);
+  if (matches.length !== 1) throw new Error(`Expected one ${name}, found ${matches.length}`);
+  return matches[0];
+}
+
+async function requireFile(file) {
+  const details = await stat(file);
+  if (!details.isFile()) throw new Error(`Expected a file: ${file}`);
+}
+
+async function hashFile(file, algorithm) {
+  return createHash(algorithm)
+    .update(await readFile(file))
+    .digest("hex");
+}
+
+async function copy(source, destination) {
+  await mkdir(path.dirname(destination), { recursive: true });
+  await copyFile(source, destination);
+}
+
+async function write(destination, contents) {
+  await mkdir(path.dirname(destination), { recursive: true });
+  await writeFile(destination, contents);
+}
+
+function relativePath(root, file) {
+  return path.relative(root, file).split(path.sep).join("/");
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  const [command, ...args] = process.argv.slice(2);
+  switch (command) {
+    case "stage": {
+      const [artifactsRoot, repositoryRoot, version] = args;
+      if (!artifactsRoot || !repositoryRoot || !version) {
+        throw new Error(
+          "Usage: prepare-linux-repositories.mjs stage <artifacts> <repository> <version>",
+        );
+      }
+      const staged = await stageLinuxPackages({ artifactsRoot, repositoryRoot, version });
+      process.stdout.write(`${JSON.stringify(staged)}\n`);
+      break;
+    }
+    case "finalize": {
+      const [repositoryRoot, version, baseUrl, publishedAt] = args;
+      if (!repositoryRoot || !version || !baseUrl) {
+        throw new Error(
+          "Usage: prepare-linux-repositories.mjs finalize <repository> <version> <base-url> [published-at]",
+        );
+      }
+      await finalizeLinuxRepositories({ repositoryRoot, version, baseUrl, publishedAt });
+      break;
+    }
+    default:
+      throw new Error(`Expected stage or finalize command, received: ${command}`);
+  }
+}

--- a/scripts/prepare-linux-repositories.test.mjs
+++ b/scripts/prepare-linux-repositories.test.mjs
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { finalizeLinuxRepositories, stageLinuxPackages } from "./prepare-linux-repositories.mjs";
+
+const version = "0.2.3";
+
+async function fixture(context) {
+  const root = await mkdtemp(path.join(os.tmpdir(), "shift-linux-repository-"));
+  context.after(() => rm(root, { force: true, recursive: true }));
+  const artifactsRoot = path.join(root, "artifacts");
+  const repositoryRoot = path.join(root, "repository");
+  await mkdir(artifactsRoot, { recursive: true });
+  await Promise.all([
+    writeFile(path.join(artifactsRoot, `Shift-${version}-Linux-x64.deb`), "deb-package"),
+    writeFile(path.join(artifactsRoot, `Shift-${version}-Linux-x64.rpm`), "rpm-package"),
+    writeFile(path.join(artifactsRoot, `Shift-${version}-Linux-x64.AppImage`), "app-image"),
+  ]);
+  return { artifactsRoot, repositoryRoot };
+}
+
+test("stages one complete versioned Linux artifact set", async (context) => {
+  const { artifactsRoot, repositoryRoot } = await fixture(context);
+  const staged = await stageLinuxPackages({ artifactsRoot, repositoryRoot, version });
+
+  assert.equal(await readFile(staged.deb, "utf8"), "deb-package");
+  assert.equal(await readFile(staged.rpm, "utf8"), "rpm-package");
+  assert.equal(
+    path.relative(repositoryRoot, staged.deb),
+    `apt/pool/main/s/shift/shift_${version}_amd64.deb`,
+  );
+  assert.equal(
+    path.relative(repositoryRoot, staged.rpm),
+    `rpm/releases/${version}/x86_64/shift-${version}-1.x86_64.rpm`,
+  );
+});
+
+test("rejects an incomplete Linux artifact set", async (context) => {
+  const { artifactsRoot, repositoryRoot } = await fixture(context);
+  await rm(path.join(artifactsRoot, `Shift-${version}-Linux-x64.AppImage`));
+
+  await assert.rejects(
+    stageLinuxPackages({ artifactsRoot, repositoryRoot, version }),
+    /Expected one Shift-0\.2\.3-Linux-x64\.AppImage, found 0/,
+  );
+});
+
+test("writes authenticated APT roots and an immutable DNF metalink", async (context) => {
+  const { artifactsRoot, repositoryRoot } = await fixture(context);
+  await stageLinuxPackages({ artifactsRoot, repositoryRoot, version });
+  const aptBinary = path.join(repositoryRoot, "apt/dists/release/main/binary-amd64");
+  const repodata = path.join(repositoryRoot, `rpm/releases/${version}/x86_64/repodata`);
+  await mkdir(repodata, { recursive: true });
+  await Promise.all([
+    writeFile(path.join(aptBinary, "Packages"), "apt-packages"),
+    writeFile(path.join(aptBinary, "Packages.gz"), "compressed-packages"),
+    writeFile(path.join(repodata, "repomd.xml"), "<repomd>signed content</repomd>"),
+    writeFile(path.join(repodata, "repomd.xml.asc"), "detached-signature"),
+  ]);
+
+  await finalizeLinuxRepositories({
+    repositoryRoot,
+    version,
+    baseUrl: "https://packages.shift.graphics/",
+    publishedAt: "2026-08-25T12:00:00Z",
+  });
+
+  const release = await readFile(path.join(repositoryRoot, "apt/dists/release/Release"), "utf8");
+  const packageDigest = createHash("sha256").update("apt-packages").digest("hex");
+  assert.match(release, /Suite: release/);
+  assert.match(release, /Acquire-By-Hash: yes/);
+  assert.match(release, new RegExp(`${packageDigest} 12 main/binary-amd64/Packages`));
+  assert.equal(
+    await readFile(path.join(aptBinary, "by-hash/SHA256", packageDigest), "utf8"),
+    "apt-packages",
+  );
+
+  const metalink = await readFile(
+    path.join(repositoryRoot, "rpm/release/x86_64/metalink.xml"),
+    "utf8",
+  );
+  const repomdDigest = createHash("sha256").update("<repomd>signed content</repomd>").digest("hex");
+  assert.match(metalink, new RegExp(repomdDigest));
+  assert.match(
+    metalink,
+    new RegExp(
+      `https://packages\\.shift\\.graphics/rpm/releases/${version}/x86_64/repodata/repomd\\.xml`,
+    ),
+  );
+
+  const aptSource = await readFile(path.join(repositoryRoot, "config/shift.sources"), "utf8");
+  assert.match(aptSource, /Suites: release/);
+  assert.match(aptSource, /Signed-By: \/etc\/apt\/keyrings\/shift-repository\.gpg/);
+
+  const dnfRepository = await readFile(path.join(repositoryRoot, "config/shift.repo"), "utf8");
+  assert.match(dnfRepository, /^\[shift-release\]$/m);
+  assert.match(dnfRepository, /gpgcheck=1/);
+  assert.match(dnfRepository, /repo_gpgcheck=1/);
+  assert.match(dnfRepository, /rpm\/release\/\$basearch\/metalink\.xml/);
+});
+
+test("rejects a non-HTTPS package origin", async (context) => {
+  const { artifactsRoot, repositoryRoot } = await fixture(context);
+  await stageLinuxPackages({ artifactsRoot, repositoryRoot, version });
+
+  await assert.rejects(
+    finalizeLinuxRepositories({
+      repositoryRoot,
+      version,
+      baseUrl: "http://packages.shift.graphics",
+    }),
+    /must use HTTPS/,
+  );
+});

--- a/scripts/prepare-nightly-release.mjs
+++ b/scripts/prepare-nightly-release.mjs
@@ -56,6 +56,10 @@ const assets = [
     pattern: new RegExp(`Shift-Nightly-${escapeRegex(version)}-Linux-x64\\.rpm$`),
     publicName: "Shift-Nightly-Linux-x64.rpm",
   },
+  {
+    pattern: new RegExp(`Shift-Nightly-${escapeRegex(version)}-Linux-x64\\.AppImage$`),
+    publicName: "Shift-Nightly-Linux-x64.AppImage",
+  },
 ];
 
 const distRoot = path.resolve(distArgument);

--- a/scripts/prepare-nightly-release.test.mjs
+++ b/scripts/prepare-nightly-release.test.mjs
@@ -25,6 +25,7 @@ const fixtures = [
   [`desktop-nightly-win32-x64/Shift-Nightly-${version}-Windows-x64-Setup.exe.blockmap`, "blockmap"],
   [`desktop-nightly-linux-x64/Shift-Nightly-${version}-Linux-x64.deb`, "linux-deb"],
   [`desktop-nightly-linux-x64/Shift-Nightly-${version}-Linux-x64.rpm`, "linux-rpm"],
+  [`desktop-nightly-linux-x64/Shift-Nightly-${version}-Linux-x64.AppImage`, "linux-appimage"],
 ];
 const publicOutputs = new Map([
   ["Shift-Nightly-macOS-arm64.zip", "mac-arm64"],
@@ -34,6 +35,7 @@ const publicOutputs = new Map([
   ["Shift-Nightly-Windows-x64-Setup.exe", "windows"],
   ["Shift-Nightly-Linux-x64.deb", "linux-deb"],
   ["Shift-Nightly-Linux-x64.rpm", "linux-rpm"],
+  ["Shift-Nightly-Linux-x64.AppImage", "linux-appimage"],
 ]);
 const updateOutputs = new Map([
   [`Shift-Nightly-${version}-macOS-arm64.zip`, "mac-arm64"],


### PR DESCRIPTION
## Summary

- add x64 AppImage artifacts to versioned Release and rolling Nightly downloads
- sign Release RPMs and the direct-download checksum manifest, then publish signed APT and DNF repositories through the existing R2 bucket
- activate APT through signed `InRelease` metadata and DNF through a single metalink pointing at an immutable version, with rollback and clean Ubuntu/Fedora installation checks

## Issue

Refs #283

The issue remains open for Flathub and Snap Store distribution.

## Testing

### Repository checks

- `pnpm test:release` — 22 passed
- `pnpm test` — 10/10 Turbo tasks passed, including 721 desktop tests
- `pnpm format:check`
- `pnpm lint:check`
- `pnpm typecheck`
- `python3 scripts/context-drift-check.py --ci` — passed with 12 pre-existing freshness warnings
- `actionlint .github/workflows/release-desktop.yml .github/workflows/nightly.yml .github/workflows/ci.yml`
- GitHub CI — passed

### Linux x86_64 validation

Validated commit `20aee4d1`, followed by the Ubuntu RPM compatibility fix in `e7d62896`, on Ubuntu 24.04 x86_64:

- built the native bridge and desktop application
- generated exactly:
  - `Shift-0.1.0-Linux-x64.deb`
  - `Shift-0.1.0-Linux-x64.rpm`
  - `Shift-0.1.0-Linux-x64.AppImage`
- smoke-tested the unpacked application with `chrome-sandbox` owned by `root:root` at mode `4755`
- inspected, extracted, and launched the AppImage under Xvfb without disabling Electron's sandbox
- generated a disposable RSA-4096 key named exactly `Shift Package Signing`
- signed and verified the RPM and `SHA256SUMS` manifest
- generated and verified APT `InRelease` and DNF `repomd.xml.asc`
- verified APT SHA256/SHA512 metadata, every by-hash object, and `Acquire-By-Hash`
- verified DNF metalink hashes and its immutable versioned `repomd.xml` URL
- installed exactly `0.1.0` from a read-only `file://` repository in clean Ubuntu 24.04 and Fedora 44 containers with repository and package signature checks enabled
- deleted all disposable private-key and passphrase material after validation

The exact Ubuntu workflow initially exposed two RPM 4.18 compatibility defects: its RPM macros expected `gpg2`, and `rpmkeys` rejected a binary exported key. Commit `e7d62896` selects the installed `gpg` executable and uses a temporary armored key for RPM verification; the complete signing and clean-container installation pipeline passed afterward.

Not executed: public R2 upload/activation, production signing credentials, or a real N → N+1 package upgrade. R2 operations were intentionally reviewed only, and upgrade validation remains deferred until two versioned releases exist.

## Risks and provisioning

Versioned Release publication intentionally fails until the following production configuration exists:

- repository variables:
  - `LINUX_PACKAGE_BASE_URL` — production value `https://packages.shift.graphics`
  - `LINUX_REPOSITORY_GPG_FINGERPRINT` — full fingerprint of the dedicated repository key
- repository secrets:
  - `LINUX_REPOSITORY_GPG_PRIVATE_KEY` — ASCII-armored private key
  - `LINUX_REPOSITORY_GPG_PASSPHRASE` — key passphrase

Create a dedicated RSA-4096 key whose identity is exactly `Shift Package Signing`, keep an offline backup, and configure the values directly in GitHub Actions. Never put the private key or passphrase in the repository, workflow inputs, artifacts, or logs.

The existing R2 account, bucket, and access credential names are already configured. `packages.shift.graphics` must also be attached to the release bucket before the first publication.

Nightlies remain unsigned and never enter the APT or DNF repositories. Store distribution remains follow-up work under #283.

